### PR TITLE
Require senior-genealogist review on all PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Every PR needs one approval from a senior genealogist (this team),
+# in addition to at least one more approval from anyone else with
+# write access. Enforced together with branch protection's
+# "required_approving_review_count: 2" + "require_code_owner_reviews".
+* @PioneerAIAcademy/senior-genealogists


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` naming `@PioneerAIAcademy/senior-genealogists` (Leduthet, ClorindaM) as owner of the whole repo.
- Once merged, `main`'s branch protection will require 2 approvals per PR, at least one from that team plus at least one more from anyone else with write access.

## Test plan
- [ ] Merge this PR
- [ ] Confirm branch protection update (`required_approving_review_count: 2`, `require_code_owner_reviews: true`) is applied on `main`
- [ ] Open a throwaway PR and confirm GitHub requests review from `senior-genealogists` and blocks merge until 2 approvals land

🤖 Generated with [Claude Code](https://claude.com/claude-code)