### PR TITLE
docs: simplify the team workflow guides — branches, roles, and a failure-first lifecycle

### DIFF
--- a/.claude/agents/rubric-critic.md
+++ b/.claude/agents/rubric-critic.md
@@ -1,6 +1,6 @@
 ---
 name: rubric-critic
-description: Use to audit a genealogy skill's eval RUBRIC and judge quality from its run logs — before trusting the skill-improver to optimize toward that rubric. Trigger phrases include "is X's rubric any good", "audit the rubric for X", "which of X's dimensions don't discriminate", "review X's eval quality". Reads a skill's run log(s) + .ann corrections + rubric.md and flags non-discriminating dimensions (always pass or always fail), flaky dimensions, dimensions no test exercises, and systematic judge-vs-human disagreement. Read-only — emits suggestions for the senior's rubric / judge-prompt review; never edits rubric.md, the judge prompt, or any skill.
+description: Use to audit a genealogy skill's eval RUBRIC and judge quality from its run logs — before trusting the skill-improver to optimize toward that rubric. Trigger phrases include "is X's rubric any good", "audit the rubric for X", "which of X's dimensions don't discriminate", "review X's eval quality". Reads a skill's run log(s) + .ann corrections + rubric.md and flags non-discriminating dimensions (always pass or always fail), flaky dimensions, dimensions no test exercises, and systematic judge-vs-human disagreement. Read-only — emits suggestions the loop-runner applies to the skill's own rubric.md, or escalates to the maintainer for the base rubric / global judge prompt; never edits rubric.md, the judge prompt, or any skill.
 tools: Read, Grep, Glob, Bash
 ---
 
@@ -12,10 +12,14 @@ behavior from its eval evidence, and surface what to fix so the rubric
 dimensions actually separate good work from bad — *before* the body optimizer
 ([`skill-improver`](skill-improver.md)) is trusted to tune toward them.
 
-You **never edit** `rubric.md`, the judge prompt, or any skill. Rubric
-dimensions are senior-owned; the judge prompt is project-global on a separate
-cadence (see [`docs/plan/per-pr-review-workflow.md`](../../docs/plan/per-pr-review-workflow.md)
-§2.6). You produce suggestions for the senior's review, not edits.
+You **never edit** `rubric.md`, the judge prompt, or any skill — you are
+read-only by construction, and produce suggestions rather than edits. Who acts
+on them differs by layer: the **skill's `rubric.md` and each test's
+`judge_context` belong to the person running the loop**, who applies your
+suggestions themselves (and must then re-run that skill's suite, since both are
+part of the run-log snapshot). The **base rubric and the project-global judge
+prompt are the maintainer's alone** — a change to either re-baselines every
+skill, so route those suggestions to them instead of proposing an edit.
 
 ## What you read
 
@@ -67,10 +71,11 @@ Per dimension (base + rubric): discriminates? (score spread across tests/version
 ## Flags
 Each issue from "What to flag", with evidence (dimension, scores across
 tests/versions, the human comments) and where it routes:
-→ rubric edit (senior) or → judge-prompt review.
+→ skill-rubric edit (the loop-runner applies it) or → escalate to the
+maintainer (base rubric / global judge prompt).
 
 ## What looks healthy
-The dimensions that discriminate cleanly — so the senior knows what NOT to touch.
+The dimensions that discriminate cleanly — so the reader knows what NOT to touch.
 ```
 
 ## Hard rules

--- a/.claude/agents/skill-improver.md
+++ b/.claude/agents/skill-improver.md
@@ -39,8 +39,11 @@ For skill `<X>` (paths relative to repo root):
 - **The current skill:** `packages/engine/plugin/skills/<X>/SKILL.md`
   (+ its `references/`, `templates/`, `scripts/`).
 - **Read-only context, never propose edits to:**
-  `eval/tests/unit/<X>/rubric.md` (what the judge scores against,
-  senior-owned) and `eval/harness/judge/prompt.md` (project-global).
+  `eval/tests/unit/<X>/rubric.md` (what the judge scores against) and
+  `eval/harness/judge/prompt.md` (project-global, maintainer-owned). The
+  rubric belongs to the loop-runner, not to you — when a finding's cause is
+  the rubric, say so and route it rather than editing; your output is
+  SKILL.md edits only.
 
 ## Process
 
@@ -112,7 +115,11 @@ For skill `<X>` (paths relative to repo root):
      or different `expected_args` than the test loads) → a test/spec
      decision for the genealogist (may need a new `allowed-tools` entry +
      fixture first); not a body fix from this run.
-   - **Rubric / judge** → route to the judge-prompt review.
+   - **Skill rubric or this test's `judge_context`** → the loop-runner's own
+     to fix directly (`eval/tests/unit/<skill>/rubric.md` / the test JSON);
+     both sit in the run-log snapshot, so the skill's suite must be re-run
+     after. **Base rubric or the global judge prompt** → the maintainer's
+     alone; escalate rather than edit.
    - **Body** — the skill's prose actually steered the model wrong → the
      *only* cause that becomes a SKILL.md edit. Proceed.
 
@@ -223,5 +230,6 @@ gate to apply>
   question → say so, report what the judge scores suggest at lower
   confidence, and do not propose edits on thin evidence.
 - The evidence points at the rubric or judge, not the skill → name it and
-  route it to the senior's judge-prompt review. Don't "fix" a grading
-  problem in the skill body.
+  route it: the skill's own `rubric.md` and the test's `judge_context` are
+  the loop-runner's to fix; the base rubric and global judge prompt go to the
+  maintainer. Don't "fix" a grading problem in the skill body.

--- a/.claude/skills/mine-unit-test/SKILL.md
+++ b/.claude/skills/mine-unit-test/SKILL.md
@@ -181,9 +181,15 @@ conventions.
 
 Derive a short kebab-case `<slug>` from the issue (e.g.
 `citation-missing-locator`). The test id is
-`ut_<skill_with_underscores>_<NNN>`, where `<NNN>` is the next unused
-integer for that skill — scan `$REPO/eval/tests/unit/<skill>/*.json`, take
-the highest, increment, zero-pad to three digits.
+`ut_<skill_with_underscores>_<xxx>`, where `<xxx>` is a **random**
+three-character suffix drawn from lowercase alphanumerics minus `0`, `o`, `1`
+and `l` (e.g. `ut_citation_k3f`). Random rather than sequential: a
+`max(N)+1` scan collides whenever two people add a test to the same skill in
+parallel, and a duplicate id makes the harness emit two run-log entries under
+one `test_id`, silently merging the two tests' annotations. Scan
+`$REPO/eval/tests/unit/<skill>/*.json` only to confirm the id you generated is
+unused — regenerate if it collides. Legacy numeric ids (`ut_citation_019`)
+stay as they are.
 
 ### 5. Carve the mid-flow scenario — the hard step
 
@@ -272,7 +278,7 @@ reference test you read in Step 3:
 ```json
 {
   "test": {
-    "id": "ut_<skill_with_underscores>_<NNN>",
+    "id": "ut_<skill_with_underscores>_<xxx>",
     "skill": "<skill>",
     "name": "<one-line summary of the Should>",
     "type": "positive",

--- a/docs/alpha-feedback-guide.md
+++ b/docs/alpha-feedback-guide.md
@@ -15,12 +15,11 @@ step, says which of three places you're working in.
 
 | Role | What they do |
 |---|---|
-| **You** (junior genealogist or any contributor) | Everything from "download the zip" through "commit the fix on a feature branch." |
-| **Developer** | Pairs with you at PR time to build the plugin `.zip`, install it into Cowork, walk through the fresh Cowork verification (Step 8), and open the PR. |
+| **You** (junior genealogist or developer) | The whole loop: download the zip, reproduce the bug, capture the test, improve the skill, build + install the plugin, verify in Cowork, and open the PR. |
 | **Senior genealogist** | Reviews the PR — skill changes, rubric quality, the new unit test — and approves the merge. |
 
-If you get stuck mid-flow, ask a developer. The spec is precise about which
-steps benefit from pairing.
+If you get stuck mid-flow, ask for help. The spec is precise about which
+steps benefit from a second pair of eyes.
 
 ## The three places
 
@@ -85,10 +84,9 @@ Already done? Skip ahead.
 
 ## The story: a parent nobody proved
 
-> **The names and the case are invented for the story.** "Marta" (alpha tester)
-> and "Sam" (the genealogist + developer pair, collapsed into one person here)
-> make it concrete, but the split is illustrative — anyone can do any step, and
-> one person can run the whole loop.
+> **The names and the case are invented for the story.** "Marta" is the alpha
+> tester; you're the one running the fix. Anyone can do any step, and one person
+> runs the whole loop.
 
 Marta is working a brick wall — John Schuster, born about 1845 in Augusta
 County. The agent finds an 1850 census household headed by a Robert Schuster
@@ -127,13 +125,13 @@ below is mechanics.
 
 ## Step 1 — Branch before you touch anything ⌨️ Terminal
 
-*(Step 0 happened days earlier, and by someone else. Sam's work starts here.)*
+*(Step 0 happened days earlier, and by someone else. Your work starts here.)*
 
 One task, one branch, always cut from an up-to-date `main` — you open a PR from
 it at the end. Name it with a few hyphenated words describing the fix — no
 slashes, no timestamps.
 
-**Developers — terminal:**
+**Terminal:**
 
 ```bash
 cd ~/cowork-genealogy
@@ -141,7 +139,7 @@ git checkout main && git pull
 git checkout -b schuster-parent-fix
 ```
 
-**Genealogists — GitHub Desktop:** Current Branch dropdown → select **main** and
+**GitHub Desktop:** Current Branch dropdown → select **main** and
 **Fetch/Pull** → **New branch…** → name it `schuster-parent-fix` → base it on
 `main` → **Create branch**.
 
@@ -244,10 +242,10 @@ That reads the case folder's current `research.json`, `tree.gedcomx.json` and
   intermittent or already fixed on this branch. Note the date and stop.
 - **`does-not-match`**, but it's wrong in a *different* way → live APIs are
   noisy; reset (below) and run once more. Still wrong? That's a "user-reported
-  bug that doesn't reproduce locally" — escalate with a developer rather than
+  bug that doesn't reproduce locally" — escalate for help rather than
   guessing at a fix.
 - **`partial`** → either the reproduction is genuinely incomplete, or it's
-  live-MCP noise. Try once more; if it oscillates, get a developer's eye on it.
+  live-MCP noise. Try once more; if it oscillates, get a second pair of eyes on it.
 
 > **Resetting between attempts.** Every rerun — here and in Step 7 — needs
 > *both* halves reset, or you're testing contaminated state:
@@ -367,9 +365,9 @@ If it doesn't match, go back to Step 6. The edit landed on the mined test
 without solving the real case, which usually means the test carved too narrow a
 scenario.
 
-## Step 8 — Confirm it in Cowork, paired 🖥️ Cowork
+## Step 8 — Confirm it in Cowork 🖥️ Cowork
 
-**Do this with a developer, and treat it as blocking.** Steps 3 and 7 both run
+**Treat this as blocking.** Steps 3 and 7 both run
 in Claude Code against symlinked skills; this is the only step that exercises
 the fix the way a user gets it — through the built plugin bundle in the real
 product.
@@ -396,14 +394,14 @@ unzip -d ~/feedback/<slug>-cowork-check ~/Downloads/feedback-<timestamp>.zip
 
 No symlinks, no `.claude/skills/`, no reset machinery — Cowork loads from its
 installed plugin bundle, so the fresh unzip is all it needs. Open that folder in
-Cowork as a project, re-issue Marta's prompt verbatim, and both of you confirm
+Cowork as a project, re-issue Marta's prompt verbatim, and confirm
 the fix holds. (If Cowork's UI won't open an existing folder directly, follow
 its workspace-creation flow and copy `research.json`, `tree.gedcomx.json`,
 `results/` and the other top-level files across.)
 
 If the fix **doesn't** hold in Cowork, the bug may be Cowork-runtime-specific —
 plugin loader, viewer context injection, OS-specific file handling. Diagnose it
-with the developer; **do not ship the PR.**
+(get help if you need it); **do not ship the PR.**
 
 ## Step 9 — Release run, PR, and reply ⌨️ Terminal → 🌐 browser → GitHub
 
@@ -455,7 +453,7 @@ in the same PR — and run `make eval-skill` for **each** touched skill, since t
 runlog gate checks every skill the PR touches. What to avoid is bundling two
 *unrelated* fixes that happened to share a branch.
 
-A developer pushes and opens the PR with you; the senior genealogist reviews and
+You push and open the PR; the senior genealogist reviews and
 merges.
 
 **Then tell Marta what changed.** An alpha tester who never hears back stops
@@ -485,7 +483,7 @@ Drive folder as the immutable record, so re-importing later is always possible.
 | 5 Capture | `/mine-unit-test --project <case-dir>`; scrub PII | 🤖 Claude Code (case dir) |
 | 6 Improve + gate | → [`skill-lifecycle.md`](skill-lifecycle.md) steps 3–6 | ⌨️ Terminal + 🤖 Claude Code (repo) |
 | 7 Verify the case | reset + `/clear` + re-paste; `/compare-state --against=desired` | 🤖 Claude Code (case dir) + Viewer |
-| 8 Confirm in Cowork | build + install; fresh unzip; re-issue the prompt, paired | 🖥️ Cowork |
+| 8 Confirm in Cowork | build + install; fresh unzip; re-issue the prompt | 🖥️ Cowork |
 | 9 Release run + PR | `make eval-skill`, grade **every** dimension, commit, PR, reply | ⌨️ Terminal → 🌐 browser → GitHub |
 | 10 Clean up | delete both case directories | ⌨️ Terminal / file manager |
 
@@ -533,14 +531,14 @@ Run it as `/mine-unit-test --skill <name>` and pick the skill you edited.
 
 **`run_tests.py` says `fixture_not_found`.**
 Your fix made the agent call a tool the failing transcript didn't. The harness
-has no fixture for that call. Ask a developer to add the fixture under
+has no fixture for that call. Ask a teammate to add the fixture under
 `eval/fixtures/mcp/`.
 
 **`/compare-state --against=desired` keeps saying `partial`.**
 Two possibilities: the fix really is incomplete — keep iterating; or live-MCP
 noise — the same query returns slightly different results run to run. Try once
 more. If it stabilizes you're good; if it oscillates, the rubric may be too
-tight and you'll want a developer's eye on it.
+tight and you'll want a second pair of eyes on it.
 
 **Setup script says the destination already exists.**
 You ran setup on the same zip before. Either delete the old case directory or

--- a/docs/alpha-feedback-guide.md
+++ b/docs/alpha-feedback-guide.md
@@ -129,14 +129,21 @@ below is mechanics.
 
 *(Step 0 happened days earlier, and by someone else. Sam's work starts here.)*
 
+One task, one branch, always cut from an up-to-date `main` — you open a PR from
+it at the end. Name it with a few hyphenated words describing the fix — no
+slashes, no timestamps.
+
+**Developers — terminal:**
+
 ```bash
 cd ~/cowork-genealogy
 git checkout main && git pull
-git checkout -b feedback/2026-07-21T09-14-22Z
+git checkout -b schuster-parent-fix
 ```
 
-**Windows (GitHub Desktop):** Current Branch dropdown → **New branch…** → base
-it on `main` → **Create branch**.
+**Genealogists — GitHub Desktop:** Current Branch dropdown → select **main** and
+**Fetch/Pull** → **New branch…** → name it `schuster-parent-fix` → base it on
+`main` → **Create branch**.
 
 Do this **before** Step 2, not after: the setup script stamps
 `.feedback-repo-root` with your checkout *as it is when you run it*, and the
@@ -431,7 +438,8 @@ git commit -m "fix: <one-line summary of the bug>"
 **cowork-genealogy** (not the case directory), tick **only** the paths above —
 the SKILL.md you edited, the new test JSON, the scenario directory, the MCP
 fixtures, and the run log **and** its `.ann.json` — type
-`fix: <one-line summary>` in the Summary box, and **Commit to feedback/…**.
+`fix: <one-line summary>` in the Summary box, and **Commit to
+`schuster-parent-fix`**.
 Commit only the test JSON and it can't run.
 
 The commit message *is* the lesson — explain what went wrong and what changed.
@@ -470,7 +478,7 @@ Drive folder as the immutable record, so re-importing later is always possible.
 | Step | What you do | Where |
 |---|---|---|
 | 0 Notice | research; spot it; write Did/Should | 🌐 Workbench |
-| 1 Branch | `git checkout -b <branch>` | ⌨️ Terminal (repo) |
+| 1 Branch | `git checkout -b <short-task-name>` | ⌨️ Terminal (repo) |
 | 2 Unpack | `make feedback-case ZIP=<zip>`; copy the prompt it prints | ⌨️ Terminal (repo) |
 | 3 Reproduce | paste the user's prompt; viewer open; `/compare-state --against=what-went-wrong` | 🤖 Claude Code (case dir) + Viewer |
 | 4 Classify | skill, tool, or grading fault? | 🤖 Claude Code (case dir) |
@@ -501,7 +509,7 @@ arguments, and rebuilds the MCP server first where that matters.
 | `make e2e-login` | `eval\Login.bat` |
 | `make plugin` / `make mcpb` | `eval\BuildPlugin.bat` / `eval\BuildMcpb.bat` |
 | `make feedback-reset CASE=<dir>` | `scripts\reset-feedback-case.bat` |
-| `git checkout -b <branch>` | GitHub Desktop → Current Branch → **New branch…** |
+| `git checkout -b <short-task-name>` | GitHub Desktop → Current Branch → **New branch…** |
 
 The `/`-commands (`/compare-state`, `/mine-unit-test`, `/audit-rubric`,
 `/improve-skill`) are typed into Claude Code and are the same on every

--- a/docs/alpha-feedback-guide.md
+++ b/docs/alpha-feedback-guide.md
@@ -18,15 +18,14 @@ step, says which of three places you're working in.
 | **You** (junior genealogist or developer) | The whole loop: download the zip, reproduce the bug, capture the test, improve the skill, build + install the plugin, verify in Cowork, and open the PR. |
 | **Senior genealogist** | Reviews the PR — skill changes, rubric quality, the new unit test — and approves the merge. |
 
-If you get stuck mid-flow, ask for help. The spec is precise about which
-steps benefit from a second pair of eyes.
+If you get stuck mid-flow, ask for help.
 
 ## The three places
 
 | Icon | Place | What it is | Used for |
 |---|---|---|---|
 | 🌐 | **The workbench** | <https://genealogy-workbench.fly.dev> in a browser. Where alpha testers research. | *Noticing* the problem and *reporting* it. |
-| 🤖 | **Claude Code** | A `claude` session — sometimes in your repo checkout, sometimes in the unpacked case folder. See below. | *Reproducing*, *classifying*, *capturing the test*, *improving the skill*. |
+| 🤖 | **Claude Code** | The **Code tab** of the Claude desktop app, or `claude` in a terminal — opened sometimes on your repo checkout, sometimes on the unpacked case folder (see below). The Code tab is the usual Windows path. | *Reproducing*, *classifying*, *capturing the test*, *improving the skill*. |
 | ⌨️ | **Terminal** | A plain shell for `make …` (Windows: the matching `.bat`). | *Unpacking* the case, *running tests*, *gating*. One `make` target opens a 🌐 browser tab — the grading UI. |
 
 Alpha testers only ever touch the first one. Everything else is us.
@@ -274,8 +273,11 @@ responses — check:
   ignore him? → a **skill** problem. Continue. ✅ *(This is the case.)*
 - Did the search **never surface** him? → a **tool** problem. Different fix, an
   engineering ticket, not a prose edit.
-- Did the skill behave correctly and a stale rubric would mark it wrong? → a
-  **grading** fix.
+- Did the skill behave correctly and the grading mark it wrong anyway? → a
+  **grading** fix, and it's **yours to make**: this skill's `rubric.md` and this
+  test's `judge_context` are both yours to edit. Re-run the skill's suite
+  afterwards — both are part of the run-log snapshot. Only the base rubric and
+  the global judge prompt belong to the maintainer.
 
 Skipping this check is the classic trap: rewriting instructions for a bug that
 lives in a tool. The full four-lane version is
@@ -299,8 +301,9 @@ same-named candidates fit the evidence, don't assert one as a conclusion* — no
 "the Schuster case." A test that only recognises this one household is a fake
 win: it turns green without the skill getting better.
 
-It prints the new test's id (like `ut_person_evidence_022`). That's the `TEST=`
-value for the gate in Step 6.
+It prints the new test's id — the skill name plus a random three-character
+suffix, like `ut_person_evidence_k3f`. That's the `TEST=` value for the gate in
+Step 6.
 
 > **Capture the test *before* you fix the bug.** That's what lets Step 6's gate
 > prove the fix did something: it compares against a pre-edit baseline, so a
@@ -322,8 +325,10 @@ from, so it lives in one place:
 **→ [`skill-lifecycle.md`](skill-lifecycle.md), steps 4–6**
 
 It covers: setting hold-out tests (do this *before* the baseline run), running
-`make eval-skill SKILL=<skill>`, pasting Marta's Did/Should onto the failing
-dimension in the grading UI, `/audit-rubric`, `/improve-skill`, applying the
+`make eval-skill SKILL=<skill>`, commenting in the grading UI on **every
+non-passing dimension** — Marta's Did/Should goes on the one that caught this
+bug, and you correct a *score* only where you disagree but comment wherever a
+dimension isn't passing — then `/audit-rubric`, `/improve-skill`, applying the
 edits yourself, and `make gate-skill SKILL=<skill> TEST=<the mined test id>`.
 
 Two things there are easy to skip and will fail CI if you do — grading **every**
@@ -380,9 +385,12 @@ make mcpb                                # Windows: eval\BuildMcpb.bat
 ```
 
 Install the `.mcpb` in Claude Desktop → Settings → Extensions, remove the old
-plugin in Cowork → Customize, upload the new `.zip`, and **fully quit and reopen
-Desktop**. Cowork runs the uploaded `.zip`, not your working tree — skip this
-and the fix will look like it did nothing.
+plugin in Cowork → Customize, and upload the new `.zip` from the **Cowork** tab
+rather than the Code tab — they keep separate plugin lists. Then **fully quit
+and reopen Desktop**. Cowork runs the uploaded `.zip`, not your working tree —
+skip this and the fix will look like it did nothing. (Canonical version of these
+rules, including what does *not* need reinstalling:
+[`skill-lifecycle.md`](skill-lifecycle.md#rebuilding-and-reinstalling).)
 
 Then unzip the **original feedback zip** into a *fresh* folder, so Cowork sees
 the pristine user state rather than your iterated-on one:

--- a/docs/alpha-feedback-guide.md
+++ b/docs/alpha-feedback-guide.md
@@ -8,7 +8,7 @@ step, says which of three places you're working in.
 
 | Doc | What it gives you |
 |---|---|
-| [`skill-lifecycle.md`](skill-lifecycle.md) | The improvement loop itself: run the test, annotate, audit the rubric, improve the `SKILL.md`, gate the edit, produce the release run. Shared with every other on-ramp — this page hands off to it at Step 6 and comes back for Steps 7–10. |
+| [`skill-lifecycle.md`](skill-lifecycle.md) | The improvement loop itself: run the test, grade it, audit the rubric, improve the `SKILL.md`, gate the edit, produce the final graded run. Shared with every other on-ramp — this page hands off to it at Step 6 and comes back for Steps 7–10. |
 | [`specs/feedback-case-spec.md`](specs/feedback-case-spec.md) | The **why**: rationale, contracts, lints. Read only when changing the workflow itself. |
 
 ## Who does what
@@ -319,7 +319,7 @@ value for the gate in Step 6.
 Everything from here to a gated fix is the same regardless of where the bug came
 from, so it lives in one place:
 
-**→ [`skill-lifecycle.md`](skill-lifecycle.md), steps 3–6**
+**→ [`skill-lifecycle.md`](skill-lifecycle.md), steps 4–6**
 
 It covers: setting hold-out tests (do this *before* the baseline run), running
 `make eval-skill SKILL=<skill>`, pasting Marta's Did/Should onto the failing
@@ -403,7 +403,7 @@ If the fix **doesn't** hold in Cowork, the bug may be Cowork-runtime-specific �
 plugin loader, viewer context injection, OS-specific file handling. Diagnose it
 (get help if you need it); **do not ship the PR.**
 
-## Step 9 — Release run, PR, and reply ⌨️ Terminal → 🌐 browser → GitHub
+## Step 9 — Final run, PR, and reply ⌨️ Terminal → 🌐 browser → GitHub
 
 The `check-runlogs` CI gate is blocking and checks two things your Step-6
 baseline run can no longer satisfy, because `SKILL.md` changed underneath it:
@@ -481,10 +481,10 @@ Drive folder as the immutable record, so re-importing later is always possible.
 | 3 Reproduce | paste the user's prompt; viewer open; `/compare-state --against=what-went-wrong` | 🤖 Claude Code (case dir) + Viewer |
 | 4 Classify | skill, tool, or grading fault? | 🤖 Claude Code (case dir) |
 | 5 Capture | `/mine-unit-test --project <case-dir>`; scrub PII | 🤖 Claude Code (case dir) |
-| 6 Improve + gate | → [`skill-lifecycle.md`](skill-lifecycle.md) steps 3–6 | ⌨️ Terminal + 🤖 Claude Code (repo) |
+| 6 Improve + gate | → [`skill-lifecycle.md`](skill-lifecycle.md) steps 4–6 | ⌨️ Terminal + 🤖 Claude Code (repo) |
 | 7 Verify the case | reset + `/clear` + re-paste; `/compare-state --against=desired` | 🤖 Claude Code (case dir) + Viewer |
 | 8 Confirm in Cowork | build + install; fresh unzip; re-issue the prompt | 🖥️ Cowork |
-| 9 Release run + PR | `make eval-skill`, grade **every** dimension, commit, PR, reply | ⌨️ Terminal → 🌐 browser → GitHub |
+| 9 Final run + PR | `make eval-skill`, grade **every** dimension, commit, PR, reply | ⌨️ Terminal → 🌐 browser → GitHub |
 | 10 Clean up | delete both case directories | ⌨️ Terminal / file manager |
 
 **Between any two attempts** (Step 3 retries, Step 7):

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -94,13 +94,20 @@ own slug as you go.
 
 ## Step 0 — Branch ⌨️ Terminal
 
+One task, one branch, always cut from an up-to-date `main` — you open a PR from
+it at the end. Name it with a few hyphenated words describing the task — no
+slashes, no timestamps.
+
+**Developers — terminal:**
+
 ```bash
 git checkout main && git pull
 git checkout -b spriggs-parents-fixture
 ```
 
-**Windows (GitHub Desktop):** Current Branch dropdown → **New branch…** → base
-it on `main` → **Create branch**.
+**Genealogists — GitHub Desktop:** Current Branch dropdown → select **main** and
+**Fetch/Pull** → **New branch…** → name it `spriggs-parents-fixture` → base it
+on `main` → **Create branch**.
 
 Everything the rest of this produces — the fixture files, the run log, the
 grade — lands on this one branch.
@@ -460,7 +467,7 @@ confirm `pass`, and commit that run log under `eval/runlogs/e2e/<slug>/`.
 
 | Step | What you do | Where |
 |---|---|---|
-| 0 Branch | `git checkout -b <branch>` | ⌨️ Terminal |
+| 0 Branch | `git checkout -b <short-task-name>` | ⌨️ Terminal |
 | 1 Author | `/author-e2e-fixture` — pick a deceased, well-sourced person | 🤖 Claude Code |
 | 2 Scope | one question, 1–5 findings; keep the search anchors | 🤖 Claude Code |
 | 3 Validate | check the answer is findable; `make e2e-validate TEST=<slug>` | ⌨️ Terminal |
@@ -490,7 +497,7 @@ it from that folder; each prompts for what it needs instead of taking
 | `make e2e-view TEST=<slug>` | `eval\ViewE2E.bat` |
 | `make electron` | `eval\Viewer.bat` |
 | `make e2e-calibrate` *(maintainer)* | `eval\RunCalibration.bat` |
-| `git checkout -b <branch>` | GitHub Desktop → Current Branch → **New branch…** |
+| `git checkout -b <short-task-name>` | GitHub Desktop → Current Branch → **New branch…** |
 
 The `/`-commands (`/author-e2e-fixture`, `/interpret-e2e-result`,
 `/grade-e2e-run`, `/mine-unit-test`) are typed into Claude Code and are the same

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -40,7 +40,7 @@ regression coverage is the unit tests in `eval/tests/unit/`.
 | Icon | Place | What it is | You use it to… |
 |---|---|---|---|
 | ⌨️ | **Terminal** | A plain shell where you type `make …` (Windows: double-click the matching `.bat` in `eval\`). | Set up, validate, seed, run, view. |
-| 🤖 | **Claude Code** | A `claude` session at your **repo root** — not Cowork. The `/`-commands below are repo-local dev skills under `.claude/skills/`, picked up automatically in this checkout. | Author the fixture, interpret the result, grade the run. |
+| 🤖 | **Claude Code** | The **Code tab** of the Claude desktop app opened on your **repo root**, or `claude` in a terminal there — either works, and the Code tab is the usual Windows path. **Not** Cowork. The `/`-commands below are repo-local dev skills under `.claude/skills/`, picked up automatically in this checkout. | Author the fixture, interpret the result, grade the run. |
 | 🖥️ | **Cowork** | The shipping product, with the plugin + MCP extension installed. | Watch `/research` work on the fixture live, before you spend money on a headless run. |
 
 A fourth surface matters throughout: the **Research Viewer** (Electron,
@@ -267,7 +267,9 @@ see, and save the headless run for the verdict.
    **Fully quit and reopen** Claude Desktop. Redo both after any MCP-server or
    skill change; without them `/research` says things like
    "validate_research_schema isn't available" and degrades to guessing, which
-   is a missing install, not a `/research` bug.
+   is a missing install, not a `/research` bug. (Canonical version of these
+   rules, including what does *not* need reinstalling:
+   [`skill-lifecycle.md`](skill-lifecycle.md#rebuilding-and-reinstalling).)
 
 2. Seed an editable project from the fixture's starting state:
 
@@ -451,6 +453,20 @@ report: spec §7.4.
 
 Commit the fixture directory, the run log, and its `.ann.json` together, push
 the Step-0 branch, and open the PR.
+
+**Terminal:**
+
+```bash
+git add eval/tests/e2e/<slug>/ eval/runlogs/e2e/<slug>/
+git commit -m "e2e: add the <slug> fixture"
+git push -u origin <your-branch>
+gh pr create                            # or open the PR from GitHub's web UI
+```
+
+**GitHub Desktop:** make sure the repository picker says **cowork-genealogy**,
+tick the fixture directory plus the run log **and** its `.ann.json`, type a
+summary, **Commit to `<your-branch>`**, then **Push origin** and **Create Pull
+Request** (it opens GitHub in your browser with the branch pre-filled).
 
 **Prove it's solvable.** Stripping proves the answer isn't *in* the starting
 tree; only a run proves it's *recoverable from live FS*. So run the fixture,

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -10,7 +10,7 @@ things it deliberately does *not* cover:
 
 | You want to… | Go to |
 |---|---|
-| Fix a skill problem — whether you noticed it while researching or a run exposed it | [`skill-lifecycle.md`](skill-lifecycle.md) — mine a unit test, improve, gate, release. That loop is the same wherever the problem came from, and Step 7 below hands off to it. |
+| Fix a skill problem — whether you noticed it while researching or a run exposed it | [`skill-lifecycle.md`](skill-lifecycle.md) — mine a unit test, improve, gate, PR. That loop is the same wherever the problem came from, and Step 7 below hands off to it. |
 | Look up an exact field, contract, or enum | [`specs/e2e-test-spec.md`](specs/e2e-test-spec.md) — the authoritative format. This guide stays task-shaped and sends you there for reference detail. |
 
 ---
@@ -410,7 +410,8 @@ of the GPS flow.
 ```
 
 That turns the miss into a unit test — cheap, runs on every PR — and drops you
-into [`skill-lifecycle.md`](skill-lifecycle.md) at step 2. Classify the finding
+into [`skill-lifecycle.md`](skill-lifecycle.md) at step 3 (its step 1(b) is this
+very door). Classify the finding
 first, though: the lane rule there exists because most e2e findings are tooling
 or eval bugs, not skill-prose gaps.
 

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -1,7 +1,7 @@
 # E2E Testing Guide — authoring and running a benchmark fixture
 
 How to author and run an end-to-end research benchmark test, walked through
-**one real fixture end to end**. Written for the genealogist + developer teams
+**one real fixture end to end**. Written for the team
 doing the work.
 
 This page covers **the e2e benchmark only** — the expensive, live-FamilySearch
@@ -98,14 +98,14 @@ One task, one branch, always cut from an up-to-date `main` — you open a PR fro
 it at the end. Name it with a few hyphenated words describing the task — no
 slashes, no timestamps.
 
-**Developers — terminal:**
+**Terminal:**
 
 ```bash
 git checkout main && git pull
 git checkout -b spriggs-parents-fixture
 ```
 
-**Genealogists — GitHub Desktop:** Current Branch dropdown → select **main** and
+**GitHub Desktop:** Current Branch dropdown → select **main** and
 **Fetch/Pull** → **New branch…** → name it `spriggs-parents-fixture` → base it
 on `main` → **Create branch**.
 

--- a/docs/skill-lifecycle.md
+++ b/docs/skill-lifecycle.md
@@ -89,16 +89,25 @@ ways.
 
 ### 0. Make a branch
 
-**Who:** whoever is driving. **Where:** ⌨️ terminal (or GitHub Desktop).
-**How:**
+**Who:** whoever is driving. **Where:** ⌨️ terminal (developers) or GitHub
+Desktop (genealogists). **How:**
+
+One task, one branch, always cut from an up-to-date `main` — you open a PR from
+it at the end.
+
+**Developers — terminal:**
 
 ```bash
 git checkout main && git pull
-git checkout -b <your-name>-<skill>        # e.g. dallan-citation
+git checkout -b <short-task-name>          # e.g. citation-locator
 ```
 
-**GitHub Desktop:** Current Branch dropdown → **New branch…** → name it
-`<your-name>-<skill>` → base it on `main` → **Create branch**.
+**Genealogists — GitHub Desktop:** Current Branch dropdown → select **main** and
+**Fetch/Pull** → **New branch…** → name it `<short-task-name>` (e.g.
+`citation-locator`) → base it on `main` → **Create branch**.
+
+Name the branch with a few hyphenated words describing the task — no slashes, no
+timestamps.
 
 Do this **first**, before you touch a file — and specifically before you seed a
 project or unpack a feedback case. Both setup paths stamp your checkout *as it
@@ -579,7 +588,7 @@ Every step has tooling in place. The whole loop, in one table:
 
 | Step | Where | macOS / Linux | Windows |
 |---|---|---|---|
-| 0 Branch | ⌨️ terminal | `git checkout -b <name>` | GitHub Desktop → New branch… |
+| 0 Branch | ⌨️ terminal | `git checkout -b <short-task-name>` | GitHub Desktop → New branch… |
 | 1 Author | 🤖 Claude Code / editor | the authoring guide + a blocking frontmatter lint in CI | same |
 | 2 Capture *(from a real failure)* | 🤖 Claude Code | `/mine-unit-test [--project \| --e2e-run <dir>]` | same |
 | 2 Test | ⌨️ terminal | `make eval-skill SKILL=<name>` | `eval\RunTests.bat` |
@@ -649,11 +658,13 @@ that, no one could ever open that exact record again.
 ### Step 0 — Branch ⌨️ Terminal
 
 ```
+git checkout main && git pull
 git checkout -b citation-locator
 ```
 
-**Windows (GitHub Desktop):** Current Branch dropdown → **New branch…** → name
-it `citation-locator`, base it on `main` → **Create branch**.
+**Windows (GitHub Desktop):** Current Branch dropdown → select **main** and
+**Fetch/Pull** → **New branch…** → name it `citation-locator`, base it on `main`
+→ **Create branch**.
 
 ### Step 1 — Notice it 🖥️ Cowork + Viewer
 
@@ -787,7 +798,7 @@ reads the corrected grades and, if it's a real improvement, releases it.
 
 | Step | What you do | Where |
 |---|---|---|
-| 0 Branch | `git checkout -b <branch>` | ⌨️ Terminal |
+| 0 Branch | `git checkout -b <short-task-name>` | ⌨️ Terminal |
 | 1 Notice | research; spot the problem; write Did/Should/Gap | 🖥️ Cowork + Viewer |
 | 2 Classify | skill's fault, or a tool/grading fault? | 🤖 Claude Code |
 | 3 Capture | `/mine-unit-test --project <dir>` | 🤖 Claude Code |
@@ -813,7 +824,7 @@ arguments, and rebuilds the MCP server first where that matters.
 | `make electron` | `eval\Viewer.bat` |
 | `make e2e-login` | `eval\Login.bat` |
 | `make plugin` / `make mcpb` | `eval\BuildPlugin.bat` / `eval\BuildMcpb.bat` |
-| `git checkout -b <branch>` | GitHub Desktop → Current Branch → **New branch…** |
+| `git checkout -b <short-task-name>` | GitHub Desktop → Current Branch → **New branch…** |
 
 The `/`-commands (`/mine-unit-test`, `/audit-rubric`, `/improve-skill`) are
 typed into Claude Code and are the same on every platform.

--- a/docs/skill-lifecycle.md
+++ b/docs/skill-lifecycle.md
@@ -1,75 +1,61 @@
 # The skill lifecycle — authoring, testing, and improving genealogy skills
 
 This is the **start-here map** for the people who build and improve the
-genealogy skills: how a skill goes from an idea to a tested, released,
-continually-improved artifact. It is the **complete flow** end to end and the
-entry point; it points at the detailed docs for each step rather than
-restating them.
+genealogy skills: how a skill problem goes from a real failure to a tested,
+committed fix. It is the **complete flow** end to end and the entry point; it
+points at the detailed docs for each step rather than restating them.
 
-You drive the whole loop — write the tests, run the harness, correct the
+You drive the whole loop — capture the test, run the harness, correct the
 grades, improve the skill, and open the PR. No step belongs to someone else.
 When a step needs a genealogy judgment you're unsure of, or a bit of harness
 mechanics you haven't hit before, pull in a teammate for a second pair of
 eyes — but the loop is yours end to end.
 
 ```
-  0 branch → 1 create → 2 test → 3 review+annotate → 4 audit rubric →
-                             5 improve body → 6 verify → 7 release
-                                    │
-              8 optimize description  ◄── co-tune ──┘
+  0 branch → 1 start from a failure → 2 whose fault? → 3 capture a test →
+       4 run + grade (baseline) → 5 improve → 6 verify → 7 confirm in Cowork →
+       8 re-run + grade + PR
 
-  One skill at a time. Body loop (5) = skill-improver, which proposes SKILL.md
-  edits and routes test-data / triggering / rubric causes elsewhere.
-  Description loop (8) = the vendored run_loop. Rubric audit (4) keeps the
-  signal honest so (5) doesn't optimize toward a weak rubric.
+  One skill at a time. Most work starts at step 1 with an alpha-feedback zip
+  or a failed e2e run. Step 5 routes each finding to the right lane — only a
+  body-located cause ever becomes SKILL.md prose.
 ```
 
 If you're brand new, read the two walkthroughs first:
 [`eval/JUNIOR-WALKTHROUGH.md`](../eval/JUNIOR-WALKTHROUGH.md) (genealogist)
 and [`eval/SENIOR-WALKTHROUGH.md`](../eval/SENIOR-WALKTHROUGH.md).
 
-## Three on-ramps, one loop
-
-A skill problem reaches you from one of three places. The on-ramp differs;
-everything from "capture it as a test" onward is this page.
-
-| Where the problem surfaced | Start there | Joins here at |
-|---|---|---|
-| You noticed it while researching in Cowork | the worked example at the bottom of this page | step 2 |
-| An e2e benchmark run missed a finding | [`e2e-testing-guide.md`](e2e-testing-guide.md) | step 2, via `/mine-unit-test --e2e-run <dir>` |
-| An alpha tester submitted a feedback zip | [`alpha-feedback-guide.md`](alpha-feedback-guide.md) | step 2, via `/mine-unit-test --project <case-dir>` |
-
-Whichever door you came through, the first question is the same — and it is
-**not** "how do I edit the skill." It's **whose fault is it?** See the lane rule
-in step 5, and answer it before you touch prose.
+Two things are **not** in this numbered loop because they're not the common
+path: authoring a brand-new skill, and tuning a skill's description. Both have
+their own short sections after step 8.
 
 ## Where each step happens
 
-Every stage below opens with a **Who / Where / How** line. There are only
-three places, and each command has both a `make` form and a Windows
-double-click form — use whichever your machine has:
+Every step below opens with a **Where / How** line. There are only three
+places, and each command has both a `make` form and a Windows double-click
+form — use whichever your machine has:
 
 | Icon | Place | What it is | How you run things there |
 |---|---|---|---|
 | ⌨️ | **Terminal** | A shell at the repo root (macOS/Linux) — or File Explorer on Windows, where you double-click a `.bat` in `eval\`. | `make <target>` — Windows: double-click `eval\<Name>.bat`, which prompts for the skill or test name instead of taking `SKILL=`/`TEST=` arguments. |
-| 🤖 | **Claude Code** | A `claude` session started at the repo root — **not** Cowork. This is where the repo-local dev skills and agents live. | Type the slash command, e.g. `/improve-skill citation`. |
-| 🖥️ | **Cowork** | The real product, with the plugin + MCP extension installed. | Only for trying a skill by hand in the shipping product. Rebuild and reinstall the artifacts first: `make plugin` (Windows: `eval\BuildPlugin.bat`) and `make mcpb` (Windows: `eval\BuildMcpb.bat`), then remove the old plugin in Cowork → Customize, upload the new `.zip`, and fully quit and reopen Desktop. |
+| 🤖 | **Claude Code** | The **Code tab** of the Claude desktop app, opened on the repo root — or `claude` in a terminal at the repo root. Either works; the Code tab is the usual Windows path. **Not** Cowork. This is where the repo-local dev skills and agents live. | Type the slash command, e.g. `/improve-skill citation`. |
+| 🖥️ | **Cowork** | The real product, running the plugin + MCP extension you installed into Claude Desktop. | Only for trying a skill by hand in the shipping product — see "Rebuilding and reinstalling" below, which is not optional. |
 
 Rule of thumb: **Claude Code = you ask Claude to do something. Terminal = you
 run a command yourself. Cowork = you do genealogy.**
 
-Two more surfaces show up alongside those three. The **grading UI** (step 3) is
+Two more surfaces show up alongside those three. The **grading UI** (step 4) is
 a 🌐 browser tab that `make eval-ui` opens. The **Research Viewer** (Electron,
 `make electron`) renders the research log, assertions, conflicts and sources of
 whichever project folder you point it at — it's how you *see* what the agent
-wrote rather than trusting the chat's summary of itself, so open it whenever you
-open a project in Cowork.
+wrote rather than trusting the chat's summary of itself, so open it whenever
+you open a project in Cowork.
 
 **Everything happens in one checkout, on one branch.** `make eval-skill` and
 `make gate-skill` test the working tree, so that's where your skill edit has to
-be; Claude Code opens at the same repo root, because `mine-unit-test` writes into
-`eval/` relative to where you started it. The one exception is the **project
-folder you research in** — a seeded scratch project under
+be; Claude Code opens at the same repo root, because `mine-unit-test` writes
+into `eval/` relative to where you started it. The one exception is the
+**project folder you research in** — a seeded scratch project under
 `eval/e2e-project/<slug>/`, or an unpacked feedback case under
 `~/feedback/<slug>/`. Those are research data, not repo source.
 
@@ -78,13 +64,51 @@ The `.bat` files live in `eval\` and are listed in
 macOS/Linux users never need the `.bat` files — every step is available both
 ways.
 
+### Rebuilding and reinstalling
+
+Three different surfaces, three different rules. Getting this wrong is the
+single most common way to spend an hour testing a fix that was never loaded.
+
+| You changed… | Claude Code / the harness | Cowork |
+|---|---|---|
+| **A skill** (`SKILL.md`, templates, references) | Nothing. The harness reads your working tree directly. | Rebuild the plugin and re-upload it. |
+| **Tool code** (`packages/engine/mcp-server/src/**`) | Rebuild the engine, then start a **fresh** Claude Code session. | Rebuild and reinstall the `.mcpb`. |
+
+**Claude Code needs no install.** The repo root has a `.mcp.json` that already
+points Claude Code at the built engine, so the genealogy tools are wired
+automatically — the Code tab and the `claude` CLI both read it. Two things to
+know: Claude Code prompts **once** to approve the project MCP server (approve
+it, or you have no genealogy tools), and after a tool-code change you rebuild
+with `make engine-build` (Windows: `eval\BuildMcpb.bat`, which also compiles)
+and start a new session so it picks up the new build. `make eval-skill` and
+`eval\RunTests.bat` rebuild automatically when the engine is stale.
+
+**Cowork needs both artifacts installed into Claude Desktop**, and you redo
+whichever one changed:
+
+```bash
+make plugin        # Windows: eval\BuildPlugin.bat   — if you changed a skill
+make mcpb          # Windows: eval\BuildMcpb.bat     — if you changed tool code
+```
+
+- **Plugin:** Claude Desktop → **Cowork tab** → Customize → **remove the old
+  Genealogy Research plugin first**, then Add → Upload Plugin → the new `.zip`.
+  Upload from the Cowork tab, not the Code tab — they keep separate plugin
+  lists.
+- **MCP:** Claude Desktop → Settings → Extensions → Advanced Settings →
+  Install extension → the new `.mcpb`. It installs straight over the old copy.
+
+Then **fully quit and reopen Claude Desktop.** Cowork runs the uploaded `.zip`,
+not your working tree — skip the rebuild and your fix will look like it did
+nothing.
+
 ---
 
-## The stages
+## The steps
 
 ### 0. Make a branch
 
-**Who:** you. **Where:** ⌨️ terminal, or GitHub Desktop. **How:**
+**Where:** ⌨️ terminal, or GitHub Desktop. **How:**
 
 One task, one branch, always cut from an up-to-date `main` — you open a PR from
 it at the end.
@@ -100,8 +124,8 @@ git checkout -b <short-task-name>          # e.g. citation-locator
 **Fetch/Pull** → **New branch…** → name it `<short-task-name>` (e.g.
 `citation-locator`) → base it on `main` → **Create branch**.
 
-Name the branch with a few hyphenated words describing the task — no slashes, no
-timestamps.
+Name the branch with a few hyphenated words describing the task — no slashes,
+no timestamps.
 
 Do this **first**, before you touch a file — and specifically before you seed a
 project or unpack a feedback case. Both setup paths stamp your checkout *as it
@@ -109,49 +133,102 @@ is when you run them*, and the test you mine later lands on whatever branch is
 checked out then. Unpack a case while still on `main` and your test ends up on
 `main`.
 
-Everything the rest of the loop produces — the SKILL.md edit, new tests, the run
-log, your grading corrections — is committed together on this one branch. Pushes
-to `main` are blocked, so starting on `main` just means moving the work later.
+Everything the rest of the loop produces — the SKILL.md edit, new tests, the
+run log, your grading corrections — is committed together on this one branch.
+Pushes to `main` are blocked, so starting on `main` just means moving the work
+later.
 
-### 1. Create / edit a skill
+### 1. Start from a real failure
 
-**Who:** you. **Where:** 🤖 Claude Code at the repo root (or any text editor —
-the skill is just `packages/engine/plugin/skills/<skill>/SKILL.md`).
-**How:** for a new tool-wrapping skill, ask Claude Code to scaffold it with
-the `cowork-skill-builder` agent; otherwise edit the file directly.
+**Where:** depends which door you came through — see below. **How:**
 
-Write the SKILL.md to the prose standard in
-[`docs/skill-authoring-guide.md`](skill-authoring-guide.md). (The authoring
-guide's "What kind of skill are you writing?" section covers whether it
-should be a skill at all and which of the three kinds — workflow,
-reference, or guardrail — it is.) You drive the domain content, the shape,
-the frontmatter limits, and any `scripts/` helper — pulling in help when a
-piece is outside your comfort zone.
+Skills get improved because something went wrong. There are three ways a
+problem reaches you, and **the first two are the norm** — most skill
+improvements start life as an alpha tester's report or a failed benchmark run.
 
-### 2. Test
+Whichever door you came through, you leave this step with the same two things:
+a plain-English **Did / Should / Gap** note, and the **`results/` files** — the
+actual tool responses, which step 2 needs.
 
-**Who:** you. **Where:** ⌨️ terminal at the repo root.
-**How:**
+> **Did:** what the skill actually did.
+> **Should:** what it should have done.
+> **Gap:** which SKILL.md guidance is missing, wrong, or being ignored.
+
+#### (a) An alpha tester sent a feedback zip 🤖 Claude Code (case folder)
+
+The common case. Unpack the case from ⌨️ the repo root, then reproduce the bug
+by replaying the tester's **exact** prompt:
 
 ```bash
-make eval-skill SKILL=<skill>     # rebuilds the engine if stale, then runs
+make feedback-case ZIP=~/Downloads/feedback-<timestamp>.zip
+# Windows: scripts\setup-feedback-case.bat <zip path>
 ```
 
-**Windows:** double-click `eval\RunTests.bat` — it rebuilds the MCP server
-and then asks which skill to test.
+Open the resulting `~/feedback/<slug>/` folder in Claude Code (**not** the
+repo — the case folder *is* the research project, with the skills linked in),
+paste the prompt the setup script printed, and watch it with the Research
+Viewer open. The tester's Did/Should is already written down for you in
+`_feedback/feedback.json`.
 
-The harness drives the skill against mocked tool responses in a seeded
-starting state (a *scenario*), an LLM judge grades each run, and it saves
-a **run-log** — the scores plus a snapshot of the exact skill, tests,
-scenario, and fixtures used, so the run can be reproduced. Each run here
-writes a new run-log — the releasable candidate; the step-6 gate runs a
-single test instead and deliberately writes none. Tests are **slow
-(~2–3 min each) and cost money** — scope every run to one skill, never run
-several invocations at once (they fight for memory and get killed).
+Between attempts, reset **both** halves — the data and the conversation:
 
-**Arriving from a real failure? Capture it as a test first.** If you got here
-because something went wrong in Cowork, in an e2e run, or in a user's feedback
-zip, run this in 🤖 Claude Code *before* the run above:
+```bash
+make feedback-reset CASE=~/feedback/<slug>
+# Windows: scripts\reset-feedback-case.bat <case folder>
+```
+
+then `/clear` so Claude isn't reading its own earlier bad reasoning. Full
+walkthrough: [`alpha-feedback-guide.md`](alpha-feedback-guide.md).
+
+#### (b) An e2e benchmark run missed a finding ⌨️ Terminal → 🤖 Claude Code
+
+The other common case. You already have the run log — it *is* the evidence, so
+there's nothing to reproduce. Read what happened, then carry the finding
+forward:
+
+```
+/interpret-e2e-result
+```
+
+To poke at it by hand, seed an editable project from the fixture and research
+it yourself (this is 🖥️ Cowork, so reinstall first):
+
+```bash
+make e2e-project TEST=<slug>        # Windows: eval\SeedProject.bat
+```
+
+Full walkthrough: [`e2e-testing-guide.md`](e2e-testing-guide.md).
+
+#### (c) You noticed it in your own Cowork session 🖥️ Cowork + Viewer
+
+You were researching and saw the agent do something wrong. Write the
+Did/Should/Gap note **while you still remember it** — that note is the most
+valuable thing you produce all day. Your project folder already has the
+`results/` files step 2 needs. Appendix B walks this door end to end.
+
+### 2. Whose fault is it?
+
+**Where:** 🤖 Claude Code, on the project or case folder. **How:** read the
+`results/` files — the actual data the tools returned.
+
+This is the question to answer *before* you touch any prose, and it takes two
+minutes:
+
+- The tool **returned** the data and the skill dropped or misused it → a
+  **skill** problem. Continue to step 3. ✅
+- The tool **never returned** it → a **tool** problem. Different fix, an
+  engineering ticket, not a prose edit. Stop here.
+- The skill did the right thing and the test or rubric marked it wrong → a
+  **grading** problem. That's yours to fix too — jump to step 5's lane 2.
+
+Skipping this check is the classic trap: rewriting a skill's instructions for a
+bug that actually lives in a tool. Step 5 has the full four-lane version for
+once you've seen the grades; this is the cheap version that stops you wasting
+the next hour.
+
+### 3. Capture it as a test
+
+**Where:** 🤖 Claude Code at the repo root. **How:**
 
 ```
 /mine-unit-test                            # asks what it needs
@@ -162,489 +239,454 @@ zip, run this in 🤖 Claude Code *before* the run above:
 
 It writes a draft test, a scenario carved from the mid-flow state the sub-skill
 actually saw, and mock fixtures built from the saved tool responses — all under
-`eval/tests/unit/<skill>/` and `eval/fixtures/`. Skim the draft and check **one
-thing above all: the test must state the general rule**, not the specific case.
-"Any census record with a page/line must include it" is a test; "this one
-Schuster record" is a fake win that turns green without the skill getting
-better. (The scenario carve is the part most worth a second look.)
+`eval/tests/unit/<skill>/` and `eval/fixtures/`.
 
-It prints the new test's **id** — `ut_<skill>_<NNN>`, e.g. `ut_citation_019`,
-which is also the `id` field in the file it wrote. That's the `TEST=` value for
-step 6.
+Skim the draft and check **one thing above all: the test must state the general
+rule**, not the specific case. "Any census record with a page/line must include
+it" is a test; "this one Schuster record" is a fake win that turns green
+without the skill getting better. (The scenario carve is the part most worth a
+second look.)
 
-> **Mine the test *before* you fix the bug.** Step 6's gate scores your edit
-> against the *pre-edit* annotated baseline for this test. Capture it after the
-> fix has landed and the bug no longer reproduces on the incumbent skill, so
-> the gate returns `INCONCLUSIVE` and proves nothing either way.
+It prints the new test's **id** — `ut_<skill>_<xxx>`, where `<xxx>` is a random
+three-character suffix, e.g. `ut_citation_k3f`. It's random rather than
+sequential so two people adding a test to the same skill at once can't collide.
+That id is the `TEST=` value for step 6. (Older tests have numeric ids like
+`ut_citation_019`; those stay as they are.)
 
-How to author a *good* test corpus is its own section below — it's the
-single biggest lever on whether the rest of the loop works.
+> **Capture the test before you fix the bug.** Step 6 proves your fix worked by
+> comparing against a run from *before* you edited anything. If you mine the
+> test after the fix has landed, the bug no longer reproduces on the un-edited
+> skill, the gate comes back `INCONCLUSIVE`, and nothing is proven either way.
 
-### 3. Review & annotate
+> **First time improving this skill? You'll need hold-out tests.** Read the
+> hold-out note in step 4 now — they have to be set *before* the run you're
+> about to do, and setting them afterwards invalidates it.
 
-**Who:** you. **Where:** 🌐 the CRUD UI in your browser
-(<http://localhost:3000>), started from a terminal. **How:**
+How to author a *good* test corpus is [Appendix A](#appendix-a-authoring-a-test-corpus) —
+it's the single biggest lever on whether the rest of the loop works.
+
+### 4. Run it and grade it — the baseline
+
+**Where:** ⌨️ terminal, then 🌐 the grading UI in your browser. **How:**
 
 ```bash
+make eval-skill SKILL=<skill>     # rebuilds the engine if stale, then runs
 make eval-ui                      # then open http://localhost:3000
 ```
 
-**Windows:** double-click `eval\Start.bat` — it starts the UI and opens the
-browser tab for you. Leave that window open while you work; closing it stops
-the app.
+**Windows:** double-click `eval\RunTests.bat` (it rebuilds the MCP server, then
+asks which skill), then `eval\Start.bat` to open the grading UI. Leave that
+window open while you work; closing it stops the app.
 
-> **First time improving this skill? Set its hold-out tests *before* the step-2
-> run.** Hold-outs are 2–3 *individual* unit tests (not whole runs) that the
-> improver in step 5 is forbidden to look at, so they can catch a "fix" that
-> only games the tests it was shown. Step 6's gate runs them as its
-> no-regression half — **if the skill has none, that half is silently inert and
-> the gate's LOOKS GOOD means less than it appears.** Set them here: open each
-> test and flip the **"Hold out from the skill-improver"** switch on. Pick
-> diverse, stable ones and leave them set.
+The harness drives the skill against mocked tool responses in a seeded starting
+state, an LLM judge grades each run, and it saves a **run log** — the scores
+plus a snapshot of the exact skill, tests, scenario and fixtures used, so the
+run can be reproduced. Tests are **slow (~2–3 min each) and cost money** — scope
+every run to one skill, and never run several at once (they fight for memory
+and get killed).
+
+**You will run these same two commands again in step 8 — that's not a
+duplicate.** This run records how the skill behaves *before* your edit, which is
+the only thing your fix can be measured against. Steps 5 and 6 both depend on it
+being fully graded: the improver reads your corrections to decide what to
+change, and the gate compares your fix against them. Grade it now and the rest
+of the loop works; leave it ungraded and step 5 proposes nothing while step 6
+has nothing to compare to.
+
+> **Hold-out tests — set them before your first run of a skill.** A hold-out is
+> just a test you hide from the improver in step 5, so it can catch a "fix"
+> that only games the tests it was shown. Pick **2–3** varied, stable tests,
+> open each in the grading UI, and flip the **"Hold out from the
+> skill-improver"** switch on. Leave them set.
 >
-> Toggling hold-out is a grading-relevant change, so doing it *after* the step-2
-> run invalidates the very baseline the gate compares against. If you've already
-> run, set the flags and re-run before continuing.
+> Why it matters: step 6's gate re-runs your hold-outs to check nothing broke.
+> **If the skill has no hold-outs, that check silently does nothing** and a
+> "LOOKS GOOD" means less than it looks. Setting or changing a hold-out also
+> changes how the run is graded, so doing it *after* a run invalidates that
+> run — if you've already run, set them and run again.
 
-Read each run and correct the judge's grades. The UI pre-fills
-every dimension with the judge's score, so you only change the ones you
-**disagree with** and add a comment on those (matching dimensions need no
-comment). This is where human judgment enters the system — it's what every
-later step trusts more than the raw judge score.
+Now read each run and correct the judge. The UI pre-fills every dimension with
+the judge's score, so there are two separate things to do:
 
-**Write correction comments a machine can act on.** A comment is the
-highest-signal input the improver gets, and "judge over-credited" is
-useless to it. Use three parts:
+- **Change the score** only on dimensions you actually **disagree** with.
+- **Write a comment on every dimension that isn't passing** — whether or not
+  you agree with the score.
+
+That second one is the part people skip, and it's what makes the difference in
+step 5. The improver only proposes a body edit when a problem either recurs
+across two or more tests *or* carries a human comment naming the gap. A failing
+dimension with no comment is something it merely **reports**; a failing
+dimension *with* your comment is something it can actually fix.
+
+**Write comments a machine can act on.** "Judge over-credited" is useless. Use
+the same three parts you wrote in step 1:
 
 > **Did:** what the skill actually did.
 > **Should:** what it should have done.
 > **Gap:** which SKILL.md guidance is missing, wrong, or being ignored.
 
-Example: *"Did: labeled the conflicting birthplaces a soft conflict.
-Should: a hard conflict — two primary informants disagree. Gap: the
-skill body never says primary-vs-primary disagreement is hard."* That
-comment is an edit waiting to happen; the first one isn't.
+Example: *"Did: labeled the conflicting birthplaces a soft conflict. Should: a
+hard conflict — two primary informants disagree. Gap: the skill body never says
+primary-vs-primary disagreement is hard."* That comment points straight at the
+fix; the "judge over-credited" version doesn't.
 
-This is not optional bookkeeping for a freshly-mined test: **the improver
-proposes nothing for a lone new test that carries no human comment.** If you
-arrived from a real failure you already wrote the Did/Should/Gap note when you
-noticed it — this is where it goes on the record.
+If you arrived from a real failure you already wrote this note in step 1 — this
+is where it goes on the record.
 
-**One skill per PR, and you own the loop:** edit the skill and/or tests,
-run the harness, correct the grades, commit all of it (skill edits + test
-changes + run-log + your corrections), and open the PR. A senior reviews it
-via the GitHub diff + the CRUD UI and leaves feedback as **PR comments** —
-respond by re-running and pushing a *new commit per round* (don't amend).
-The senior is the gate: they release when the corrected grades show a real
-improvement and the skill + tests look right — a holistic judgment, not a
-number. Most PRs land in 1–2 rounds; 3+ is a signal to flag a senior
-engineer rather than grind.
+### 5. Improve the skill
 
-### 4. Audit the rubric (periodic; before a body-optimization push)
-
-**Who:** you. **Where:** 🤖 Claude Code at the repo root — not Cowork, not the
-terminal. **How:**
+**Where:** 🤖 Claude Code at the repo root. **How:**
 
 ```
 /audit-rubric <skill>
-```
-
-Type the slash command; don't ask for it in prose (see "Type the commands"
-below for why that matters). There is no `make` target or `.bat` for this
-one — it runs inside Claude Code.
-
-Before trusting the improver to optimize toward a rubric, make sure
-the rubric *discriminates*. The **rubric-critic** agent (read-only) reads a
-skill's run logs (best across versions) + `.ann` corrections + `rubric.md` and
-flags non-discriminating dimensions (always 3 or always 1), flaky dimensions,
-dimensions no test exercises, and systematic judge-vs-human disagreement. It
-only *suggests* — rubric edits are the senior's, judge-prompt edits a separate
-cadence. A skill-improver that hill-climbs a weak rubric optimizes noise, so
-run this periodically and whenever a dimension looks off.
-
-### 5. Improve the skill body
-
-**Who:** you. **Where:** 🤖 Claude Code at the repo root. **How:**
-
-```
 /improve-skill <skill>
 ```
 
-The agent is report-only: it proposes a diff, you apply it (in Claude Code
-or any editor). No `make` target or `.bat` — it runs inside Claude Code.
+Run the rubric audit first — it's a health check on the *grading*, so you're
+not chasing a score that was wrong to begin with. The **rubric-critic** agent
+reads the skill's run logs, your corrections and its `rubric.md`, and flags
+dimensions that never discriminate (always pass or always fail), flaky ones,
+and ones no test exercises. Then **skill-improver** reads the annotated run log
+and proposes an evidence-cited diff. Both are read-only: they propose, **you**
+apply the edits.
 
-**The lane rule — classify every finding BEFORE touching skill prose.**
-The 2026-07 record-extraction audit found most of a month's SKILL.md
-edits were tool bugs or eval bugs wearing skill-prose clothing — teams
-patched a 780-line prompt because it was the only lever they held, while
-the real defect lived elsewhere. Every e2e/eval/user finding gets a lane
-first:
+#### The lane rule — classify every finding before touching skill prose
 
-1. **Tooling defect** (rejected valid payloads, missing tool capability,
-   silent corruption) → MCP tool PR + vitest; prose never compensates
-   for a tool bug.
-2. **Eval defect** (judge confabulation, rubric contradicting the skill,
-   fixture expecting stale contracts) → rubric / judge-prompt / fixture
-   PR. If the skill followed its instructions and got dinged, the eval
-   is the bug.
-3. **Record-type craft gap** (a death-cert/probate/church nuance) → that
-   record type's playbook/table, not new global prose.
-4. **Core doctrine** (a genuine cross-record-type behavior change) →
-   SKILL.md / agent-body edit, stewarded, gated by the unit suite.
+Most findings are *not* skill-prose problems. A 2026-07 audit found most of a
+month's SKILL.md edits were tool bugs or grading bugs wearing skill-prose
+clothing — people patched a 780-line prompt because it was the only lever they
+held. Place every finding first:
 
-Lanes 1–2 merge conflict-free and in parallel; only lane 4 touches the
-contended prompt. When in doubt between 2 and 4, check whether the
-transcript shows the skill *following* its written instruction — if yes,
-it's lane 2.
+1. **Tool defect** (rejected valid payloads, missing capability, silent
+   corruption) → an MCP tool fix + test. Prose never compensates for a tool bug.
+2. **Grading defect** (the skill did the right thing and got dinged) → fix the
+   grading, not the skill. **This is yours** — see below.
+3. **Record-type craft gap** (a death-certificate, probate or church-record
+   nuance) → that record type's reference document, not new global prose. These
+   live in the skill's own `references/` directory (e.g.
+   `citation/references/gps-citation-standards.md`), which the skill loads on
+   demand — keeping the main body short.
+4. **Core doctrine** (a genuine cross-record-type behavior change) → a
+   SKILL.md edit, gated by the unit suite.
 
-**In the field, that classification is three questions asked against the saved
-tool responses** — the `results/` files in the project or case folder, which
-record what the tools actually returned:
+Lanes 1–3 merge conflict-free and in parallel; only lane 4 touches the
+contended prompt. When you're torn between 2 and 4, check the transcript: if
+the skill *followed* its written instruction and still got marked wrong, it's
+lane 2. `/improve-skill` does this routing too — it will hand a finding back as
+a test-data, fixture or grading problem rather than inventing prose for it.
 
-- The tool **returned** the data and the skill dropped or misused it → a
-  **skill** problem (lane 3 or 4). Continue.
-- The tool **never returned** it → a **tool** problem (lane 1). Different fix,
-  an engineering ticket, not a prose edit. Stop here.
-- The skill did the right thing and the test or rubric would mark it wrong → a
-  **grading** problem (lane 2). That goes to step 4, not into the body.
+#### What you own in lane 2
 
-Skipping this check is the classic trap: rewriting a skill's instructions for a
-bug that actually lives in a tool.
+Four different things feed a grade, and only two of them are yours:
 
-Cluster the failures across the skill's tests and revise the
-SKILL.md prose to fix them — explaining the *why*, not bolting on
-another MUST (see the authoring guide). The **skill-improver** agent
-(report-only) assists by reading the latest annotated run-log,
-clustering, and proposing an evidence-cited diff for you to approve. It
-**routes by cause** — a correction that actually points at a test-data gap, a
-triggering miss, or a rubric problem goes to the test author / description
-optimizer (step 8) / rubric review (step 4), not into a body edit; only a
-body-located cause becomes SKILL.md prose. It proposes **at most 3** edits.
-Either way the discipline is the same:
+| Thing | Where | Yours? |
+|---|---|---|
+| **This test's expectations** | `judge_context` in the test JSON | **Yes** — fix it |
+| **This skill's rubric** | `eval/tests/unit/<skill>/rubric.md` | **Yes** — fix it |
+| Base rubric (every skill) | shared | No — Dallan's |
+| Global judge prompt | `eval/harness/judge/prompt.md` | No — Dallan's |
+
+If the grading problem is in the first two, **just fix it** — that's the whole
+point of lane 2. One catch: both are part of the run-log snapshot, so editing
+either makes your latest run stale and you have to **re-run the skill's suite**
+(CI blocks otherwise). Do the edit before your final run in step 8, not after.
+
+If the problem is in the bottom two, don't touch them — they're global, and a
+change re-baselines every skill in the project. Post the problem and your
+proposed wording in Slack and let Dallan make the call.
+
+#### When it is a body edit
+
+Cluster the failures across the skill's tests and revise the prose to explain
+the *why* rather than bolting on another MUST. `/improve-skill` proposes **at
+most 3** edits per round. The discipline:
 
 - **Generalize, don't patch the case.** The test is the question, not the
-  answer key. Ask "does this edit read as a general principle?" An edit
-  that only helps the Flynn scenario is a regression in disguise. This —
-  not a statistical hold-out — is the primary overfitting guard at our
-  test counts.
-- **Hold out a few tests.** Marked back in step 3; the improver never reads
-  them while forming an edit. They exist only to check the edit helped cases
-  it wasn't written from. Keep them stable — don't rewrite a holdout test to
-  make it pass.
-- **Trust the human over the judge.** Where a correction comment
-  disagrees with the judge, the comment governs the edit. Don't tune the
-  skill toward judge quirks — that's the judge prompt's problem, on a
-  separate cadence.
+  answer key. An edit that only helps one scenario is a regression in disguise.
+- **Leave the hold-outs alone.** They exist to check the edit helped cases it
+  wasn't written from. Don't rewrite one to make it pass.
+- **Trust your comment over the judge.** Where they disagree, your comment
+  governs the edit.
 - **Subtract, too.** If a run shows the skill sending the model down
-  unproductive paths, delete the offending instruction. Net SKILL.md
-  length should trend flat or down, not always up.
-
-**When the trigger is a real user bug** (a feedback report) instead of an
-annotated run-log, the on-ramp differs but the machinery is the same.
-First **reproduce it live** — replay the user's exact prompt against the
-real skill and watch the bug happen before you change anything; live APIs
-are noisy, so re-run once if it doesn't show. Do that replay in 🤖 **Claude
-Code opened on the unpacked case directory**, which is the cheap loop — the
-skills are symlinked in, so an edit takes effect on the next run with no
-rebuild. Between fix attempts, reset *two* things: start a fresh conversation
-(so the agent isn't anchored on its earlier bad reasoning) and reset the case's
-data with `make feedback-reset CASE=<dir>` (leftover changes contaminate the
-next run). Full walkthrough:
-[`alpha-feedback-guide.md`](alpha-feedback-guide.md).
+  unproductive paths, delete the offending instruction. Net length should trend
+  flat or down.
 
 ### 6. Verify the fix
 
-**Who:** you. **Where:** ⌨️ terminal at the repo root. **How:**
+**Where:** ⌨️ terminal at the repo root. **How:** apply the edits **first**,
+then:
 
 ```bash
 make gate-skill SKILL=<skill> TEST=<test-id>
 ```
 
-**Windows:** double-click `eval\GateSkill.bat` — it asks for the skill and
-the test id.
+**Windows:** double-click `eval\GateSkill.bat` — it asks for the skill and the
+test id.
 
-We are early in the cycle — **catching big problems, not
-polishing small ones** — so verification is cheap and qualitative, not a
-statistical bake-off:
+The gate re-runs just the test you mined plus the skill's hold-outs, and
+compares them against **your corrected grades** from step 4 — human judgment,
+not judge-versus-judge. It's fast and cheap, so iterate here rather than
+re-running the whole suite. It prints one of:
 
-- **Iterate with the gate, not the full suite.** `make gate-skill` runs only
-  the affected test plus the hold-outs; reserve the full `make eval-skill`
-  run for the release candidate.
-- **One run is enough for a big fix.** A real problem is a dimension that
-  fails *consistently* (a 1, not a flicker); a single run sees that.
-  Don't require multiple runs to chase small score deltas you can't trust
-  — the skill run has no `temperature=0` (only the judge is pinned), so
-  treat a sub-noise movement as noise, not victory. (Bump `runs_per_test`
-  only when you genuinely need to measure a marginal change later.)
-- **Gate on the named problem, not the mean.** The question is "did the
-  dimension that was failing now pass, with nothing obvious regressing?"
-  — a binary a single run answers — not "did the weighted mean rise by
-  X."
+- **LOOKS GOOD** — the failing dimension passes and nothing else broke.
+- **NEEDS YOUR EYES** — the fix didn't land, or a hold-out got worse. Read the
+  table, adjust your edit, run it again. Don't open the PR yet.
+- **INCONCLUSIVE** — the bug never showed up on the *old* skill, so nothing was
+  proven either way. Usually the test is too weak. Grading isn't perfectly
+  repeatable, so run it once more before going back to step 3 for a sharper
+  test.
 
-**The gate answers that binary for you.** Apply the improver's edits to
-SKILL.md **first**, then run it. It runs the named test plus the skill's
-hold-out set against your edited skill and compares to the **annotated**
-scores from your pre-edit run — so
-you're measuring against human ground truth, not judge-versus-judge. It
-prints one of:
+Two things to keep in mind. **One run is enough here** — a real problem fails
+consistently, and a single run shows that. Small score wobbles between runs are
+noise, not progress. And **judge the named problem, not the average**: the
+question is "does the dimension that was failing now pass, without anything
+obvious breaking?" — not "did the overall score go up."
 
-- **LOOKS GOOD** — the failing dimension passes and nothing regressed.
-- **NEEDS YOUR EYES** — the fix didn't land, or a hold-out dropped. Read the
-  table, adjust the edit in `SKILL.md`, and re-run — don't open the PR yet.
-- **INCONCLUSIVE** — the bug never reproduced on the *old* skill, so nothing
-  was proven either way. Usually a too-weak test; grading isn't deterministic,
-  so re-run once before going back to step 2 for a sharper test.
+The gate deliberately writes **no run log**, which is why it's cheap enough to
+iterate on — and why step 8 still has a full run in it.
 
-It's advice, not a verdict — you still decide. Two things to know: it needs a
-pre-edit annotated run to compare against, and **it writes no run logs**,
-which is why it's cheap enough to iterate on and why the release run in step 7
-still has to happen.
+### 7. Confirm it in Cowork
 
-> **Why not just re-run `make eval-skill` and diff the scores?** You could, and
-> you'd get a worse answer for more money. Four differences:
->
-> - **It runs one side, not two.** The "before" numbers come from the step-2 run
->   log you already have. A re-run-and-compare pays for a full suite twice and
->   needs you to grade both.
-> - **The "before" side is human ground truth.** The gate overlays your `.ann`
->   corrections onto the step-2 scores. Comparing two raw runs compares judge to
->   judge — and the judge is the thing you just spent step 4 not fully trusting.
-> - **It's the mined test + hold-outs, not the whole suite** — seconds, so you
->   can iterate on the edit instead of committing to it.
-> - **It tells you when the *test* is the problem.** `INCONCLUSIVE` means the
->   bug never reproduced on the un-edited skill, so nothing was proven either
->   way. A score diff can't distinguish that from "the fix didn't work" — it
->   just shows two passing runs and you conclude, wrongly, that you're done.
+**Required** if you came through the alpha-feedback door (step 1a) — optional,
+but cheap insurance, for the other two.
 
-### 7. Release
+**Where:** 🖥️ Cowork + the Research Viewer. **How:** rebuild and reinstall
+first — see [Rebuilding and reinstalling](#rebuilding-and-reinstalling). Cowork
+runs the uploaded plugin, not your working tree.
 
-**Who:** you ship; a senior blesses. **Where:** two places — ⌨️ a terminal
-for the release run and the push, 🌐 the CRUD UI for the Release click.
-**How:**
+Steps 4 and 6 proved the fix against *mocked* data. This proves it the way a
+user actually gets it. Redo the research that failed in step 1, with the
+Research Viewer open on the project folder — the fix usually shows up as
+something written into the research log or the assertions pane, which is not
+something the chat's summary of itself will tell you honestly.
 
-1. **Terminal** — do the full release run on the edited skill (the gate in
-   step 6 writes no run log, so this is not optional):
+Coming from the alpha-feedback door, re-unzip the **original** zip into a fresh
+folder so Cowork sees the pristine user state, and re-issue the tester's exact
+prompt. If the fix holds in the harness but *not* in Cowork, the bug
+may be Cowork-specific — plugin loading, viewer context, OS file handling — so
+get help diagnosing it and **do not ship the PR**.
 
-   ```bash
-   make eval-skill SKILL=<skill>          # Windows: eval\RunTests.bat
-   ```
+### 8. Re-run, grade, commit, and PR
 
-2. **CRUD UI** (`make eval-ui`; Windows: `eval\Start.bat`) — grade it: click
-   **Agree with all**, then correct only the few dimensions you actually
-   disagree with. **Every** dimension has to be reviewed; CI fails on a
-   partly-annotated run.
+**Where:** ⌨️ terminal, 🌐 the grading UI, then GitHub. **How:**
 
-3. **Terminal or GitHub Desktop** — commit the skill edit, the new test *and
-   its scenario folder and mock fixtures* (commit only the test JSON and it
-   can't run), the run log and its `.ann.json` together, push the step-0
-   branch, and open the PR:
-
-   ```bash
-   git add packages/engine/plugin/skills/<skill>/ eval/tests/unit/<skill>/ \
-           eval/fixtures/scenarios/<slug>/ eval/fixtures/mcp/ \
-           eval/runlogs/unit/<skill>/
-   git commit -m "<skill>: <what changed and why>"
-   git push -u origin <your-branch>
-   gh pr create                            # or open the PR from GitHub's web UI
-   ```
-
-   The commit message *is* the lesson — explain what went wrong and what
-   changed. There's no separate lesson file by design.
-
-4. **CRUD UI, senior** — they review the PR diff plus your corrected grades,
-   then click **Release** on the good candidate and push that rename to your
-   branch. The project owner merges.
-
-Each full run you commit is a **candidate**; releasing one makes it the
-official version (v1, v2, … — one released run-log per version). The
-`check-runlogs` CI gate is blocking and checks two things your step-2 run can no
-longer satisfy, because `SKILL.md` changed underneath it:
-
-- the latest run log per touched skill must be **active** — its embedded
-  snapshot still matching the branch's current skill files. Edit SKILL.md or a
-  test and the UI shows "no active version" until you re-run the harness;
-  that's your signal the latest results are stale.
-- its `.ann.json` must carry a correction for **every** (test, dimension) pair.
-
-**One *problem* per PR — which is usually, but not always, one skill.** A
-locator rule that belongs in `citation` alone is a one-skill PR. But some fixes
-genuinely span skills: a doctrine change about how evidence is classified may
-have to land in `person-evidence`, `conflict-resolution` and `proof-conclusion`
-together, because shipping it in one and not the others leaves the skills
-contradicting each other mid-research. When that happens, edit them all in the
-same PR — and run `make eval-skill` for **each** touched skill, since the runlog
-gate checks every skill the PR touches, not just the first. What you should not
-do is bundle two *unrelated* fixes because they happened to be on your branch at
-the same time.
-
-**Want to see it in the real product before you ship?** That's the one step that
-happens in 🖥️ **Cowork**: `make plugin` and `make mcpb` (Windows:
-`eval\BuildPlugin.bat`, `eval\BuildMcpb.bat`), remove the old plugin in Cowork →
-Customize, upload the new `.zip`, install the `.mcpb` in Desktop → Settings →
-Extensions, then fully quit and reopen Desktop. Cowork runs the uploaded plugin
-`.zip`, not your working tree — skip the rebuild and the fix will look like it
-did nothing. Optional in general: the harness run, not the Cowork walkthrough, is
-what CI and the release gate check. The one place it is *not* optional is an
-alpha feedback case, where a Cowork verification is a specced pre-PR step
-— see [`alpha-feedback-guide.md`](alpha-feedback-guide.md).
-
-### 8. Optimize the description (separate, automated loop)
-
-**Who:** you. **Where:** ⌨️ terminal at the repo root. **How:**
+The gate in step 6 wrote no run log, and your edits changed the skill
+underneath the step-4 run — so do one full run against the edited skill and
+grade it:
 
 ```bash
-make optimize-skill SKILL=<skill>
+make eval-skill SKILL=<skill>          # Windows: eval\RunTests.bat
+make eval-ui                           # Windows: eval\Start.bat
 ```
 
-**Windows:** double-click `eval\OptimizeSkill.bat` — it asks which skill's
-description to tune. Both forms build the trigger query set and then run the
-optimizer; it makes real `claude -p` calls, so it needs network and costs
-money, and it is **not** in CI.
+Grade it: click **Agree with all**, then correct the few dimensions you
+actually disagree with. **Every dimension has to be reviewed** — CI fails on a
+partly-graded run.
 
-A skill has two parts that are tuned separately: the
-one-line **description** controls *when* the skill fires; the **body**
-(steps 5–7) teaches Claude *how* to do the task. A *triggering* problem —
-the skill fires when it shouldn't, or doesn't when it should — is a
-**description** fix; an "it did the task wrong" problem is a **body** fix.
-Don't conflate them.
+Then commit everything together — the skill edit, the new test *and its
+scenario folder and mock fixtures* (commit only the test JSON and it can't
+run), the run log and its `.ann.json`:
 
-The optimizer builds should-trigger / should-not-trigger query sets for free
-from your positive and negative tests, then tunes the description against
-them. It tunes the **description only** — it never runs the skill or a tool.
-Apply the proposed new description as a human-reviewed SKILL.md edit; the
-optimizer's report lands in `eval/runlogs/optimizer/`, separate from your
-test run-logs.
+**Terminal:**
 
-**The two loops interact, so sequence them.** Fix the body first — a skill
-that never fires can't be body-improved. After a body change that alters
-*what the skill does*, re-run the description optimizer (the old triggers
-may no longer fit). After a description change, re-run the skill's tests to
-confirm its behavior didn't move. Body first, then description.
+```bash
+git add packages/engine/plugin/skills/<skill>/ eval/tests/unit/<skill>/ \
+        eval/fixtures/scenarios/<slug>/ eval/fixtures/mcp/ \
+        eval/runlogs/unit/<skill>/
+git commit -m "<skill>: <what changed and why>"
+git push -u origin <your-branch>
+gh pr create                            # or open the PR from GitHub's web UI
+```
+
+**GitHub Desktop:** make sure the repository picker says **cowork-genealogy**,
+tick the paths above, type a summary in the Summary box, **Commit to
+`<your-branch>`**, then **Push origin** and **Create Pull Request** (it opens
+GitHub in your browser with the branch pre-filled).
+
+The commit message *is* the lesson — explain what went wrong and what changed.
+There's no separate lesson file by design.
+
+A senior genealogist reviews the PR — the diff plus your corrected grades — and
+merges it. They leave feedback as **PR comments**; respond by re-running and
+pushing a *new commit per round* (don't amend). Most PRs land in 1–2 rounds;
+3+ is a signal to ask for help rather than grind.
+
+**What CI checks.** The `check-runlogs` gate is blocking and enforces two
+things your step-4 run can no longer satisfy, because the skill changed
+underneath it:
+
+- The latest run log per touched skill must be **active** — its snapshot still
+  matching the branch's current skill files, tests and rubric. Edit any of
+  those and the UI shows "no active version" until you re-run; that's your
+  signal the results are stale.
+- Its `.ann.json` must carry a correction for **every** (test, dimension) pair.
+
+**One *problem* per PR — which is usually, but not always, one skill.** A
+locator rule that belongs in `citation` alone is a one-skill PR. But a doctrine
+change about how evidence is classified may have to land in `person-evidence`,
+`conflict-resolution` and `proof-conclusion` together, because shipping it in
+one and not the others leaves the skills contradicting each other mid-research.
+When that happens, edit them all in the same PR — and run `make eval-skill` for
+**each** touched skill, since the gate checks every skill the PR touches. What
+you should not do is bundle two *unrelated* fixes because they happened to
+share a branch.
 
 ---
 
-## Authoring a test corpus that the loop can actually use
+## Side loop: authoring a brand-new skill
 
-A test is four things you fill in the CRUD UI — no JSON: the **user
-message**, a starting **scenario** (project state) from a dropdown,
-optional **fixtures** (canned tool responses so the skill doesn't hit a
-live API), and plain-English **criteria**. You can ship a useful test with
-just a message and a scenario — the skill's shared rubric does the heavy
-grading; your criteria only add what's unique to *this* case. (If no
-scenario fits, pick the closest and note the gap — the test saves but
-won't run until the matching scenario is built.)
+**Where:** 🤖 Claude Code at the repo root (or any text editor — the skill is
+just `packages/engine/plugin/skills/<skill>/SKILL.md`).
 
-Aim for **at least 8 tests per skill** — no upper bound; we don't yet know
-enough to set one. Spend them on **coverage, not repetition**: eight easy
-happy-path tests can't tell a good skill from a bad one. Each skill's set
-should span:
+Occasionally you're not fixing a skill but creating one. For a new
+tool-wrapping skill, ask Claude Code to scaffold it with the
+`cowork-skill-builder` agent; otherwise write the file directly, to the prose
+standard in [`docs/skill-authoring-guide.md`](skill-authoring-guide.md). (That
+guide's "What kind of skill are you writing?" section covers whether it should
+be a skill at all, and which of the three kinds — workflow, reference, or
+guardrail — it is.) You drive the domain content, the shape, the frontmatter
+limits, and any `scripts/` helper, pulling in help when a piece is outside your
+comfort zone.
 
-- **Positive** — the skill should fire and do the task well (happy path
-  *and* messier variants).
-- **Negative / routing** — a near-miss that should go to a *different*
-  skill (you name which one, or "none"). Mine these from the "Do NOT use
-  when…" clauses in the description (see the authoring guide); build them
-  from both directions of each confusable pair.
-- **Edge cases** — the messy genealogy realities: conflicting records,
-  missing data, ambiguous places, multi-person households.
-- **At least one hard case** — something the skill currently gets wrong.
-  A corpus with no failures has nothing to improve against.
+Then rejoin the loop at **step 3**: it needs a test corpus
+([Appendix A](#appendix-a-authoring-a-test-corpus)) and hold-outs before it can
+be improved like any other skill.
 
-Then mark **2–3 diverse, representative tests as holdout** up front —
-toggle the "Hold out from the skill-improver" switch on each in the CRUD
-UI. Authoring the hold-out into the corpus now is far cheaper than carving
-it out after the improver has already been trained against everything.
+## Side loop: tuning a skill's description
 
-Keep your criteria **neutral** — grade the *reasoning*, never a preferred
-answer. "Should resolve in favor of the Irish birthplace" is leakage: the
-judge then just agrees with you. Rewrite it to "resolution should weigh
-informant proximity as a factor, regardless of which birthplace it picks."
-The test: would a genealogist who reached the *opposite* conclusion still
-call your criterion fair? If not, it's leaking — the biggest validity
-threat to LLM-as-judge grading.
+**Where:** ⌨️ terminal at the repo root. **How:**
+
+```bash
+make optimize-skill SKILL=<skill>      # Windows: eval\OptimizeSkill.bat
+```
+
+A skill has two parts that are tuned separately. The one-line **description**
+controls *when* the skill fires; the **body** (the loop above) teaches Claude
+*how* to do the task. A *triggering* problem — the skill fires when it
+shouldn't, or doesn't when it should — is a **description** fix. An "it did the
+task wrong" problem is a **body** fix. Don't conflate them.
+
+The optimizer builds should-trigger / should-not-trigger query sets from your
+positive and negative tests, then tunes the description against them. It never
+runs the skill or a tool. Apply the proposed description as a human-reviewed
+SKILL.md edit; its report lands in `eval/runlogs/optimizer/`, separate from
+your test run logs. It makes real API calls, so it costs money and is **not**
+in CI.
+
+**Sequence the two loops.** Fix the body first — a skill that never fires can't
+be body-improved. After a body change that alters *what the skill does*, re-run
+the optimizer. After a description change, re-run the skill's tests to confirm
+its behavior didn't move.
 
 ---
 
 ## Is the loop working?
 
-The real metric isn't pass rate — it's whether the system **compounds.**
-When you catch the *same kind of mistake* across several tests, stop fixing
-it by hand: push it down into something that catches it automatically. A
-yes/no check on a single output (e.g. "citation missing") becomes an
-automated test; something you only see by reading the whole output and
-weighing it (e.g. "overconfident conclusion") becomes a **rubric**
-dimension. If you're still hand-catching the same class of issue ten rounds
-in, the loop isn't learning.
+The real metric isn't pass rate — it's whether the system **compounds.** When
+you catch the *same kind of mistake* across several tests, stop fixing it by
+hand: push it down into something that catches it automatically. A yes/no check
+on a single output (e.g. "citation missing") becomes an automated test;
+something you only see by reading the whole output and weighing it (e.g.
+"overconfident conclusion") becomes a **rubric** dimension. If you're still
+hand-catching the same class of issue ten rounds in, the loop isn't learning.
 
 ## Command card
-
-Every step has tooling in place. The whole loop, in one table:
 
 | Step | Where | macOS / Linux | Windows |
 |---|---|---|---|
 | 0 Branch | ⌨️ terminal | `git checkout -b <short-task-name>` | GitHub Desktop → New branch… |
-| 1 Author | 🤖 Claude Code / editor | the authoring guide + a blocking frontmatter lint in CI | same |
-| 2 Capture *(from a real failure)* | 🤖 Claude Code | `/mine-unit-test [--project \| --e2e-run <dir>]` | same |
-| 2 Test | ⌨️ terminal | `make eval-skill SKILL=<name>` | `eval\RunTests.bat` |
-| 3 Review | 🌐 CRUD UI (browser) | `make eval-ui` | `eval\Start.bat` |
-| 4 Audit | 🤖 Claude Code | `/audit-rubric <name>` | `/audit-rubric <name>` |
-| 5 Improve | 🤖 Claude Code | `/improve-skill <name>` | `/improve-skill <name>` |
-| 6 Gate | ⌨️ terminal | `make gate-skill SKILL=<name> TEST=<id>` | `eval\GateSkill.bat` |
-| 7 Release | ⌨️ terminal + 🌐 CRUD UI | `make eval-skill`, then Release in the UI, then push + PR | `eval\RunTests.bat`, then Release in the UI, then GitHub Desktop |
-| 8 Optimize | ⌨️ terminal | `make optimize-skill SKILL=<name>` | `eval\OptimizeSkill.bat` |
-| *(optional)* try it in Cowork | 🖥️ Cowork | `make plugin`, `make mcpb` | `eval\BuildPlugin.bat`, `eval\BuildMcpb.bat` |
+| 1 Start from a failure | 🤖 / ⌨️ / 🖥️ | `make feedback-case ZIP=…` · `/interpret-e2e-result` · `make e2e-project TEST=…` | `scripts\setup-feedback-case.bat` · `eval\SeedProject.bat` |
+| 2 Whose fault? | 🤖 Claude Code | read the project's `results/` files | same |
+| 3 Capture | 🤖 Claude Code | `/mine-unit-test [--project \| --e2e-run <dir>]` | same |
+| 4 Run + grade *(baseline)* | ⌨️ terminal → 🌐 browser | `make eval-skill SKILL=<name>`, `make eval-ui` | `eval\RunTests.bat`, `eval\Start.bat` |
+| 5 Improve | 🤖 Claude Code | `/audit-rubric <name>`, `/improve-skill <name>` | same |
+| 6 Verify | ⌨️ terminal | `make gate-skill SKILL=<name> TEST=<id>` | `eval\GateSkill.bat` |
+| 7 Confirm in Cowork | 🖥️ Cowork | `make plugin`, `make mcpb`, then reinstall | `eval\BuildPlugin.bat`, `eval\BuildMcpb.bat` |
+| 8 Re-run + grade + PR | ⌨️ terminal → 🌐 → GitHub | `make eval-skill`, grade all, commit, PR | `eval\RunTests.bat`, then GitHub Desktop |
+| *(side)* new skill | 🤖 Claude Code | the authoring guide + `cowork-skill-builder` | same |
+| *(side)* description | ⌨️ terminal | `make optimize-skill SKILL=<name>` | `eval\OptimizeSkill.bat` |
 
-Steps 4 and 5 are Claude Code slash commands on both platforms — the agents
-(`rubric-critic`, `skill-improver`) are read-only and propose edits you
-apply. The `.bat` files prompt for the skill or test name instead of taking
-`SKILL=`/`TEST=` arguments; they are listed in
-[`eval/README.md`](../eval/README.md).
+**To run the improver on skill `X`:** it needs an *active*, *annotated* run
+log. So run the harness on current code (`make eval-skill SKILL=X`), grade it
+in the UI, then type `/improve-skill X`. Against a stale or ungraded run log it
+proposes nothing and asks you to re-run — that's correct, not a failure.
 
-**To run the improver on skill `X`:** it needs an *active*, *annotated*
-run-log. So run the harness on current code (`make eval-skill SKILL=X`;
-Windows `eval\RunTests.bat`), annotate the candidate in the CRUD UI, then
-type `/improve-skill X`. Against a stale or unannotated run-log it proposes
-nothing and asks you to re-run — that's correct, not a failure.
-
-**Type the commands rather than asking in prose.** Both agents are read-only
-by construction — they propose, you apply. Phrasing it as a request relies on
-description matching, and a miss doesn't fail loudly: you get ordinary Claude,
-which *does* have Edit and Write, doing the job instead, and the 3-edit budget
-and the you-apply-them gate quietly disappear. The commands also check you're
-at the repo root and warn when hold-outs or annotations are missing.
+**Type the slash commands rather than asking in prose.** Both agents are
+read-only by construction — they propose, you apply. Phrasing it as a request
+relies on description matching, and a miss doesn't fail loudly: you get
+ordinary Claude, which *does* have Edit and Write, doing the job instead, and
+the 3-edit budget and the you-apply-them gate quietly disappear. The commands
+also check you're at the repo root and warn when hold-outs or grades are
+missing.
 
 ---
 
-## Worked example: a citation nobody could find again
+## Appendix A: Authoring a test corpus
 
-The stages above are the reference. This is one run through them, start to
-finish, doing it for the first time — with the place marked at every step.
+Referenced from step 3 — this is how to build the corpus the whole loop grades
+against, and it's the single biggest lever on whether any of the rest works.
+
+A test is four things you fill in the grading UI — no JSON: the **user
+message**, a starting **scenario** (project state) from a dropdown, optional
+**fixtures** (canned tool responses so the skill doesn't hit a live API), and
+plain-English **expectations**. You can ship a useful test with just a message
+and a scenario — the skill's shared rubric does the heavy grading; your
+expectations only add what's unique to *this* case. (If no scenario fits, pick
+the closest and note the gap — the test saves but won't run until the matching
+scenario is built.)
+
+Aim for **at least 8 tests per skill** — no upper bound. Spend them on
+**coverage, not repetition**: eight easy happy-path tests can't tell a good
+skill from a bad one. Each skill's set should span:
+
+- **Positive** — the skill should fire and do the task well (happy path *and*
+  messier variants).
+- **Negative / routing** — a near-miss that should go to a *different* skill
+  (you name which one, or "none"). Mine these from the "Do NOT use when…"
+  clauses in the description; build them from both directions of each
+  confusable pair.
+- **Edge cases** — the messy genealogy realities: conflicting records, missing
+  data, ambiguous places, multi-person households.
+- **At least one hard case** — something the skill currently gets wrong. A
+  corpus with no failures has nothing to improve against.
+
+Then mark **2–3 diverse, representative tests as hold-outs** up front (step 4).
+Authoring the hold-out into the corpus now is far cheaper than carving it out
+after the improver has already been run against everything.
+
+Keep your expectations **neutral** — grade the *reasoning*, never a preferred
+answer. "Should resolve in favor of the Irish birthplace" is leakage: the judge
+then just agrees with you. Rewrite it to "resolution should weigh informant
+proximity as a factor, regardless of which birthplace it picks." The test:
+would a genealogist who reached the *opposite* conclusion still call your
+expectation fair? If not, it's leaking — the biggest threat to the validity of
+LLM grading.
+
+---
+
+## Appendix B: Worked example — a citation nobody could find again
+
+One run through steps 0–8, start to finish, for the "you noticed it yourself"
+door. The step numbers here are the same step numbers as above.
 
 > **The story follows one person — "you" — running the whole loop**, which is
 > the normal case; **pull in a teammate for any step you're not comfortable
-> with.** The Schuster family and the `schuster-census` slug are invented; for a
-> real run, use an existing fixture slug from `eval/tests/e2e/`.
-
-**The problem.** You're researching the Schuster family. You ask Claude to
-cite a 1900 U.S. census record you just used. The `citation` skill writes a
-tidy-looking citation — but it **leaves out the page and line number**. Without
-that, no one could ever open that exact record again.
+> with.** The Schuster family and the `schuster-census` slug are invented; for
+> a real run, use an existing fixture slug from `eval/tests/e2e/`.
 
 > **Before you start (one-time setup).** Two things gate this loop; skip them
 > and the steps below silently do nothing.
 > - **Cowork steps (1 and 7)** need the genealogy tools installed *into
 >   Cowork*: log in to FamilySearch (`make e2e-login` / `eval\Login.bat`, once
->   a day), then `make mcpb` and `make plugin` (Windows: `eval\BuildMcpb.bat`,
->   `eval\BuildPlugin.bat`). Plain `make engine-build` wires only the Claude
->   Code side — in Cowork the project would open with no tools and there'd be
->   nothing to notice or confirm.
+>   a day), then build and install both artifacts per
+>   [Rebuilding and reinstalling](#rebuilding-and-reinstalling). Plain
+>   `make engine-build` wires only the Claude Code side — in Cowork the project
+>   would open with no tools and there'd be nothing to notice or confirm.
 > - **Grading steps (4 and 8)** call the LLM judge, which needs an Anthropic
 >   API key in `eval/.env` (`ANTHROPIC_API_KEY=…`; `Setup.bat` sets this on
->   Windows). Without it every dimension comes back *ungraded* and the loop
->   produces nothing gradeable.
+>   Windows). Without it every dimension comes back *ungraded*.
 >
-> The middle steps run on saved mock data, so you don't need to be online for
-> them.
+> The middle steps run on saved mock data, so you don't need to be online.
 
 ### Step 0 — Branch ⌨️ Terminal
 
@@ -654,10 +696,10 @@ git checkout -b citation-locator
 ```
 
 **Windows (GitHub Desktop):** Current Branch dropdown → select **main** and
-**Fetch/Pull** → **New branch…** → name it `citation-locator`, base it on `main`
-→ **Create branch**.
+**Fetch/Pull** → **New branch…** → name it `citation-locator`, base it on
+`main` → **Create branch**.
 
-### Step 1 — Notice it 🖥️ Cowork + Viewer
+### Step 1 — Start from a real failure: you notice it 🖥️ Cowork + Viewer
 
 You're working in a practice project you seeded earlier from a terminal:
 
@@ -674,35 +716,33 @@ terminal and left running:
 make electron                                # Windows: eval\Viewer.bat
 ```
 
-Then **Open Project** in the viewer and pick the same
-`eval/e2e-project/schuster-census/` folder. It live-updates as the agent works.
-Skip this and you're judging the research from the chat transcript alone, which
-is exactly how a bad citation slips past.
+Then **Open Project** in the viewer and pick the same folder. It live-updates
+as the agent works. Skip this and you're judging the research from the chat
+transcript alone, which is exactly how a bad citation slips past.
 
-Mid-research you spot it and write down, in plain words, what's wrong:
+You ask Claude to cite a 1900 U.S. census record you just used. It writes a
+tidy-looking citation — but it **leaves out the page and line number**. Without
+that, no one could ever open that exact record again. You write down, in plain
+words, what's wrong:
 
 > **Did:** the citation gave the census year and county but no page or line.
 > **Should:** it must include the page/line so the record can be found again.
 > **Gap:** the citation skill never says a citation has to be *relocatable*.
 
-That three-part note is the single most valuable thing you produce all day.
-Keep it — it goes on the record in Step 4 and drives Step 5.
+### Step 2 — Whose fault is it? 🤖 Claude Code
 
-### Step 2 — Is it even the skill's fault? 🤖 Claude Code
-
-Open **Claude Code** at the **repo root** on the branch and check the
-project's `results/` files — the actual data the tools returned. The census tool
-**did** return the page/line and the skill dropped it → a **skill** problem.
+Open Claude Code at the **repo root** on your branch and check the project's
+`results/` files — the actual data the tools returned. The census tool **did**
+return the page/line and the skill dropped it → a **skill** problem.
 Continue. ✅
 
 Had the tool never returned it, that would be a tool problem and an engineering
-ticket, not a skill edit — stage 5's lane rule. Skipping this check is the
-classic trap.
+ticket, not a skill edit.
 
 ### Step 3 — Capture it as a test 🤖 Claude Code
 
-In the same session, run **`mine-unit-test`**, point it at the project
-folder, and paste your Did/Should/Gap note:
+In the same session, point `mine-unit-test` at the project folder and paste
+your note:
 
 ```
 /mine-unit-test --project eval/e2e-project/schuster-census
@@ -710,69 +750,61 @@ folder, and paste your Did/Should/Gap note:
 
 It writes a unit test that reproduces the bug — "given a census record that has
 a page/line, the citation must include it" — plus a scenario and mock fixtures,
-all marked *draft* under `eval/tests/unit/citation/` and `eval/fixtures/`. Skim
-it and check that the **general** rule is what's stated, not "this one
-Schuster record."
+all marked *draft*. Skim it and check the **general** rule is what's stated,
+not "this one Schuster record."
 
-It prints the new test's id — say `ut_citation_019`. That's the `TEST=` value
+It prints the new test's id — say `ut_citation_k3f`. That's the `TEST=` value
 for Step 6.
 
-### Step 4 — Run it, and mark what's wrong ⌨️ Terminal → 🌐 browser
+### Step 4 — Run it and grade it: the baseline ⌨️ Terminal → 🌐 browser
 
-`citation` already has its hold-out tests set (`ut_citation_001` and
-`ut_citation_014`), so you go straight to the run — a brand-new skill would
-need them set in the UI first, *before* this run.
+`citation` already has its hold-out tests set, so you go straight to the run —
+a brand-new skill would need them set in the UI first, *before* this run.
 
 ```
 make eval-skill SKILL=citation               # Windows: eval\RunTests.bat
 make eval-ui                                 # Windows: eval\Start.bat
 ```
 
-Find the new test in the grading UI, see which quality dimension it failed,
-and paste **your Did/Should/Gap note** into that dimension's comment. The
-improver in the next step will do nothing with a brand-new test *unless* it
-carries a human comment like this.
+Find the new test in the grading UI, see which dimension it failed, and paste
+**your Did/Should/Gap note** into that dimension's comment — even though you
+agree with the judge that it failed. Without the comment the improver will only
+report it, not fix it.
 
-### Step 5 — Audit, then improve 🤖 Claude Code
+### Step 5 — Improve the skill 🤖 Claude Code
 
 ```
 /audit-rubric citation
 /improve-skill citation
 ```
 
-The first is a health check on the grading itself — do it once per skill so
-you're not chasing a broken grade. The second reads the test + your comment and
-proposes **at most 3** small, plain-English edits — e.g. *"every citation must
-include a locator (page/line/entry) that lets a reader reopen the exact record;
-if the record has none, write a 'missing locator' marker instead."* The agent
-only **proposes**; you paste the edits into `citation/SKILL.md` yourself.
+The first is a health check on the grading, so you're not chasing a broken
+score. The second reads the test + your comment and proposes **at most 3**
+small, plain-English edits — e.g. *"every citation must include a locator
+(page/line/entry) that lets a reader reopen the exact record; if the record has
+none, write a 'missing locator' marker instead."* The agent only **proposes**;
+you paste the edits into `citation/SKILL.md` yourself.
 
-### Step 6 — Check the fix helps and breaks nothing ⌨️ Terminal
+### Step 6 — Verify the fix ⌨️ Terminal
 
 ```
-make gate-skill SKILL=citation TEST=ut_citation_019   # Windows: eval\GateSkill.bat
+make gate-skill SKILL=citation TEST=ut_citation_k3f   # Windows: eval\GateSkill.bat
 ```
 
-**LOOKS GOOD** → go do the release run. **NEEDS YOUR EYES** → adjust the edit
-and re-run; don't open the PR yet. **INCONCLUSIVE** → re-run once; if it stays
+**LOOKS GOOD** → go do the final run. **NEEDS YOUR EYES** → adjust the edit and
+run again; don't open the PR yet. **INCONCLUSIVE** → run once more; if it stays
 inconclusive, go back to Step 3 for a sharper test.
 
 ### Step 7 — Confirm it in Cowork 🖥️ Cowork + Viewer
 
-Rebuild and re-upload the plugin first so Cowork runs the *edited* skill:
-`make plugin` (Windows: `eval\BuildPlugin.bat`), then remove the old plugin in
-Cowork → Customize and upload the new `.zip`.
+Rebuild the plugin and re-upload it so Cowork runs the *edited* skill (see
+[Rebuilding and reinstalling](#rebuilding-and-reinstalling)) — you only changed
+a skill here, so the `.mcpb` doesn't need reinstalling. Then redo the same
+citation with the Research Viewer open. The viewer is the point, not a nicety:
+the fix is a *citation string in the research log*, and reading it there is how
+you confirm the page/line is actually present.
 
-Then redo the same citation, with the **Research Viewer** open on the same
-project folder. The viewer is the point here, not a nicety: the fix is a
-*citation string in the research log*, and reading it there is how you confirm
-the page/line is actually present rather than trusting the chat's summary of
-what it wrote.
-
-This is the real-world sanity check; the unit test from Step 3 is the durable
-guard that stops the bug from ever coming back.
-
-### Step 8 — Release run and PR ⌨️ Terminal → 🌐 browser / GitHub
+### Step 8 — Re-run, grade, commit, and PR ⌨️ Terminal → 🌐 browser / GitHub
 
 ```
 make eval-skill SKILL=citation               # Windows: eval\RunTests.bat
@@ -781,43 +813,8 @@ make eval-ui                                 # Windows: eval\Start.bat
 
 Grade every dimension (**Agree with all**, then correct the few you disagree
 with), then commit the skill edit + the new test *and its scenario folder and
-mock fixtures* + the run record + the grades, and open the PR. A senior reviewer
-reads the corrected grades and, if it's a real improvement, releases it.
-
-### Cheat sheet: where each step happens
-
-| Step | What you do | Where |
-|---|---|---|
-| 0 Branch | `git checkout -b <short-task-name>` | ⌨️ Terminal |
-| 1 Notice | research; spot the problem; write Did/Should/Gap | 🖥️ Cowork + Viewer |
-| 2 Classify | skill's fault, or a tool/grading fault? | 🤖 Claude Code |
-| 3 Capture | `/mine-unit-test --project <dir>` | 🤖 Claude Code |
-| 4 Run + mark | run the tests; paste the note on the failing dimension | ⌨️ Terminal → 🌐 browser |
-| 5 Audit + improve | `/audit-rubric`, then `/improve-skill`; you apply the edits | 🤖 Claude Code |
-| 6 Gate | check the fix helps and breaks nothing | ⌨️ Terminal |
-| 7 Verify | rebuild + re-upload the plugin; redo the research; see it fixed | 🖥️ Cowork + Viewer |
-| 8 Release + PR | full run, grade every dimension, submit | ⌨️ Terminal → 🌐 browser / GitHub |
-
-### Windows equivalents
-
-Every `make` target above has a batch file. Double-click it, or run it from
-`eval\`; each prompts for what it needs instead of taking `SKILL=`-style
-arguments, and rebuilds the MCP server first where that matters.
-
-| Instead of | Double-click |
-|---|---|
-| `make e2e-project TEST=<slug>` | `eval\SeedProject.bat` |
-| `make eval-skill SKILL=<skill>` | `eval\RunTests.bat` |
-| `make eval-ui` | `eval\Start.bat` |
-| `make gate-skill SKILL=… TEST=…` | `eval\GateSkill.bat` |
-| `make optimize-skill SKILL=<skill>` | `eval\OptimizeSkill.bat` |
-| `make electron` | `eval\Viewer.bat` |
-| `make e2e-login` | `eval\Login.bat` |
-| `make plugin` / `make mcpb` | `eval\BuildPlugin.bat` / `eval\BuildMcpb.bat` |
-| `git checkout -b <short-task-name>` | GitHub Desktop → Current Branch → **New branch…** |
-
-The `/`-commands (`/mine-unit-test`, `/audit-rubric`, `/improve-skill`) are
-typed into Claude Code and are the same on every platform.
+mock fixtures* + the run log + the grades, and open the PR. A senior
+genealogist reads the corrected grades and merges.
 
 ---
 
@@ -828,7 +825,7 @@ Everyday docs:
 | You want to… | Go to |
 |---|---|
 | Write a SKILL.md well | [`docs/skill-authoring-guide.md`](skill-authoring-guide.md) |
-| Run the harness / read a run-log | [`eval/README.md`](../eval/README.md) |
+| Run the harness / read a run log | [`eval/README.md`](../eval/README.md) |
 | Audit a skill's rubric quality | `/audit-rubric <name>` — the `rubric-critic` agent |
 | Improve a SKILL.md body from eval results | `/improve-skill <name>` — the `skill-improver` agent |
 | Author and run an e2e benchmark fixture | [`docs/e2e-testing-guide.md`](e2e-testing-guide.md) |
@@ -842,7 +839,7 @@ these to follow the flow above:
 |---|---|
 | Skill architecture & the three skill kinds | [`docs/specs/skill-architecture-spec.md`](specs/skill-architecture-spec.md) |
 | Test JSON format, fixtures, validators | [`docs/specs/unit-test-spec.md`](specs/unit-test-spec.md) |
-| Per-PR review + run-log release/active/candidate mechanics | [`docs/plan/per-pr-review-workflow.md`](plan/per-pr-review-workflow.md), [`docs/plan/eval-runlog-versioning.md`](plan/eval-runlog-versioning.md) |
+| Per-PR review + run-log versioning mechanics | [`docs/plan/per-pr-review-workflow.md`](plan/per-pr-review-workflow.md), [`docs/plan/eval-runlog-versioning.md`](plan/eval-runlog-versioning.md) |
 | The vendored description optimizer | `eval/triggering/` (vendoring notes in `VENDORED.md`) |
 | The e2e fixture format and judge contract | [`docs/specs/e2e-test-spec.md`](specs/e2e-test-spec.md) |
 | The feedback-case contract (baseline, marker file, lints) | [`docs/specs/feedback-case-spec.md`](specs/feedback-case-spec.md) |

--- a/docs/skill-lifecycle.md
+++ b/docs/skill-lifecycle.md
@@ -6,11 +6,11 @@ continually-improved artifact. It is the **complete flow** end to end and the
 entry point; it points at the detailed docs for each step rather than
 restating them.
 
-The work is done by a **genealogist and a developer pairing.**
-Genealogists are learning to run tests; developers are learning
-genealogy. Neither role does the whole loop alone — the genealogist owns
-*what good looks like*, the developer owns *how the skill and harness
-work*, and they decide together at the points that matter.
+You drive the whole loop — write the tests, run the harness, correct the
+grades, improve the skill, and open the PR. No step belongs to someone else.
+When a step needs a genealogy judgment you're unsure of, or a bit of harness
+mechanics you haven't hit before, pull in a teammate for a second pair of
+eyes — but the loop is yours end to end.
 
 ```
   0 branch → 1 create → 2 test → 3 review+annotate → 4 audit rubric →
@@ -23,11 +23,6 @@ work*, and they decide together at the points that matter.
   Description loop (8) = the vendored run_loop. Rubric audit (4) keeps the
   signal honest so (5) doesn't optimize toward a weak rubric.
 ```
-
-| Role | Owns | Across the lifecycle |
-|---|---|---|
-| **Genealogist** | Correctness — does the skill do genealogy right? | Writes tests + rubric, runs the harness, annotates grades, judges whether a proposed edit is *genealogically* correct, blesses releases. |
-| **Developer** | Mechanics — skills, scripts, harness, the loop. | Pairs on skill prose and scripts, runs the improver and the optimizer, builds the plugin, opens PRs, keeps the harness honest. |
 
 If you're brand new, read the two walkthroughs first:
 [`eval/JUNIOR-WALKTHROUGH.md`](../eval/JUNIOR-WALKTHROUGH.md) (genealogist)
@@ -89,20 +84,19 @@ ways.
 
 ### 0. Make a branch
 
-**Who:** whoever is driving. **Where:** ⌨️ terminal (developers) or GitHub
-Desktop (genealogists). **How:**
+**Who:** you. **Where:** ⌨️ terminal, or GitHub Desktop. **How:**
 
 One task, one branch, always cut from an up-to-date `main` — you open a PR from
 it at the end.
 
-**Developers — terminal:**
+**Terminal:**
 
 ```bash
 git checkout main && git pull
 git checkout -b <short-task-name>          # e.g. citation-locator
 ```
 
-**Genealogists — GitHub Desktop:** Current Branch dropdown → select **main** and
+**GitHub Desktop:** Current Branch dropdown → select **main** and
 **Fetch/Pull** → **New branch…** → name it `<short-task-name>` (e.g.
 `citation-locator`) → base it on `main` → **Create branch**.
 
@@ -121,7 +115,7 @@ to `main` are blocked, so starting on `main` just means moving the work later.
 
 ### 1. Create / edit a skill
 
-**Who:** pair. **Where:** 🤖 Claude Code at the repo root (or any text editor —
+**Who:** you. **Where:** 🤖 Claude Code at the repo root (or any text editor —
 the skill is just `packages/engine/plugin/skills/<skill>/SKILL.md`).
 **How:** for a new tool-wrapping skill, ask Claude Code to scaffold it with
 the `cowork-skill-builder` agent; otherwise edit the file directly.
@@ -130,13 +124,13 @@ Write the SKILL.md to the prose standard in
 [`docs/skill-authoring-guide.md`](skill-authoring-guide.md). (The authoring
 guide's "What kind of skill are you writing?" section covers whether it
 should be a skill at all and which of the three kinds — workflow,
-reference, or guardrail — it is.) The genealogist drives the domain
-content; the developer drives shape, frontmatter limits, and any
-`scripts/` helper.
+reference, or guardrail — it is.) You drive the domain content, the shape,
+the frontmatter limits, and any `scripts/` helper — pulling in help when a
+piece is outside your comfort zone.
 
 ### 2. Test
 
-**Who:** pair, genealogist-led. **Where:** ⌨️ terminal at the repo root.
+**Who:** you. **Where:** ⌨️ terminal at the repo root.
 **How:**
 
 ```bash
@@ -188,7 +182,7 @@ single biggest lever on whether the rest of the loop works.
 
 ### 3. Review & annotate
 
-**Who:** genealogist. **Where:** 🌐 the CRUD UI in your browser
+**Who:** you. **Where:** 🌐 the CRUD UI in your browser
 (<http://localhost:3000>), started from a terminal. **How:**
 
 ```bash
@@ -248,7 +242,7 @@ engineer rather than grind.
 
 ### 4. Audit the rubric (periodic; before a body-optimization push)
 
-**Who:** pair. **Where:** 🤖 Claude Code at the repo root — not Cowork, not the
+**Who:** you. **Where:** 🤖 Claude Code at the repo root — not Cowork, not the
 terminal. **How:**
 
 ```
@@ -270,7 +264,7 @@ run this periodically and whenever a dimension looks off.
 
 ### 5. Improve the skill body
 
-**Who:** pair. **Where:** 🤖 Claude Code at the repo root. **How:**
+**Who:** you. **Where:** 🤖 Claude Code at the repo root. **How:**
 
 ```
 /improve-skill <skill>
@@ -321,7 +315,7 @@ Cluster the failures across the skill's tests and revise the
 SKILL.md prose to fix them — explaining the *why*, not bolting on
 another MUST (see the authoring guide). The **skill-improver** agent
 (report-only) assists by reading the latest annotated run-log,
-clustering, and proposing an evidence-cited diff for the pair to approve. It
+clustering, and proposing an evidence-cited diff for you to approve. It
 **routes by cause** — a correction that actually points at a test-data gap, a
 triggering miss, or a rubric problem goes to the test author / description
 optimizer (step 8) / rubric review (step 4), not into a body edit; only a
@@ -360,7 +354,7 @@ next run). Full walkthrough:
 
 ### 6. Verify the fix
 
-**Who:** pair. **Where:** ⌨️ terminal at the repo root. **How:**
+**Who:** you. **Where:** ⌨️ terminal at the repo root. **How:**
 
 ```bash
 make gate-skill SKILL=<skill> TEST=<test-id>
@@ -424,7 +418,7 @@ still has to happen.
 
 ### 7. Release
 
-**Who:** senior blesses, developer ships. **Where:** two places — ⌨️ a terminal
+**Who:** you ship; a senior blesses. **Where:** two places — ⌨️ a terminal
 for the release run and the push, 🌐 the CRUD UI for the Release click.
 **How:**
 
@@ -491,12 +485,12 @@ Extensions, then fully quit and reopen Desktop. Cowork runs the uploaded plugin
 `.zip`, not your working tree — skip the rebuild and the fix will look like it
 did nothing. Optional in general: the harness run, not the Cowork walkthrough, is
 what CI and the release gate check. The one place it is *not* optional is an
-alpha feedback case, where a paired Cowork verification is a specced pre-PR step
+alpha feedback case, where a Cowork verification is a specced pre-PR step
 — see [`alpha-feedback-guide.md`](alpha-feedback-guide.md).
 
 ### 8. Optimize the description (separate, automated loop)
 
-**Who:** developer. **Where:** ⌨️ terminal at the repo root. **How:**
+**Who:** you. **Where:** ⌨️ terminal at the repo root. **How:**
 
 ```bash
 make optimize-skill SKILL=<skill>
@@ -538,7 +532,7 @@ live API), and plain-English **criteria**. You can ship a useful test with
 just a message and a scenario — the skill's shared rubric does the heavy
 grading; your criteria only add what's unique to *this* case. (If no
 scenario fits, pick the closest and note the gap — the test saves but
-won't run until a developer builds the matching scenario.)
+won't run until the matching scenario is built.)
 
 Aim for **at least 8 tests per skill** — no upper bound; we don't yet know
 enough to set one. Spend them on **coverage, not repetition**: eight easy
@@ -624,18 +618,15 @@ at the repo root and warn when hold-outs or annotations are missing.
 ## Worked example: a citation nobody could find again
 
 The stages above are the reference. This is one run through them, start to
-finish, for a pair doing it the first time — with the place marked at every
-step.
+finish, doing it for the first time — with the place marked at every step.
 
-> **The roles and names are for the story.** "Ana" (genealogist) and "Ben"
-> (developer) split the work to make it concrete, but the split is only
-> illustrative — **anyone can do any step they're comfortable with**, and one
-> person can run the whole loop. The Schuster family and the `schuster-census`
-> slug are invented too; for a real run, use an existing fixture slug from
-> `eval/tests/e2e/`.
+> **The story follows one person — "you" — running the whole loop**, which is
+> the normal case; **pull in a teammate for any step you're not comfortable
+> with.** The Schuster family and the `schuster-census` slug are invented; for a
+> real run, use an existing fixture slug from `eval/tests/e2e/`.
 
-**The problem.** Ana is researching the Schuster family. She asks Claude to
-cite a 1900 U.S. census record she just used. The `citation` skill writes a
+**The problem.** You're researching the Schuster family. You ask Claude to
+cite a 1900 U.S. census record you just used. The `citation` skill writes a
 tidy-looking citation — but it **leaves out the page and line number**. Without
 that, no one could ever open that exact record again.
 
@@ -668,15 +659,14 @@ git checkout -b citation-locator
 
 ### Step 1 — Notice it 🖥️ Cowork + Viewer
 
-Ana is working in a practice project. Ben seeded it for her earlier from a
-terminal:
+You're working in a practice project you seeded earlier from a terminal:
 
 ```
 make e2e-project TEST=schuster-census        # Windows: eval\SeedProject.bat
 ```
 
-That writes an editable project into `eval/e2e-project/schuster-census/`. Ana
-opens that folder in **two** places: **Cowork**, to do the research, and the
+That writes an editable project into `eval/e2e-project/schuster-census/`. Open
+that folder in **two** places: **Cowork**, to do the research, and the
 **Research Viewer**, to watch what gets written — launched from a *second*
 terminal and left running:
 
@@ -689,18 +679,18 @@ Then **Open Project** in the viewer and pick the same
 Skip this and you're judging the research from the chat transcript alone, which
 is exactly how a bad citation slips past.
 
-Mid-research she spots it and writes down, in plain words, what's wrong:
+Mid-research you spot it and write down, in plain words, what's wrong:
 
 > **Did:** the citation gave the census year and county but no page or line.
 > **Should:** it must include the page/line so the record can be found again.
 > **Gap:** the citation skill never says a citation has to be *relocatable*.
 
-That three-part note is the single most valuable thing she produces all day.
+That three-part note is the single most valuable thing you produce all day.
 Keep it — it goes on the record in Step 4 and drives Step 5.
 
 ### Step 2 — Is it even the skill's fault? 🤖 Claude Code
 
-Ben opens **Claude Code** at the **repo root** on the branch, and they check the
+Open **Claude Code** at the **repo root** on the branch and check the
 project's `results/` files — the actual data the tools returned. The census tool
 **did** return the page/line and the skill dropped it → a **skill** problem.
 Continue. ✅
@@ -711,8 +701,8 @@ classic trap.
 
 ### Step 3 — Capture it as a test 🤖 Claude Code
 
-In the same session, Ben runs **`mine-unit-test`**, points it at Ana's project
-folder, and pastes her Did/Should/Gap note:
+In the same session, run **`mine-unit-test`**, point it at the project
+folder, and paste your Did/Should/Gap note:
 
 ```
 /mine-unit-test --project eval/e2e-project/schuster-census
@@ -720,8 +710,8 @@ folder, and pastes her Did/Should/Gap note:
 
 It writes a unit test that reproduces the bug — "given a census record that has
 a page/line, the citation must include it" — plus a scenario and mock fixtures,
-all marked *draft* under `eval/tests/unit/citation/` and `eval/fixtures/`. Ben
-skims it and checks that the **general** rule is what's stated, not "this one
+all marked *draft* under `eval/tests/unit/citation/` and `eval/fixtures/`. Skim
+it and check that the **general** rule is what's stated, not "this one
 Schuster record."
 
 It prints the new test's id — say `ut_citation_019`. That's the `TEST=` value
@@ -730,7 +720,7 @@ for Step 6.
 ### Step 4 — Run it, and mark what's wrong ⌨️ Terminal → 🌐 browser
 
 `citation` already has its hold-out tests set (`ut_citation_001` and
-`ut_citation_014`), so Ben goes straight to the run — a brand-new skill would
+`ut_citation_014`), so you go straight to the run — a brand-new skill would
 need them set in the UI first, *before* this run.
 
 ```
@@ -738,8 +728,8 @@ make eval-skill SKILL=citation               # Windows: eval\RunTests.bat
 make eval-ui                                 # Windows: eval\Start.bat
 ```
 
-He finds the new test in the grading UI, sees which quality dimension it failed,
-and pastes **Ana's Did/Should/Gap note** into that dimension's comment. The
+Find the new test in the grading UI, see which quality dimension it failed,
+and paste **your Did/Should/Gap note** into that dimension's comment. The
 improver in the next step will do nothing with a brand-new test *unless* it
 carries a human comment like this.
 
@@ -751,11 +741,11 @@ carries a human comment like this.
 ```
 
 The first is a health check on the grading itself — do it once per skill so
-you're not chasing a broken grade. The second reads the test + Ana's comment and
+you're not chasing a broken grade. The second reads the test + your comment and
 proposes **at most 3** small, plain-English edits — e.g. *"every citation must
 include a locator (page/line/entry) that lets a reader reopen the exact record;
 if the record has none, write a 'missing locator' marker instead."* The agent
-only **proposes**; Ben pastes the edits into `citation/SKILL.md` himself.
+only **proposes**; you paste the edits into `citation/SKILL.md` yourself.
 
 ### Step 6 — Check the fix helps and breaks nothing ⌨️ Terminal
 
@@ -773,7 +763,7 @@ Rebuild and re-upload the plugin first so Cowork runs the *edited* skill:
 `make plugin` (Windows: `eval\BuildPlugin.bat`), then remove the old plugin in
 Cowork → Customize and upload the new `.zip`.
 
-Then Ana redoes the same citation, with the **Research Viewer** open on the same
+Then redo the same citation, with the **Research Viewer** open on the same
 project folder. The viewer is the point here, not a nicety: the fix is a
 *citation string in the research log*, and reading it there is how you confirm
 the page/line is actually present rather than trusting the chat's summary of
@@ -789,7 +779,7 @@ make eval-skill SKILL=citation               # Windows: eval\RunTests.bat
 make eval-ui                                 # Windows: eval\Start.bat
 ```
 
-Grade every dimension (**Agree with all**, then correct the few he disagrees
+Grade every dimension (**Agree with all**, then correct the few you disagree
 with), then commit the skill edit + the new test *and its scenario folder and
 mock fixtures* + the run record + the grades, and open the PR. A senior reviewer
 reads the corrected grades and, if it's a real improvement, releases it.

--- a/docs/specs/unit-test-spec.md
+++ b/docs/specs/unit-test-spec.md
@@ -46,9 +46,9 @@ True multi-turn dialogue support (canned user replies, scripted turn arrays) is 
 
 | Who | Writes | Graded by |
 |-----|--------|-----------|
-| Junior genealogists | JSON test files, scenarios, MCP fixtures via CRUD UI | LLM judge + human verification |
-| Developers | Python pytest files | pytest (deterministic) |
-| Senior genealogists | Skill rubrics, golden sets | Used as calibration baseline |
+| Junior genealogists + developers (one combined role) | JSON test files, scenarios, MCP fixtures, per-test `judge_context`, the **skill rubric** (`eval/tests/unit/<skill>/rubric.md`), and the Python pytest validators | LLM judge + human verification; pytest for the validators |
+| Senior genealogists | Golden sets; PR review and merge | Used as calibration baseline |
+| Project maintainer | Base rubric (shared by every skill), global judge prompt | — |
 
 ### What the test file contains
 
@@ -689,9 +689,16 @@ The judge scores two rubric tiers and additionally reads per-test background con
 
 | Tier | Defined where | Applies to | Who maintains | Scored? |
 |------|--------------|------------|---------------|---------|
-| Base rubric | Shared across all skills | Every unit test | Developers | yes — dimensions |
-| Skill rubric | `eval/tests/unit/<skill>/rubric.md` | Every test for one skill | Senior genealogists | yes — dimensions |
+| Base rubric | Shared across all skills | Every unit test | Project maintainer | yes — dimensions |
+| Skill rubric | `eval/tests/unit/<skill>/rubric.md` | Every test for one skill | Junior genealogists | yes — dimensions |
 | Per-test context | `judge_context` in test JSON | One test only | Junior genealogists | no — background only |
+
+The two junior-owned layers are both embedded in the run-log snapshot, so
+editing either invalidates the skill's latest run and forces a re-run before CI
+will pass. The base rubric and the global judge prompt are the maintainer's
+alone — a change to either re-baselines every skill in the project, which is why
+the judge prompt is tracked out-of-band as `judge_prompt_hash` (warn-only) rather
+than as skill-side state.
 
 The base and skill rubrics produce scored dimensions. `judge_context` is **not** scored: the judge reads it only as background to ground its rationales for the base + rubric dimensions (see §5.4).
 


### PR DESCRIPTION
Three passes over the team-facing workflow docs, for the junior team who work
one task at a time.

## 1. Standardize git branch management

One task, one whole-repo branch, no worktrees, PR at the end.

- Every "Branch" step offers two role-neutral paths with identical wording:
  **Terminal** (`git checkout main && git pull` → `git checkout -b <short-task-name>`)
  and **GitHub Desktop**.
- Flattened `feedback/2026-07-21T09-14-22Z` → `schuster-parent-fix`; no
  slash-namespaced or timestamped branch names.
- Dropped the `<your-name>-<skill>` prefix; unified the placeholder to
  `<short-task-name>`.

## 2. Collapse junior-genealogist + developer into "you"

One person takes point end to end and pulls in help when they need it. Removed
the Owns table, the per-stage `Who:` labels, the Ana/Ben/Sam split, and the
"ask a developer" escalations. **Senior genealogists** (PR review + merge) and
**alpha testers** are unchanged.

## 3. Restructure `skill-lifecycle.md` on a failure-first spine

Nearly all skill work starts from a real failure, not from authoring a skill:

`0 branch · 1 start from a real failure · 2 whose fault? · 3 capture a test · 4 run + grade (baseline) · 5 improve · 6 verify · 7 confirm in Cowork · 8 re-run + grade + PR`

The main body and the worked example (now **Appendix B**) share these step
numbers and titles verbatim. Step 1 gives **alpha feedback**, **e2e runs**, and
"you noticed it" equal billing — the first two are the norm. Authoring a new
skill and tuning a description move out of the numbered loop into side
sections. Test-corpus guidance becomes **Appendix A**.

### Substantive corrections that came out of it

- **Ownership.** The skill rubric and each test's `judge_context` belong to the
  person running the loop; the base rubric and global judge prompt are the
  maintainer's alone. Fixed in `unit-test-spec.md`'s two ownership tables and
  in both agents, which routed rubric findings to "the senior." Now documents
  that the two loop-runner-owned layers sit in the run-log snapshot, so editing
  either forces a re-run.
- **Test ids** are a random 3-char suffix (`ut_citation_k3f`), not sequential
  `<NNN>`. `mine-unit-test` still told the model to scan-and-increment — the
  exact collision the format change was meant to avoid.
- **Rebuild vs reinstall** made explicit: Claude Code (Desktop **Code tab** or
  CLI) needs no install because `.mcp.json` wires it — only a rebuild after a
  tool-code change. Cowork needs both the `.mcpb` and the plugin `.zip`.
- **Grading:** correct the score only where you disagree, but comment on *every
  non-passing dimension* — an uncommented failure only gets reported, not fixed.
- **Releases removed** (not doing them yet); a senior reviews and merges.
- Steps 4 and 8 retitled so the baseline run and the committed run stop looking
  like the same step done twice.
- Dropped the "why not just re-run `make eval-skill`?" box and de-jargoned the
  verification section.

## Files
`docs/skill-lifecycle.md` · `docs/e2e-testing-guide.md` ·
`docs/alpha-feedback-guide.md` · `docs/specs/unit-test-spec.md` ·
`.claude/agents/rubric-critic.md` · `.claude/agents/skill-improver.md` ·
`.claude/skills/mine-unit-test/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)