### PR TITLE
Add 32 draft record-hint e2e fixtures from filtered-list-samples.csv

### DIFF
--- a/eval/tests/e2e/anna-findejsova-daughter/README.md
+++ b/eval/tests/e2e/anna-findejsova-daughter/README.md
@@ -1,0 +1,34 @@
+# Anna Marie Findejsová — additional daughter Agnes (b. 1818)
+
+**Source PID:** `P915-7QP`
+**Anna Marie Findejsová is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+13 March 1784, Bystré, Polička, Bohemia; died not recorded in the tree.
+
+## Research question
+
+> Did Anna Marie Findejsová and her husband Maxmilián Michl have a daughter named Agnes, born 1818, in addition to their daughter Anna (b. 1823)?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `P915-7QP` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 4, flag `adds_daughter`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Czech Republic, Church Books, 1552-1981: baptismal entry, 1 March 1818, Svitavy, Moravská Třebová, naming parents Maxmilian Michal and Anna. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming the 1818 Agnes baptism, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the tree's spouse is recorded only as "Maxmilián Michl" (surname spelled without the hint record's "Michal"/"Michalová" variant) with no forename for the mother in the hint record beyond "Anna" — a first-name-only match against a subject whose full name is Anna Marie Findejsová. The tree's only other child, Anna Michlová, was born 16 September 1823 in the same parish (Bystré/Svitavy area) and died in infancy (1833) — a second daughter born five years earlier, in 1818, is chronologically plausible for a couple of Anna Marie's generation (b. 1784) but rests on a bare-forename match with no surname or patronymic corroboration in the extracted record.

--- a/eval/tests/e2e/anna-findejsova-daughter/expected-findings.json
+++ b/eval/tests/e2e/anna-findejsova-daughter/expected-findings.json
@@ -1,0 +1,21 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Anna Marie Findejsová and Maxmilián Michl had a daughter, Agnes, baptized 1 March 1818 in Svitavy, Moravská Třebová, in addition to their daughter Anna Michlová (b. 1823, d. 1833).",
+      "details": {
+        "subject_person": "Anna Marie Findejsová (P915-7QP)",
+        "relation": "child",
+        "target_person": {
+          "name": "Agnes Michl",
+          "birth": "1 March 1818, Bohemia (baptized Svitavy, Moravská Třebová)"
+        }
+      },
+      "supporting_sources": [
+        "Czech Republic, Church Books, 1552-1981 — baptismal entry, 1 Mar 1818, Svitavy, Moravská Třebová, naming parents Maxmilian Michal and Anna"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/anna-findejsova-daughter/fixture.json
+++ b/eval/tests/e2e/anna-findejsova-daughter/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "anna-findejsova-daughter",
+  "name": "Anna Marie Findejsová — additional daughter Agnes (b. 1818)",
+  "genre": "record-hint",
+  "source_pid": "P915-7QP",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Anna Marie Findejsová and her husband Maxmilián Michl have a daughter named Agnes, born 1818, in addition to their daughter Anna (b. 1823)?",
+  "tags": {
+    "question_type": "children",
+    "era": "1810s",
+    "geography": "CZ"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 4, flag adds_daughter, confidence 3). Draft transcribed from a Czech church baptismal record; unverified."
+}

--- a/eval/tests/e2e/anna-findejsova-daughter/starting-research.json
+++ b/eval/tests/e2e/anna-findejsova-daughter/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_anna_findejsova_daughter",
+    "objective": "Did Anna Marie Findejsová and her husband Maxmilián Michl have a daughter named Agnes, born 1818, in addition to their daughter Anna (b. 1823)?",
+    "subject_person_ids": [
+      "P915-7QP"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/anna-findejsova-daughter/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/anna-findejsova-daughter/starting-tree.gedcomx.json
@@ -1,0 +1,200 @@
+{
+  "persons": [
+    {
+      "id": "P915-7QP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Anna Marie",
+          "surname": "Findejsová"
+        }
+      ],
+      "facts": [
+        {
+          "id": "cdebdb72-84a9-483d-a2b4-f68a9f087b70",
+          "type": "Birth",
+          "date": "13. března 1784",
+          "standard_date": "13 1784",
+          "place": "Bystré 39, Polička, Čechy, Rakousko",
+          "standard_place": "Bistrau, Polička, Bohemia, Austria"
+        },
+        {
+          "id": "c052e626-e501-4ed0-81c5-04d3c6d698e2",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P915-SXM",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Maxmilián",
+          "surname": "Michl"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ecdbc620-b338-47a2-b81d-bd7fb24d3f26",
+          "type": "Birth",
+          "date": "1795",
+          "standard_date": "1795"
+        },
+        {
+          "id": "c8208efb-3776-4546-8ee7-55543c65847c",
+          "type": "Death",
+          "date": "2. června 1864",
+          "standard_date": "2 1864",
+          "place": "Bystré 30, Polička, Čechy, Rakousko",
+          "standard_place": "Bistrau, Polička, Bohemia, Austria"
+        }
+      ]
+    },
+    {
+      "id": "P91P-VCD",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Anna",
+          "surname": "Michlová"
+        }
+      ],
+      "facts": [
+        {
+          "id": "a6b36b17-54ec-4d5e-9208-771291fc9ac0",
+          "type": "Birth",
+          "date": "16. září 1823",
+          "standard_date": "16 1823",
+          "place": "Bystré 30, Polička, Čechy, Rakousko",
+          "standard_place": "Bistrau, Polička, Bohemia, Austria"
+        },
+        {
+          "id": "5392b51e-120d-4cd7-a52e-c93e2a38bbc3",
+          "type": "Baptism",
+          "date": "17 Sep 1823",
+          "standard_date": "17 Sep 1823",
+          "place": "Svitavy, Moravská Třebová, Morava, Rakousko",
+          "standard_place": "Zwittau, Mährisch Trübau, Moravia, Changgŭm-ni, SHIN-WON-GUN, South Hwanghae, North Korea"
+        },
+        {
+          "id": "8f8e603f-119c-4e33-8ac5-e95d00ef6312",
+          "type": "Death",
+          "date": "7. dubna 1833",
+          "standard_date": "7 1833",
+          "place": "Bystré 30, Polička, Čechy, Rakousko",
+          "standard_place": "Bistrau, Polička, Bohemia, Austria"
+        }
+      ]
+    },
+    {
+      "id": "P9VC-F53",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Marie",
+          "surname": "Češková"
+        }
+      ],
+      "facts": [
+        {
+          "id": "5dd06278-babd-42e6-8898-823bef4365ce",
+          "type": "Birth",
+          "date": "8. června 1761",
+          "standard_date": "8 1761",
+          "place": "Stašov, Polička, Čechy, Rakousko",
+          "standard_place": "Dittersbach, Polička, Bohemia"
+        },
+        {
+          "id": "02e03dd3-290d-43a8-8f4d-750c578a2265",
+          "type": "Death",
+          "date": "19. října 1842",
+          "standard_date": "19 1842",
+          "place": "Bystré 41, Polička, Čechy, Rakousko",
+          "standard_place": "Bistrau, Polička, Bohemia, Austria"
+        }
+      ]
+    },
+    {
+      "id": "P9VH-LKQ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Antonín",
+          "surname": "Findejs"
+        }
+      ],
+      "facts": [
+        {
+          "id": "e9ddb48d-ad0e-4161-b60a-1058f810bacd",
+          "type": "Birth",
+          "date": "27. října 1749",
+          "standard_date": "27 1749",
+          "place": "Bystré 49, Polička, Čechy, Rakousko",
+          "standard_place": "Bistrau, Polička, Bohemia, Austria"
+        },
+        {
+          "id": "0a3b6755-bc3f-4823-b7c8-73c00542df56",
+          "type": "Death",
+          "date": "10. května 1797",
+          "standard_date": "10 1797"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "P915-SXM",
+      "person2": "P915-7QP"
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "P9VH-LKQ",
+      "person2": "P9VC-F53"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "P9VH-LKQ",
+      "child": "P915-7QP"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "P9VC-F53",
+      "child": "P915-7QP"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "P915-SXM",
+      "child": "P91P-VCD"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "P915-7QP",
+      "child": "P91P-VCD"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7NNH-4Z1",
+      "title": "Anna, \"Czech Republic, Church Books, 1552-1981\"",
+      "citation": "\"Czech Republic, Church Books, 1552-1981\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6PJZ-CTT9 : Fri Mar 08 03:18:53 UTC 2024), Entry for Anna and Maxmilian Michl, 17 Sep 1823.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6PJZ-CTTZ"
+    }
+  ]
+}

--- a/eval/tests/e2e/anna-findejsova-daughter/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/anna-findejsova-daughter/unstripped-tree.gedcomx.json
@@ -1,0 +1,200 @@
+{
+  "persons": [
+    {
+      "id": "P915-7QP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Anna Marie",
+          "surname": "Findejsová"
+        }
+      ],
+      "facts": [
+        {
+          "id": "cdebdb72-84a9-483d-a2b4-f68a9f087b70",
+          "type": "Birth",
+          "date": "13. března 1784",
+          "standard_date": "13 1784",
+          "place": "Bystré 39, Polička, Čechy, Rakousko",
+          "standard_place": "Bistrau, Polička, Bohemia, Austria"
+        },
+        {
+          "id": "c052e626-e501-4ed0-81c5-04d3c6d698e2",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P915-SXM",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Maxmilián",
+          "surname": "Michl"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ecdbc620-b338-47a2-b81d-bd7fb24d3f26",
+          "type": "Birth",
+          "date": "1795",
+          "standard_date": "1795"
+        },
+        {
+          "id": "c8208efb-3776-4546-8ee7-55543c65847c",
+          "type": "Death",
+          "date": "2. června 1864",
+          "standard_date": "2 1864",
+          "place": "Bystré 30, Polička, Čechy, Rakousko",
+          "standard_place": "Bistrau, Polička, Bohemia, Austria"
+        }
+      ]
+    },
+    {
+      "id": "P91P-VCD",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Anna",
+          "surname": "Michlová"
+        }
+      ],
+      "facts": [
+        {
+          "id": "a6b36b17-54ec-4d5e-9208-771291fc9ac0",
+          "type": "Birth",
+          "date": "16. září 1823",
+          "standard_date": "16 1823",
+          "place": "Bystré 30, Polička, Čechy, Rakousko",
+          "standard_place": "Bistrau, Polička, Bohemia, Austria"
+        },
+        {
+          "id": "5392b51e-120d-4cd7-a52e-c93e2a38bbc3",
+          "type": "Baptism",
+          "date": "17 Sep 1823",
+          "standard_date": "17 Sep 1823",
+          "place": "Svitavy, Moravská Třebová, Morava, Rakousko",
+          "standard_place": "Zwittau, Mährisch Trübau, Moravia, Changgŭm-ni, SHIN-WON-GUN, South Hwanghae, North Korea"
+        },
+        {
+          "id": "8f8e603f-119c-4e33-8ac5-e95d00ef6312",
+          "type": "Death",
+          "date": "7. dubna 1833",
+          "standard_date": "7 1833",
+          "place": "Bystré 30, Polička, Čechy, Rakousko",
+          "standard_place": "Bistrau, Polička, Bohemia, Austria"
+        }
+      ]
+    },
+    {
+      "id": "P9VC-F53",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Marie",
+          "surname": "Češková"
+        }
+      ],
+      "facts": [
+        {
+          "id": "5dd06278-babd-42e6-8898-823bef4365ce",
+          "type": "Birth",
+          "date": "8. června 1761",
+          "standard_date": "8 1761",
+          "place": "Stašov, Polička, Čechy, Rakousko",
+          "standard_place": "Dittersbach, Polička, Bohemia"
+        },
+        {
+          "id": "02e03dd3-290d-43a8-8f4d-750c578a2265",
+          "type": "Death",
+          "date": "19. října 1842",
+          "standard_date": "19 1842",
+          "place": "Bystré 41, Polička, Čechy, Rakousko",
+          "standard_place": "Bistrau, Polička, Bohemia, Austria"
+        }
+      ]
+    },
+    {
+      "id": "P9VH-LKQ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Antonín",
+          "surname": "Findejs"
+        }
+      ],
+      "facts": [
+        {
+          "id": "e9ddb48d-ad0e-4161-b60a-1058f810bacd",
+          "type": "Birth",
+          "date": "27. října 1749",
+          "standard_date": "27 1749",
+          "place": "Bystré 49, Polička, Čechy, Rakousko",
+          "standard_place": "Bistrau, Polička, Bohemia, Austria"
+        },
+        {
+          "id": "0a3b6755-bc3f-4823-b7c8-73c00542df56",
+          "type": "Death",
+          "date": "10. května 1797",
+          "standard_date": "10 1797"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "P915-SXM",
+      "person2": "P915-7QP"
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "P9VH-LKQ",
+      "person2": "P9VC-F53"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "P9VH-LKQ",
+      "child": "P915-7QP"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "P9VC-F53",
+      "child": "P915-7QP"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "P915-SXM",
+      "child": "P91P-VCD"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "P915-7QP",
+      "child": "P91P-VCD"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7NNH-4Z1",
+      "title": "Anna, \"Czech Republic, Church Books, 1552-1981\"",
+      "citation": "\"Czech Republic, Church Books, 1552-1981\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6PJZ-CTT9 : Fri Mar 08 03:18:53 UTC 2024), Entry for Anna and Maxmilian Michl, 17 Sep 1823.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6PJZ-CTTZ"
+    }
+  ]
+}

--- a/eval/tests/e2e/anna-macek-son/README.md
+++ b/eval/tests/e2e/anna-macek-son/README.md
@@ -1,0 +1,34 @@
+# Anna Macek — additional son František (b. 1867)
+
+**Source PID:** `PW3W-LJN`
+**Anna Macek is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+1851; died not recorded in the tree.
+
+## Research question
+
+> Did Anna Macek and her husband Václav Jičinský of Rohovládova Bělá, Pardubice, Czechia have a son named František, baptized 1867?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `PW3W-LJN` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+hard — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 12, flag `adds_son`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Czech Republic, Church Books, 1552-1981: baptismal entry, 26 June 1867, Rohovládova Bělá, Pardubice, naming parents Váčlav Jičinsky and Anna. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming the 1867 František baptism, plus a `required` finding that the report documents the rejection.
+
+**Strong reason to doubt this match**: the tree records Anna Macek's own birth as **1851** and her marriage to Václav Jičinský as **7 February 1871**. A son baptized in **1867** would make Anna only 16 years old and would predate her recorded marriage by four years — a serious internal inconsistency. Either the tree's 1851 birth year for Anna is wrong, this "Anna" and "Václav Jičinský" (a bare-forename mother and a very common Czech husband-surname pairing) are a different couple in the same region, or the baptismal date was misindexed. This fixture is a strong candidate for outcome (c) (false match) but is left as a recover-type draft finding pending the genealogist's review of the underlying parish register.

--- a/eval/tests/e2e/anna-macek-son/expected-findings.json
+++ b/eval/tests/e2e/anna-macek-son/expected-findings.json
@@ -1,0 +1,21 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Anna Macek and Václav Jičinský had a son, František, baptized 26 June 1867 in Rohovládova Bělá, Pardubice. The tree currently records no children for Anna Macek.",
+      "details": {
+        "subject_person": "Anna Macek (PW3W-LJN)",
+        "relation": "child",
+        "target_person": {
+          "name": "František Jičinský",
+          "birth": "26 June 1867, Rohovládova Bělá, Pardubice, Czechia"
+        }
+      },
+      "supporting_sources": [
+        "Czech Republic, Church Books, 1552-1981 — baptismal entry, 26 Jun 1867, Rohovládova Bělá, Pardubice, naming parents Váčlav Jičinsky and Anna"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/anna-macek-son/fixture.json
+++ b/eval/tests/e2e/anna-macek-son/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "anna-macek-son",
+  "name": "Anna Macek — additional son František (b. 1867)",
+  "genre": "record-hint",
+  "source_pid": "PW3W-LJN",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Anna Macek and her husband Václav Jičinský of Rohovládova Bělá, Pardubice, Czechia have a son named František, baptized 1867?",
+  "tags": {
+    "question_type": "children",
+    "era": "1860s",
+    "geography": "CZ"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 12, flag adds_son, confidence 3). Draft transcribed from a Czech church baptismal record; unverified."
+}

--- a/eval/tests/e2e/anna-macek-son/starting-research.json
+++ b/eval/tests/e2e/anna-macek-son/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_anna_macek_son",
+    "objective": "Did Anna Macek and her husband Václav Jičinský of Rohovládova Bělá, Pardubice, Czechia have a son named František, baptized 1867?",
+    "subject_person_ids": [
+      "PW3W-LJN"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/anna-macek-son/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/anna-macek-son/starting-tree.gedcomx.json
@@ -1,0 +1,154 @@
+{
+  "persons": [
+    {
+      "id": "PW3W-LJN",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Anna",
+          "surname": "Macek"
+        }
+      ],
+      "facts": [
+        {
+          "id": "53c8a2cd-4ecd-47de-a283-9ab15bed100a",
+          "type": "Birth",
+          "date": "1851",
+          "standard_date": "1851"
+        },
+        {
+          "id": "7f25be0b-4680-4802-b3e6-bbdf0aa9ceaf",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PW34-KKV",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Jan",
+          "surname": "Macek"
+        }
+      ],
+      "facts": [
+        {
+          "id": "50728405-e381-4f46-bd92-35a4d9d2bc3f",
+          "type": "Death"
+        },
+        {
+          "id": "02dbf661-c696-432a-9931-cd47a8567a30",
+          "type": "Birth",
+          "place": "Rohoznice, Pardubice, Czechia",
+          "standard_place": "Rohoznice, Pardubice, Czechia"
+        }
+      ]
+    },
+    {
+      "id": "PW34-KK8",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Václav",
+          "surname": "Jičinský"
+        }
+      ],
+      "facts": [
+        {
+          "id": "302c08d7-3e9f-4332-b0e4-7824fa3f5e98",
+          "type": "Birth",
+          "date": "1844",
+          "standard_date": "1844",
+          "place": "Rohovládova Bělá, Pardubice, Czechia",
+          "standard_place": "Rohovládova Bělá, Pardubice, Czechia"
+        },
+        {
+          "id": "aa61679d-e252-45a3-a540-11950cd6229d",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PW34-H3N",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Kateřina",
+          "surname": "Doležal"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1b60d844-f3e7-4b3a-9da5-cee400711319",
+          "type": "Death"
+        },
+        {
+          "id": "c85e1e5f-ae7e-4168-9b13-ec748477592d",
+          "type": "Birth",
+          "place": "Rohoznice, Pardubice, Czechia",
+          "standard_place": "Rohoznice, Pardubice, Czechia"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "PW34-KK8",
+      "person2": "PW3W-LJN",
+      "facts": [
+        {
+          "id": "e10411a3-48f1-4867-8b61-2d51bfc6cd16",
+          "type": "Marriage",
+          "date": "7 February 1871",
+          "standard_date": "7 Feb 1871",
+          "place": "Křičeň, Pardubice, Čechy, Rakousko ",
+          "standard_place": "Křičeň, Bezirk Pardubitz, Bohemia, Manchester, Lancashire, England, United Kingdom"
+        },
+        {
+          "id": "a6298941-d207-492a-abdf-697e0e2628c4",
+          "type": "Marriage",
+          "date": "7 Feb 1871",
+          "standard_date": "7 Feb 1871",
+          "place": "Křičeň, Pardubice, Čechy, Rakousko",
+          "standard_place": "Křičeň, Bezirk Pardubitz, Bohemia, Manchester, Lancashire, England, United Kingdom"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "PW34-KKV",
+      "person2": "PW34-H3N"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "PW34-KKV",
+      "child": "PW3W-LJN"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "PW34-H3N",
+      "child": "PW3W-LJN"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7Y8G-D3W",
+      "title": "Anna Macek, \"Czech Republic, Church Books, 1552-1981\"",
+      "citation": "\"Czech Republic, Church Books, 1552-1981\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6PFD-Q43C : Tue Sep 03 17:49:48 UTC 2024), Entry for Václav Jičinský and Františka Jičinský, 7 Feb 1871.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6PFD-Q43D"
+    }
+  ]
+}

--- a/eval/tests/e2e/anna-macek-son/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/anna-macek-son/unstripped-tree.gedcomx.json
@@ -1,0 +1,154 @@
+{
+  "persons": [
+    {
+      "id": "PW3W-LJN",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Anna",
+          "surname": "Macek"
+        }
+      ],
+      "facts": [
+        {
+          "id": "53c8a2cd-4ecd-47de-a283-9ab15bed100a",
+          "type": "Birth",
+          "date": "1851",
+          "standard_date": "1851"
+        },
+        {
+          "id": "7f25be0b-4680-4802-b3e6-bbdf0aa9ceaf",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PW34-KKV",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Jan",
+          "surname": "Macek"
+        }
+      ],
+      "facts": [
+        {
+          "id": "50728405-e381-4f46-bd92-35a4d9d2bc3f",
+          "type": "Death"
+        },
+        {
+          "id": "02dbf661-c696-432a-9931-cd47a8567a30",
+          "type": "Birth",
+          "place": "Rohoznice, Pardubice, Czechia",
+          "standard_place": "Rohoznice, Pardubice, Czechia"
+        }
+      ]
+    },
+    {
+      "id": "PW34-KK8",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Václav",
+          "surname": "Jičinský"
+        }
+      ],
+      "facts": [
+        {
+          "id": "302c08d7-3e9f-4332-b0e4-7824fa3f5e98",
+          "type": "Birth",
+          "date": "1844",
+          "standard_date": "1844",
+          "place": "Rohovládova Bělá, Pardubice, Czechia",
+          "standard_place": "Rohovládova Bělá, Pardubice, Czechia"
+        },
+        {
+          "id": "aa61679d-e252-45a3-a540-11950cd6229d",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PW34-H3N",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Kateřina",
+          "surname": "Doležal"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1b60d844-f3e7-4b3a-9da5-cee400711319",
+          "type": "Death"
+        },
+        {
+          "id": "c85e1e5f-ae7e-4168-9b13-ec748477592d",
+          "type": "Birth",
+          "place": "Rohoznice, Pardubice, Czechia",
+          "standard_place": "Rohoznice, Pardubice, Czechia"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "PW34-KK8",
+      "person2": "PW3W-LJN",
+      "facts": [
+        {
+          "id": "e10411a3-48f1-4867-8b61-2d51bfc6cd16",
+          "type": "Marriage",
+          "date": "7 February 1871",
+          "standard_date": "7 Feb 1871",
+          "place": "Křičeň, Pardubice, Čechy, Rakousko ",
+          "standard_place": "Křičeň, Bezirk Pardubitz, Bohemia, Manchester, Lancashire, England, United Kingdom"
+        },
+        {
+          "id": "a6298941-d207-492a-abdf-697e0e2628c4",
+          "type": "Marriage",
+          "date": "7 Feb 1871",
+          "standard_date": "7 Feb 1871",
+          "place": "Křičeň, Pardubice, Čechy, Rakousko",
+          "standard_place": "Křičeň, Bezirk Pardubitz, Bohemia, Manchester, Lancashire, England, United Kingdom"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "PW34-KKV",
+      "person2": "PW34-H3N"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "PW34-KKV",
+      "child": "PW3W-LJN"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "PW34-H3N",
+      "child": "PW3W-LJN"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7Y8G-D3W",
+      "title": "Anna Macek, \"Czech Republic, Church Books, 1552-1981\"",
+      "citation": "\"Czech Republic, Church Books, 1552-1981\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6PFD-Q43C : Tue Sep 03 17:49:48 UTC 2024), Entry for Václav Jičinský and Františka Jičinský, 7 Feb 1871.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6PFD-Q43D"
+    }
+  ]
+}

--- a/eval/tests/e2e/antonio-lucas-spouse/README.md
+++ b/eval/tests/e2e/antonio-lucas-spouse/README.md
@@ -1,0 +1,34 @@
+# Antonio Fernandes Lucas — a second wife, Antonia de Jesus?
+
+**Source PID:** `GK89-82B`
+**Antonio Fernandes Lucas is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+1838, Santo António, Funchal, Madeira, Portugal; died not recorded in the tree.
+
+## Research question
+
+> Did Antonio Fernandes Lucas of Funchal, Madeira have a wife named Antonia de Jesus, distinct from his tree-recorded wife Maria Joana (m. 1890), and a daughter named Maria who died young?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `GK89-82B` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+hard — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 27, flags `adds_spouse`/`adds_daughter`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Portugal, Registro Civil, 1437-2023: death registration for Maria (b. Jul 1894, Santo António, Funchal, Madeira), naming parents Antonio Fernandes Fernandes Lucas and Antonia de Jesus de Jesus. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Antonia de Jesus de Jesus as a wife of the subject, plus a `required` finding that the report documents the rejection.
+
+**Strong reason to doubt this match**: the tree already records Antonio Fernandes Lucas married to **Maria Joana** on 8 February 1890, with two children (Antonio b. 1896, Julia b. 1899). The hint record instead pairs him with an entirely **different** wife, "Antonia de Jesus de Jesus", and a daughter "Maria" born 1894 — squarely in the middle of his documented marriage to Maria Joana, yet naming a different mother. "Antonio Fernandes Lucas" (and the doubled-surname variant "Fernandes Fernandes Lucas", a known Portuguese patronymic-doubling quirk) is a common name combination in the small parish of Santo António, Funchal, raising real odds that this record belongs to a different man of the same name. This fixture is a strong candidate for outcome (c) (false match) but is left as a recover-type draft finding pending the genealogist's review; the daughter finding is marked `required: false` given it rides entirely on the more doubtful spouse claim.

--- a/eval/tests/e2e/antonio-lucas-spouse/expected-findings.json
+++ b/eval/tests/e2e/antonio-lucas-spouse/expected-findings.json
@@ -1,0 +1,38 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Antonio Fernandes Fernandes Lucas's wife was Antonia de Jesus de Jesus — a different name from the tree's recorded wife, Maria Joana (married 1890).",
+      "details": {
+        "subject_person": "Antonio Fernandes Lucas (GK89-82B)",
+        "relation": "spouse",
+        "target_person": {
+          "name": "Antonia de Jesus de Jesus",
+          "birth": "unknown, likely Santo António, Funchal, Madeira, Portugal"
+        }
+      },
+      "supporting_sources": [
+        "Portugal, Registro Civil, 1437-2023 — death registration for Maria (b. Jul 1894), naming parents Antonio Fernandes Fernandes Lucas and Antonia de Jesus de Jesus"
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "relationship",
+      "description": "Antonio Fernandes Fernandes Lucas and Antonia de Jesus de Jesus had a daughter, Maria, born July 1894 and who died young, per the same death registration.",
+      "details": {
+        "subject_person": "Antonio Fernandes Lucas (GK89-82B)",
+        "relation": "child",
+        "target_person": {
+          "name": "Maria",
+          "birth": "July 1894, Santo António, Funchal, Madeira, Portugal"
+        }
+      },
+      "supporting_sources": [
+        "Portugal, Registro Civil, 1437-2023 — death registration for Maria, b. Jul 1894, Santo António, Funchal, Madeira"
+      ],
+      "required": false
+    }
+  ]
+}

--- a/eval/tests/e2e/antonio-lucas-spouse/fixture.json
+++ b/eval/tests/e2e/antonio-lucas-spouse/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "antonio-lucas-spouse",
+  "name": "Antonio Fernandes Lucas — a second wife, Antonia de Jesus?",
+  "genre": "record-hint",
+  "source_pid": "GK89-82B",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Antonio Fernandes Lucas of Funchal, Madeira have a wife named Antonia de Jesus, distinct from his tree-recorded wife Maria Joana (m. 1890), and a daughter named Maria who died young?",
+  "tags": {
+    "question_type": "spouse",
+    "era": "1890s",
+    "geography": "PT"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 27, flags adds_spouse/adds_daughter, confidence 3). Draft transcribed from a Portuguese civil death record; unverified."
+}

--- a/eval/tests/e2e/antonio-lucas-spouse/starting-research.json
+++ b/eval/tests/e2e/antonio-lucas-spouse/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_antonio_lucas_spouse",
+    "objective": "Did Antonio Fernandes Lucas of Funchal, Madeira have a wife named Antonia de Jesus, distinct from his tree-recorded wife Maria Joana (m. 1890), and a daughter named Maria who died young?",
+    "subject_person_ids": [
+      "GK89-82B"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/antonio-lucas-spouse/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/antonio-lucas-spouse/starting-tree.gedcomx.json
@@ -1,0 +1,282 @@
+{
+  "persons": [
+    {
+      "id": "GK89-82B",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Antonio Fernandes",
+          "surname": "Lucas"
+        }
+      ],
+      "facts": [
+        {
+          "id": "baaad2fb-35a1-49c4-a855-fd91e3dd8834",
+          "type": "Birth",
+          "date": "1838",
+          "standard_date": "1838",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "940e5148-66f0-45ad-9521-7185b77f3a5c",
+          "type": "Death"
+        },
+        {
+          "id": "68633657-90a4-4dfe-8d18-2ea25498efa8",
+          "type": "Christening",
+          "date": "22 de abril de 1838",
+          "standard_date": "22 Apr 1838",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        }
+      ]
+    },
+    {
+      "id": "GK89-48Z",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Maria",
+          "surname": "Joana"
+        }
+      ],
+      "facts": [
+        {
+          "id": "0699d8db-89f8-4743-b0d8-f142820b349a",
+          "type": "Birth",
+          "date": "1869",
+          "standard_date": "1869",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "092c492b-ef46-4668-9693-83612fa5e834",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GK8M-J38",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Antonio Fernandes de",
+          "surname": "Lucas"
+        }
+      ],
+      "facts": [
+        {
+          "id": "7760cb2b-56c9-4a52-88be-f468a9219748",
+          "type": "Birth",
+          "date": "1896",
+          "standard_date": "1896",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "73a4ee81-108b-4062-ba20-a8b34d667857",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GK8S-VV6",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Francisca",
+          "surname": "Luisa"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1fed7bf0-4673-4d87-823f-3806a3ee41ff",
+          "type": "Birth",
+          "date": "1803",
+          "standard_date": "1803",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "1708be62-8996-4d1a-bb16-888cf7ed72e9",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GK8S-ZDH",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "José Fernandes",
+          "surname": "Lucas"
+        }
+      ],
+      "facts": [
+        {
+          "id": "16634a90-3f10-4d26-ae4c-59fa337ed214",
+          "type": "Birth",
+          "date": "1802",
+          "standard_date": "1802",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "853e44f6-6299-4b26-8235-7c016b316577",
+          "type": "Death",
+          "date": "31 de julho de 1871",
+          "standard_date": "31 Jul 1871",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "f2754a93-5e1d-4f49-b387-bb0fac49cbdb",
+          "type": "Burial",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        }
+      ]
+    },
+    {
+      "id": "GK89-T3X",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Julia do Espirito Santo",
+          "surname": "Lucas"
+        }
+      ],
+      "facts": [
+        {
+          "id": "f5c58317-123c-4d91-a69b-6cfffda87d85",
+          "type": "Birth",
+          "date": "1899",
+          "standard_date": "1899",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "ffc25120-4619-40db-8273-18ae2ae28461",
+          "type": "Death",
+          "date": "13 de março de 1967",
+          "standard_date": "13 Mar 1967",
+          "place": "Nossa Senhora do Monte, Monte, Funchal, Madeira, Portugal",
+          "standard_place": "Nossa Senhora do Monte, Monte, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "4c933070-a237-45b7-aa3f-ccac3376516b",
+          "type": "Burial",
+          "place": "Monte, Funchal, Madeira, Portugal",
+          "standard_place": "Monte, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "1d06a6c6-db31-4903-a612-2bdb09b9883f",
+          "type": "Occupation",
+          "value": "domestica"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GK89-82B",
+      "person2": "GK89-48Z",
+      "facts": [
+        {
+          "id": "a9faea3e-4483-41a0-8cdf-7b20eeb21205",
+          "type": "Marriage",
+          "date": "8 de fevereiro de 1890",
+          "standard_date": "8 Feb 1890",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "GK8S-ZDH",
+      "person2": "GK8S-VV6",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "1826",
+          "standard_date": "1826",
+          "place": "Funchal, Madeira, Portugal",
+          "standard_place": "Funchal, Madeira, Portugal"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GK8S-ZDH",
+      "child": "GK89-82B"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GK8S-VV6",
+      "child": "GK89-82B"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GK89-82B",
+      "child": "GK8M-J38"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "GK89-48Z",
+      "child": "GK8M-J38"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "GK89-82B",
+      "child": "GK89-T3X"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "GK89-48Z",
+      "child": "GK89-T3X"
+    }
+  ],
+  "sources": [
+    {
+      "id": "QWYM-8LP",
+      "title": "Casamento",
+      "citation": "continua\nhttps://arquivo-abm.madeira.gov.pt/storageimage/?id=DISSEMINATION/525EBC0C7D746819352C1B1A7846E128&proto=vault&",
+      "url": "https://arquivo-abm.madeira.gov.pt/storageimage/?id=DISSEMINATION/EE9DA42F08CC080BEACE1C8D7A6BC198&proto=vault&"
+    },
+    {
+      "id": "QWYM-R4M",
+      "title": "Batismo",
+      "url": "https://arquivo-abm.madeira.gov.pt/storageimage/?id=DISSEMINATION/332D72389E405181B8EF8876FAA4D92C&proto=vault&"
+    },
+    {
+      "id": "748G-VSR",
+      "title": "Antônio Fernandes Lucas, “Portugal, Registro Civil, 1437-2023”",
+      "citation": "\"Portugal, Registro Civil, 1437-2023\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:65Y2-YP94 : Fri Jan 09 19:10:42 UTC 2026), Entry for Julia do Espirito Santo Lucas and Antônio Fernandes Lucas, 13 de março de 1967.",
+      "url": "https://familysearch.org/ark:/61903/1:1:65Y2-YP9H"
+    }
+  ]
+}

--- a/eval/tests/e2e/antonio-lucas-spouse/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/antonio-lucas-spouse/unstripped-tree.gedcomx.json
@@ -1,0 +1,282 @@
+{
+  "persons": [
+    {
+      "id": "GK89-82B",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Antonio Fernandes",
+          "surname": "Lucas"
+        }
+      ],
+      "facts": [
+        {
+          "id": "baaad2fb-35a1-49c4-a855-fd91e3dd8834",
+          "type": "Birth",
+          "date": "1838",
+          "standard_date": "1838",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "940e5148-66f0-45ad-9521-7185b77f3a5c",
+          "type": "Death"
+        },
+        {
+          "id": "68633657-90a4-4dfe-8d18-2ea25498efa8",
+          "type": "Christening",
+          "date": "22 de abril de 1838",
+          "standard_date": "22 Apr 1838",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        }
+      ]
+    },
+    {
+      "id": "GK89-48Z",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Maria",
+          "surname": "Joana"
+        }
+      ],
+      "facts": [
+        {
+          "id": "0699d8db-89f8-4743-b0d8-f142820b349a",
+          "type": "Birth",
+          "date": "1869",
+          "standard_date": "1869",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "092c492b-ef46-4668-9693-83612fa5e834",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GK8M-J38",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Antonio Fernandes de",
+          "surname": "Lucas"
+        }
+      ],
+      "facts": [
+        {
+          "id": "7760cb2b-56c9-4a52-88be-f468a9219748",
+          "type": "Birth",
+          "date": "1896",
+          "standard_date": "1896",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "73a4ee81-108b-4062-ba20-a8b34d667857",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GK8S-VV6",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Francisca",
+          "surname": "Luisa"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1fed7bf0-4673-4d87-823f-3806a3ee41ff",
+          "type": "Birth",
+          "date": "1803",
+          "standard_date": "1803",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "1708be62-8996-4d1a-bb16-888cf7ed72e9",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GK8S-ZDH",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "José Fernandes",
+          "surname": "Lucas"
+        }
+      ],
+      "facts": [
+        {
+          "id": "16634a90-3f10-4d26-ae4c-59fa337ed214",
+          "type": "Birth",
+          "date": "1802",
+          "standard_date": "1802",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "853e44f6-6299-4b26-8235-7c016b316577",
+          "type": "Death",
+          "date": "31 de julho de 1871",
+          "standard_date": "31 Jul 1871",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "f2754a93-5e1d-4f49-b387-bb0fac49cbdb",
+          "type": "Burial",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        }
+      ]
+    },
+    {
+      "id": "GK89-T3X",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Julia do Espirito Santo",
+          "surname": "Lucas"
+        }
+      ],
+      "facts": [
+        {
+          "id": "f5c58317-123c-4d91-a69b-6cfffda87d85",
+          "type": "Birth",
+          "date": "1899",
+          "standard_date": "1899",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "ffc25120-4619-40db-8273-18ae2ae28461",
+          "type": "Death",
+          "date": "13 de março de 1967",
+          "standard_date": "13 Mar 1967",
+          "place": "Nossa Senhora do Monte, Monte, Funchal, Madeira, Portugal",
+          "standard_place": "Nossa Senhora do Monte, Monte, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "4c933070-a237-45b7-aa3f-ccac3376516b",
+          "type": "Burial",
+          "place": "Monte, Funchal, Madeira, Portugal",
+          "standard_place": "Monte, Funchal, Madeira, Portugal"
+        },
+        {
+          "id": "1d06a6c6-db31-4903-a612-2bdb09b9883f",
+          "type": "Occupation",
+          "value": "domestica"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GK89-82B",
+      "person2": "GK89-48Z",
+      "facts": [
+        {
+          "id": "a9faea3e-4483-41a0-8cdf-7b20eeb21205",
+          "type": "Marriage",
+          "date": "8 de fevereiro de 1890",
+          "standard_date": "8 Feb 1890",
+          "place": "Santo António, Funchal, Madeira, Portugal",
+          "standard_place": "Santo António, Funchal, Madeira, Portugal"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "GK8S-ZDH",
+      "person2": "GK8S-VV6",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "1826",
+          "standard_date": "1826",
+          "place": "Funchal, Madeira, Portugal",
+          "standard_place": "Funchal, Madeira, Portugal"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GK8S-ZDH",
+      "child": "GK89-82B"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GK8S-VV6",
+      "child": "GK89-82B"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GK89-82B",
+      "child": "GK8M-J38"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "GK89-48Z",
+      "child": "GK8M-J38"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "GK89-82B",
+      "child": "GK89-T3X"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "GK89-48Z",
+      "child": "GK89-T3X"
+    }
+  ],
+  "sources": [
+    {
+      "id": "QWYM-8LP",
+      "title": "Casamento",
+      "citation": "continua\nhttps://arquivo-abm.madeira.gov.pt/storageimage/?id=DISSEMINATION/525EBC0C7D746819352C1B1A7846E128&proto=vault&",
+      "url": "https://arquivo-abm.madeira.gov.pt/storageimage/?id=DISSEMINATION/EE9DA42F08CC080BEACE1C8D7A6BC198&proto=vault&"
+    },
+    {
+      "id": "QWYM-R4M",
+      "title": "Batismo",
+      "url": "https://arquivo-abm.madeira.gov.pt/storageimage/?id=DISSEMINATION/332D72389E405181B8EF8876FAA4D92C&proto=vault&"
+    },
+    {
+      "id": "748G-VSR",
+      "title": "Antônio Fernandes Lucas, “Portugal, Registro Civil, 1437-2023”",
+      "citation": "\"Portugal, Registro Civil, 1437-2023\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:65Y2-YP94 : Fri Jan 09 19:10:42 UTC 2026), Entry for Julia do Espirito Santo Lucas and Antônio Fernandes Lucas, 13 de março de 1967.",
+      "url": "https://familysearch.org/ark:/61903/1:1:65Y2-YP9H"
+    }
+  ]
+}

--- a/eval/tests/e2e/chresten-nielsen-daughter/README.md
+++ b/eval/tests/e2e/chresten-nielsen-daughter/README.md
@@ -1,0 +1,34 @@
+# Chresten Nielsen — additional daughter Birte (b. 1805)
+
+**Source PID:** `KN3K-9Q3`
+**Chresten Nielsen is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+1760, of Bjerre, Vejle, Denmark; died not recorded in the tree.
+
+## Research question
+
+> Did Chresten Nielsen and his wife Birte Kirstine Sørensdatter of Tyrsted, Vejle, Denmark have a daughter named Birte, born 1805, in addition to their nine known children (b. 1791-1801)?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `KN3K-9Q3` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 13, flag `adds_daughter`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Denmark, Baptisms, 1618-1923: christening entry, 6 October 1805, Tyrsted, Vejle, naming parents Chresten Nielsen and Birte Kirstine. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming the 1805 Birte christening, plus a `required` finding that the report documents the rejection.
+
+In favor of the match: both parents' names match exactly (Chresten Nielsen and Birte Kirstine, the tree's spouse being christened "Birte Kirstine Sørensdatter"), the parish (Tyrsted, Vejle) matches every one of the couple's nine other children exactly, and a birth in 1805 fits neatly after the youngest child already in the tree (Rasmus, b. 1801, died in infancy) — a gap of four years, plausible for a couple married in 1790. No contradicting evidence was found in the fetched tree data.

--- a/eval/tests/e2e/chresten-nielsen-daughter/expected-findings.json
+++ b/eval/tests/e2e/chresten-nielsen-daughter/expected-findings.json
@@ -1,0 +1,21 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Chresten Nielsen and Birte Kirstine had a daughter, Birte, born 3 August 1805 in Dallerup and christened 6 October 1805 in Tyrsted, Vejle, in addition to their nine children already in the tree (b. 1791-1801).",
+      "details": {
+        "subject_person": "Chresten Nielsen (KN3K-9Q3)",
+        "relation": "child",
+        "target_person": {
+          "name": "Birte Nielsen",
+          "birth": "3 August 1805, Dallerup, Vejle, Denmark"
+        }
+      },
+      "supporting_sources": [
+        "Denmark, Baptisms, 1618-1923 — christening entry, 6 Oct 1805, Tyrsted, Vejle, naming parents Chresten Nielsen and Birte Kirstine"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/chresten-nielsen-daughter/fixture.json
+++ b/eval/tests/e2e/chresten-nielsen-daughter/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "chresten-nielsen-daughter",
+  "name": "Chresten Nielsen — additional daughter Birte (b. 1805)",
+  "genre": "record-hint",
+  "source_pid": "KN3K-9Q3",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Chresten Nielsen and his wife Birte Kirstine Sørensdatter of Tyrsted, Vejle, Denmark have a daughter named Birte, born 1805, in addition to their nine known children (b. 1791-1801)?",
+  "tags": {
+    "question_type": "children",
+    "era": "1800s",
+    "geography": "DK"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 13, flag adds_daughter, confidence 3). Draft transcribed from a Danish baptismal record; unverified."
+}

--- a/eval/tests/e2e/chresten-nielsen-daughter/starting-research.json
+++ b/eval/tests/e2e/chresten-nielsen-daughter/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_chresten_nielsen_daughter",
+    "objective": "Did Chresten Nielsen and his wife Birte Kirstine Sørensdatter of Tyrsted, Vejle, Denmark have a daughter named Birte, born 1805, in addition to their nine known children (b. 1791-1801)?",
+    "subject_person_ids": [
+      "KN3K-9Q3"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/chresten-nielsen-daughter/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/chresten-nielsen-daughter/starting-tree.gedcomx.json
@@ -1,0 +1,516 @@
+{
+  "persons": [
+    {
+      "id": "KN3K-9Q3",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Chresten",
+          "surname": "Nielsen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1760",
+          "standard_date": "1760",
+          "place": "of Bjerre, Vejle, Denmark",
+          "standard_place": "Bjerre, Stjernholm, Denmark"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MNL5-NHM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Anne",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "27 Apr 1796",
+          "standard_date": "27 Apr 1796",
+          "place": "Uth, Vejle, Den.",
+          "standard_place": "Uth, Stjernholm, Denmark"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "infant",
+          "standard_date": "(in infancy)"
+        }
+      ]
+    },
+    {
+      "id": "MK6Q-GRK",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Soren",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "10 JAN 1793",
+          "standard_date": "10 Jan 1793"
+        },
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "10 JAN 1793",
+          "standard_date": "10 Jan 1793",
+          "place": "Tyrsted,Vejle,Denmark",
+          "standard_place": "Tyrsted, Vejle, Denmark"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "KF5M-XQ6",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Birte Kirstine",
+          "surname": "Sorensdr."
+        }
+      ],
+      "facts": [
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "13 Jun 1762",
+          "standard_date": "13 Jun 1762",
+          "place": "Uth, Vejle, Den.",
+          "standard_place": "Uth, Stjernholm, Denmark"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "KHFD-S9C",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Soren",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1793",
+          "standard_date": "1793",
+          "place": "Uth, Vejle, Denmark",
+          "standard_place": "Uth, Stjernholm, Denmark"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MK6Q-FK4",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Anne",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "27 APR 1797",
+          "standard_date": "27 Apr 1797"
+        },
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "27 APR 1797",
+          "standard_date": "27 Apr 1797",
+          "place": "Tyrsted,Vejle,Denmark",
+          "standard_place": "Tyrsted, Vejle, Denmark"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "KDMR-HF8",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Peder",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "15 FEB 1799",
+          "standard_date": "15 Feb 1799",
+          "place": "Tyrsted,Vejle,Denmark",
+          "standard_place": "Tyrsted, Vejle, Denmark"
+        },
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "15Feb1799",
+          "standard_date": "15 Feb 1799",
+          "place": "Uth, Vejle, Denmark",
+          "standard_place": "Uth, Stjernholm, Denmark"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MK6Q-5S9",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Jesper",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "09 DEC 1794",
+          "standard_date": "9 Dec 1794"
+        },
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "09 DEC 1794",
+          "standard_date": "9 Dec 1794",
+          "place": "Tyrsted,Vejle,Denmark",
+          "standard_place": "Tyrsted, Vejle, Denmark"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "K8R3-YR7",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Rasmus",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "29 Apr 1801",
+          "standard_date": "29 Apr 1801",
+          "place": "Uth, Vejle, Den.",
+          "standard_place": "Uth, Stjernholm, Denmark"
+        },
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "29 APR 1801",
+          "standard_date": "29 Apr 1801",
+          "place": "Tyrsted,Vejle,Denmark",
+          "standard_place": "Tyrsted, Vejle, Denmark"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death",
+          "date": "infant",
+          "standard_date": "(in infancy)"
+        }
+      ]
+    },
+    {
+      "id": "KCJV-D6Z",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "Jesper",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "9Dec1795",
+          "standard_date": "9 Dec 1795",
+          "place": "Uth, Vejle, Denmark",
+          "standard_place": "Uth, Stjernholm, Denmark"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "K82K-9GG",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N11",
+          "given": "Karen",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1791",
+          "standard_date": "1791",
+          "place": "Uth, Vejle, Denmark",
+          "standard_place": "Uth, Stjernholm, Denmark"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "KN3K-9Q3",
+      "person2": "KF5M-XQ6",
+      "facts": [
+        {
+          "id": "c2548be5-44c9-49c5-ae5a-d0a959a813e6",
+          "type": "Marriage",
+          "date": "13Mar1790",
+          "standard_date": "13 Mar 1790"
+        },
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "13 MAR 1790",
+          "standard_date": "13 Mar 1790",
+          "place": "Tyrsted,Vejle,Denmark",
+          "standard_place": "Tyrsted, Vejle, Denmark"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "K82K-9GG",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "K82K-9GG",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "MK6Q-GRK",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "MK6Q-GRK",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "KHFD-S9C",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "KHFD-S9C",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "MK6Q-5S9",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "MK6Q-5S9",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "KCJV-D6Z",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "KCJV-D6Z",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "MNL5-NHM",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "MNL5-NHM",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "MK6Q-FK4",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "MK6Q-FK4",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "KDMR-HF8",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R17",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "KDMR-HF8",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R18",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "K8R3-YR7",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R19",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "K8R3-YR7",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7T2G-MGH",
+      "title": "Chresten Nielsen in entry for Jesper, \"Denmark, Baptisms, 1618-1923\"",
+      "citation": "\"Denmark, Baptisms, 1618-1923\", database, <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H2GP-QHZM : 23 June 2020), Chresten Nielsen in entry for Jesper, 1795.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H2GP-QHZM"
+    },
+    {
+      "id": "7T2G-MBM",
+      "title": "Chresten Nielsen in entry for Anne, \"Denmark, Baptisms, 1618-1923\"",
+      "citation": "\"Denmark, Baptisms, 1618-1923\", database, <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H2GK-5Z6Z : 23 June 2020), Chresten Nielsen in entry for Anne, 1797.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H2GK-5Z6Z"
+    },
+    {
+      "id": "7T2G-9SN",
+      "title": "Chresten Nielsen in entry for Rasmus, \"Denmark, Baptisms, 1618-1923\"",
+      "citation": "\"Denmark, Baptisms, 1618-1923\", database, <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H2GL-9L2M : 23 June 2020), Chresten Nielsen in entry for Rasmus, 1801.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H2GL-9L2M"
+    },
+    {
+      "id": "7T2G-9XW",
+      "title": "Chresten Nielsen in entry for Karen, \"Denmark, Baptisms, 1618-1923\"",
+      "citation": "\"Denmark, Baptisms, 1618-1923\", database, <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H2G2-F4N2 : 23 June 2020), Chresten Nielsen in entry for Karen, 1790.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H2G2-F4N2"
+    },
+    {
+      "id": "7T2G-M5B",
+      "title": "Chresten Nielsen in entry for Soren, \"Denmark, Baptisms, 1618-1923\"",
+      "citation": "\"Denmark, Baptisms, 1618-1923\", , <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H2GG-ZYW2 : 23 June 2020), Chresten Nielsen in entry for Soren, 1793.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H2GG-ZYW2"
+    },
+    {
+      "id": "7T2G-9WD",
+      "title": "Chresten Nielsen in entry for Peder, \"Denmark, Baptisms, 1618-1923\"",
+      "citation": "\"Denmark, Baptisms, 1618-1923\", database, <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H2GL-6YT2 : 23 June 2020), Chresten Nielsen in entry for Peder, 1799.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H2GL-6YT2"
+    }
+  ]
+}

--- a/eval/tests/e2e/chresten-nielsen-daughter/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/chresten-nielsen-daughter/unstripped-tree.gedcomx.json
@@ -1,0 +1,516 @@
+{
+  "persons": [
+    {
+      "id": "KN3K-9Q3",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Chresten",
+          "surname": "Nielsen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1760",
+          "standard_date": "1760",
+          "place": "of Bjerre, Vejle, Denmark",
+          "standard_place": "Bjerre, Stjernholm, Denmark"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MNL5-NHM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Anne",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "27 Apr 1796",
+          "standard_date": "27 Apr 1796",
+          "place": "Uth, Vejle, Den.",
+          "standard_place": "Uth, Stjernholm, Denmark"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "infant",
+          "standard_date": "(in infancy)"
+        }
+      ]
+    },
+    {
+      "id": "MK6Q-GRK",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Soren",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "10 JAN 1793",
+          "standard_date": "10 Jan 1793"
+        },
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "10 JAN 1793",
+          "standard_date": "10 Jan 1793",
+          "place": "Tyrsted,Vejle,Denmark",
+          "standard_place": "Tyrsted, Vejle, Denmark"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "KF5M-XQ6",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Birte Kirstine",
+          "surname": "Sorensdr."
+        }
+      ],
+      "facts": [
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "13 Jun 1762",
+          "standard_date": "13 Jun 1762",
+          "place": "Uth, Vejle, Den.",
+          "standard_place": "Uth, Stjernholm, Denmark"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "KHFD-S9C",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Soren",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1793",
+          "standard_date": "1793",
+          "place": "Uth, Vejle, Denmark",
+          "standard_place": "Uth, Stjernholm, Denmark"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MK6Q-FK4",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Anne",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "27 APR 1797",
+          "standard_date": "27 Apr 1797"
+        },
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "27 APR 1797",
+          "standard_date": "27 Apr 1797",
+          "place": "Tyrsted,Vejle,Denmark",
+          "standard_place": "Tyrsted, Vejle, Denmark"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "KDMR-HF8",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Peder",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "15 FEB 1799",
+          "standard_date": "15 Feb 1799",
+          "place": "Tyrsted,Vejle,Denmark",
+          "standard_place": "Tyrsted, Vejle, Denmark"
+        },
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "15Feb1799",
+          "standard_date": "15 Feb 1799",
+          "place": "Uth, Vejle, Denmark",
+          "standard_place": "Uth, Stjernholm, Denmark"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MK6Q-5S9",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Jesper",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "09 DEC 1794",
+          "standard_date": "9 Dec 1794"
+        },
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "09 DEC 1794",
+          "standard_date": "9 Dec 1794",
+          "place": "Tyrsted,Vejle,Denmark",
+          "standard_place": "Tyrsted, Vejle, Denmark"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "K8R3-YR7",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Rasmus",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "29 Apr 1801",
+          "standard_date": "29 Apr 1801",
+          "place": "Uth, Vejle, Den.",
+          "standard_place": "Uth, Stjernholm, Denmark"
+        },
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "29 APR 1801",
+          "standard_date": "29 Apr 1801",
+          "place": "Tyrsted,Vejle,Denmark",
+          "standard_place": "Tyrsted, Vejle, Denmark"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death",
+          "date": "infant",
+          "standard_date": "(in infancy)"
+        }
+      ]
+    },
+    {
+      "id": "KCJV-D6Z",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "Jesper",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "9Dec1795",
+          "standard_date": "9 Dec 1795",
+          "place": "Uth, Vejle, Denmark",
+          "standard_place": "Uth, Stjernholm, Denmark"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "K82K-9GG",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N11",
+          "given": "Karen",
+          "surname": "Christensen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1791",
+          "standard_date": "1791",
+          "place": "Uth, Vejle, Denmark",
+          "standard_place": "Uth, Stjernholm, Denmark"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "KN3K-9Q3",
+      "person2": "KF5M-XQ6",
+      "facts": [
+        {
+          "id": "c2548be5-44c9-49c5-ae5a-d0a959a813e6",
+          "type": "Marriage",
+          "date": "13Mar1790",
+          "standard_date": "13 Mar 1790"
+        },
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "13 MAR 1790",
+          "standard_date": "13 Mar 1790",
+          "place": "Tyrsted,Vejle,Denmark",
+          "standard_place": "Tyrsted, Vejle, Denmark"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "K82K-9GG",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "K82K-9GG",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "MK6Q-GRK",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "MK6Q-GRK",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "KHFD-S9C",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "KHFD-S9C",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "MK6Q-5S9",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "MK6Q-5S9",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "KCJV-D6Z",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "KCJV-D6Z",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "MNL5-NHM",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "MNL5-NHM",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "MK6Q-FK4",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "MK6Q-FK4",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "KDMR-HF8",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R17",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "KDMR-HF8",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R18",
+      "type": "ParentChild",
+      "parent": "KN3K-9Q3",
+      "child": "K8R3-YR7",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R19",
+      "type": "ParentChild",
+      "parent": "KF5M-XQ6",
+      "child": "K8R3-YR7",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7T2G-MGH",
+      "title": "Chresten Nielsen in entry for Jesper, \"Denmark, Baptisms, 1618-1923\"",
+      "citation": "\"Denmark, Baptisms, 1618-1923\", database, <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H2GP-QHZM : 23 June 2020), Chresten Nielsen in entry for Jesper, 1795.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H2GP-QHZM"
+    },
+    {
+      "id": "7T2G-MBM",
+      "title": "Chresten Nielsen in entry for Anne, \"Denmark, Baptisms, 1618-1923\"",
+      "citation": "\"Denmark, Baptisms, 1618-1923\", database, <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H2GK-5Z6Z : 23 June 2020), Chresten Nielsen in entry for Anne, 1797.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H2GK-5Z6Z"
+    },
+    {
+      "id": "7T2G-9SN",
+      "title": "Chresten Nielsen in entry for Rasmus, \"Denmark, Baptisms, 1618-1923\"",
+      "citation": "\"Denmark, Baptisms, 1618-1923\", database, <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H2GL-9L2M : 23 June 2020), Chresten Nielsen in entry for Rasmus, 1801.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H2GL-9L2M"
+    },
+    {
+      "id": "7T2G-9XW",
+      "title": "Chresten Nielsen in entry for Karen, \"Denmark, Baptisms, 1618-1923\"",
+      "citation": "\"Denmark, Baptisms, 1618-1923\", database, <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H2G2-F4N2 : 23 June 2020), Chresten Nielsen in entry for Karen, 1790.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H2G2-F4N2"
+    },
+    {
+      "id": "7T2G-M5B",
+      "title": "Chresten Nielsen in entry for Soren, \"Denmark, Baptisms, 1618-1923\"",
+      "citation": "\"Denmark, Baptisms, 1618-1923\", , <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H2GG-ZYW2 : 23 June 2020), Chresten Nielsen in entry for Soren, 1793.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H2GG-ZYW2"
+    },
+    {
+      "id": "7T2G-9WD",
+      "title": "Chresten Nielsen in entry for Peder, \"Denmark, Baptisms, 1618-1923\"",
+      "citation": "\"Denmark, Baptisms, 1618-1923\", database, <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H2GL-6YT2 : 23 June 2020), Chresten Nielsen in entry for Peder, 1799.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H2GL-6YT2"
+    }
+  ]
+}

--- a/eval/tests/e2e/concepcion-alegre-parents/README.md
+++ b/eval/tests/e2e/concepcion-alegre-parents/README.md
@@ -1,0 +1,34 @@
+# Concepción Alegre — birth, marriage and parents (Paraguay)
+
+**Source PID:** `G384-ZCZ`
+**Concepción Alegre is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+not recorded in the tree; died not recorded in the tree.
+
+## Research question
+
+> When and where was Concepción Alegre of Altos, Cordillera, Paraguay born, who were her parents, and when did she marry Vicente Figueredo?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `G384-ZCZ` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 25, flags `adds_father`/`adds_mother`/`adds_birth`/`adds_marriage`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Paraguay, Catholic Church Records, 1754-2015: marriage entry, 11 May 1940, San Lorenzo, Altos, Cordillera, for Vicente Figueredo and Concepción Alegre (daughter of Juan Delgado and Hipólita Martínez). The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the groom's name "Vicente Figueredo" and the town "Altos" both match the tree's recorded spouse and family location exactly, and the tree currently has **no** birth, marriage, or parent data for Concepción at all, so this record would be the first anchor for all four. The one wrinkle: the tree's eldest recorded child, Paulino, was born **1938** — two years **before** the hint record's 1940 marriage date. A child born before a couple's registered church marriage is common in this region and era (a civil or common-law union formalized later by the church), so this is not necessarily disqualifying, but a reviewer should weigh it.

--- a/eval/tests/e2e/concepcion-alegre-parents/expected-findings.json
+++ b/eval/tests/e2e/concepcion-alegre-parents/expected-findings.json
@@ -1,0 +1,68 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "fact",
+      "description": "Concepción Alegre was born 1917 in Altos, Cordillera, Paraguay. The tree currently records no birth fact for her.",
+      "details": {
+        "subject_person": "Concepción Alegre (G384-ZCZ)",
+        "fact_type": "Birth",
+        "date": "1917",
+        "place": "Altos, Cordillera, Paraguay"
+      },
+      "supporting_sources": [
+        "Paraguay, Catholic Church Records, 1754-2015 — marriage entry, 11 May 1940, San Lorenzo, Altos, Cordillera"
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "fact",
+      "description": "Concepción Alegre married Vicente Figueredo on 11 May 1940 in San Lorenzo, Altos, Cordillera. The tree currently records this couple with no marriage date.",
+      "details": {
+        "subject_person": "Concepción Alegre (G384-ZCZ)",
+        "fact_type": "Marriage",
+        "date": "11 May 1940",
+        "place": "San Lorenzo, Altos, Cordillera, Paraguay"
+      },
+      "supporting_sources": [
+        "Paraguay, Catholic Church Records, 1754-2015 — marriage entry, 11 May 1940, San Lorenzo, Altos, Cordillera"
+      ],
+      "required": true
+    },
+    {
+      "id": "f3",
+      "type": "relationship",
+      "description": "Concepción Alegre's father was Juan Delgado, per the same marriage record.",
+      "details": {
+        "subject_person": "Concepción Alegre (G384-ZCZ)",
+        "relation": "parent",
+        "target_person": {
+          "name": "Juan Delgado",
+          "birth": "unknown, likely Paraguay"
+        }
+      },
+      "supporting_sources": [
+        "Paraguay, Catholic Church Records, 1754-2015 — marriage entry, 11 May 1940, San Lorenzo, Altos, Cordillera"
+      ],
+      "required": true
+    },
+    {
+      "id": "f4",
+      "type": "relationship",
+      "description": "Concepción Alegre's mother was Hipólita Martínez, per the same marriage record.",
+      "details": {
+        "subject_person": "Concepción Alegre (G384-ZCZ)",
+        "relation": "parent",
+        "target_person": {
+          "name": "Hipólita Martínez",
+          "birth": "unknown, likely Paraguay"
+        }
+      },
+      "supporting_sources": [
+        "Paraguay, Catholic Church Records, 1754-2015 — marriage entry, 11 May 1940, San Lorenzo, Altos, Cordillera"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/concepcion-alegre-parents/fixture.json
+++ b/eval/tests/e2e/concepcion-alegre-parents/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "concepcion-alegre-parents",
+  "name": "Concepción Alegre — birth, marriage and parents (Paraguay)",
+  "genre": "record-hint",
+  "source_pid": "G384-ZCZ",
+  "captured": "2026-07-24",
+  "researcher_question": "When and where was Concepción Alegre of Altos, Cordillera, Paraguay born, who were her parents, and when did she marry Vicente Figueredo?",
+  "tags": {
+    "question_type": "parents",
+    "era": "1910s",
+    "geography": "PY"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 25, flags adds_father/adds_mother/adds_birth/adds_marriage, confidence 3). Draft transcribed from a Paraguayan parish record; unverified."
+}

--- a/eval/tests/e2e/concepcion-alegre-parents/starting-research.json
+++ b/eval/tests/e2e/concepcion-alegre-parents/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_concepcion_alegre_parents",
+    "objective": "When and where was Concepción Alegre of Altos, Cordillera, Paraguay born, who were her parents, and when did she marry Vicente Figueredo?",
+    "subject_person_ids": [
+      "G384-ZCZ"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/concepcion-alegre-parents/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/concepcion-alegre-parents/starting-tree.gedcomx.json
@@ -1,0 +1,281 @@
+{
+  "persons": [
+    {
+      "id": "G384-ZCZ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Concepción",
+          "surname": "Alegre"
+        }
+      ],
+      "facts": [
+        {
+          "id": "315c11b3-dfdc-4067-ab07-12dd73db4526",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P73C-ZRQ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Paulino",
+          "surname": "Figueredo Alegre"
+        }
+      ],
+      "facts": [
+        {
+          "id": "803583a5-7a09-434e-84b1-5791724ee187",
+          "type": "Birth",
+          "date": "30 de agosto de 1938",
+          "standard_date": "30 Aug 1938",
+          "place": "Altos",
+          "standard_place": "Alto, Rio Arriba, New Mexico, United States"
+        },
+        {
+          "id": "dd22fd68-c5d9-4af5-962d-b9d31148c55d",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GYB4-FNS",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Antonia",
+          "surname": "Figueredo"
+        }
+      ],
+      "facts": [
+        {
+          "id": "48172d0d-f471-4140-a01e-f34f91ea7312",
+          "type": "Birth",
+          "place": "Guapotá, Santander, Colombia",
+          "standard_place": "Guapotá, Santander, Colombia"
+        },
+        {
+          "id": "039bf1ca-b0fa-4b21-978d-4683fa387698",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PZTC-SM6",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Vicente",
+          "surname": "Figueredo"
+        }
+      ],
+      "facts": [
+        {
+          "id": "bfd4b9b5-b9f0-4c6d-a5f2-46be5f40dbab",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "G384-Z5K",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Vicente",
+          "surname": "Figueredo"
+        }
+      ],
+      "facts": [
+        {
+          "id": "926ac396-774f-4c2b-9d46-ed571a799603",
+          "type": "Birth",
+          "date": "19 de julho de 1915",
+          "standard_date": "19 Jul 1915",
+          "place": "Altos",
+          "standard_place": "Alto, Rio Arriba, New Mexico, United States"
+        },
+        {
+          "id": "3b6ca076-dbae-4195-af45-c9224dc341ca",
+          "type": "Death",
+          "date": "29 de março de 2009",
+          "standard_date": "29 Mar 2009"
+        },
+        {
+          "id": "bbd6ec37-034e-49cd-b191-8a1a0c81ce92",
+          "type": "Pension",
+          "date": "22 de outubro de 2009",
+          "standard_date": "22 Oct 2009",
+          "place": "La Catedral, Asunción, Paraguai",
+          "standard_place": "La Catedral, Asunción, Paraguay"
+        }
+      ]
+    },
+    {
+      "id": "PZTC-VFW",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Agustin",
+          "surname": "Figueredo Alegre"
+        }
+      ],
+      "facts": [
+        {
+          "id": "8a4034c6-f7df-496c-8916-28455f49dab9",
+          "type": "Birth",
+          "date": "28 de agosto de 1941",
+          "standard_date": "28 Aug 1941",
+          "place": "Altos",
+          "standard_place": "Alto, Banks, Georgia, United States"
+        },
+        {
+          "id": "1763af1b-5e0c-4c48-9559-000ef3ea2801",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P73Z-2WC",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "natimorto",
+          "surname": ""
+        }
+      ],
+      "facts": [
+        {
+          "id": "637e3ea8-eab3-455b-ac59-4c8fdfd45ced",
+          "type": "Birth",
+          "date": "06031947",
+          "place": "Altos, Cordillera, Paraguai",
+          "standard_place": "Altos, Cordillera, Paraguay"
+        },
+        {
+          "id": "6c954a22-7046-4772-93c2-b2872414a24a",
+          "type": "Death",
+          "date": "6 de março de 1947",
+          "standard_date": "6 Mar 1947",
+          "place": "Altos, Cordillera, Paraguai",
+          "standard_place": "Altos, Cordillera, Paraguay"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "PZTC-SM6",
+      "person2": "G384-ZCZ"
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "G384-Z5K",
+      "person2": "G384-ZCZ"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "G384-Z5K",
+      "child": "P73C-ZRQ"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "G384-ZCZ",
+      "child": "P73C-ZRQ"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "PZTC-SM6",
+      "child": "PZTC-VFW"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "G384-ZCZ",
+      "child": "PZTC-VFW"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "G384-Z5K",
+      "child": "P73Z-2WC"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "G384-ZCZ",
+      "child": "P73Z-2WC"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "PZTC-SM6",
+      "child": "GYB4-FNS"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "G384-ZCZ",
+      "child": "GYB4-FNS"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7RW9-SDX",
+      "title": "Concepcion Alegre, \"Paraguay, registros militares, 1870-1965\"",
+      "citation": "\"Paraguay, registros militares, 1870-1965\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:62WX-R727 : Fri Jan 23 14:41:28 UTC 2026), Entry for Adriano Figueredo Alegre and Vicente Figueredo.",
+      "url": "https://familysearch.org/ark:/61903/1:1:62WX-R724"
+    },
+    {
+      "id": "WW4L-3YF",
+      "title": "Concepción Alegre, \"Paraguay, registros militares, 1870-1965\"",
+      "citation": "\"Paraguay, registros militares, 1870-1965\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:62H5-313P : Mon Jan 13 10:53:21 UTC 2025), Entry for Agustin Figueredo Alegre and Vicente Figueredo.",
+      "url": "https://familysearch.org/ark:/61903/1:1:62H5-313R"
+    },
+    {
+      "id": "7RW9-QWG",
+      "title": "Concepción Alegre, \"Paraguay, Civil Registration, 1842-2012\"",
+      "citation": "\"Paraguay, Civil Registration, 1842-2012\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:65T3-ZR5M : Mon Sep 15 21:45:37 UTC 2025), Entry for <Unknown> and Vicente Figueredo, 6 de marzo de 1947.",
+      "url": "https://familysearch.org/ark:/61903/1:1:65T3-ZR5S"
+    },
+    {
+      "id": "7RW9-DBJ",
+      "title": "Concepcion Alegre, \"Paraguay, registros militares, 1870-1965\"",
+      "citation": "\"Paraguay, registros militares, 1870-1965\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:629L-9GH5 : Tue Oct 14 05:03:09 UTC 2025), Entry for Silvio Figueredo Alegre and Vicente Figuredo.",
+      "url": "https://familysearch.org/ark:/61903/1:1:629L-9GHT"
+    },
+    {
+      "id": "7RW9-3CH",
+      "title": "Concepcion Alegre, \"Paraguay, registros militares, 1870-1965\"",
+      "citation": "\"Paraguay, registros militares, 1870-1965\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6ZP3-88WN : Thu Oct 09 04:22:19 UTC 2025), Entry for Paulino Figueredo Alegre and Vicente Figueredo.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6ZP3-88WV"
+    },
+    {
+      "id": "7RWS-2LT",
+      "title": "Concepción Alegre, \"Paraguay, Military Pensions, 1932 - 2015\"",
+      "citation": "\"Paraguay, Military Pensions, 1932 - 2015\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6BLS-4DK8 : Fri Jan 23 00:26:21 UTC 2026), Entry for Vicente Figueredo Bogado and Sixta Idalina, 22 Oct 2009.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6BLS-4DKX"
+    }
+  ]
+}

--- a/eval/tests/e2e/concepcion-alegre-parents/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/concepcion-alegre-parents/unstripped-tree.gedcomx.json
@@ -1,0 +1,281 @@
+{
+  "persons": [
+    {
+      "id": "G384-ZCZ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Concepción",
+          "surname": "Alegre"
+        }
+      ],
+      "facts": [
+        {
+          "id": "315c11b3-dfdc-4067-ab07-12dd73db4526",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P73C-ZRQ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Paulino",
+          "surname": "Figueredo Alegre"
+        }
+      ],
+      "facts": [
+        {
+          "id": "803583a5-7a09-434e-84b1-5791724ee187",
+          "type": "Birth",
+          "date": "30 de agosto de 1938",
+          "standard_date": "30 Aug 1938",
+          "place": "Altos",
+          "standard_place": "Alto, Rio Arriba, New Mexico, United States"
+        },
+        {
+          "id": "dd22fd68-c5d9-4af5-962d-b9d31148c55d",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GYB4-FNS",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Antonia",
+          "surname": "Figueredo"
+        }
+      ],
+      "facts": [
+        {
+          "id": "48172d0d-f471-4140-a01e-f34f91ea7312",
+          "type": "Birth",
+          "place": "Guapotá, Santander, Colombia",
+          "standard_place": "Guapotá, Santander, Colombia"
+        },
+        {
+          "id": "039bf1ca-b0fa-4b21-978d-4683fa387698",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PZTC-SM6",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Vicente",
+          "surname": "Figueredo"
+        }
+      ],
+      "facts": [
+        {
+          "id": "bfd4b9b5-b9f0-4c6d-a5f2-46be5f40dbab",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "G384-Z5K",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Vicente",
+          "surname": "Figueredo"
+        }
+      ],
+      "facts": [
+        {
+          "id": "926ac396-774f-4c2b-9d46-ed571a799603",
+          "type": "Birth",
+          "date": "19 de julho de 1915",
+          "standard_date": "19 Jul 1915",
+          "place": "Altos",
+          "standard_place": "Alto, Rio Arriba, New Mexico, United States"
+        },
+        {
+          "id": "3b6ca076-dbae-4195-af45-c9224dc341ca",
+          "type": "Death",
+          "date": "29 de março de 2009",
+          "standard_date": "29 Mar 2009"
+        },
+        {
+          "id": "bbd6ec37-034e-49cd-b191-8a1a0c81ce92",
+          "type": "Pension",
+          "date": "22 de outubro de 2009",
+          "standard_date": "22 Oct 2009",
+          "place": "La Catedral, Asunción, Paraguai",
+          "standard_place": "La Catedral, Asunción, Paraguay"
+        }
+      ]
+    },
+    {
+      "id": "PZTC-VFW",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Agustin",
+          "surname": "Figueredo Alegre"
+        }
+      ],
+      "facts": [
+        {
+          "id": "8a4034c6-f7df-496c-8916-28455f49dab9",
+          "type": "Birth",
+          "date": "28 de agosto de 1941",
+          "standard_date": "28 Aug 1941",
+          "place": "Altos",
+          "standard_place": "Alto, Banks, Georgia, United States"
+        },
+        {
+          "id": "1763af1b-5e0c-4c48-9559-000ef3ea2801",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P73Z-2WC",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "natimorto",
+          "surname": ""
+        }
+      ],
+      "facts": [
+        {
+          "id": "637e3ea8-eab3-455b-ac59-4c8fdfd45ced",
+          "type": "Birth",
+          "date": "06031947",
+          "place": "Altos, Cordillera, Paraguai",
+          "standard_place": "Altos, Cordillera, Paraguay"
+        },
+        {
+          "id": "6c954a22-7046-4772-93c2-b2872414a24a",
+          "type": "Death",
+          "date": "6 de março de 1947",
+          "standard_date": "6 Mar 1947",
+          "place": "Altos, Cordillera, Paraguai",
+          "standard_place": "Altos, Cordillera, Paraguay"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "PZTC-SM6",
+      "person2": "G384-ZCZ"
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "G384-Z5K",
+      "person2": "G384-ZCZ"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "G384-Z5K",
+      "child": "P73C-ZRQ"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "G384-ZCZ",
+      "child": "P73C-ZRQ"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "PZTC-SM6",
+      "child": "PZTC-VFW"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "G384-ZCZ",
+      "child": "PZTC-VFW"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "G384-Z5K",
+      "child": "P73Z-2WC"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "G384-ZCZ",
+      "child": "P73Z-2WC"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "PZTC-SM6",
+      "child": "GYB4-FNS"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "G384-ZCZ",
+      "child": "GYB4-FNS"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7RW9-SDX",
+      "title": "Concepcion Alegre, \"Paraguay, registros militares, 1870-1965\"",
+      "citation": "\"Paraguay, registros militares, 1870-1965\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:62WX-R727 : Fri Jan 23 14:41:28 UTC 2026), Entry for Adriano Figueredo Alegre and Vicente Figueredo.",
+      "url": "https://familysearch.org/ark:/61903/1:1:62WX-R724"
+    },
+    {
+      "id": "WW4L-3YF",
+      "title": "Concepción Alegre, \"Paraguay, registros militares, 1870-1965\"",
+      "citation": "\"Paraguay, registros militares, 1870-1965\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:62H5-313P : Mon Jan 13 10:53:21 UTC 2025), Entry for Agustin Figueredo Alegre and Vicente Figueredo.",
+      "url": "https://familysearch.org/ark:/61903/1:1:62H5-313R"
+    },
+    {
+      "id": "7RW9-QWG",
+      "title": "Concepción Alegre, \"Paraguay, Civil Registration, 1842-2012\"",
+      "citation": "\"Paraguay, Civil Registration, 1842-2012\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:65T3-ZR5M : Mon Sep 15 21:45:37 UTC 2025), Entry for <Unknown> and Vicente Figueredo, 6 de marzo de 1947.",
+      "url": "https://familysearch.org/ark:/61903/1:1:65T3-ZR5S"
+    },
+    {
+      "id": "7RW9-DBJ",
+      "title": "Concepcion Alegre, \"Paraguay, registros militares, 1870-1965\"",
+      "citation": "\"Paraguay, registros militares, 1870-1965\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:629L-9GH5 : Tue Oct 14 05:03:09 UTC 2025), Entry for Silvio Figueredo Alegre and Vicente Figuredo.",
+      "url": "https://familysearch.org/ark:/61903/1:1:629L-9GHT"
+    },
+    {
+      "id": "7RW9-3CH",
+      "title": "Concepcion Alegre, \"Paraguay, registros militares, 1870-1965\"",
+      "citation": "\"Paraguay, registros militares, 1870-1965\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6ZP3-88WN : Thu Oct 09 04:22:19 UTC 2025), Entry for Paulino Figueredo Alegre and Vicente Figueredo.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6ZP3-88WV"
+    },
+    {
+      "id": "7RWS-2LT",
+      "title": "Concepción Alegre, \"Paraguay, Military Pensions, 1932 - 2015\"",
+      "citation": "\"Paraguay, Military Pensions, 1932 - 2015\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6BLS-4DK8 : Fri Jan 23 00:26:21 UTC 2026), Entry for Vicente Figueredo Bogado and Sixta Idalina, 22 Oct 2009.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6BLS-4DKX"
+    }
+  ]
+}

--- a/eval/tests/e2e/cornelius-booysen-death/README.md
+++ b/eval/tests/e2e/cornelius-booysen-death/README.md
@@ -1,0 +1,34 @@
+# Cornelius Hermanus Zacharias Booysen — death in the Transvaal
+
+**Source PID:** `GWDS-CKP`
+**Cornelius Hermanus Zacharias Booysen is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+1906; died not recorded in the tree.
+
+## Research question
+
+> When and where did Cornelius Hermanus Zacharias Booysen of Pretoria, Transvaal, South Africa die?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `GWDS-CKP` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 30, flag `adds_death`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — South Africa, Transvaal, Probate Records from the Master of the Supreme Court, 1869-1961: entry for Cornelis Hermanus Zacharias Booysen, place Transvaal, South Africa (no date in the indexed extract). The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the full name "Cornelis/Cornelius Hermanus Zacharias Booysen" is distinctive (four given/family name elements), making a same-name coincidence less likely than for the batch's more common names. The tree records his birth as 1906 and marriage as 1930 in Pretoria, Transvaal — the same province as the probate record, though the FamilySearch API extract captured no death date for this record, only the bare place. The agent researching this fixture would need to consult the underlying probate file (likely via `image_read` or `record_read` with fuller detail) to recover an actual date; this fixture may be better suited to testing whether the agent can locate and read through to that date rather than treating the bare hint as the full answer.

--- a/eval/tests/e2e/cornelius-booysen-death/expected-findings.json
+++ b/eval/tests/e2e/cornelius-booysen-death/expected-findings.json
@@ -1,0 +1,19 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "fact",
+      "description": "Cornelius Hermanus Zacharias Booysen died in the Transvaal, South Africa, per a probate record from the Master of the Supreme Court. The record's extracted data carries no specific date — the underlying probate file would need to be consulted for an exact death date.",
+      "details": {
+        "subject_person": "Cornelius Hermanus Zacharias Booysen (GWDS-CKP)",
+        "fact_type": "Death",
+        "date": "unknown (probate record gives no date in the indexed extract)",
+        "place": "Transvaal, South Africa"
+      },
+      "supporting_sources": [
+        "South Africa, Transvaal, Probate Records from the Master of the Supreme Court, 1869-1961 — entry for Cornelis Hermanus Zacharias Booysen"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/cornelius-booysen-death/fixture.json
+++ b/eval/tests/e2e/cornelius-booysen-death/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "cornelius-booysen-death",
+  "name": "Cornelius Hermanus Zacharias Booysen — death in the Transvaal",
+  "genre": "record-hint",
+  "source_pid": "GWDS-CKP",
+  "captured": "2026-07-24",
+  "researcher_question": "When and where did Cornelius Hermanus Zacharias Booysen of Pretoria, Transvaal, South Africa die?",
+  "tags": {
+    "question_type": "death_date",
+    "era": "1930s",
+    "geography": "ZA"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 30, flag adds_death, confidence 3). Draft transcribed from a South African probate record; unverified."
+}

--- a/eval/tests/e2e/cornelius-booysen-death/starting-research.json
+++ b/eval/tests/e2e/cornelius-booysen-death/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_cornelius_booysen_death",
+    "objective": "When and where did Cornelius Hermanus Zacharias Booysen of Pretoria, Transvaal, South Africa die?",
+    "subject_person_ids": [
+      "GWDS-CKP"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/cornelius-booysen-death/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/cornelius-booysen-death/starting-tree.gedcomx.json
@@ -1,0 +1,234 @@
+{
+  "persons": [
+    {
+      "id": "GWDS-CKP",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Cornelius Hermanus Zacharias",
+          "surname": "Booysen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "dc475aed-2f4c-49c2-bde0-7ed96202513d",
+          "type": "Birth",
+          "date": "1906",
+          "standard_date": "1906"
+        },
+        {
+          "id": "6b5345b8-a777-45ef-857e-eb57813f4374",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PSJ3-PZC",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Daniel Jacobus",
+          "surname": "Bester"
+        }
+      ],
+      "facts": [
+        {
+          "id": "fa78e4e7-2f59-46fb-b961-28de576447ff",
+          "type": "Birth",
+          "date": "1908",
+          "standard_date": "1908"
+        },
+        {
+          "id": "ebdcc903-54a8-4f69-b1e8-1d7987ea0457",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PSJ3-8YY",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Katrina Johanna",
+          "surname": "Booysen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "fd7d3c70-47c3-487d-972d-71f89ddfb497",
+          "type": "Birth",
+          "date": "1933",
+          "standard_date": "1933"
+        },
+        {
+          "id": "8a779c6c-725b-4059-84b5-4775b64e4346",
+          "type": "Death",
+          "date": "19 December 1933",
+          "standard_date": "19 Dec 1933",
+          "place": "Pretoria, Transvaal, South Africa",
+          "standard_place": "Pretoria, Transvaal, South Africa"
+        }
+      ]
+    },
+    {
+      "id": "GWDS-71V",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Jan Jonathan",
+          "surname": "Booysen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebcb7700-e1ce-41c1-905e-db0abafae3b1",
+          "type": "Birth",
+          "date": "21 October 1879",
+          "standard_date": "21 Oct 1879",
+          "place": "Heidelberg, Transvaal, South Africa",
+          "standard_place": "Heidelberg, Lydenburg, Transvaal, South Africa"
+        },
+        {
+          "id": "0c3e56c2-9e2f-430d-917e-bfc20079929b",
+          "type": "Baptism",
+          "date": "7 December 1879",
+          "standard_date": "7 Dec 1879",
+          "place": "Heidelberg, Transvaal, South Africa",
+          "standard_place": "Heidelberg, Lydenburg, Transvaal, South Africa"
+        },
+        {
+          "id": "2364ec0e-4799-4038-b4d8-f08e5d5db545",
+          "type": "Probate",
+          "date": "1931",
+          "standard_date": "1931",
+          "place": "Transvaal, South Africa",
+          "standard_place": "Transvaal, South Africa"
+        },
+        {
+          "id": "bfdc5cfd-5825-4b3e-8f4e-7c811bb590d6",
+          "type": "Death",
+          "date": "15 October 1931",
+          "standard_date": "15 Oct 1931",
+          "place": "Pretoria, Transvaal, South Africa",
+          "standard_place": "Pretoria, Pretoria, Transvaal, South Africa"
+        }
+      ]
+    },
+    {
+      "id": "GWDS-HSV",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Catharina Johanna",
+          "surname": "Deysel"
+        }
+      ],
+      "facts": [
+        {
+          "id": "3b07e425-cfa2-47b3-9283-e0270ff22b13",
+          "type": "Birth",
+          "date": "25 November 1885",
+          "standard_date": "25 Nov 1885"
+        },
+        {
+          "id": "ac99c712-375b-4756-beb7-a999733ae61a",
+          "type": "Death",
+          "date": "4 March 1948",
+          "standard_date": "4 Mar 1948",
+          "place": "Pretoria, Transvaal, South Africa",
+          "standard_place": "Pretoria, Pretoria, Transvaal, South Africa"
+        },
+        {
+          "id": "5034a296-40a2-4f77-bc65-9bedecf353c5",
+          "type": "Probate",
+          "date": "1948",
+          "standard_date": "1948",
+          "place": "Transvaal, South Africa",
+          "standard_place": "Transvaal, South Africa"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GWDS-CKP",
+      "person2": "PSJ3-PZC",
+      "facts": [
+        {
+          "id": "42b2f3b1-4597-4183-87e4-67a9b5bd9322",
+          "type": "Marriage",
+          "date": "31 December 1930",
+          "standard_date": "31 Dec 1930",
+          "place": "Pretoria, Transvaal, South Africa",
+          "standard_place": "Pretoria, Transvaal, South Africa"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "GWDS-71V",
+      "person2": "GWDS-HSV",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "16 May 1905",
+          "standard_date": "16 May 1905",
+          "place": "Standerton, Transvaal, South Africa",
+          "standard_place": "Standerton, Standerton, Transvaal, South Africa"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GWDS-71V",
+      "child": "GWDS-CKP"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GWDS-HSV",
+      "child": "GWDS-CKP"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GWDS-CKP",
+      "child": "PSJ3-8YY"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "PSJ3-PZC",
+      "child": "PSJ3-8YY"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7VDX-DGP",
+      "title": "Cornelius Hermanus Zacharius Booysen, \"South Africa, Transvaal, Civil Marriages, 1870-1931\"",
+      "citation": "\"South Africa, Transvaal, Civil Marriages, 1870-1931\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPWJ-CF3V : Sat Mar 09 17:09:34 UTC 2024), Entry for Cornelius Hermanus Zacharius Booysen and Daniel Jacobus Bester, 31 December 1930.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPWJ-CF3V"
+    },
+    {
+      "id": "7VDF-1LK",
+      "title": "Cornelius Hermanus Booysen, \"South Africa, Transvaal, Civil Death, 1869-1954\"",
+      "citation": "\"South Africa, Transvaal, Civil Death, 1869-1954\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:74MD-BDT2 : Thu Jan 16 14:57:10 UTC 2025), Entry for Katrina Johanna Booysen and Cornelius Hermanus Booysen, 19 Dec 1933.",
+      "url": "https://familysearch.org/ark:/61903/1:1:74MD-BDPZ"
+    }
+  ]
+}

--- a/eval/tests/e2e/cornelius-booysen-death/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/cornelius-booysen-death/unstripped-tree.gedcomx.json
@@ -1,0 +1,234 @@
+{
+  "persons": [
+    {
+      "id": "GWDS-CKP",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Cornelius Hermanus Zacharias",
+          "surname": "Booysen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "dc475aed-2f4c-49c2-bde0-7ed96202513d",
+          "type": "Birth",
+          "date": "1906",
+          "standard_date": "1906"
+        },
+        {
+          "id": "6b5345b8-a777-45ef-857e-eb57813f4374",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PSJ3-PZC",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Daniel Jacobus",
+          "surname": "Bester"
+        }
+      ],
+      "facts": [
+        {
+          "id": "fa78e4e7-2f59-46fb-b961-28de576447ff",
+          "type": "Birth",
+          "date": "1908",
+          "standard_date": "1908"
+        },
+        {
+          "id": "ebdcc903-54a8-4f69-b1e8-1d7987ea0457",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PSJ3-8YY",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Katrina Johanna",
+          "surname": "Booysen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "fd7d3c70-47c3-487d-972d-71f89ddfb497",
+          "type": "Birth",
+          "date": "1933",
+          "standard_date": "1933"
+        },
+        {
+          "id": "8a779c6c-725b-4059-84b5-4775b64e4346",
+          "type": "Death",
+          "date": "19 December 1933",
+          "standard_date": "19 Dec 1933",
+          "place": "Pretoria, Transvaal, South Africa",
+          "standard_place": "Pretoria, Transvaal, South Africa"
+        }
+      ]
+    },
+    {
+      "id": "GWDS-71V",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Jan Jonathan",
+          "surname": "Booysen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebcb7700-e1ce-41c1-905e-db0abafae3b1",
+          "type": "Birth",
+          "date": "21 October 1879",
+          "standard_date": "21 Oct 1879",
+          "place": "Heidelberg, Transvaal, South Africa",
+          "standard_place": "Heidelberg, Lydenburg, Transvaal, South Africa"
+        },
+        {
+          "id": "0c3e56c2-9e2f-430d-917e-bfc20079929b",
+          "type": "Baptism",
+          "date": "7 December 1879",
+          "standard_date": "7 Dec 1879",
+          "place": "Heidelberg, Transvaal, South Africa",
+          "standard_place": "Heidelberg, Lydenburg, Transvaal, South Africa"
+        },
+        {
+          "id": "2364ec0e-4799-4038-b4d8-f08e5d5db545",
+          "type": "Probate",
+          "date": "1931",
+          "standard_date": "1931",
+          "place": "Transvaal, South Africa",
+          "standard_place": "Transvaal, South Africa"
+        },
+        {
+          "id": "bfdc5cfd-5825-4b3e-8f4e-7c811bb590d6",
+          "type": "Death",
+          "date": "15 October 1931",
+          "standard_date": "15 Oct 1931",
+          "place": "Pretoria, Transvaal, South Africa",
+          "standard_place": "Pretoria, Pretoria, Transvaal, South Africa"
+        }
+      ]
+    },
+    {
+      "id": "GWDS-HSV",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Catharina Johanna",
+          "surname": "Deysel"
+        }
+      ],
+      "facts": [
+        {
+          "id": "3b07e425-cfa2-47b3-9283-e0270ff22b13",
+          "type": "Birth",
+          "date": "25 November 1885",
+          "standard_date": "25 Nov 1885"
+        },
+        {
+          "id": "ac99c712-375b-4756-beb7-a999733ae61a",
+          "type": "Death",
+          "date": "4 March 1948",
+          "standard_date": "4 Mar 1948",
+          "place": "Pretoria, Transvaal, South Africa",
+          "standard_place": "Pretoria, Pretoria, Transvaal, South Africa"
+        },
+        {
+          "id": "5034a296-40a2-4f77-bc65-9bedecf353c5",
+          "type": "Probate",
+          "date": "1948",
+          "standard_date": "1948",
+          "place": "Transvaal, South Africa",
+          "standard_place": "Transvaal, South Africa"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GWDS-CKP",
+      "person2": "PSJ3-PZC",
+      "facts": [
+        {
+          "id": "42b2f3b1-4597-4183-87e4-67a9b5bd9322",
+          "type": "Marriage",
+          "date": "31 December 1930",
+          "standard_date": "31 Dec 1930",
+          "place": "Pretoria, Transvaal, South Africa",
+          "standard_place": "Pretoria, Transvaal, South Africa"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "GWDS-71V",
+      "person2": "GWDS-HSV",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "16 May 1905",
+          "standard_date": "16 May 1905",
+          "place": "Standerton, Transvaal, South Africa",
+          "standard_place": "Standerton, Standerton, Transvaal, South Africa"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GWDS-71V",
+      "child": "GWDS-CKP"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GWDS-HSV",
+      "child": "GWDS-CKP"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GWDS-CKP",
+      "child": "PSJ3-8YY"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "PSJ3-PZC",
+      "child": "PSJ3-8YY"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7VDX-DGP",
+      "title": "Cornelius Hermanus Zacharius Booysen, \"South Africa, Transvaal, Civil Marriages, 1870-1931\"",
+      "citation": "\"South Africa, Transvaal, Civil Marriages, 1870-1931\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPWJ-CF3V : Sat Mar 09 17:09:34 UTC 2024), Entry for Cornelius Hermanus Zacharius Booysen and Daniel Jacobus Bester, 31 December 1930.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPWJ-CF3V"
+    },
+    {
+      "id": "7VDF-1LK",
+      "title": "Cornelius Hermanus Booysen, \"South Africa, Transvaal, Civil Death, 1869-1954\"",
+      "citation": "\"South Africa, Transvaal, Civil Death, 1869-1954\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:74MD-BDT2 : Thu Jan 16 14:57:10 UTC 2025), Entry for Katrina Johanna Booysen and Cornelius Hermanus Booysen, 19 Dec 1933.",
+      "url": "https://familysearch.org/ark:/61903/1:1:74MD-BDPZ"
+    }
+  ]
+}

--- a/eval/tests/e2e/elisabetha-sugecz-parents/README.md
+++ b/eval/tests/e2e/elisabetha-sugecz-parents/README.md
@@ -1,0 +1,34 @@
+# Elisabetha Sugecz — parents Thomas Sugecz and Susanna Petrich
+
+**Source PID:** `G4C9-Y6C`
+**Elisabetha Sugecz is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+not recorded in the tree (married abt. 1814, Madžarevo, Varaždin, Croatia); died not recorded in the tree.
+
+## Research question
+
+> Who were the parents of Elisabetha Sugecz, wife of Thomas Pofuk-Harmicar of Madžarevo, Varaždin, Croatia?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `G4C9-Y6C` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 11, flags `adds_father`/`adds_mother`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Croatia, Church Books, 1516-1994: baptismal entry, 14 August 1786, Madžarevo, Varaždin, naming parents Thomæ Sugecz and Susanæ Petrich. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Thomas Sugecz and Susanna Petrich as the subject's parents, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the tree has **no** birth or baptismal date at all currently recorded for Elisabetha Sugecz, so this record would be the first anchor date for her. Her marriage to Thomas Pofuk-Harmicar is dated "about 1814" in the same parish (Madžarevo, Varaždin), and a 1786 baptism would make her about 28 at marriage — plausible. The surname "Sugecz" matches exactly and the parish matches exactly, which is a reasonably strong signal for a name this specific, though there is no independent date already in the tree to cross-check the 1786 baptism against.

--- a/eval/tests/e2e/elisabetha-sugecz-parents/expected-findings.json
+++ b/eval/tests/e2e/elisabetha-sugecz-parents/expected-findings.json
@@ -1,0 +1,38 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Elisabetha Sugecz's father was Thomas Sugecz, per a baptismal record dated 14 August 1786 in Madžarevo, Varaždin, Croatia.",
+      "details": {
+        "subject_person": "Elisabetha Sugecz (G4C9-Y6C)",
+        "relation": "parent",
+        "target_person": {
+          "name": "Thomas Sugecz",
+          "birth": "unknown, likely Madžarevo, Varaždin, Croatia"
+        }
+      },
+      "supporting_sources": [
+        "Croatia, Church Books, 1516-1994 — baptismal entry, 14 Aug 1786, Madžarevo, Varaždin, naming parents Thomæ Sugecz and Susanæ Petrich"
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "relationship",
+      "description": "Elisabetha Sugecz's mother was Susanna Petrich, per the same baptismal record.",
+      "details": {
+        "subject_person": "Elisabetha Sugecz (G4C9-Y6C)",
+        "relation": "parent",
+        "target_person": {
+          "name": "Susanna Petrich",
+          "birth": "unknown, likely Madžarevo, Varaždin, Croatia"
+        }
+      },
+      "supporting_sources": [
+        "Croatia, Church Books, 1516-1994 — baptismal entry, 14 Aug 1786, Madžarevo, Varaždin"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/elisabetha-sugecz-parents/fixture.json
+++ b/eval/tests/e2e/elisabetha-sugecz-parents/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "elisabetha-sugecz-parents",
+  "name": "Elisabetha Sugecz — parents Thomas Sugecz and Susanna Petrich",
+  "genre": "record-hint",
+  "source_pid": "G4C9-Y6C",
+  "captured": "2026-07-24",
+  "researcher_question": "Who were the parents of Elisabetha Sugecz, wife of Thomas Pofuk-Harmicar of Madžarevo, Varaždin, Croatia?",
+  "tags": {
+    "question_type": "parents",
+    "era": "1780s",
+    "geography": "HR"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 11, flags adds_father/adds_mother, confidence 3). Draft transcribed from a Croatian church baptismal record; unverified."
+}

--- a/eval/tests/e2e/elisabetha-sugecz-parents/starting-research.json
+++ b/eval/tests/e2e/elisabetha-sugecz-parents/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_elisabetha_sugecz_parents",
+    "objective": "Who were the parents of Elisabetha Sugecz, wife of Thomas Pofuk-Harmicar of Madžarevo, Varaždin, Croatia?",
+    "subject_person_ids": [
+      "G4C9-Y6C"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/elisabetha-sugecz-parents/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/elisabetha-sugecz-parents/starting-tree.gedcomx.json
@@ -1,0 +1,455 @@
+{
+  "persons": [
+    {
+      "id": "G4C9-Y6C",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Elisabetha",
+          "surname": "Sugecz"
+        }
+      ],
+      "facts": [
+        {
+          "id": "2d04cbd6-18d2-4893-8c75-186ebaf05d80",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GWVL-BXC",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Andreas",
+          "surname": "Harmicar"
+        }
+      ],
+      "facts": [
+        {
+          "id": "924901fe-8ae0-4473-b5a3-a9c065e60733",
+          "type": "Christening",
+          "date": "8 October 1837",
+          "standard_date": "8 Oct 1837",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "e2a7c2dc-3920-4102-84fe-d81e02a47a80",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LKLZ-KQH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Catharina",
+          "surname": "Pofuk"
+        }
+      ],
+      "facts": [
+        {
+          "id": "534bef7e-367f-4993-8aa9-edde5655157e",
+          "type": "Christening",
+          "date": "16 December 1816",
+          "standard_date": "16 Dec 1816",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GWVG-S43",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Stephanus",
+          "surname": "Pofuk"
+        }
+      ],
+      "facts": [
+        {
+          "id": "39199acf-36f3-4db0-806f-279ab03f007f",
+          "type": "Christening",
+          "date": "30 August 1824",
+          "standard_date": "30 Aug 1824",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "546d2a73-b7dd-4e94-a7b7-5b2bc370b543",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GWVK-WKJ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Thomas",
+          "surname": "Pofuk-Harmicar"
+        }
+      ],
+      "facts": [
+        {
+          "id": "318d79ba-66fe-4402-8cbf-51c01b42377d",
+          "type": "Birth",
+          "date": "1793",
+          "standard_date": "1793",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "010ef6d3-daae-4050-aa64-51063efbd3c9",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LKL8-4VC",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Dorothea",
+          "surname": "Poffuk"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "20 Jan 1820",
+          "standard_date": "20 Jan 1820",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LKL8-H4L",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Helena",
+          "surname": "Poffuk"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "09 Feb 1821",
+          "standard_date": "9 Feb 1821",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GWVL-RW9",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Jacobus",
+          "surname": "Pofuk"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1dcd20d2-8060-491a-8db3-1d96c3bb0f97",
+          "type": "Christening",
+          "date": "8 June 1829",
+          "standard_date": "8 Jun 1829",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "1b7f4cd4-3b7f-4054-b5a8-f22fe319323f",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LKLH-YZX",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Martinus",
+          "surname": "Harmicar"
+        }
+      ],
+      "facts": [
+        {
+          "id": "5f76249a-853c-476f-862a-bfec3cdaf16b",
+          "type": "Christening",
+          "date": "2 October 1832",
+          "standard_date": "2 Oct 1832",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GWVL-571",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "Mathias",
+          "surname": "Pofuk"
+        }
+      ],
+      "facts": [
+        {
+          "id": "d7fc93ae-6a33-4073-b3db-f6008238e759",
+          "type": "Christening",
+          "date": "18 February 1826",
+          "standard_date": "18 Feb 1826",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "501c38d9-e47b-462d-9597-bd4053829fe6",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LKLC-W74",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N11",
+          "given": "Sophia",
+          "surname": "Harmiczar"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "18 May 1836",
+          "standard_date": "18 May 1836",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GWVK-WKJ",
+      "person2": "G4C9-Y6C",
+      "facts": [
+        {
+          "id": "6591f8fd-829c-4f3a-ba82-2e38380b850b",
+          "type": "Marriage",
+          "date": "Abt 1814",
+          "standard_date": "Abt 1814",
+          "place": "Madžarevo, Varaždin, Croatia",
+          "standard_place": "Madžarevo, Varaždin, Croatia"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "LKLZ-KQH",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "LKLZ-KQH"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "LKL8-4VC"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "LKL8-4VC"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "LKL8-H4L",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "LKL8-H4L",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "GWVG-S43",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "GWVG-S43",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "GWVL-571",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "GWVL-571",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "GWVL-RW9",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "GWVL-RW9",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "LKLH-YZX",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "LKLH-YZX",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "LKLC-W74",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R17",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "LKLC-W74",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R18",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "GWVL-BXC",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R19",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "GWVL-BXC",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "S13H-P1R",
+      "title": "Elisabethæ Sugecz, \"Croatia, Church Books, 1516-1994\"",
+      "citation": "\"Croatia, Church Books, 1516-1994\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKMN-25C7 : Fri Mar 08 12:37:44 UTC 2024), Entry for Dorothea Poffuk and Thomæ Poffuk, 20 January 1820.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKMN-25C4"
+    },
+    {
+      "id": "S13H-54V",
+      "title": "Elisabethæ Sugecz, \"Croatia, Church Books, 1516-1994\"",
+      "citation": "\"Croatia, Church Books, 1516-1994\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKMN-LN2B : Sat Mar 09 16:38:32 UTC 2024), Entry for Chatarina Pofuk and Thomæ Pofuk, 16 December 1816.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKMN-LNLM"
+    },
+    {
+      "id": "S13H-RGZ",
+      "title": "Elisabethæ Sugecz, \"Croatia, Church Books, 1516-1994\"",
+      "citation": "\"Croatia, Church Books, 1516-1994\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKMN-L8XH : Sat Mar 09 21:22:02 UTC 2024), Entry for Sophia Harmiczar and Thomæ Harmiczar, 18 May 1836.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKMN-L8XZ"
+    },
+    {
+      "id": "SBJG-TKK",
+      "title": "Elizabethæ Sugecz, \"Croatia, Church Books, 1516-1994\"",
+      "citation": "\"Croatia, Church Books, 1516-1994\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKMN-LM5B : Sat Mar 09 20:45:17 UTC 2024), Entry for Andreas Harmiczar and Thomæ Harmiczar, 8 October 1837.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKMN-LMRM"
+    },
+    {
+      "id": "S13H-57S",
+      "title": "Elisabethæ Sugecz, \"Croatia, Church Books, 1516-1994\"",
+      "citation": "\"Croatia, Church Books, 1516-1994\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKMN-LN6S : Fri Mar 08 22:26:44 UTC 2024), Entry for Martinus Harmiczar and Thomæ Harmiczar, 2 October 1832.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKMN-LN6Q"
+    }
+  ]
+}

--- a/eval/tests/e2e/elisabetha-sugecz-parents/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/elisabetha-sugecz-parents/unstripped-tree.gedcomx.json
@@ -1,0 +1,455 @@
+{
+  "persons": [
+    {
+      "id": "G4C9-Y6C",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Elisabetha",
+          "surname": "Sugecz"
+        }
+      ],
+      "facts": [
+        {
+          "id": "2d04cbd6-18d2-4893-8c75-186ebaf05d80",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GWVL-BXC",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Andreas",
+          "surname": "Harmicar"
+        }
+      ],
+      "facts": [
+        {
+          "id": "924901fe-8ae0-4473-b5a3-a9c065e60733",
+          "type": "Christening",
+          "date": "8 October 1837",
+          "standard_date": "8 Oct 1837",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "e2a7c2dc-3920-4102-84fe-d81e02a47a80",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LKLZ-KQH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Catharina",
+          "surname": "Pofuk"
+        }
+      ],
+      "facts": [
+        {
+          "id": "534bef7e-367f-4993-8aa9-edde5655157e",
+          "type": "Christening",
+          "date": "16 December 1816",
+          "standard_date": "16 Dec 1816",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GWVG-S43",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Stephanus",
+          "surname": "Pofuk"
+        }
+      ],
+      "facts": [
+        {
+          "id": "39199acf-36f3-4db0-806f-279ab03f007f",
+          "type": "Christening",
+          "date": "30 August 1824",
+          "standard_date": "30 Aug 1824",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "546d2a73-b7dd-4e94-a7b7-5b2bc370b543",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GWVK-WKJ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Thomas",
+          "surname": "Pofuk-Harmicar"
+        }
+      ],
+      "facts": [
+        {
+          "id": "318d79ba-66fe-4402-8cbf-51c01b42377d",
+          "type": "Birth",
+          "date": "1793",
+          "standard_date": "1793",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "010ef6d3-daae-4050-aa64-51063efbd3c9",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LKL8-4VC",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Dorothea",
+          "surname": "Poffuk"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "20 Jan 1820",
+          "standard_date": "20 Jan 1820",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LKL8-H4L",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Helena",
+          "surname": "Poffuk"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "09 Feb 1821",
+          "standard_date": "9 Feb 1821",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GWVL-RW9",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Jacobus",
+          "surname": "Pofuk"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1dcd20d2-8060-491a-8db3-1d96c3bb0f97",
+          "type": "Christening",
+          "date": "8 June 1829",
+          "standard_date": "8 Jun 1829",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "1b7f4cd4-3b7f-4054-b5a8-f22fe319323f",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LKLH-YZX",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Martinus",
+          "surname": "Harmicar"
+        }
+      ],
+      "facts": [
+        {
+          "id": "5f76249a-853c-476f-862a-bfec3cdaf16b",
+          "type": "Christening",
+          "date": "2 October 1832",
+          "standard_date": "2 Oct 1832",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GWVL-571",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "Mathias",
+          "surname": "Pofuk"
+        }
+      ],
+      "facts": [
+        {
+          "id": "d7fc93ae-6a33-4073-b3db-f6008238e759",
+          "type": "Christening",
+          "date": "18 February 1826",
+          "standard_date": "18 Feb 1826",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "501c38d9-e47b-462d-9597-bd4053829fe6",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LKLC-W74",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N11",
+          "given": "Sophia",
+          "surname": "Harmiczar"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "18 May 1836",
+          "standard_date": "18 May 1836",
+          "place": "Remetinec, Varaždin, Croatia",
+          "standard_place": "Remetinec, Varaždin, Croatia"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GWVK-WKJ",
+      "person2": "G4C9-Y6C",
+      "facts": [
+        {
+          "id": "6591f8fd-829c-4f3a-ba82-2e38380b850b",
+          "type": "Marriage",
+          "date": "Abt 1814",
+          "standard_date": "Abt 1814",
+          "place": "Madžarevo, Varaždin, Croatia",
+          "standard_place": "Madžarevo, Varaždin, Croatia"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "LKLZ-KQH",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "LKLZ-KQH"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "LKL8-4VC"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "LKL8-4VC"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "LKL8-H4L",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "LKL8-H4L",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "GWVG-S43",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "GWVG-S43",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "GWVL-571",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "GWVL-571",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "GWVL-RW9",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "GWVL-RW9",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "LKLH-YZX",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "LKLH-YZX",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "LKLC-W74",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R17",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "LKLC-W74",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R18",
+      "type": "ParentChild",
+      "parent": "GWVK-WKJ",
+      "child": "GWVL-BXC",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R19",
+      "type": "ParentChild",
+      "parent": "G4C9-Y6C",
+      "child": "GWVL-BXC",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "S13H-P1R",
+      "title": "Elisabethæ Sugecz, \"Croatia, Church Books, 1516-1994\"",
+      "citation": "\"Croatia, Church Books, 1516-1994\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKMN-25C7 : Fri Mar 08 12:37:44 UTC 2024), Entry for Dorothea Poffuk and Thomæ Poffuk, 20 January 1820.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKMN-25C4"
+    },
+    {
+      "id": "S13H-54V",
+      "title": "Elisabethæ Sugecz, \"Croatia, Church Books, 1516-1994\"",
+      "citation": "\"Croatia, Church Books, 1516-1994\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKMN-LN2B : Sat Mar 09 16:38:32 UTC 2024), Entry for Chatarina Pofuk and Thomæ Pofuk, 16 December 1816.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKMN-LNLM"
+    },
+    {
+      "id": "S13H-RGZ",
+      "title": "Elisabethæ Sugecz, \"Croatia, Church Books, 1516-1994\"",
+      "citation": "\"Croatia, Church Books, 1516-1994\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKMN-L8XH : Sat Mar 09 21:22:02 UTC 2024), Entry for Sophia Harmiczar and Thomæ Harmiczar, 18 May 1836.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKMN-L8XZ"
+    },
+    {
+      "id": "SBJG-TKK",
+      "title": "Elizabethæ Sugecz, \"Croatia, Church Books, 1516-1994\"",
+      "citation": "\"Croatia, Church Books, 1516-1994\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKMN-LM5B : Sat Mar 09 20:45:17 UTC 2024), Entry for Andreas Harmiczar and Thomæ Harmiczar, 8 October 1837.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKMN-LMRM"
+    },
+    {
+      "id": "S13H-57S",
+      "title": "Elisabethæ Sugecz, \"Croatia, Church Books, 1516-1994\"",
+      "citation": "\"Croatia, Church Books, 1516-1994\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKMN-LN6S : Fri Mar 08 22:26:44 UTC 2024), Entry for Martinus Harmiczar and Thomæ Harmiczar, 2 October 1832.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKMN-LN6Q"
+    }
+  ]
+}

--- a/eval/tests/e2e/estefania-zambrana-son/README.md
+++ b/eval/tests/e2e/estefania-zambrana-son/README.md
@@ -1,0 +1,34 @@
+# Estefania Zambrana — additional son Ricardo (b. 1874)
+
+**Source PID:** `9QTV-KDZ`
+**Estefania Zambrana is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+not recorded in the tree; died not recorded in the tree.
+
+## Research question
+
+> Did Estefania Zambrana and her husband Antonio Beisaga of Cochabamba, Bolivia have a son named Ricardo, baptized 1874, in addition to their two known children (b. 1867 and 1877)?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `9QTV-KDZ` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 7, flag `adds_son`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Bolivia, Catholic Church Records, 1566-2020: baptismal entry, 3 April 1874, Santo Domingo, Cochabamba, naming parents Antonio Veizaga and Estefania Zambrana. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming the 1874 Ricardo baptism, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the father's surname is recorded as "Veizaga" in the hint record vs. "Beisaga" in the tree — a common regional spelling variant (both plausible renderings of the same Bolivian surname) also seen on the tree's own children (Beisaga Zambrana). The mother's name "Estefania Zambrana" matches exactly. A baptism in 1874 slots neatly between the tree's two known children (1867, 1877), and the parish (Cochabamba) matches the tree's known family location.

--- a/eval/tests/e2e/estefania-zambrana-son/expected-findings.json
+++ b/eval/tests/e2e/estefania-zambrana-son/expected-findings.json
@@ -1,0 +1,21 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Estefania Zambrana and Antonio Beisaga (recorded in the hint as Veizaga) had a son, Ricardo Veizaga Zambrana, baptized 3 April 1874 in Santo Domingo, Cochabamba, Bolivia, in addition to their two children already in the tree (Fructuosa b. 1867, Geronimo b. 1877).",
+      "details": {
+        "subject_person": "Estefania Zambrana (9QTV-KDZ)",
+        "relation": "child",
+        "target_person": {
+          "name": "Ricardo Veizaga Zambrana",
+          "birth": "baptized 3 April 1874, Santo Domingo, Cochabamba, Bolivia"
+        }
+      },
+      "supporting_sources": [
+        "Bolivia, Catholic Church Records, 1566-2020 — baptismal entry, 3 Apr 1874, Santo Domingo, Cochabamba, naming parents Antonio Veizaga and Estefania Zambrana"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/estefania-zambrana-son/fixture.json
+++ b/eval/tests/e2e/estefania-zambrana-son/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "estefania-zambrana-son",
+  "name": "Estefania Zambrana — additional son Ricardo (b. 1874)",
+  "genre": "record-hint",
+  "source_pid": "9QTV-KDZ",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Estefania Zambrana and her husband Antonio Beisaga of Cochabamba, Bolivia have a son named Ricardo, baptized 1874, in addition to their two known children (b. 1867 and 1877)?",
+  "tags": {
+    "question_type": "children",
+    "era": "1870s",
+    "geography": "BO"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 7, flag adds_son, confidence 3). Draft transcribed from a Bolivian parish baptismal record; unverified."
+}

--- a/eval/tests/e2e/estefania-zambrana-son/starting-research.json
+++ b/eval/tests/e2e/estefania-zambrana-son/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_estefania_zambrana_son",
+    "objective": "Did Estefania Zambrana and her husband Antonio Beisaga of Cochabamba, Bolivia have a son named Ricardo, baptized 1874, in addition to their two known children (b. 1867 and 1877)?",
+    "subject_person_ids": [
+      "9QTV-KDZ"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/estefania-zambrana-son/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/estefania-zambrana-son/starting-tree.gedcomx.json
@@ -1,0 +1,132 @@
+{
+  "persons": [
+    {
+      "id": "9QTV-KDZ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Estefania",
+          "surname": "Zambrana"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "9QTV-KD3",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Antonio",
+          "surname": "Beisaga"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "9QTV-K8P",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Geronimo",
+          "surname": "Beisaga"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "30 SEP 1877",
+          "standard_date": "30 Sep 1877",
+          "place": "Cochabamba,Cochabamba,Bolivia",
+          "standard_place": "Cochabamba, Cochabamba, Cercado, Cochabamba, Bolivia"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P89Y-ZJK",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Fructuosa",
+          "surname": "Beisaga Zambrana"
+        }
+      ],
+      "facts": [
+        {
+          "id": "bdc63b76-3739-449f-8756-e6fa80a4c265",
+          "type": "Birth",
+          "date": "1867",
+          "standard_date": "1867"
+        },
+        {
+          "id": "88a63feb-32f5-4042-8c8b-a9f0efa7dd5a",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "9QTV-KD3",
+      "person2": "9QTV-KDZ"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "9QTV-KD3",
+      "child": "P89Y-ZJK"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "9QTV-KDZ",
+      "child": "P89Y-ZJK"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "9QTV-KD3",
+      "child": "9QTV-K8P",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "9QTV-KDZ",
+      "child": "9QTV-K8P",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "WW25-GT6",
+      "title": "Estefania Zambrana, \"Bolivia, registros parroquiales, 1566-2020\"",
+      "citation": "\"Bolivia, registros parroquiales, 1566-2020\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:4FC5-7B3Z : Sun Mar 10 15:12:49 UTC 2024), Entry for Lauriano Torrico and Mariano Torrico, 30 Mar 1890.",
+      "url": "https://familysearch.org/ark:/61903/1:1:4FC5-7BMM"
+    }
+  ]
+}

--- a/eval/tests/e2e/estefania-zambrana-son/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/estefania-zambrana-son/unstripped-tree.gedcomx.json
@@ -1,0 +1,132 @@
+{
+  "persons": [
+    {
+      "id": "9QTV-KDZ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Estefania",
+          "surname": "Zambrana"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "9QTV-KD3",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Antonio",
+          "surname": "Beisaga"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "9QTV-K8P",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Geronimo",
+          "surname": "Beisaga"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "30 SEP 1877",
+          "standard_date": "30 Sep 1877",
+          "place": "Cochabamba,Cochabamba,Bolivia",
+          "standard_place": "Cochabamba, Cochabamba, Cercado, Cochabamba, Bolivia"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P89Y-ZJK",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Fructuosa",
+          "surname": "Beisaga Zambrana"
+        }
+      ],
+      "facts": [
+        {
+          "id": "bdc63b76-3739-449f-8756-e6fa80a4c265",
+          "type": "Birth",
+          "date": "1867",
+          "standard_date": "1867"
+        },
+        {
+          "id": "88a63feb-32f5-4042-8c8b-a9f0efa7dd5a",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "9QTV-KD3",
+      "person2": "9QTV-KDZ"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "9QTV-KD3",
+      "child": "P89Y-ZJK"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "9QTV-KDZ",
+      "child": "P89Y-ZJK"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "9QTV-KD3",
+      "child": "9QTV-K8P",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "9QTV-KDZ",
+      "child": "9QTV-K8P",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "WW25-GT6",
+      "title": "Estefania Zambrana, \"Bolivia, registros parroquiales, 1566-2020\"",
+      "citation": "\"Bolivia, registros parroquiales, 1566-2020\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:4FC5-7B3Z : Sun Mar 10 15:12:49 UTC 2024), Entry for Lauriano Torrico and Mariano Torrico, 30 Mar 1890.",
+      "url": "https://familysearch.org/ark:/61903/1:1:4FC5-7BMM"
+    }
+  ]
+}

--- a/eval/tests/e2e/eulogia-gatica-burial/README.md
+++ b/eval/tests/e2e/eulogia-gatica-burial/README.md
@@ -1,0 +1,34 @@
+# Eulojia del Carmen Gatica Alfaro — burial record (Santiago, 1908)
+
+**Source PID:** `LZ3Z-RHM`
+**Eulojia del Carmen Gatica Alfaro is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+christened 2 October 1862, Los Andes, Aconcagua, Chile; died 29 May 1908, Santiago, Chile.
+
+## Research question
+
+> Where and when was Eulojia del Carmen Gatica Alfaro of Santiago, Chile buried, and does a cemetery record corroborate her recorded death date and birth year?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `LZ3Z-RHM` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+easy — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 9, flags `adds_birth`/`adds_burial`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Chile, Cemetery Records, 1701-2021: burial entry, 30 May 1908, Santiago, for Eulogia Gatica Alfaro, with an estimated birth year of 1865. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard, plus a `required` finding that the report documents the rejection.
+
+This is the **strongest** candidate match in the batch: the tree already records Eulojia's death as 29 May 1908 in Santiago, and the cemetery burial record is dated one day later (30 May 1908) in the same city — an entirely expected sequence, not a coincidence needing much scrutiny. The one wrinkle is the estimated birth year (1865) conflicting with the tree's already-recorded christening date (2 October 1862) by three years; cemetery-record birth-year estimates (often derived from an age-at-death notation) are commonly a few years off a true birth/christening date, so this is marked bonus-only (`required: false`) rather than treated as disqualifying.

--- a/eval/tests/e2e/eulogia-gatica-burial/expected-findings.json
+++ b/eval/tests/e2e/eulogia-gatica-burial/expected-findings.json
@@ -1,0 +1,34 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "fact",
+      "description": "Eulogia Gatica Alfaro was buried 30 May 1908 in Santiago, Chile, one day after the death date (29 May 1908) already recorded in the tree.",
+      "details": {
+        "subject_person": "Eulojia del Carmen Gatica Alfaro (LZ3Z-RHM)",
+        "fact_type": "Burial",
+        "date": "30 May 1908",
+        "place": "Santiago, Chile"
+      },
+      "supporting_sources": [
+        "Chile, Cemetery Records, 1701-2021 — burial entry, 30 May 1908, Santiago, for Eulogia Gatica Alfaro"
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "fact",
+      "description": "The cemetery record estimates Eulogia Gatica Alfaro's birth year as 1865 — three years later than the christening date (2 October 1862) already recorded in the tree. Bonus credit only, since it conflicts with an already-established date.",
+      "details": {
+        "subject_person": "Eulojia del Carmen Gatica Alfaro (LZ3Z-RHM)",
+        "fact_type": "Birth",
+        "date": "1865 (estimated)",
+        "place": "unknown"
+      },
+      "supporting_sources": [
+        "Chile, Cemetery Records, 1701-2021 — burial entry, 30 May 1908, Santiago, for Eulogia Gatica Alfaro"
+      ],
+      "required": false
+    }
+  ]
+}

--- a/eval/tests/e2e/eulogia-gatica-burial/fixture.json
+++ b/eval/tests/e2e/eulogia-gatica-burial/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "eulogia-gatica-burial",
+  "name": "Eulojia del Carmen Gatica Alfaro — burial record (Santiago, 1908)",
+  "genre": "record-hint",
+  "source_pid": "LZ3Z-RHM",
+  "captured": "2026-07-24",
+  "researcher_question": "Where and when was Eulojia del Carmen Gatica Alfaro of Santiago, Chile buried, and does a cemetery record corroborate her recorded death date and birth year?",
+  "tags": {
+    "question_type": "death_date",
+    "era": "1900s",
+    "geography": "CL"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "easy",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 9, flags adds_birth/adds_burial, confidence 3). Draft transcribed from a Chilean cemetery record; unverified."
+}

--- a/eval/tests/e2e/eulogia-gatica-burial/starting-research.json
+++ b/eval/tests/e2e/eulogia-gatica-burial/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_eulogia_gatica_burial",
+    "objective": "Where and when was Eulojia del Carmen Gatica Alfaro of Santiago, Chile buried, and does a cemetery record corroborate her recorded death date and birth year?",
+    "subject_person_ids": [
+      "LZ3Z-RHM"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/eulogia-gatica-burial/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/eulogia-gatica-burial/starting-tree.gedcomx.json
@@ -1,0 +1,762 @@
+{
+  "persons": [
+    {
+      "id": "LZ3Z-RHM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Eulojia del Carmen",
+          "surname": "Gatica Alfaro"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "29 May 1908",
+          "standard_date": "29 May 1908",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        },
+        {
+          "id": "52729987-b801-4c05-9589-48bab887e5ec",
+          "type": "Christening",
+          "date": "2 October 1862",
+          "standard_date": "2 Oct 1862",
+          "place": "Los Andes, Aconcagua, Chile",
+          "standard_place": "Los Andes, Valparaíso, Chile"
+        },
+        {
+          "id": "f49f8217-39b6-48b9-9412-9043b5fa1fab",
+          "type": "Residence",
+          "place": "Los Andes, Aconcagua, Chile",
+          "standard_place": "Los Andes, Valparaíso, Chile"
+        }
+      ]
+    },
+    {
+      "id": "MX45-9HH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Carmen",
+          "surname": "Alfaro Vilches"
+        }
+      ],
+      "facts": [
+        {
+          "id": "79a42bc4-0c43-400c-9527-71a2c9c4d8b7",
+          "type": "Birth",
+          "date": "1828",
+          "standard_date": "1828"
+        },
+        {
+          "id": "071f4ca6-8d83-4d7e-a2cd-ce0cfeb1c45d",
+          "type": "Death",
+          "date": "2 January 1888",
+          "standard_date": "2 Jan 1888",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "KNT6-7ZR",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Buenaventura",
+          "surname": "Gatica Árias"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "12 January 1829",
+          "standard_date": "12 Jan 1829",
+          "place": "Santa Rosa, Los Andes, Aconcagua, Chile",
+          "standard_place": "Santa Rosa, Calle Larga, Los Andes, Valparaíso, Chile"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        },
+        {
+          "id": "b6f5b1b1-3b35-4137-9e83-5a3242422f99",
+          "type": "Residence",
+          "place": "Los Andes, Aconcagua, Chile",
+          "standard_place": "Los Andes, Valparaíso, Chile"
+        }
+      ]
+    },
+    {
+      "id": "GDV2-WWJ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "María Luísa del Rosario",
+          "surname": ""
+        }
+      ],
+      "facts": [
+        {
+          "id": "ba096a99-37b5-435c-b144-6a986be1826e",
+          "type": "Birth",
+          "date": "6 de septiembre de 1889",
+          "standard_date": "6 Sep 1889"
+        },
+        {
+          "id": "33a8b685-620a-46f7-9c97-13dbe1e585cd",
+          "type": "Christening",
+          "date": "28 de septiembre de 1889",
+          "standard_date": "28 Sep 1889",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        },
+        {
+          "id": "21b00a44-2d14-4f25-bdb1-eab982cb9e0c",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GDVK-Y8P",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Juan de Dios",
+          "surname": "González"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1a1e1675-bc82-4410-9337-384248aa1822",
+          "type": "Birth",
+          "date": "11 de diciembre de 1890",
+          "standard_date": "11 Dec 1890"
+        },
+        {
+          "id": "37985ba8-0e72-4c08-b515-e79a3d911afe",
+          "type": "Christening",
+          "date": "16 de diciembre de 1890",
+          "standard_date": "16 Dec 1890",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        },
+        {
+          "id": "ecdb4531-b6a6-44c9-a45c-98744305306c",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "L5YK-JVZ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Manuel  Jesus",
+          "surname": "Gonzalez Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1e37564a-5b34-41bc-994a-b1efdcc5de67",
+          "type": "Birth",
+          "date": "17 junio 1898",
+          "standard_date": "17 Jun 1898",
+          "place": "Recoleta, Santiago, Región Metropolitana de Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        },
+        {
+          "id": "e0be2c4f-f084-41d6-9620-63c2f0e187d3",
+          "type": "Christening",
+          "date": "21 de junio de 1898",
+          "standard_date": "21 Jun 1898",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        },
+        {
+          "id": "7048fa55-d54e-4e02-accc-5169ace2c94a",
+          "type": "Death",
+          "date": "13 January 1900",
+          "standard_date": "13 Jan 1900",
+          "place": "Chile",
+          "standard_place": "Chile"
+        },
+        {
+          "id": "8f90d18d-3d9d-4510-8576-d19273aabb4c",
+          "type": "Birth+Registration"
+        }
+      ]
+    },
+    {
+      "id": "L5NJ-WPP",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "José Antonio",
+          "surname": "González Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "0977275f-ec05-47bb-9bf6-a70e3e84bf41",
+          "type": "Birth",
+          "date": "21 October 1892",
+          "standard_date": "21 Oct 1892",
+          "place": "Chile",
+          "standard_place": "Chile"
+        },
+        {
+          "id": "9cae60e5-c90f-4b63-b0ed-645cf606bbb7",
+          "type": "Death",
+          "date": "04 Oct 1893",
+          "standard_date": "4 Oct 1893"
+        },
+        {
+          "id": "b5b8788b-415c-4bd3-afc3-0f07d1478ff2",
+          "type": "Birth+Registration",
+          "place": "Recoleta, Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "LZ3Z-R41",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Juan José",
+          "surname": "González"
+        }
+      ],
+      "facts": [
+        {
+          "id": "09a070f9-ccc5-4fc6-a462-7d850a6f9af0",
+          "type": "Birth",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "Talca, Talca, Maule, Chile",
+          "standard_place": "Talca, Talca, Chile"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "antes de 1908",
+          "standard_date": "1908"
+        }
+      ]
+    },
+    {
+      "id": "G8S3-DC5",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Luisa del Carmen",
+          "surname": "González Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "38eed826-c6a5-483f-8246-c0732d353eb6",
+          "type": "Birth",
+          "date": "31 March 1884",
+          "standard_date": "31 Mar 1884",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        },
+        {
+          "id": "567ed504-028b-4ecc-aa5d-9381a10ff096",
+          "type": "Christening",
+          "date": "6 de abril de 1884",
+          "standard_date": "6 Apr 1884",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        },
+        {
+          "id": "a80f9035-df34-479a-b307-8e9543b46dde",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LT8G-ZNK",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "Zoila Blanca De La Luz",
+          "surname": "González Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ff5ccf38-1a6d-45b8-b960-da6d5b08c7be",
+          "type": "Birth",
+          "date": "1886",
+          "standard_date": "1886",
+          "place": "Chile",
+          "standard_place": "Chile"
+        },
+        {
+          "id": "e072f10f-0b65-4ec0-8b38-bfdb232a819c",
+          "type": "Death",
+          "date": "24 December 1902",
+          "standard_date": "24 Dec 1902",
+          "place": "Chile",
+          "standard_place": "Chile"
+        },
+        {
+          "id": "0372d68c-11c0-4269-8138-aa67cde56cfd",
+          "type": "Death Registration",
+          "place": "Santiago, Región Metropolitana de Santiago, Chile",
+          "standard_place": "Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "LZ3Z-R4B",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N11",
+          "given": "Mercedes",
+          "surname": "Gonzalez Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "12 septiembre 1886",
+          "standard_date": "12 Sep 1886",
+          "place": "Moneda, Santiago, Chile",
+          "standard_place": "Metropolitana de Santiago, Chile"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        },
+        {
+          "id": "11ba562b-fd8f-47b1-9487-ac6e29fd25fe",
+          "type": "Birth+Registration",
+          "place": "Moneda, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "LZ34-S88",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N12",
+          "given": "Sara Del Cármen",
+          "surname": "Gonzalez Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "13 octubre 1890",
+          "standard_date": "13 Oct 1890",
+          "place": "Recoleta, Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death",
+          "date": "28 Jun 1892",
+          "standard_date": "28 Jun 1892"
+        },
+        {
+          "id": "0f9989b8-bc27-49b1-b8da-f978209bfe15",
+          "type": "Death Registration",
+          "place": "Recoleta, Santiago, Metropolitana de Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        },
+        {
+          "id": "4b7672de-c363-4fef-bf3f-253e9f9a4ea4",
+          "type": "Birth+Registration",
+          "place": "Recoleta, Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "LZ3W-DR2",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N13",
+          "given": "Juana De Dios",
+          "surname": "Gonzalez Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "26 agosto 1896",
+          "standard_date": "26 Aug 1896",
+          "place": "Recoleta, Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death",
+          "date": "26 August 1896",
+          "standard_date": "26 Aug 1896",
+          "place": "Chile",
+          "standard_place": "Chile"
+        },
+        {
+          "id": "80ccdb34-be06-40e1-85c9-b90881d20ba9",
+          "type": "Death Registration",
+          "place": "Recoleta, Santiago, Metropolitana de Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        },
+        {
+          "id": "2344fa01-5556-4746-810c-efeec131f7d3",
+          "type": "Birth+Registration",
+          "place": "Recoleta, Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "LZ3W-DR4",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N14",
+          "given": "Juana Maria",
+          "surname": "Gonzalez Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "e0b6e802-cb5f-48f0-a185-4249ab913568",
+          "type": "Christening",
+          "date": "1896",
+          "standard_date": "1896",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        },
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "26 agosto 1896",
+          "standard_date": "26 Aug 1896",
+          "place": "Recoleta, Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        },
+        {
+          "id": "884e7151-b210-4a7a-9a32-3c29db80425d",
+          "type": "Birth+Registration",
+          "place": "Recoleta, Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "LZ3Z-R41",
+      "person2": "LZ3Z-RHM",
+      "facts": [
+        {
+          "id": "4276c4cd-89a5-4093-bf50-5b33769eb68d",
+          "type": "Marriage",
+          "date": "13 de marzo de 1882",
+          "standard_date": "13 Mar 1882",
+          "place": "Santiago de Chile, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "KNT6-7ZR",
+      "person2": "MX45-9HH",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "25 October 1852",
+          "standard_date": "25 Oct 1852",
+          "place": "Santa Rosa de los Andes, Aconcagua, Chile",
+          "standard_place": "San Pedro, San Pedro, Melipilla, Metropolitana de Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "KNT6-7ZR",
+      "child": "LZ3Z-RHM"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "MX45-9HH",
+      "child": "LZ3Z-RHM"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "G8S3-DC5"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "LT8G-ZNK"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "LT8G-ZNK"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "LZ3Z-R4B"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "LZ3Z-R4B"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "GDV2-WWJ"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "GDV2-WWJ"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "LZ34-S88"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "LZ34-S88"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "GDVK-Y8P"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "GDVK-Y8P"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "L5NJ-WPP"
+    },
+    {
+      "id": "R17",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "L5NJ-WPP"
+    },
+    {
+      "id": "R18",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "LZ3W-DR2"
+    },
+    {
+      "id": "R19",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "LZ3W-DR2"
+    },
+    {
+      "id": "R20",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "LZ3W-DR4"
+    },
+    {
+      "id": "R21",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "LZ3W-DR4"
+    },
+    {
+      "id": "R22",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "L5YK-JVZ"
+    },
+    {
+      "id": "R23",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "L5YK-JVZ"
+    }
+  ],
+  "sources": [
+    {
+      "id": "9FTD-NF4",
+      "title": "Eulogia Gatica, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VXPN-8DM : Fri Oct 24 16:06:25 UTC 2025), Entry for Mercedes and Juan Jose Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VXPN-881"
+    },
+    {
+      "id": "9YL5-Y37",
+      "title": "Eulojia Gatica Alfaro, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q2S2-4XS9 : Thu Nov 20 02:26:17 UTC 2025), Entry for Eulojia Gatica Alfaro and Ventura Gatica.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q2S2-4XS9"
+    },
+    {
+      "id": "3C18-DPZ",
+      "title": "Eulojia Gatica, \"Chile, registros parroquiales y diocesanos, 1633-2015\"",
+      "citation": "\"Chile, registros parroquiales y diocesanos, 1633-2015\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6ZHY-FDKW : Thu Jan 01 09:20:11 UTC 2026), Entry for Luísa del Carmen and Miranda Pino del Campo, 6 de abril de 1884.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6ZHY-FDKH"
+    },
+    {
+      "id": "9FTD-K53",
+      "title": "Eulojia Gatica de Gonzalez, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VXPZ-9G2 : Sat Nov 01 09:45:09 UTC 2025), Entry for José Antonio and Juan José Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VXPZ-9GK"
+    },
+    {
+      "id": "9LS6-KMM",
+      "title": "Eulojia Del Carmen Gatica, \"Chile Baptisms, 1585-1932\"",
+      "citation": "\"Chile, bautismos, 1585-1932\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:FJ8Q-N73 : 14 February 2020), Eulojia del Carmen Gatica, 1862.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FJ8Q-N73"
+    },
+    {
+      "id": "9R4V-P7J",
+      "title": "Eulojia Gatica de Gonzalez, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QLX9-LJ2R : Sat Aug 09 01:07:56 UTC 2025), Entry for Zoila Blanca de la Luz Gonzalez Gatica and Juan José Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QLX9-LJLM"
+    },
+    {
+      "id": "9FTD-27Q",
+      "title": "Eulojia Gatica, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VXP4-DBW : Fri Oct 24 16:47:06 UTC 2025), Entry for Juana de Dios and Juan Jos? Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VXP4-DB7"
+    },
+    {
+      "id": "9R4V-RWQ",
+      "title": "Eulojia Gatica, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QLXM-L7J9 : Tue Oct 28 21:17:07 UTC 2025), Entry for Manuel Jesus Gonzalez Gatica and Juan José Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QLXM-L7J7"
+    },
+    {
+      "id": "7K7C-8QW",
+      "title": "Eulojia Gatica, \"Chile, registros parroquiales y diocesanos, 1633-2015\"",
+      "citation": "\"Chile, registros parroquiales y diocesanos, 1633-2015\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6V7S-N7C9 : Sat May 16 00:24:59 UTC 2026), Entry for Juan José Gonzalez and Carmen Gonzalez, 13 Mar 1882.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6V7S-N7CQ"
+    },
+    {
+      "id": "924R-LGP",
+      "title": "Eulogia Gatica en el registro de Zoila González Gatica, \"Chile, Registro Civil, 1885-1903\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q241-Q8ZW : Wed Mar 12 03:54:55 UTC 2025), Entry for Zoila Gonzalez Gatica and Juan José Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q241-Q8ZN"
+    },
+    {
+      "id": "9YLP-YX9",
+      "title": "Eulojia Gatica, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPS6-6NFD : Wed Nov 05 21:44:33 UTC 2025), Entry for Sara del Carmen Gonzalez Gatica and Juan José Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPS6-6NFV"
+    },
+    {
+      "id": "9YL5-1XX",
+      "title": "Eulojia Gatica Alfaro, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q2S2-4XV5 : Thu Nov 20 02:12:27 UTC 2025), Entry for Eulojia Gatica Alfaro and Ventura Gatica.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q2S2-4XV5"
+    },
+    {
+      "id": "3C18-8CL",
+      "title": "Eulojia del Carmen Gatica, \"Chile, Baptisms, 1585-1932\"",
+      "citation": "\"Chile, bautismos, 1585-1932\", database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:FJ2W-S82 : 14 February 2020), Eulojia del Carmen Gatica, 1862.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FJ2W-S82"
+    },
+    {
+      "id": "9FTD-R2D",
+      "title": "Eulojia Gatica de Gonzalez, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VXP4-DBC : Fri Oct 24 16:47:06 UTC 2025), Entry for Juana Maria and Juan Jos? Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VXP4-DBH"
+    },
+    {
+      "id": "9R4V-6W4",
+      "title": "Eulojia Gatica, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QLX9-HNJ6 : Tue Oct 28 21:47:44 UTC 2025), Entry for Jose Antonio Gonzalez Gatica and Juan Jose Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QLX9-HNV9"
+    },
+    {
+      "id": "9YLP-T4J",
+      "title": "Eulojia Gatica, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPS6-LQML : Thu Nov 20 18:15:02 UTC 2025), Entry for Juana de Dios Gonzalez Gatica and Juan José Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPS6-LQ99"
+    },
+    {
+      "id": "9FTD-VS3",
+      "title": "Eulojia Gatica de Gonzalez, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VXPC-DR2 : Sat Nov 01 09:43:16 UTC 2025), Entry for Sara del Cármen and Juan José Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VXPC-DRK"
+    },
+    {
+      "id": "9NVT-QYM",
+      "title": "Eulogia Gatica de Gonzalez, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VXP4-PJD : Sat Nov 01 09:45:04 UTC 2025), Entry for Manuel Jesus and Juan Jose Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VXP4-PJ8"
+    }
+  ]
+}

--- a/eval/tests/e2e/eulogia-gatica-burial/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/eulogia-gatica-burial/unstripped-tree.gedcomx.json
@@ -1,0 +1,762 @@
+{
+  "persons": [
+    {
+      "id": "LZ3Z-RHM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Eulojia del Carmen",
+          "surname": "Gatica Alfaro"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "29 May 1908",
+          "standard_date": "29 May 1908",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        },
+        {
+          "id": "52729987-b801-4c05-9589-48bab887e5ec",
+          "type": "Christening",
+          "date": "2 October 1862",
+          "standard_date": "2 Oct 1862",
+          "place": "Los Andes, Aconcagua, Chile",
+          "standard_place": "Los Andes, Valparaíso, Chile"
+        },
+        {
+          "id": "f49f8217-39b6-48b9-9412-9043b5fa1fab",
+          "type": "Residence",
+          "place": "Los Andes, Aconcagua, Chile",
+          "standard_place": "Los Andes, Valparaíso, Chile"
+        }
+      ]
+    },
+    {
+      "id": "MX45-9HH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Carmen",
+          "surname": "Alfaro Vilches"
+        }
+      ],
+      "facts": [
+        {
+          "id": "79a42bc4-0c43-400c-9527-71a2c9c4d8b7",
+          "type": "Birth",
+          "date": "1828",
+          "standard_date": "1828"
+        },
+        {
+          "id": "071f4ca6-8d83-4d7e-a2cd-ce0cfeb1c45d",
+          "type": "Death",
+          "date": "2 January 1888",
+          "standard_date": "2 Jan 1888",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "KNT6-7ZR",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Buenaventura",
+          "surname": "Gatica Árias"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "12 January 1829",
+          "standard_date": "12 Jan 1829",
+          "place": "Santa Rosa, Los Andes, Aconcagua, Chile",
+          "standard_place": "Santa Rosa, Calle Larga, Los Andes, Valparaíso, Chile"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        },
+        {
+          "id": "b6f5b1b1-3b35-4137-9e83-5a3242422f99",
+          "type": "Residence",
+          "place": "Los Andes, Aconcagua, Chile",
+          "standard_place": "Los Andes, Valparaíso, Chile"
+        }
+      ]
+    },
+    {
+      "id": "GDV2-WWJ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "María Luísa del Rosario",
+          "surname": ""
+        }
+      ],
+      "facts": [
+        {
+          "id": "ba096a99-37b5-435c-b144-6a986be1826e",
+          "type": "Birth",
+          "date": "6 de septiembre de 1889",
+          "standard_date": "6 Sep 1889"
+        },
+        {
+          "id": "33a8b685-620a-46f7-9c97-13dbe1e585cd",
+          "type": "Christening",
+          "date": "28 de septiembre de 1889",
+          "standard_date": "28 Sep 1889",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        },
+        {
+          "id": "21b00a44-2d14-4f25-bdb1-eab982cb9e0c",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GDVK-Y8P",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Juan de Dios",
+          "surname": "González"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1a1e1675-bc82-4410-9337-384248aa1822",
+          "type": "Birth",
+          "date": "11 de diciembre de 1890",
+          "standard_date": "11 Dec 1890"
+        },
+        {
+          "id": "37985ba8-0e72-4c08-b515-e79a3d911afe",
+          "type": "Christening",
+          "date": "16 de diciembre de 1890",
+          "standard_date": "16 Dec 1890",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        },
+        {
+          "id": "ecdb4531-b6a6-44c9-a45c-98744305306c",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "L5YK-JVZ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Manuel  Jesus",
+          "surname": "Gonzalez Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1e37564a-5b34-41bc-994a-b1efdcc5de67",
+          "type": "Birth",
+          "date": "17 junio 1898",
+          "standard_date": "17 Jun 1898",
+          "place": "Recoleta, Santiago, Región Metropolitana de Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        },
+        {
+          "id": "e0be2c4f-f084-41d6-9620-63c2f0e187d3",
+          "type": "Christening",
+          "date": "21 de junio de 1898",
+          "standard_date": "21 Jun 1898",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        },
+        {
+          "id": "7048fa55-d54e-4e02-accc-5169ace2c94a",
+          "type": "Death",
+          "date": "13 January 1900",
+          "standard_date": "13 Jan 1900",
+          "place": "Chile",
+          "standard_place": "Chile"
+        },
+        {
+          "id": "8f90d18d-3d9d-4510-8576-d19273aabb4c",
+          "type": "Birth+Registration"
+        }
+      ]
+    },
+    {
+      "id": "L5NJ-WPP",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "José Antonio",
+          "surname": "González Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "0977275f-ec05-47bb-9bf6-a70e3e84bf41",
+          "type": "Birth",
+          "date": "21 October 1892",
+          "standard_date": "21 Oct 1892",
+          "place": "Chile",
+          "standard_place": "Chile"
+        },
+        {
+          "id": "9cae60e5-c90f-4b63-b0ed-645cf606bbb7",
+          "type": "Death",
+          "date": "04 Oct 1893",
+          "standard_date": "4 Oct 1893"
+        },
+        {
+          "id": "b5b8788b-415c-4bd3-afc3-0f07d1478ff2",
+          "type": "Birth+Registration",
+          "place": "Recoleta, Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "LZ3Z-R41",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Juan José",
+          "surname": "González"
+        }
+      ],
+      "facts": [
+        {
+          "id": "09a070f9-ccc5-4fc6-a462-7d850a6f9af0",
+          "type": "Birth",
+          "date": "1860",
+          "standard_date": "1860",
+          "place": "Talca, Talca, Maule, Chile",
+          "standard_place": "Talca, Talca, Chile"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "antes de 1908",
+          "standard_date": "1908"
+        }
+      ]
+    },
+    {
+      "id": "G8S3-DC5",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Luisa del Carmen",
+          "surname": "González Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "38eed826-c6a5-483f-8246-c0732d353eb6",
+          "type": "Birth",
+          "date": "31 March 1884",
+          "standard_date": "31 Mar 1884",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        },
+        {
+          "id": "567ed504-028b-4ecc-aa5d-9381a10ff096",
+          "type": "Christening",
+          "date": "6 de abril de 1884",
+          "standard_date": "6 Apr 1884",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        },
+        {
+          "id": "a80f9035-df34-479a-b307-8e9543b46dde",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LT8G-ZNK",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "Zoila Blanca De La Luz",
+          "surname": "González Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ff5ccf38-1a6d-45b8-b960-da6d5b08c7be",
+          "type": "Birth",
+          "date": "1886",
+          "standard_date": "1886",
+          "place": "Chile",
+          "standard_place": "Chile"
+        },
+        {
+          "id": "e072f10f-0b65-4ec0-8b38-bfdb232a819c",
+          "type": "Death",
+          "date": "24 December 1902",
+          "standard_date": "24 Dec 1902",
+          "place": "Chile",
+          "standard_place": "Chile"
+        },
+        {
+          "id": "0372d68c-11c0-4269-8138-aa67cde56cfd",
+          "type": "Death Registration",
+          "place": "Santiago, Región Metropolitana de Santiago, Chile",
+          "standard_place": "Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "LZ3Z-R4B",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N11",
+          "given": "Mercedes",
+          "surname": "Gonzalez Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "12 septiembre 1886",
+          "standard_date": "12 Sep 1886",
+          "place": "Moneda, Santiago, Chile",
+          "standard_place": "Metropolitana de Santiago, Chile"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        },
+        {
+          "id": "11ba562b-fd8f-47b1-9487-ac6e29fd25fe",
+          "type": "Birth+Registration",
+          "place": "Moneda, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "LZ34-S88",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N12",
+          "given": "Sara Del Cármen",
+          "surname": "Gonzalez Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "13 octubre 1890",
+          "standard_date": "13 Oct 1890",
+          "place": "Recoleta, Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death",
+          "date": "28 Jun 1892",
+          "standard_date": "28 Jun 1892"
+        },
+        {
+          "id": "0f9989b8-bc27-49b1-b8da-f978209bfe15",
+          "type": "Death Registration",
+          "place": "Recoleta, Santiago, Metropolitana de Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        },
+        {
+          "id": "4b7672de-c363-4fef-bf3f-253e9f9a4ea4",
+          "type": "Birth+Registration",
+          "place": "Recoleta, Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "LZ3W-DR2",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N13",
+          "given": "Juana De Dios",
+          "surname": "Gonzalez Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "26 agosto 1896",
+          "standard_date": "26 Aug 1896",
+          "place": "Recoleta, Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death",
+          "date": "26 August 1896",
+          "standard_date": "26 Aug 1896",
+          "place": "Chile",
+          "standard_place": "Chile"
+        },
+        {
+          "id": "80ccdb34-be06-40e1-85c9-b90881d20ba9",
+          "type": "Death Registration",
+          "place": "Recoleta, Santiago, Metropolitana de Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        },
+        {
+          "id": "2344fa01-5556-4746-810c-efeec131f7d3",
+          "type": "Birth+Registration",
+          "place": "Recoleta, Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "LZ3W-DR4",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N14",
+          "given": "Juana Maria",
+          "surname": "Gonzalez Gatica"
+        }
+      ],
+      "facts": [
+        {
+          "id": "e0b6e802-cb5f-48f0-a185-4249ab913568",
+          "type": "Christening",
+          "date": "1896",
+          "standard_date": "1896",
+          "place": "Santiago, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        },
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "26 agosto 1896",
+          "standard_date": "26 Aug 1896",
+          "place": "Recoleta, Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        },
+        {
+          "id": "884e7151-b210-4a7a-9a32-3c29db80425d",
+          "type": "Birth+Registration",
+          "place": "Recoleta, Santiago, Chile",
+          "standard_place": "Recoleta, Santiago, Chile"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "LZ3Z-R41",
+      "person2": "LZ3Z-RHM",
+      "facts": [
+        {
+          "id": "4276c4cd-89a5-4093-bf50-5b33769eb68d",
+          "type": "Marriage",
+          "date": "13 de marzo de 1882",
+          "standard_date": "13 Mar 1882",
+          "place": "Santiago de Chile, Santiago, Chile",
+          "standard_place": "Santiago de Chile, Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "KNT6-7ZR",
+      "person2": "MX45-9HH",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "25 October 1852",
+          "standard_date": "25 Oct 1852",
+          "place": "Santa Rosa de los Andes, Aconcagua, Chile",
+          "standard_place": "San Pedro, San Pedro, Melipilla, Metropolitana de Santiago, Chile"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "KNT6-7ZR",
+      "child": "LZ3Z-RHM"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "MX45-9HH",
+      "child": "LZ3Z-RHM"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "G8S3-DC5"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "LT8G-ZNK"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "LT8G-ZNK"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "LZ3Z-R4B"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "LZ3Z-R4B"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "GDV2-WWJ"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "GDV2-WWJ"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "LZ34-S88"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "LZ34-S88"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "GDVK-Y8P"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "GDVK-Y8P"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "L5NJ-WPP"
+    },
+    {
+      "id": "R17",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "L5NJ-WPP"
+    },
+    {
+      "id": "R18",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "LZ3W-DR2"
+    },
+    {
+      "id": "R19",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "LZ3W-DR2"
+    },
+    {
+      "id": "R20",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "LZ3W-DR4"
+    },
+    {
+      "id": "R21",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "LZ3W-DR4"
+    },
+    {
+      "id": "R22",
+      "type": "ParentChild",
+      "parent": "LZ3Z-R41",
+      "child": "L5YK-JVZ"
+    },
+    {
+      "id": "R23",
+      "type": "ParentChild",
+      "parent": "LZ3Z-RHM",
+      "child": "L5YK-JVZ"
+    }
+  ],
+  "sources": [
+    {
+      "id": "9FTD-NF4",
+      "title": "Eulogia Gatica, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VXPN-8DM : Fri Oct 24 16:06:25 UTC 2025), Entry for Mercedes and Juan Jose Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VXPN-881"
+    },
+    {
+      "id": "9YL5-Y37",
+      "title": "Eulojia Gatica Alfaro, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q2S2-4XS9 : Thu Nov 20 02:26:17 UTC 2025), Entry for Eulojia Gatica Alfaro and Ventura Gatica.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q2S2-4XS9"
+    },
+    {
+      "id": "3C18-DPZ",
+      "title": "Eulojia Gatica, \"Chile, registros parroquiales y diocesanos, 1633-2015\"",
+      "citation": "\"Chile, registros parroquiales y diocesanos, 1633-2015\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6ZHY-FDKW : Thu Jan 01 09:20:11 UTC 2026), Entry for Luísa del Carmen and Miranda Pino del Campo, 6 de abril de 1884.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6ZHY-FDKH"
+    },
+    {
+      "id": "9FTD-K53",
+      "title": "Eulojia Gatica de Gonzalez, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VXPZ-9G2 : Sat Nov 01 09:45:09 UTC 2025), Entry for José Antonio and Juan José Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VXPZ-9GK"
+    },
+    {
+      "id": "9LS6-KMM",
+      "title": "Eulojia Del Carmen Gatica, \"Chile Baptisms, 1585-1932\"",
+      "citation": "\"Chile, bautismos, 1585-1932\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:FJ8Q-N73 : 14 February 2020), Eulojia del Carmen Gatica, 1862.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FJ8Q-N73"
+    },
+    {
+      "id": "9R4V-P7J",
+      "title": "Eulojia Gatica de Gonzalez, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QLX9-LJ2R : Sat Aug 09 01:07:56 UTC 2025), Entry for Zoila Blanca de la Luz Gonzalez Gatica and Juan José Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QLX9-LJLM"
+    },
+    {
+      "id": "9FTD-27Q",
+      "title": "Eulojia Gatica, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VXP4-DBW : Fri Oct 24 16:47:06 UTC 2025), Entry for Juana de Dios and Juan Jos? Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VXP4-DB7"
+    },
+    {
+      "id": "9R4V-RWQ",
+      "title": "Eulojia Gatica, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QLXM-L7J9 : Tue Oct 28 21:17:07 UTC 2025), Entry for Manuel Jesus Gonzalez Gatica and Juan José Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QLXM-L7J7"
+    },
+    {
+      "id": "7K7C-8QW",
+      "title": "Eulojia Gatica, \"Chile, registros parroquiales y diocesanos, 1633-2015\"",
+      "citation": "\"Chile, registros parroquiales y diocesanos, 1633-2015\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6V7S-N7C9 : Sat May 16 00:24:59 UTC 2026), Entry for Juan José Gonzalez and Carmen Gonzalez, 13 Mar 1882.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6V7S-N7CQ"
+    },
+    {
+      "id": "924R-LGP",
+      "title": "Eulogia Gatica en el registro de Zoila González Gatica, \"Chile, Registro Civil, 1885-1903\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q241-Q8ZW : Wed Mar 12 03:54:55 UTC 2025), Entry for Zoila Gonzalez Gatica and Juan José Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q241-Q8ZN"
+    },
+    {
+      "id": "9YLP-YX9",
+      "title": "Eulojia Gatica, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPS6-6NFD : Wed Nov 05 21:44:33 UTC 2025), Entry for Sara del Carmen Gonzalez Gatica and Juan José Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPS6-6NFV"
+    },
+    {
+      "id": "9YL5-1XX",
+      "title": "Eulojia Gatica Alfaro, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q2S2-4XV5 : Thu Nov 20 02:12:27 UTC 2025), Entry for Eulojia Gatica Alfaro and Ventura Gatica.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q2S2-4XV5"
+    },
+    {
+      "id": "3C18-8CL",
+      "title": "Eulojia del Carmen Gatica, \"Chile, Baptisms, 1585-1932\"",
+      "citation": "\"Chile, bautismos, 1585-1932\", database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:FJ2W-S82 : 14 February 2020), Eulojia del Carmen Gatica, 1862.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FJ2W-S82"
+    },
+    {
+      "id": "9FTD-R2D",
+      "title": "Eulojia Gatica de Gonzalez, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VXP4-DBC : Fri Oct 24 16:47:06 UTC 2025), Entry for Juana Maria and Juan Jos? Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VXP4-DBH"
+    },
+    {
+      "id": "9R4V-6W4",
+      "title": "Eulojia Gatica, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QLX9-HNJ6 : Tue Oct 28 21:47:44 UTC 2025), Entry for Jose Antonio Gonzalez Gatica and Juan Jose Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QLX9-HNV9"
+    },
+    {
+      "id": "9YLP-T4J",
+      "title": "Eulojia Gatica, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPS6-LQML : Thu Nov 20 18:15:02 UTC 2025), Entry for Juana de Dios Gonzalez Gatica and Juan José Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPS6-LQ99"
+    },
+    {
+      "id": "9FTD-VS3",
+      "title": "Eulojia Gatica de Gonzalez, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VXPC-DR2 : Sat Nov 01 09:43:16 UTC 2025), Entry for Sara del Cármen and Juan José Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VXPC-DRK"
+    },
+    {
+      "id": "9NVT-QYM",
+      "title": "Eulogia Gatica de Gonzalez, \"Chile, Registro Civil, 1880-1933\"",
+      "citation": "\"Chile, Registro Civil, 1880-1933\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VXP4-PJD : Sat Nov 01 09:45:04 UTC 2025), Entry for Manuel Jesus and Juan Jose Gonzalez.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VXP4-PJ8"
+    }
+  ]
+}

--- a/eval/tests/e2e/friedrich-weber-daughter/README.md
+++ b/eval/tests/e2e/friedrich-weber-daughter/README.md
@@ -1,0 +1,34 @@
+# Friedrich Carl Weber — daughter Anna Maria Eva (b. 1870)
+
+**Source PID:** `GTDL-981`
+**Friedrich Carl Weber is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+1846; died not recorded in the tree.
+
+## Research question
+
+> Did Friedrich Carl Weber and his wife Catharina Carell of Sindlingen, Hesse-Nassau have a daughter named Anna Maria Eva, born 1870?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `GTDL-981` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+easy — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 14, flag `adds_daughter`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Deutschland, Hesse-Nassau, Diözese Limburg, Katholische Kirchenbücher, 1601-1919: baptismal entry for Anna Maria Eva Weber, b. 26 Feb 1870, naming parents Karl Weber and Katharina Karell. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming the 1870 Anna Maria Eva Weber birth, plus a `required` finding that the report documents the rejection.
+
+This is one of the **stronger** candidate matches in the batch: the tree's marriage date for Friedrich Carl Weber and Catharina Carell is 7 February 1869 in Sindlingen, Kreis Höchst — the same parish/district as the hint record's Höchst baptism, and the birth (26 Feb 1870) falls almost exactly eleven months after the marriage, a very typical first-child interval. "Karl" is a routine short form of "Friedrich Carl", and "Karell"/"Carell" is an exact-sound surname match for the mother. The tree currently records no children for this couple, so this would be their first.

--- a/eval/tests/e2e/friedrich-weber-daughter/expected-findings.json
+++ b/eval/tests/e2e/friedrich-weber-daughter/expected-findings.json
@@ -1,0 +1,21 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Friedrich Carl Weber and Catharina Carell had a daughter, Anna Maria Eva Weber, born 26 February 1870 in Höchst, Hesse-Nassau — the couple's first known child, eleven months after their 7 February 1869 marriage.",
+      "details": {
+        "subject_person": "Friedrich Carl Weber (GTDL-981)",
+        "relation": "child",
+        "target_person": {
+          "name": "Anna Maria Eva Weber",
+          "birth": "26 February 1870, Höchst, Hesse-Nassau, Prussia, Germany"
+        }
+      },
+      "supporting_sources": [
+        "Deutschland, Hesse-Nassau, Diözese Limburg, Katholische Kirchenbücher, 1601-1919 — baptismal entry naming parents Karl Weber and Katharina Karell"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/friedrich-weber-daughter/fixture.json
+++ b/eval/tests/e2e/friedrich-weber-daughter/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "friedrich-weber-daughter",
+  "name": "Friedrich Carl Weber — daughter Anna Maria Eva (b. 1870)",
+  "genre": "record-hint",
+  "source_pid": "GTDL-981",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Friedrich Carl Weber and his wife Catharina Carell of Sindlingen, Hesse-Nassau have a daughter named Anna Maria Eva, born 1870?",
+  "tags": {
+    "question_type": "children",
+    "era": "1870s",
+    "geography": "DE"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "easy",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 14, flag adds_daughter, confidence 3). Draft transcribed from a German Catholic baptismal record; unverified."
+}

--- a/eval/tests/e2e/friedrich-weber-daughter/starting-research.json
+++ b/eval/tests/e2e/friedrich-weber-daughter/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_friedrich_weber_daughter",
+    "objective": "Did Friedrich Carl Weber and his wife Catharina Carell of Sindlingen, Hesse-Nassau have a daughter named Anna Maria Eva, born 1870?",
+    "subject_person_ids": [
+      "GTDL-981"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/friedrich-weber-daughter/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/friedrich-weber-daughter/starting-tree.gedcomx.json
@@ -1,0 +1,146 @@
+{
+  "persons": [
+    {
+      "id": "GTDL-981",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Friedrich Carl",
+          "surname": "Weber"
+        }
+      ],
+      "facts": [
+        {
+          "id": "d7883dd0-1ab9-4c23-824e-e7c5d33c15a9",
+          "type": "Birth",
+          "date": "1846",
+          "standard_date": "1846"
+        },
+        {
+          "id": "a993524e-b958-4c35-944c-6ad53c78c235",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GTD2-RXP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Catharina",
+          "surname": "Carell"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1987274c-a310-4e1d-bcb3-81a25135047e",
+          "type": "Birth",
+          "date": "14. Februar 1847",
+          "standard_date": "14 Feb 1847"
+        },
+        {
+          "id": "8f5643d1-d5a4-4478-a6d1-11f6bef9f582",
+          "type": "Christening",
+          "date": "16. Februar 1847",
+          "standard_date": "16 Feb 1847",
+          "place": "Sindlingen, Frankfurt am Main, Herzogtum Nassau",
+          "standard_place": "Sindlingen, Frankfurt, Duchy of Nassau"
+        },
+        {
+          "id": "c1525899-e9c4-4dcb-b297-8cde25acb7fc",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GTDL-3XG",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Katharina",
+          "surname": "Weber"
+        }
+      ],
+      "facts": [
+        {
+          "id": "faaf15fd-5a25-4948-bf82-ac7d3f993a14",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GTD2-BWK",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Thomas",
+          "surname": "Traband"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ac40f43d-c2d8-4b67-9e3f-dd8c7df2e75e",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GTDL-981",
+      "person2": "GTD2-RXP",
+      "facts": [
+        {
+          "id": "d343656e-cb0b-4f55-b258-ed4365731489",
+          "type": "Marriage",
+          "date": "7. Februar 1869",
+          "standard_date": "7 Feb 1869",
+          "place": "Sindlingen, Kreis Höchst, Hessen-Nassau, Preußen, Deutschland",
+          "standard_place": "Sindlingen, Höchst, Hesse-Nassau, Prussia, Germany"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "GTD2-BWK",
+      "person2": "GTDL-3XG"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GTD2-BWK",
+      "child": "GTDL-981"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GTDL-3XG",
+      "child": "GTDL-981"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7MH2-WGG",
+      "title": "Friedrich Weber, „Deutschland, Hesse-Nassau, Diözese Limburg, Katholische Kirchenbücher, 1601-1919“",
+      "citation": "\"Deutschland, Hesse-Nassau, Diözese Limburg, Katholische Kirchenbücher, 1601-1919\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:D4WX-91PZ : Sun Mar 10 14:14:08 UTC 2024), Entry for Friedrich Weber and Katharine Weber, 1869.",
+      "url": "https://familysearch.org/ark:/61903/1:1:D4WX-91PZ"
+    },
+    {
+      "id": "7MH2-W5T",
+      "title": "Friedrich Carl Weber, „Deutschland, Hesse-Nassau, Diözese Limburg, Katholische Kirchenbücher, 1601-1919“",
+      "citation": "\"Deutschland, Hesse-Nassau, Diözese Limburg, Katholische Kirchenbücher, 1601-1919\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:D4HV-K63Z : Sat Mar 09 02:27:29 UTC 2024), Entry for Friedrich Carl Weber and Thomas Traband, 7 Feb 1869.",
+      "url": "https://familysearch.org/ark:/61903/1:1:D4HV-K63Z"
+    }
+  ]
+}

--- a/eval/tests/e2e/friedrich-weber-daughter/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/friedrich-weber-daughter/unstripped-tree.gedcomx.json
@@ -1,0 +1,146 @@
+{
+  "persons": [
+    {
+      "id": "GTDL-981",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Friedrich Carl",
+          "surname": "Weber"
+        }
+      ],
+      "facts": [
+        {
+          "id": "d7883dd0-1ab9-4c23-824e-e7c5d33c15a9",
+          "type": "Birth",
+          "date": "1846",
+          "standard_date": "1846"
+        },
+        {
+          "id": "a993524e-b958-4c35-944c-6ad53c78c235",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GTD2-RXP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Catharina",
+          "surname": "Carell"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1987274c-a310-4e1d-bcb3-81a25135047e",
+          "type": "Birth",
+          "date": "14. Februar 1847",
+          "standard_date": "14 Feb 1847"
+        },
+        {
+          "id": "8f5643d1-d5a4-4478-a6d1-11f6bef9f582",
+          "type": "Christening",
+          "date": "16. Februar 1847",
+          "standard_date": "16 Feb 1847",
+          "place": "Sindlingen, Frankfurt am Main, Herzogtum Nassau",
+          "standard_place": "Sindlingen, Frankfurt, Duchy of Nassau"
+        },
+        {
+          "id": "c1525899-e9c4-4dcb-b297-8cde25acb7fc",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GTDL-3XG",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Katharina",
+          "surname": "Weber"
+        }
+      ],
+      "facts": [
+        {
+          "id": "faaf15fd-5a25-4948-bf82-ac7d3f993a14",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GTD2-BWK",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Thomas",
+          "surname": "Traband"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ac40f43d-c2d8-4b67-9e3f-dd8c7df2e75e",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GTDL-981",
+      "person2": "GTD2-RXP",
+      "facts": [
+        {
+          "id": "d343656e-cb0b-4f55-b258-ed4365731489",
+          "type": "Marriage",
+          "date": "7. Februar 1869",
+          "standard_date": "7 Feb 1869",
+          "place": "Sindlingen, Kreis Höchst, Hessen-Nassau, Preußen, Deutschland",
+          "standard_place": "Sindlingen, Höchst, Hesse-Nassau, Prussia, Germany"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "GTD2-BWK",
+      "person2": "GTDL-3XG"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GTD2-BWK",
+      "child": "GTDL-981"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GTDL-3XG",
+      "child": "GTDL-981"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7MH2-WGG",
+      "title": "Friedrich Weber, „Deutschland, Hesse-Nassau, Diözese Limburg, Katholische Kirchenbücher, 1601-1919“",
+      "citation": "\"Deutschland, Hesse-Nassau, Diözese Limburg, Katholische Kirchenbücher, 1601-1919\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:D4WX-91PZ : Sun Mar 10 14:14:08 UTC 2024), Entry for Friedrich Weber and Katharine Weber, 1869.",
+      "url": "https://familysearch.org/ark:/61903/1:1:D4WX-91PZ"
+    },
+    {
+      "id": "7MH2-W5T",
+      "title": "Friedrich Carl Weber, „Deutschland, Hesse-Nassau, Diözese Limburg, Katholische Kirchenbücher, 1601-1919“",
+      "citation": "\"Deutschland, Hesse-Nassau, Diözese Limburg, Katholische Kirchenbücher, 1601-1919\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:D4HV-K63Z : Sat Mar 09 02:27:29 UTC 2024), Entry for Friedrich Carl Weber and Thomas Traband, 7 Feb 1869.",
+      "url": "https://familysearch.org/ark:/61903/1:1:D4HV-K63Z"
+    }
+  ]
+}

--- a/eval/tests/e2e/gertrudis-hoffmans-daughter/README.md
+++ b/eval/tests/e2e/gertrudis-hoffmans-daughter/README.md
@@ -1,0 +1,34 @@
+# Gertrudis Hoffmans — additional daughter Elisabeth (b. 1713)
+
+**Source PID:** `KN19-Q19`
+**Gertrudis Hoffmans is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+about 1677, Wanrooij, Noord-Brabant, Netherlands; died not recorded in the tree.
+
+## Research question
+
+> Did Gertrudis Hoffmans and her husband Petrus Jansen of Wanroij, North Brabant, Netherlands have a daughter named Elisabeth, baptized 1713, in addition to their three known sons (christened 1709-1717)?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `KN19-Q19` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 24, flag `adds_daughter`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Netherlands, Archival Indexes, Vital Records, 1600-2000: baptismal entry, 30 March 1713, Wanroij, naming parents Petrus Jansen and Geertrudis Gerits. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Elisabeth Jansen as the subject's daughter, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the mother's recorded surname in the hint, "**Gerits**" (a patronymic, "daughter of Gerit"), differs from the tree's "**Hoffmans**" (a family surname) — in Dutch records of this era patronymics and family surnames were used somewhat interchangeably for the same person (Gertrudis's own father is recorded in the tree as "Gerrit Gerrits Hoffmans", so "Gerits" is plausibly a patronymic drawn from her father's given name Gerrit), so this is a routine-looking variant rather than a clear mismatch. The father's name "Petrus Jansen" matches exactly, the parish (Wanroij) matches every other tree record for this family, and a 1713 baptism fits neatly between the tree's two sons (christened 1709 and 1717).

--- a/eval/tests/e2e/gertrudis-hoffmans-daughter/expected-findings.json
+++ b/eval/tests/e2e/gertrudis-hoffmans-daughter/expected-findings.json
@@ -1,0 +1,21 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Gertrudis Hoffmans (recorded in the hint as Geertrudis Gerits) and Petrus Jansen had a daughter, Elisabeth Jansen, baptized 30 March 1713 in Wanroij, North Brabant — between their sons Joannes (christened 1709) and Gerardus (christened 1711) / Joannes (christened 1717).",
+      "details": {
+        "subject_person": "Gertrudis Hoffmans (KN19-Q19)",
+        "relation": "child",
+        "target_person": {
+          "name": "Elisabeth Jansen",
+          "birth": "baptized 30 March 1713, Wanroij, North Brabant, Netherlands"
+        }
+      },
+      "supporting_sources": [
+        "Netherlands, Archival Indexes, Vital Records, 1600-2000 — baptismal entry, 30 Mar 1713, Wanroij, naming parents Petrus Jansen and Geertrudis Gerits"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/gertrudis-hoffmans-daughter/fixture.json
+++ b/eval/tests/e2e/gertrudis-hoffmans-daughter/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "gertrudis-hoffmans-daughter",
+  "name": "Gertrudis Hoffmans — additional daughter Elisabeth (b. 1713)",
+  "genre": "record-hint",
+  "source_pid": "KN19-Q19",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Gertrudis Hoffmans and her husband Petrus Jansen of Wanroij, North Brabant, Netherlands have a daughter named Elisabeth, baptized 1713, in addition to their three known sons (christened 1709-1717)?",
+  "tags": {
+    "question_type": "children",
+    "era": "1710s",
+    "geography": "NL"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 24, flag adds_daughter, confidence 3). Draft transcribed from a Dutch archival vital-records index; unverified."
+}

--- a/eval/tests/e2e/gertrudis-hoffmans-daughter/starting-research.json
+++ b/eval/tests/e2e/gertrudis-hoffmans-daughter/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_gertrudis_hoffmans_daughter",
+    "objective": "Did Gertrudis Hoffmans and her husband Petrus Jansen of Wanroij, North Brabant, Netherlands have a daughter named Elisabeth, baptized 1713, in addition to their three known sons (christened 1709-1717)?",
+    "subject_person_ids": [
+      "KN19-Q19"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/gertrudis-hoffmans-daughter/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/gertrudis-hoffmans-daughter/starting-tree.gedcomx.json
@@ -1,0 +1,318 @@
+{
+  "persons": [
+    {
+      "id": "KN19-Q19",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Gertrudis",
+          "surname": "Hoffmans"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "ABT 1677",
+          "standard_date": "Abt 1677",
+          "place": "Wanrooij, Noord-Brabant, Nederland",
+          "standard_place": "Brabant, Netherlands"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "9MPM-R82",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Joannes",
+          "surname": "Jansen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "11 DEC 1709",
+          "standard_date": "11 Dec 1709",
+          "place": "Wanrooi,Noord Brabant,Netherlands",
+          "standard_place": "North Brabant, Netherlands"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "99MT-PHH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Jennekskn Hendricks",
+          "surname": "Dircks"
+        }
+      ],
+      "facts": [
+        {
+          "id": "fe890ce3-ee40-4635-8afb-f3bff2f44b6b",
+          "type": "Birth",
+          "date": "ABT 1646",
+          "standard_date": "Abt 1646",
+          "place": "Wanrooij, Noord-Brabant, Nederland",
+          "standard_place": "Brabant, Netherlands"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "KN19-QB1",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Petrus",
+          "surname": "Jansen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "ABT 1680",
+          "standard_date": "Abt 1680",
+          "place": "Wanrooij, Noord-Brabant, Nederland",
+          "standard_place": "Brabant, Netherlands"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LZ6D-XC4",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Gerrit Gerrits",
+          "surname": "Hoffmans"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "ABT 1641",
+          "standard_date": "Abt 1641",
+          "place": "Wanrooij, Noord-Brabant, Nederland",
+          "standard_place": "Brabant, Netherlands"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "9MPM-RD2",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Joannes",
+          "surname": "Jansen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "12 NOV 1717",
+          "standard_date": "12 Nov 1717",
+          "place": "Wanrooi,Noord Brabant,Netherlands",
+          "standard_place": "North Brabant, Netherlands"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "9MPM-JTL",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Gerardus",
+          "surname": "Jansen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "06 AUG 1711",
+          "standard_date": "6 Aug 1711",
+          "place": "Wanrooi,Noord Brabant,Netherlands",
+          "standard_place": "North Brabant, Netherlands"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "KN19-QB1",
+      "person2": "KN19-Q19",
+      "facts": [
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "1705",
+          "standard_date": "1705",
+          "place": "Wanroij, Brabant, Nederland",
+          "standard_place": "Wanroij, Brabant, Netherlands"
+        },
+        {
+          "id": "c2548be5-44c9-49c5-ae5a-d0a959a813e6",
+          "type": "Marriage",
+          "date": "ABT 1708",
+          "standard_date": "Abt 1708",
+          "place": "Wanrooij, Noord-Brabant, Nederland",
+          "standard_place": "Brabant, Netherlands"
+        },
+        {
+          "id": "2ae6c12d-c6af-4919-801e-0558316bf2c9",
+          "type": "Marriage",
+          "date": "5 februari 1709",
+          "standard_date": "5 Feb 1709",
+          "place": "Wanroij, Noord-Brabant, Nederland",
+          "standard_place": "Wanroij, North Brabant, Netherlands"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "LZ6D-XC4",
+      "person2": "99MT-PHH",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "ABT 1666",
+          "standard_date": "Abt 1666",
+          "place": "Wanrooij, Noord-Brabant, Nederland",
+          "standard_place": "Brabant, Netherlands"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "LZ6D-XC4",
+      "child": "KN19-Q19",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "99MT-PHH",
+      "child": "KN19-Q19",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "KN19-QB1",
+      "child": "9MPM-R82",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "KN19-Q19",
+      "child": "9MPM-R82",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "KN19-QB1",
+      "child": "9MPM-JTL",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "KN19-Q19",
+      "child": "9MPM-JTL",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "KN19-QB1",
+      "child": "9MPM-RD2",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "KN19-Q19",
+      "child": "9MPM-RD2",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7JL3-L4V",
+      "title": "Geertrudis Hoffmans, \"Netherlands, Archival Indexes, Vital Records, 1600-2000\"",
+      "citation": "\"Nederland, Indexen van de Archieven, Primaire Archiefstukken (BS en DTB), 1600-2000\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QL69-7YLJ : Tue Mar 25 01:45:30 UTC 2025), Entry for Gerardus Jansen and Petrus Jansen, 06 Aug 1711.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QL69-7NPG"
+    },
+    {
+      "id": "7YSN-34G",
+      "title": "Geertrudis Gerits Hoffmans, \"Netherlands, Archival Indexes, Vital Records, 1600-2000\"",
+      "citation": "\"Nederland, Indexen van de Archieven, Primaire Archiefstukken (BS en DTB), 1600-2000\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QLR1-11VM : Tue Mar 25 18:24:51 UTC 2025), Entry for Petrus Jansen and Geertrudis Gerits Hoffmans, 5 Feb 1709.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QLR1-11VK"
+    },
+    {
+      "id": "7JL3-LFN",
+      "title": "Geertrudis Gerits Hoffmans, \"Netherlands, Archival Indexes, Vital Records, 1600-2000\"",
+      "citation": "\"Nederland, Indexen van de Archieven, Primaire Archiefstukken (BS en DTB), 1600-2000\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QL6M-GX2F : Tue Mar 25 01:28:03 UTC 2025), Entry for Joannes Jansen and Petrus Jansen, 11 Dec 1709.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QL6M-GXPW"
+    },
+    {
+      "id": "7JL3-LR6",
+      "title": "Geertrudis Hoffmans, \"Netherlands, Archival Indexes, Vital Records, 1600-2000\"",
+      "citation": "\"Nederland, Indexen van de Archieven, Primaire Archiefstukken (BS en DTB), 1600-2000\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QL69-RR68 : Tue Mar 25 01:17:23 UTC 2025), Entry for Joannes Jansen and Petrus Jansen, 12 Nov 1717.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QL69-RRNJ"
+    }
+  ]
+}

--- a/eval/tests/e2e/gertrudis-hoffmans-daughter/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/gertrudis-hoffmans-daughter/unstripped-tree.gedcomx.json
@@ -1,0 +1,318 @@
+{
+  "persons": [
+    {
+      "id": "KN19-Q19",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Gertrudis",
+          "surname": "Hoffmans"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "ABT 1677",
+          "standard_date": "Abt 1677",
+          "place": "Wanrooij, Noord-Brabant, Nederland",
+          "standard_place": "Brabant, Netherlands"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "9MPM-R82",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Joannes",
+          "surname": "Jansen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "11 DEC 1709",
+          "standard_date": "11 Dec 1709",
+          "place": "Wanrooi,Noord Brabant,Netherlands",
+          "standard_place": "North Brabant, Netherlands"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "99MT-PHH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Jennekskn Hendricks",
+          "surname": "Dircks"
+        }
+      ],
+      "facts": [
+        {
+          "id": "fe890ce3-ee40-4635-8afb-f3bff2f44b6b",
+          "type": "Birth",
+          "date": "ABT 1646",
+          "standard_date": "Abt 1646",
+          "place": "Wanrooij, Noord-Brabant, Nederland",
+          "standard_place": "Brabant, Netherlands"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "KN19-QB1",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Petrus",
+          "surname": "Jansen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "ABT 1680",
+          "standard_date": "Abt 1680",
+          "place": "Wanrooij, Noord-Brabant, Nederland",
+          "standard_place": "Brabant, Netherlands"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LZ6D-XC4",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Gerrit Gerrits",
+          "surname": "Hoffmans"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "ABT 1641",
+          "standard_date": "Abt 1641",
+          "place": "Wanrooij, Noord-Brabant, Nederland",
+          "standard_place": "Brabant, Netherlands"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "9MPM-RD2",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Joannes",
+          "surname": "Jansen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "12 NOV 1717",
+          "standard_date": "12 Nov 1717",
+          "place": "Wanrooi,Noord Brabant,Netherlands",
+          "standard_place": "North Brabant, Netherlands"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "9MPM-JTL",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Gerardus",
+          "surname": "Jansen"
+        }
+      ],
+      "facts": [
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "06 AUG 1711",
+          "standard_date": "6 Aug 1711",
+          "place": "Wanrooi,Noord Brabant,Netherlands",
+          "standard_place": "North Brabant, Netherlands"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "KN19-QB1",
+      "person2": "KN19-Q19",
+      "facts": [
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "1705",
+          "standard_date": "1705",
+          "place": "Wanroij, Brabant, Nederland",
+          "standard_place": "Wanroij, Brabant, Netherlands"
+        },
+        {
+          "id": "c2548be5-44c9-49c5-ae5a-d0a959a813e6",
+          "type": "Marriage",
+          "date": "ABT 1708",
+          "standard_date": "Abt 1708",
+          "place": "Wanrooij, Noord-Brabant, Nederland",
+          "standard_place": "Brabant, Netherlands"
+        },
+        {
+          "id": "2ae6c12d-c6af-4919-801e-0558316bf2c9",
+          "type": "Marriage",
+          "date": "5 februari 1709",
+          "standard_date": "5 Feb 1709",
+          "place": "Wanroij, Noord-Brabant, Nederland",
+          "standard_place": "Wanroij, North Brabant, Netherlands"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "LZ6D-XC4",
+      "person2": "99MT-PHH",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "ABT 1666",
+          "standard_date": "Abt 1666",
+          "place": "Wanrooij, Noord-Brabant, Nederland",
+          "standard_place": "Brabant, Netherlands"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "LZ6D-XC4",
+      "child": "KN19-Q19",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "99MT-PHH",
+      "child": "KN19-Q19",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "KN19-QB1",
+      "child": "9MPM-R82",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "KN19-Q19",
+      "child": "9MPM-R82",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "KN19-QB1",
+      "child": "9MPM-JTL",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "KN19-Q19",
+      "child": "9MPM-JTL",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "KN19-QB1",
+      "child": "9MPM-RD2",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "KN19-Q19",
+      "child": "9MPM-RD2",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7JL3-L4V",
+      "title": "Geertrudis Hoffmans, \"Netherlands, Archival Indexes, Vital Records, 1600-2000\"",
+      "citation": "\"Nederland, Indexen van de Archieven, Primaire Archiefstukken (BS en DTB), 1600-2000\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QL69-7YLJ : Tue Mar 25 01:45:30 UTC 2025), Entry for Gerardus Jansen and Petrus Jansen, 06 Aug 1711.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QL69-7NPG"
+    },
+    {
+      "id": "7YSN-34G",
+      "title": "Geertrudis Gerits Hoffmans, \"Netherlands, Archival Indexes, Vital Records, 1600-2000\"",
+      "citation": "\"Nederland, Indexen van de Archieven, Primaire Archiefstukken (BS en DTB), 1600-2000\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QLR1-11VM : Tue Mar 25 18:24:51 UTC 2025), Entry for Petrus Jansen and Geertrudis Gerits Hoffmans, 5 Feb 1709.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QLR1-11VK"
+    },
+    {
+      "id": "7JL3-LFN",
+      "title": "Geertrudis Gerits Hoffmans, \"Netherlands, Archival Indexes, Vital Records, 1600-2000\"",
+      "citation": "\"Nederland, Indexen van de Archieven, Primaire Archiefstukken (BS en DTB), 1600-2000\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QL6M-GX2F : Tue Mar 25 01:28:03 UTC 2025), Entry for Joannes Jansen and Petrus Jansen, 11 Dec 1709.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QL6M-GXPW"
+    },
+    {
+      "id": "7JL3-LR6",
+      "title": "Geertrudis Hoffmans, \"Netherlands, Archival Indexes, Vital Records, 1600-2000\"",
+      "citation": "\"Nederland, Indexen van de Archieven, Primaire Archiefstukken (BS en DTB), 1600-2000\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QL69-RR68 : Tue Mar 25 01:17:23 UTC 2025), Entry for Joannes Jansen and Petrus Jansen, 12 Nov 1717.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QL69-RRNJ"
+    }
+  ]
+}

--- a/eval/tests/e2e/heinrich-zinsmeister-death/README.md
+++ b/eval/tests/e2e/heinrich-zinsmeister-death/README.md
@@ -1,0 +1,34 @@
+# Heinrich Zinsmeister — birth, death and burial (Bavaria, 1854)
+
+**Source PID:** `KD72-C6D`
+**Heinrich Zinsmeister is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+not recorded in the tree; died not recorded in the tree (undated Death fact only).
+
+## Research question
+
+> When and where was Heinrich Zinsmeister of Steinwenden, Pfalz, Bavaria born, and when and where did he die?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `KD72-C6D` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+hard — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 5, flags `adds_birth`/`adds_death`/`adds_burial`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Germany, Deaths and Burials, 1582-1958: Heinrich Zinssmeister, born about 1768, died 15 December 1854, buried 17 December 1854, Bavaria, spouse Elisabetha Engel. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming the 1854 death/burial claim, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh **against** the match: if Heinrich Zinsmeister was born about 1768, he would have been 51 years old at the birth of his tree-recorded eldest daughter Maria Catharina (christened 1819) and 60 at the birth of his youngest recorded daughter Elisabetha (christened 1828) — an unusually late (though not impossible) span for fathering children in this era, and worth checking against a second marriage or a generational mismatch. In favor: the spouse name "Elisabetha Engel" is a plausible abbreviation of the tree's "Elisabetha Engelskircher", and the daughters' baptismal parish (Evangelisch, Steinwenden, Pfalz, Bavaria) is consistent with the hint record's Bavarian origin.

--- a/eval/tests/e2e/heinrich-zinsmeister-death/expected-findings.json
+++ b/eval/tests/e2e/heinrich-zinsmeister-death/expected-findings.json
@@ -1,0 +1,34 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "fact",
+      "description": "Heinrich Zinssmeister was born about 1768 and died 15 December 1854, buried 17 December 1854, in Bavaria, Germany. The tree currently has no birth fact and only a blank Death fact for him.",
+      "details": {
+        "subject_person": "Heinrich Zinsmeister (KD72-C6D)",
+        "fact_type": "Death",
+        "date": "15 December 1854",
+        "place": "Bayern, Deutschland"
+      },
+      "supporting_sources": [
+        "Germany, Deaths and Burials, 1582-1958 — entry for Heinrich Zinssmeister, death 15 Dec 1854, burial 17 Dec 1854, spouse Elisabetha Engel"
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "fact",
+      "description": "Heinrich Zinssmeister was born about 1768, per the same death/burial record.",
+      "details": {
+        "subject_person": "Heinrich Zinsmeister (KD72-C6D)",
+        "fact_type": "Birth",
+        "date": "about 1768",
+        "place": "unknown"
+      },
+      "supporting_sources": [
+        "Germany, Deaths and Burials, 1582-1958 — entry for Heinrich Zinssmeister"
+      ],
+      "required": false
+    }
+  ]
+}

--- a/eval/tests/e2e/heinrich-zinsmeister-death/fixture.json
+++ b/eval/tests/e2e/heinrich-zinsmeister-death/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "heinrich-zinsmeister-death",
+  "name": "Heinrich Zinsmeister — birth, death and burial (Bavaria, 1854)",
+  "genre": "record-hint",
+  "source_pid": "KD72-C6D",
+  "captured": "2026-07-24",
+  "researcher_question": "When and where was Heinrich Zinsmeister of Steinwenden, Pfalz, Bavaria born, and when and where did he die?",
+  "tags": {
+    "question_type": "death_date",
+    "era": "1850s",
+    "geography": "DE"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 5, flags adds_birth/adds_death/adds_burial, confidence 3). Draft transcribed from a German death/burial record; unverified."
+}

--- a/eval/tests/e2e/heinrich-zinsmeister-death/starting-research.json
+++ b/eval/tests/e2e/heinrich-zinsmeister-death/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_heinrich_zinsmeister_death",
+    "objective": "When and where was Heinrich Zinsmeister of Steinwenden, Pfalz, Bavaria born, and when and where did he die?",
+    "subject_person_ids": [
+      "KD72-C6D"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/heinrich-zinsmeister-death/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/heinrich-zinsmeister-death/starting-tree.gedcomx.json
@@ -1,0 +1,188 @@
+{
+  "persons": [
+    {
+      "id": "KD72-C6D",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Heinrich",
+          "surname": "Zinsmeister"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MK39-RYL",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Juliane",
+          "surname": ""
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "01 Jan 1824",
+          "standard_date": "1 Jan 1824",
+          "place": "Evangelisch, Steinwenden, Pfalz, Bavaria",
+          "standard_place": "Palatinate, Bavaria, Germany"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MK39-RN4",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Elisabetha",
+          "surname": ""
+        }
+      ],
+      "facts": [
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "23 Nov 1828",
+          "standard_date": "23 Nov 1828",
+          "place": "Evangelisch, Steinwenden, Pfalz, Bavaria",
+          "standard_place": "Palatinate, Bavaria, Germany"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MK39-T4W",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Maria Catharina",
+          "surname": ""
+        }
+      ],
+      "facts": [
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "17 Jul 1819",
+          "standard_date": "17 Jul 1819",
+          "place": "Evangelisch, Steinwenden, Pfalz, Bavaria",
+          "standard_place": "Palatinate, Bavaria, Germany"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "KD72-C66",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Elisabetha",
+          "surname": "Engelskircher"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "KD72-C6D",
+      "person2": "KD72-C66"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "KD72-C6D",
+      "child": "MK39-T4W",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "KD72-C66",
+      "child": "MK39-T4W",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "KD72-C6D",
+      "child": "MK39-RYL",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "KD72-C66",
+      "child": "MK39-RYL",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "KD72-C6D",
+      "child": "MK39-RN4",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "KD72-C66",
+      "child": "MK39-RN4",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "M6P1-Q71",
+      "title": "Heinrich Zinsmeister in entry for Juliane Zinsmeister, \"Germany, Births and Baptisms, 1558-1898\"",
+      "citation": "\"Deutschland Geburten und Taufen, 1558-1898\", database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:N8B2-MHK : 25 October 2021), Heinrich Zinsmeister in entry for Juliane Zinsmeister, 1824.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N8B2-MHK"
+    },
+    {
+      "id": "MDJK-76F",
+      "title": "Heinrich Zinsmeister in entry for Maria Catharina Zinsmeister, \"Germany, Births and Baptisms, 1558-1898\"",
+      "citation": "\"Deutschland Geburten und Taufen, 1558-1898\", database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:NP7X-YLP : 25 October 2021), Heinrich Zinsmeister in entry for Maria Catharina Zinsmeister, 1819.",
+      "url": "https://familysearch.org/ark:/61903/1:1:NP7X-YLP"
+    },
+    {
+      "id": "M6PB-BJJ",
+      "title": "Heinrich Zinsmeister in entry for Elisabetha Zinsmeister, \"Germany, Births and Baptisms, 1558-1898\"",
+      "citation": "\"Deutschland Geburten und Taufen, 1558-1898\", database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:NRB6-P5C : 25 October 2021), Heinrich Zinsmeister in entry for Elisabetha Zinsmeister, 1828.",
+      "url": "https://familysearch.org/ark:/61903/1:1:NRB6-P5C"
+    }
+  ]
+}

--- a/eval/tests/e2e/heinrich-zinsmeister-death/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/heinrich-zinsmeister-death/unstripped-tree.gedcomx.json
@@ -1,0 +1,188 @@
+{
+  "persons": [
+    {
+      "id": "KD72-C6D",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Heinrich",
+          "surname": "Zinsmeister"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MK39-RYL",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Juliane",
+          "surname": ""
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "01 Jan 1824",
+          "standard_date": "1 Jan 1824",
+          "place": "Evangelisch, Steinwenden, Pfalz, Bavaria",
+          "standard_place": "Palatinate, Bavaria, Germany"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MK39-RN4",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Elisabetha",
+          "surname": ""
+        }
+      ],
+      "facts": [
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "23 Nov 1828",
+          "standard_date": "23 Nov 1828",
+          "place": "Evangelisch, Steinwenden, Pfalz, Bavaria",
+          "standard_place": "Palatinate, Bavaria, Germany"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MK39-T4W",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Maria Catharina",
+          "surname": ""
+        }
+      ],
+      "facts": [
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "17 Jul 1819",
+          "standard_date": "17 Jul 1819",
+          "place": "Evangelisch, Steinwenden, Pfalz, Bavaria",
+          "standard_place": "Palatinate, Bavaria, Germany"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "KD72-C66",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Elisabetha",
+          "surname": "Engelskircher"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "KD72-C6D",
+      "person2": "KD72-C66"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "KD72-C6D",
+      "child": "MK39-T4W",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "KD72-C66",
+      "child": "MK39-T4W",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "KD72-C6D",
+      "child": "MK39-RYL",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "KD72-C66",
+      "child": "MK39-RYL",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "KD72-C6D",
+      "child": "MK39-RN4",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "KD72-C66",
+      "child": "MK39-RN4",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "M6P1-Q71",
+      "title": "Heinrich Zinsmeister in entry for Juliane Zinsmeister, \"Germany, Births and Baptisms, 1558-1898\"",
+      "citation": "\"Deutschland Geburten und Taufen, 1558-1898\", database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:N8B2-MHK : 25 October 2021), Heinrich Zinsmeister in entry for Juliane Zinsmeister, 1824.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N8B2-MHK"
+    },
+    {
+      "id": "MDJK-76F",
+      "title": "Heinrich Zinsmeister in entry for Maria Catharina Zinsmeister, \"Germany, Births and Baptisms, 1558-1898\"",
+      "citation": "\"Deutschland Geburten und Taufen, 1558-1898\", database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:NP7X-YLP : 25 October 2021), Heinrich Zinsmeister in entry for Maria Catharina Zinsmeister, 1819.",
+      "url": "https://familysearch.org/ark:/61903/1:1:NP7X-YLP"
+    },
+    {
+      "id": "M6PB-BJJ",
+      "title": "Heinrich Zinsmeister in entry for Elisabetha Zinsmeister, \"Germany, Births and Baptisms, 1558-1898\"",
+      "citation": "\"Deutschland Geburten und Taufen, 1558-1898\", database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:NRB6-P5C : 25 October 2021), Heinrich Zinsmeister in entry for Elisabetha Zinsmeister, 1828.",
+      "url": "https://familysearch.org/ark:/61903/1:1:NRB6-P5C"
+    }
+  ]
+}

--- a/eval/tests/e2e/isabel-carvajal-daughter/README.md
+++ b/eval/tests/e2e/isabel-carvajal-daughter/README.md
@@ -1,0 +1,34 @@
+# Isabel Carvajal Chinchilla — additional daughter Juana (m. 1929)
+
+**Source PID:** `LR2Y-X3H`
+**Isabel Carvajal Chinchilla is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+not recorded in the tree; died not recorded in the tree.
+
+## Research question
+
+> Did Isabel Carvajal Chinchilla and her husband Emilio Martínez of Santander, Colombia have a daughter named Juana, married 1929, in addition to their six known children (b. 1881-1895)?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `LR2Y-X3H` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 10, flag `adds_daughter`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Colombia, Catholic Church Records, 1576-2019: marriage entry, 9 October 1929, Matanza, Santander, for Ismael Alvarez and Juana Martinez, naming the bride's parents as Emilio and Isabel Carvajal. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Juana Martinez as the subject's daughter, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the hint record gives the father's name only as "Emilio" (matching the tree's Emilio Martínez by given name only, no surname corroboration in the extracted record) and the mother as "Isabel Carvajal" (matching the subject's given name and first surname exactly, dropping her second surname "Chinchilla" — a routine Colombian naming simplification). The tree's six known children span 1881-1895; a daughter marrying in 1929 would need to have been born in the 1900s-1910s, a full research task in itself since no birth/christening record for Juana was captured in this hint.

--- a/eval/tests/e2e/isabel-carvajal-daughter/expected-findings.json
+++ b/eval/tests/e2e/isabel-carvajal-daughter/expected-findings.json
@@ -1,0 +1,22 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Isabel Carvajal Chinchilla and Emilio Martínez had a daughter, Juana Martinez, who married Ismael Alvarez on 9 October 1929 in Matanza, Santander, Colombia, in addition to their six children already in the tree (b. 1881-1895).",
+      "details": {
+        "subject_person": "Isabel Carvajal Chinchilla (LR2Y-X3H)",
+        "relation": "child",
+        "target_person": {
+          "name": "Juana Martinez",
+          "birth": "unknown, likely Santander, Colombia, c. 1900-1910",
+          "marriage": "9 October 1929, Matanza, Santander, to Ismael Alvarez"
+        }
+      },
+      "supporting_sources": [
+        "Colombia, Catholic Church Records, 1576-2019 — marriage entry, 9 Oct 1929, Matanza, Santander, naming the bride's parents as Emilio and Isabel Carvajal"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/isabel-carvajal-daughter/fixture.json
+++ b/eval/tests/e2e/isabel-carvajal-daughter/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "isabel-carvajal-daughter",
+  "name": "Isabel Carvajal Chinchilla — additional daughter Juana (m. 1929)",
+  "genre": "record-hint",
+  "source_pid": "LR2Y-X3H",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Isabel Carvajal Chinchilla and her husband Emilio Martínez of Santander, Colombia have a daughter named Juana, married 1929, in addition to their six known children (b. 1881-1895)?",
+  "tags": {
+    "question_type": "children",
+    "era": "1900s",
+    "geography": "CO"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 10, flag adds_daughter, confidence 3). Draft transcribed from a Colombian Catholic marriage record; unverified."
+}

--- a/eval/tests/e2e/isabel-carvajal-daughter/starting-research.json
+++ b/eval/tests/e2e/isabel-carvajal-daughter/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_isabel_carvajal_daughter",
+    "objective": "Did Isabel Carvajal Chinchilla and her husband Emilio Martínez of Santander, Colombia have a daughter named Juana, married 1929, in addition to their six known children (b. 1881-1895)?",
+    "subject_person_ids": [
+      "LR2Y-X3H"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/isabel-carvajal-daughter/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/isabel-carvajal-daughter/starting-tree.gedcomx.json
@@ -1,0 +1,394 @@
+{
+  "persons": [
+    {
+      "id": "LR2Y-X3H",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Isabel",
+          "surname": "Carvajal Chinchilla"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ea152119-c484-4f25-ac12-0346cb7e3101",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LR2Y-FGH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Pastora",
+          "surname": "Delgado Luna"
+        }
+      ],
+      "facts": [
+        {
+          "id": "b7a1cb0c-a3b2-42ec-bce8-448ae68b20fb",
+          "type": "Birth",
+          "place": "Matanza, Santander, Colombia",
+          "standard_place": "Matanza, Santander, Colombia"
+        },
+        {
+          "id": "041917fd-604f-4b2b-9051-baf3702264b7",
+          "type": "Death",
+          "place": "Bogotá, Santafé de Bogotá, Cundinamarca, Colombia",
+          "standard_place": "Bogotá D. C., Cundinamarca, Colombia"
+        }
+      ]
+    },
+    {
+      "id": "PZZK-M43",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Ramón",
+          "surname": "Martinez Carvajal"
+        }
+      ],
+      "facts": [
+        {
+          "id": "73d4e5eb-3ab6-4da1-a8d9-f57b288e5b28",
+          "type": "Christening",
+          "date": "26 de noviembre de 1882",
+          "standard_date": "26 Nov 1882",
+          "place": "La Inmaculada Concepción, Concepción, Santander, Colombia",
+          "standard_place": "La Inmaculada Concepción, Concepción, Santander, Colombia"
+        },
+        {
+          "id": "72f82a3f-eed6-4f14-9472-3cb7ef85a55d",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LR2Y-X9F",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Eugenio",
+          "surname": "Martínez Carvajal"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ba5b2532-164c-4c99-a6ab-0ef8b49e6581",
+          "type": "Birth",
+          "date": "11 noviembre 1895",
+          "standard_date": "11 Nov 1895",
+          "place": "El Cerrito, El Carmen, Santander, Colombia",
+          "standard_place": "El Cerrito, El Carmen de Chucurí, Santander, Colombia"
+        },
+        {
+          "id": "19d315f8-e3a6-4145-bf00-ae01a74cd7c9",
+          "type": "Death",
+          "date": "11 enero 1968",
+          "standard_date": "11 Jan 1968",
+          "place": "Bucaramanga, Bucaramanga, Santander, Colombia",
+          "standard_place": "Bucaramanga, Santander, Colombia"
+        }
+      ]
+    },
+    {
+      "id": "LR2Y-6F1",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Fermín",
+          "surname": "Delgado Luna"
+        }
+      ],
+      "facts": [
+        {
+          "id": "2ac2762d-5c59-4c0e-b531-6438767763ba",
+          "type": "Death"
+        },
+        {
+          "id": "381787e2-3933-4d19-967b-915349553ad8",
+          "type": "Birth",
+          "place": "Matanza, Santander, Colombia",
+          "standard_place": "Matanza, Santander, Colombia"
+        }
+      ]
+    },
+    {
+      "id": "G5CM-DZW",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Emilio",
+          "surname": "Martínez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "873d40ac-ab85-478f-aa14-4237bbbce5a5",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PWJF-XY6",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Adelaida",
+          "surname": "Martinez Carvajal"
+        }
+      ],
+      "facts": [
+        {
+          "id": "697fa965-fced-48d8-905a-848b8987fb31",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PH5H-VMJ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Ana María",
+          "surname": "Martinez Carvajal"
+        }
+      ],
+      "facts": [
+        {
+          "id": "10ad3a44-1890-469e-821e-f7b6c00e4025",
+          "type": "Birth",
+          "date": "1881",
+          "standard_date": "1881"
+        },
+        {
+          "id": "f63f7afd-5af0-4c48-be8e-d81adbc81fe2",
+          "type": "Burial",
+          "date": "24 de mayo de 1911",
+          "standard_date": "24 May 1911",
+          "place": "Nuestra Señora de las Mercedes, Matanza, Santander, Colombia",
+          "standard_place": "Nuestra Señora de las Mercedes, Matanza, Santander, Colombia"
+        },
+        {
+          "id": "f27470ea-06ff-42a4-8931-ecf92ebab68b",
+          "type": "Death",
+          "date": "24 de mayo de 1911",
+          "standard_date": "24 May 1911",
+          "place": "Matanza, Santander, Colombia",
+          "standard_place": "Matanza, Santander, Colombia"
+        }
+      ]
+    },
+    {
+      "id": "PWJN-MCF",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Ramon",
+          "surname": "Martinez Carvajal"
+        }
+      ],
+      "facts": [
+        {
+          "id": "5420adf6-cdf0-48b6-b6f1-9a053186ed58",
+          "type": "Birth",
+          "date": "noviembre de 1886",
+          "standard_date": "Nov 1886"
+        },
+        {
+          "id": "9c1dc249-9517-4c2b-907d-eef6994b7e9d",
+          "type": "Burial",
+          "date": "11 de noviembre de 1911",
+          "standard_date": "11 Nov 1911",
+          "place": "Nuestra Señora de las Mercedes, Matanza, Santander, Colombia",
+          "standard_place": "Nuestra Señora de las Mercedes, Matanza, Santander, Colombia"
+        },
+        {
+          "id": "3c1f153a-e9e7-4485-b420-aede917a25bd",
+          "type": "Death",
+          "date": "noviembre de 1911",
+          "standard_date": "Nov 1911"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "G5CM-DZW",
+      "person2": "LR2Y-X3H"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "G5CM-DZW",
+      "child": "PH5H-VMJ"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "LR2Y-X3H",
+      "child": "PH5H-VMJ"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "G5CM-DZW",
+      "child": "PZZK-M43"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "LR2Y-X3H",
+      "child": "PZZK-M43"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "G5CM-DZW",
+      "child": "PWJN-MCF"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "LR2Y-X3H",
+      "child": "PWJN-MCF"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "G5CM-DZW",
+      "child": "LR2Y-X9F"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "LR2Y-X3H",
+      "child": "LR2Y-X9F"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "G5CM-DZW",
+      "child": "PWJF-XY6"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "LR2Y-X3H",
+      "child": "PWJF-XY6"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "G5CM-DZW",
+      "child": "LR2Y-6F1"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "LR2Y-X3H",
+      "child": "LR2Y-6F1"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "G5CM-DZW",
+      "child": "LR2Y-FGH"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "LR2Y-X3H",
+      "child": "LR2Y-FGH"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "PZZK-M43",
+      "child": "G5CM-DZW"
+    }
+  ],
+  "sources": [
+    {
+      "id": "71B8-W63",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6TBC-XV8H : Tue May 28 12:20:51 UTC 2024), Entry for Eugenio Martínez Carvajal and Emilio Martinez, 14 Apr 1923.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6TBC-XV8Z"
+    },
+    {
+      "id": "W3RP-YS1",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QK1Y-8ZQ1 : Wed Jan 22 11:11:30 UTC 2025), Entry for Ramón Martinez and Emilio, 11 Nov 1911.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QK1Y-8Z77"
+    },
+    {
+      "id": "7BHX-QGF",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6TK6-5L4G : Wed May 15 23:42:53 UTC 2024), Entry for Jairo Angarita and Miguel Angarita, 3 Feb 1923.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6TK6-5L4L"
+    },
+    {
+      "id": "QTGR-KNW",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QK1Y-ZG4J : Sat Jan 18 13:51:15 UTC 2025), Entry for Eugenio Martínez and Mercedes Delgado, 14 Apr 1923.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QK1Y-ZGHM"
+    },
+    {
+      "id": "WQJK-FSF",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6T25-RPCS : Mon May 20 03:37:35 UTC 2024), Entry for Ana María Martínez Carvajal and Emilio Martínez, 24 May 1911.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6T25-RPCQ"
+    },
+    {
+      "id": "7BHX-C3D",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6TKN-KFSJ : Thu May 16 09:59:02 UTC 2024), Entry for Ramon Martinez and Emilio Martinez, 11 Nov 1911.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6TKN-KFSK"
+    },
+    {
+      "id": "W74H-T7X",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6PKB-HF4Q : Wed Dec 31 14:01:48 UTC 2025), Entry for Ramón and Emilio Martínez, 26 de noviembre de 1882.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6PKB-HF4W"
+    },
+    {
+      "id": "WSR8-Z8T",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QK1Y-88QK : Mon Oct 13 19:23:07 UTC 2025), Entry for Ana María Martinez and Emilio Martinez, 24 May 1911.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QK1Y-887M"
+    },
+    {
+      "id": "7BH6-1L8",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QK1Y-ZR19 : Wed Jan 15 10:59:34 UTC 2025), Entry for Trino Angarita and Adelaida Martinez, 11 Jan 1923.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QK1Y-ZTMX"
+    },
+    {
+      "id": "7BHX-488",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QK1Y-Z2BW : Sat Jan 11 23:26:33 UTC 2025), Entry for Trino Angarita and Adelaida Martinez, 3 Feb 1923.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QK1Y-Z211"
+    }
+  ]
+}

--- a/eval/tests/e2e/isabel-carvajal-daughter/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/isabel-carvajal-daughter/unstripped-tree.gedcomx.json
@@ -1,0 +1,394 @@
+{
+  "persons": [
+    {
+      "id": "LR2Y-X3H",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Isabel",
+          "surname": "Carvajal Chinchilla"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ea152119-c484-4f25-ac12-0346cb7e3101",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LR2Y-FGH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Pastora",
+          "surname": "Delgado Luna"
+        }
+      ],
+      "facts": [
+        {
+          "id": "b7a1cb0c-a3b2-42ec-bce8-448ae68b20fb",
+          "type": "Birth",
+          "place": "Matanza, Santander, Colombia",
+          "standard_place": "Matanza, Santander, Colombia"
+        },
+        {
+          "id": "041917fd-604f-4b2b-9051-baf3702264b7",
+          "type": "Death",
+          "place": "Bogotá, Santafé de Bogotá, Cundinamarca, Colombia",
+          "standard_place": "Bogotá D. C., Cundinamarca, Colombia"
+        }
+      ]
+    },
+    {
+      "id": "PZZK-M43",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Ramón",
+          "surname": "Martinez Carvajal"
+        }
+      ],
+      "facts": [
+        {
+          "id": "73d4e5eb-3ab6-4da1-a8d9-f57b288e5b28",
+          "type": "Christening",
+          "date": "26 de noviembre de 1882",
+          "standard_date": "26 Nov 1882",
+          "place": "La Inmaculada Concepción, Concepción, Santander, Colombia",
+          "standard_place": "La Inmaculada Concepción, Concepción, Santander, Colombia"
+        },
+        {
+          "id": "72f82a3f-eed6-4f14-9472-3cb7ef85a55d",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LR2Y-X9F",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Eugenio",
+          "surname": "Martínez Carvajal"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ba5b2532-164c-4c99-a6ab-0ef8b49e6581",
+          "type": "Birth",
+          "date": "11 noviembre 1895",
+          "standard_date": "11 Nov 1895",
+          "place": "El Cerrito, El Carmen, Santander, Colombia",
+          "standard_place": "El Cerrito, El Carmen de Chucurí, Santander, Colombia"
+        },
+        {
+          "id": "19d315f8-e3a6-4145-bf00-ae01a74cd7c9",
+          "type": "Death",
+          "date": "11 enero 1968",
+          "standard_date": "11 Jan 1968",
+          "place": "Bucaramanga, Bucaramanga, Santander, Colombia",
+          "standard_place": "Bucaramanga, Santander, Colombia"
+        }
+      ]
+    },
+    {
+      "id": "LR2Y-6F1",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Fermín",
+          "surname": "Delgado Luna"
+        }
+      ],
+      "facts": [
+        {
+          "id": "2ac2762d-5c59-4c0e-b531-6438767763ba",
+          "type": "Death"
+        },
+        {
+          "id": "381787e2-3933-4d19-967b-915349553ad8",
+          "type": "Birth",
+          "place": "Matanza, Santander, Colombia",
+          "standard_place": "Matanza, Santander, Colombia"
+        }
+      ]
+    },
+    {
+      "id": "G5CM-DZW",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Emilio",
+          "surname": "Martínez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "873d40ac-ab85-478f-aa14-4237bbbce5a5",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PWJF-XY6",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Adelaida",
+          "surname": "Martinez Carvajal"
+        }
+      ],
+      "facts": [
+        {
+          "id": "697fa965-fced-48d8-905a-848b8987fb31",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PH5H-VMJ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Ana María",
+          "surname": "Martinez Carvajal"
+        }
+      ],
+      "facts": [
+        {
+          "id": "10ad3a44-1890-469e-821e-f7b6c00e4025",
+          "type": "Birth",
+          "date": "1881",
+          "standard_date": "1881"
+        },
+        {
+          "id": "f63f7afd-5af0-4c48-be8e-d81adbc81fe2",
+          "type": "Burial",
+          "date": "24 de mayo de 1911",
+          "standard_date": "24 May 1911",
+          "place": "Nuestra Señora de las Mercedes, Matanza, Santander, Colombia",
+          "standard_place": "Nuestra Señora de las Mercedes, Matanza, Santander, Colombia"
+        },
+        {
+          "id": "f27470ea-06ff-42a4-8931-ecf92ebab68b",
+          "type": "Death",
+          "date": "24 de mayo de 1911",
+          "standard_date": "24 May 1911",
+          "place": "Matanza, Santander, Colombia",
+          "standard_place": "Matanza, Santander, Colombia"
+        }
+      ]
+    },
+    {
+      "id": "PWJN-MCF",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Ramon",
+          "surname": "Martinez Carvajal"
+        }
+      ],
+      "facts": [
+        {
+          "id": "5420adf6-cdf0-48b6-b6f1-9a053186ed58",
+          "type": "Birth",
+          "date": "noviembre de 1886",
+          "standard_date": "Nov 1886"
+        },
+        {
+          "id": "9c1dc249-9517-4c2b-907d-eef6994b7e9d",
+          "type": "Burial",
+          "date": "11 de noviembre de 1911",
+          "standard_date": "11 Nov 1911",
+          "place": "Nuestra Señora de las Mercedes, Matanza, Santander, Colombia",
+          "standard_place": "Nuestra Señora de las Mercedes, Matanza, Santander, Colombia"
+        },
+        {
+          "id": "3c1f153a-e9e7-4485-b420-aede917a25bd",
+          "type": "Death",
+          "date": "noviembre de 1911",
+          "standard_date": "Nov 1911"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "G5CM-DZW",
+      "person2": "LR2Y-X3H"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "G5CM-DZW",
+      "child": "PH5H-VMJ"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "LR2Y-X3H",
+      "child": "PH5H-VMJ"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "G5CM-DZW",
+      "child": "PZZK-M43"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "LR2Y-X3H",
+      "child": "PZZK-M43"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "G5CM-DZW",
+      "child": "PWJN-MCF"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "LR2Y-X3H",
+      "child": "PWJN-MCF"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "G5CM-DZW",
+      "child": "LR2Y-X9F"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "LR2Y-X3H",
+      "child": "LR2Y-X9F"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "G5CM-DZW",
+      "child": "PWJF-XY6"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "LR2Y-X3H",
+      "child": "PWJF-XY6"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "G5CM-DZW",
+      "child": "LR2Y-6F1"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "LR2Y-X3H",
+      "child": "LR2Y-6F1"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "G5CM-DZW",
+      "child": "LR2Y-FGH"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "LR2Y-X3H",
+      "child": "LR2Y-FGH"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "PZZK-M43",
+      "child": "G5CM-DZW"
+    }
+  ],
+  "sources": [
+    {
+      "id": "71B8-W63",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6TBC-XV8H : Tue May 28 12:20:51 UTC 2024), Entry for Eugenio Martínez Carvajal and Emilio Martinez, 14 Apr 1923.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6TBC-XV8Z"
+    },
+    {
+      "id": "W3RP-YS1",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QK1Y-8ZQ1 : Wed Jan 22 11:11:30 UTC 2025), Entry for Ramón Martinez and Emilio, 11 Nov 1911.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QK1Y-8Z77"
+    },
+    {
+      "id": "7BHX-QGF",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6TK6-5L4G : Wed May 15 23:42:53 UTC 2024), Entry for Jairo Angarita and Miguel Angarita, 3 Feb 1923.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6TK6-5L4L"
+    },
+    {
+      "id": "QTGR-KNW",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QK1Y-ZG4J : Sat Jan 18 13:51:15 UTC 2025), Entry for Eugenio Martínez and Mercedes Delgado, 14 Apr 1923.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QK1Y-ZGHM"
+    },
+    {
+      "id": "WQJK-FSF",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6T25-RPCS : Mon May 20 03:37:35 UTC 2024), Entry for Ana María Martínez Carvajal and Emilio Martínez, 24 May 1911.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6T25-RPCQ"
+    },
+    {
+      "id": "7BHX-C3D",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6TKN-KFSJ : Thu May 16 09:59:02 UTC 2024), Entry for Ramon Martinez and Emilio Martinez, 11 Nov 1911.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6TKN-KFSK"
+    },
+    {
+      "id": "W74H-T7X",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6PKB-HF4Q : Wed Dec 31 14:01:48 UTC 2025), Entry for Ramón and Emilio Martínez, 26 de noviembre de 1882.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6PKB-HF4W"
+    },
+    {
+      "id": "WSR8-Z8T",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QK1Y-88QK : Mon Oct 13 19:23:07 UTC 2025), Entry for Ana María Martinez and Emilio Martinez, 24 May 1911.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QK1Y-887M"
+    },
+    {
+      "id": "7BH6-1L8",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QK1Y-ZR19 : Wed Jan 15 10:59:34 UTC 2025), Entry for Trino Angarita and Adelaida Martinez, 11 Jan 1923.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QK1Y-ZTMX"
+    },
+    {
+      "id": "7BHX-488",
+      "title": "Isabel Carvajal, \"Colombia, registros parroquiales y diocesanos, 1576-2019\"",
+      "citation": "\"Colombia, registros parroquiales y diocesanos, 1576-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QK1Y-Z2BW : Sat Jan 11 23:26:33 UTC 2025), Entry for Trino Angarita and Adelaida Martinez, 3 Feb 1923.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QK1Y-Z211"
+    }
+  ]
+}

--- a/eval/tests/e2e/joseph-david-daughter/README.md
+++ b/eval/tests/e2e/joseph-david-daughter/README.md
@@ -1,0 +1,34 @@
+# Joseph David — a different Joseph Davies household? (1901 census)
+
+**Source PID:** `GNR6-VWS`
+**Joseph David is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+1873, Clydach near Llantrisant, Glamorgan, Wales; died not recorded in the tree.
+
+## Research question
+
+> Did Joseph David and his wife Hannah David of Clydach, Glamorgan, Wales have a daughter named Elizabeth A., born 1899, in addition to their three known children (b. 1897-1908)?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `GNR6-VWS` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+hard — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 33, flag `adds_daughter`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — England and Wales, Census, 1901: household of Joseph Davies and Hannah Davies, Merthyr Tydfil, Glamorgan, with daughter Elizabeth A Davies (b. 1899, Treharris). The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Elizabeth A Davies as the subject's daughter, plus a `required` finding that the report documents the rejection.
+
+**Strong reason to doubt this match**: the census household's Joseph Davies is recorded born **1876 in Hirwaun**, versus the tree's Joseph David born **1873 in Clydach near Llantrisant** — a different year and a different town. The household's Hannah Davies is recorded born **1878 in Llanidloes, Montgomeryshire** — a town in a completely different county from the tree's Hannah David (b. 1875, same Clydach parish as her husband). "David"/"Davies" is one of the most common surnames in Wales, and a household census match on common given names with two independently conflicting birthplaces for both spouses is a classic false-hint pattern. This fixture is a strong candidate for outcome (c) (false match — most likely an unrelated, same-named couple) but is left as a recover-type draft finding pending the genealogist's review.

--- a/eval/tests/e2e/joseph-david-daughter/expected-findings.json
+++ b/eval/tests/e2e/joseph-david-daughter/expected-findings.json
@@ -1,0 +1,21 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Joseph Davies and Hannah Davies had a daughter, Elizabeth A. Davies, born 1899 in Treharris, Glamorganshire, per the 1901 census household in Merthyr Tydfil — in addition to the subject's three children already in the tree (Ethel b. 1897, Illiam G. b. 1900, Enid b. 1908).",
+      "details": {
+        "subject_person": "Joseph David (GNR6-VWS)",
+        "relation": "child",
+        "target_person": {
+          "name": "Elizabeth A Davies",
+          "birth": "1899, Treharris, Glamorganshire, Wales"
+        }
+      },
+      "supporting_sources": [
+        "England and Wales, Census, 1901 — household of Joseph Davies and Hannah Davies, Merthyr Tydfil, Glamorgan"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/joseph-david-daughter/fixture.json
+++ b/eval/tests/e2e/joseph-david-daughter/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "joseph-david-daughter",
+  "name": "Joseph David — a different Joseph Davies household? (1901 census)",
+  "genre": "record-hint",
+  "source_pid": "GNR6-VWS",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Joseph David and his wife Hannah David of Clydach, Glamorgan, Wales have a daughter named Elizabeth A., born 1899, in addition to their three known children (b. 1897-1908)?",
+  "tags": {
+    "question_type": "children",
+    "era": "1900s",
+    "geography": "GB"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 33, flag adds_daughter, confidence 3). Draft transcribed from an England & Wales 1901 census household; unverified."
+}

--- a/eval/tests/e2e/joseph-david-daughter/starting-research.json
+++ b/eval/tests/e2e/joseph-david-daughter/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_joseph_david_daughter",
+    "objective": "Did Joseph David and his wife Hannah David of Clydach, Glamorgan, Wales have a daughter named Elizabeth A., born 1899, in addition to their three known children (b. 1897-1908)?",
+    "subject_person_ids": [
+      "GNR6-VWS"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/joseph-david-daughter/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/joseph-david-daughter/starting-tree.gedcomx.json
@@ -1,0 +1,289 @@
+{
+  "persons": [
+    {
+      "id": "GNR6-VWS",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Joseph",
+          "surname": "David"
+        }
+      ],
+      "facts": [
+        {
+          "id": "5fbaf44a-3cd3-4928-af5d-7e9633a463ce",
+          "type": "Birth",
+          "date": "1873",
+          "standard_date": "1873",
+          "place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "8a4fde37-f09b-4086-be43-1a1eae73c1e6",
+          "type": "Death"
+        },
+        {
+          "id": "e690121d-5670-405c-a0b9-d84cc7028a8f",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "b8652ec0-a697-4e1e-9109-dbd93a10f5c7",
+          "type": "Residence",
+          "date": "1911",
+          "standard_date": "1911",
+          "place": "Clydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "1981b55f-6688-4e68-8cd3-1736b517d67e",
+          "type": "Marital Status",
+          "value": "Married"
+        },
+        {
+          "id": "5cb9c3fd-059f-43eb-975b-1d3432c6ea66",
+          "type": "Occupation",
+          "value": "STONE MASON"
+        }
+      ]
+    },
+    {
+      "id": "GNR6-RHN",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Hannah",
+          "surname": "David"
+        }
+      ],
+      "facts": [
+        {
+          "id": "b7ab0f08-c1a4-43ae-8cd1-10c5905c36a7",
+          "type": "Birth",
+          "date": "1875",
+          "standard_date": "1875",
+          "place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "0b78f0f8-5bc2-45e4-b15a-2e8fff7fc2fb",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "7c42d190-4226-4bbe-a761-6049bb751ea8",
+          "type": "Residence",
+          "date": "1911",
+          "standard_date": "1911",
+          "place": "Clydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "dceed078-2348-4f7c-a914-99b1b0b68510",
+          "type": "Death"
+        },
+        {
+          "id": "ed5aa5f0-19e8-45c6-988f-def3a30cdbd4",
+          "type": "Marital Status",
+          "value": "Married"
+        }
+      ]
+    },
+    {
+      "id": "GNR6-547",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Ethel",
+          "surname": "David"
+        }
+      ],
+      "facts": [
+        {
+          "id": "640c44fd-c69b-4cde-955b-79914ecf664f",
+          "type": "Birth",
+          "date": "1897",
+          "standard_date": "1897",
+          "place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "d442ebec-078f-47ac-b387-5a952704db0b",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "2bb667b4-c166-41d7-b080-f2cd1642af14",
+          "type": "Residence",
+          "date": "1911",
+          "standard_date": "1911",
+          "place": "Clydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "9783f423-6c2a-4a46-8a39-485d43926014",
+          "type": "Death"
+        },
+        {
+          "id": "74978d73-5180-4895-a07d-342d19221ca8",
+          "type": "Marital Status",
+          "value": "Single"
+        }
+      ]
+    },
+    {
+      "id": "GNR6-V53",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Enid",
+          "surname": "David"
+        }
+      ],
+      "facts": [
+        {
+          "id": "7aecb1ca-02e5-4715-9db7-823451b95478",
+          "type": "Birth",
+          "date": "1908",
+          "standard_date": "1908",
+          "place": "R Clydach, Glamorganshire",
+          "standard_place": "Clydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "f77c32aa-b288-49eb-8284-da6ba033495b",
+          "type": "Residence",
+          "date": "1911",
+          "standard_date": "1911",
+          "place": "Clydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "cb749b8d-2aef-4aeb-9848-1537fed1ce3f",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GNR6-TRJ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Illiam G",
+          "surname": "David"
+        }
+      ],
+      "facts": [
+        {
+          "id": "50d4b7ad-fbd3-47d4-9a87-0d53a64c7dfd",
+          "type": "Birth",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "ae3a1ad7-f163-4701-a29d-9635ef778d50",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "d002efbf-6182-4763-ab66-cab724044c97",
+          "type": "Residence",
+          "date": "1911",
+          "standard_date": "1911",
+          "place": "Clydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "ce247752-7814-43bb-a9bb-096f48e02bfd",
+          "type": "Death"
+        },
+        {
+          "id": "6726b733-b10d-4d13-9260-fbb5959b0e1a",
+          "type": "Marital Status",
+          "value": "Single"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GNR6-VWS",
+      "person2": "GNR6-RHN"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "GNR6-VWS",
+      "child": "GNR6-547"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GNR6-RHN",
+      "child": "GNR6-547"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GNR6-VWS",
+      "child": "GNR6-TRJ"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GNR6-RHN",
+      "child": "GNR6-TRJ"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "GNR6-VWS",
+      "child": "GNR6-V53"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "GNR6-RHN",
+      "child": "GNR6-V53"
+    }
+  ],
+  "sources": [
+    {
+      "id": "QYWG-R2N",
+      "title": "Joseph David, \"England and Wales, Census, 1901\"",
+      "citation": "\"England and Wales, Census, 1901\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XSMQ-X77 : Thu Feb 13 02:38:33 UTC 2025), Entry for Joseph David and Hannah David, 31 Mar 1901.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XSMQ-X77"
+    },
+    {
+      "id": "317B-W3M",
+      "title": "Joseph David, \"England and Wales, Census, 1911\"",
+      "citation": "\"England and Wales, Census, 1911\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XWXJ-RC1 : Thu Feb 13 13:01:31 UTC 2025), Entry for Joseph David and Hannah David, 1911.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XWXJ-RC1"
+    }
+  ]
+}

--- a/eval/tests/e2e/joseph-david-daughter/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/joseph-david-daughter/unstripped-tree.gedcomx.json
@@ -1,0 +1,289 @@
+{
+  "persons": [
+    {
+      "id": "GNR6-VWS",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Joseph",
+          "surname": "David"
+        }
+      ],
+      "facts": [
+        {
+          "id": "5fbaf44a-3cd3-4928-af5d-7e9633a463ce",
+          "type": "Birth",
+          "date": "1873",
+          "standard_date": "1873",
+          "place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "8a4fde37-f09b-4086-be43-1a1eae73c1e6",
+          "type": "Death"
+        },
+        {
+          "id": "e690121d-5670-405c-a0b9-d84cc7028a8f",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "b8652ec0-a697-4e1e-9109-dbd93a10f5c7",
+          "type": "Residence",
+          "date": "1911",
+          "standard_date": "1911",
+          "place": "Clydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "1981b55f-6688-4e68-8cd3-1736b517d67e",
+          "type": "Marital Status",
+          "value": "Married"
+        },
+        {
+          "id": "5cb9c3fd-059f-43eb-975b-1d3432c6ea66",
+          "type": "Occupation",
+          "value": "STONE MASON"
+        }
+      ]
+    },
+    {
+      "id": "GNR6-RHN",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Hannah",
+          "surname": "David"
+        }
+      ],
+      "facts": [
+        {
+          "id": "b7ab0f08-c1a4-43ae-8cd1-10c5905c36a7",
+          "type": "Birth",
+          "date": "1875",
+          "standard_date": "1875",
+          "place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "0b78f0f8-5bc2-45e4-b15a-2e8fff7fc2fb",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "7c42d190-4226-4bbe-a761-6049bb751ea8",
+          "type": "Residence",
+          "date": "1911",
+          "standard_date": "1911",
+          "place": "Clydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "dceed078-2348-4f7c-a914-99b1b0b68510",
+          "type": "Death"
+        },
+        {
+          "id": "ed5aa5f0-19e8-45c6-988f-def3a30cdbd4",
+          "type": "Marital Status",
+          "value": "Married"
+        }
+      ]
+    },
+    {
+      "id": "GNR6-547",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Ethel",
+          "surname": "David"
+        }
+      ],
+      "facts": [
+        {
+          "id": "640c44fd-c69b-4cde-955b-79914ecf664f",
+          "type": "Birth",
+          "date": "1897",
+          "standard_date": "1897",
+          "place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "d442ebec-078f-47ac-b387-5a952704db0b",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "2bb667b4-c166-41d7-b080-f2cd1642af14",
+          "type": "Residence",
+          "date": "1911",
+          "standard_date": "1911",
+          "place": "Clydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "9783f423-6c2a-4a46-8a39-485d43926014",
+          "type": "Death"
+        },
+        {
+          "id": "74978d73-5180-4895-a07d-342d19221ca8",
+          "type": "Marital Status",
+          "value": "Single"
+        }
+      ]
+    },
+    {
+      "id": "GNR6-V53",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Enid",
+          "surname": "David"
+        }
+      ],
+      "facts": [
+        {
+          "id": "7aecb1ca-02e5-4715-9db7-823451b95478",
+          "type": "Birth",
+          "date": "1908",
+          "standard_date": "1908",
+          "place": "R Clydach, Glamorganshire",
+          "standard_place": "Clydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "f77c32aa-b288-49eb-8284-da6ba033495b",
+          "type": "Residence",
+          "date": "1911",
+          "standard_date": "1911",
+          "place": "Clydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "cb749b8d-2aef-4aeb-9848-1537fed1ce3f",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GNR6-TRJ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Illiam G",
+          "surname": "David"
+        }
+      ],
+      "facts": [
+        {
+          "id": "50d4b7ad-fbd3-47d4-9a87-0d53a64c7dfd",
+          "type": "Birth",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach near Llantrissant, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "ae3a1ad7-f163-4701-a29d-9635ef778d50",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Rhyndwyclydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "d002efbf-6182-4763-ab66-cab724044c97",
+          "type": "Residence",
+          "date": "1911",
+          "standard_date": "1911",
+          "place": "Clydach, Glamorgan, Wales, United Kingdom",
+          "standard_place": "Clydach, Glamorgan, Wales, United Kingdom"
+        },
+        {
+          "id": "ce247752-7814-43bb-a9bb-096f48e02bfd",
+          "type": "Death"
+        },
+        {
+          "id": "6726b733-b10d-4d13-9260-fbb5959b0e1a",
+          "type": "Marital Status",
+          "value": "Single"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GNR6-VWS",
+      "person2": "GNR6-RHN"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "GNR6-VWS",
+      "child": "GNR6-547"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GNR6-RHN",
+      "child": "GNR6-547"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GNR6-VWS",
+      "child": "GNR6-TRJ"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GNR6-RHN",
+      "child": "GNR6-TRJ"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "GNR6-VWS",
+      "child": "GNR6-V53"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "GNR6-RHN",
+      "child": "GNR6-V53"
+    }
+  ],
+  "sources": [
+    {
+      "id": "QYWG-R2N",
+      "title": "Joseph David, \"England and Wales, Census, 1901\"",
+      "citation": "\"England and Wales, Census, 1901\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XSMQ-X77 : Thu Feb 13 02:38:33 UTC 2025), Entry for Joseph David and Hannah David, 31 Mar 1901.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XSMQ-X77"
+    },
+    {
+      "id": "317B-W3M",
+      "title": "Joseph David, \"England and Wales, Census, 1911\"",
+      "citation": "\"England and Wales, Census, 1911\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XWXJ-RC1 : Thu Feb 13 13:01:31 UTC 2025), Entry for Joseph David and Hannah David, 1911.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XWXJ-RC1"
+    }
+  ]
+}

--- a/eval/tests/e2e/juan-rodriguez-son/README.md
+++ b/eval/tests/e2e/juan-rodriguez-son/README.md
@@ -1,0 +1,34 @@
+# Juan Rodríguez Martínez — additional son Juan (b./d. 1801)
+
+**Source PID:** `9634-PS9`
+**Juan Rodríguez Martínez is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+16 November 1777, Pozuelo, Albacete, Spain; died buried 18 January 1855, San Bartolomé, Pozuelo, Albacete, Spain.
+
+## Research question
+
+> Did Juan Rodríguez Martínez and his wife Marcelina Garcia of Pozuelo, Albacete, Spain have a son also named Juan, who died in infancy in 1801, in addition to their eight known children (b. 1799-1822)?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `9634-PS9` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 31, flag `adds_son`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — España, Diócesis de Albacete, registros parroquiales, 1504-1979: burial entry, 17 February 1801, San Bartolomé, Pozuelo, naming parents Juan Rodriguez and Marcelina Garcia. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming this 1801 infant Juan Rodriguez, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: both parents' names match the tree exactly (Juan Rodriguez and Marcelina Garcia — the tree's fuller "Juan Rodríguez Martínez" and "Marcelina Garcia"), and the parish (San Bartolomé, Pozuelo) matches every other child's record exactly. A son who died as an infant in 1801 is chronologically close to the tree's daughter Juana (b. 1799) and son Francisco (christened 4 December 1801) — a reviewer should check whether this burial could in fact be the same event as Francisco's christening (i.e., possibly the same child recorded twice under different names, rather than a genuine additional son) before accepting this as a distinct new child.

--- a/eval/tests/e2e/juan-rodriguez-son/expected-findings.json
+++ b/eval/tests/e2e/juan-rodriguez-son/expected-findings.json
@@ -1,0 +1,22 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Juan Rodriguez and Marcelina Garcia had a son also named Juan Rodriguez, buried in infancy on 17 February 1801 in San Bartolomé, Pozuelo, Albacete — close in time to their tree-recorded daughter Juana (b. 1799) and son Francisco (christened 1801).",
+      "details": {
+        "subject_person": "Juan Rodríguez Martínez (9634-PS9)",
+        "relation": "child",
+        "target_person": {
+          "name": "Juan Rodriguez",
+          "birth": "unknown, likely Pozuelo, Albacete, Spain",
+          "death": "17 February 1801 (burial), San Bartolomé, Pozuelo, Albacete, Spain"
+        }
+      },
+      "supporting_sources": [
+        "España, Diócesis de Albacete, registros parroquiales, 1504-1979 — burial entry, 17 Feb 1801, San Bartolomé, Pozuelo, naming parents Juan Rodriguez and Marcelina Garcia"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/juan-rodriguez-son/fixture.json
+++ b/eval/tests/e2e/juan-rodriguez-son/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "juan-rodriguez-son",
+  "name": "Juan Rodríguez Martínez — additional son Juan (b./d. 1801)",
+  "genre": "record-hint",
+  "source_pid": "9634-PS9",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Juan Rodríguez Martínez and his wife Marcelina Garcia of Pozuelo, Albacete, Spain have a son also named Juan, who died in infancy in 1801, in addition to their eight known children (b. 1799-1822)?",
+  "tags": {
+    "question_type": "children",
+    "era": "1800s",
+    "geography": "ES"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 31, flag adds_son, confidence 3). Draft transcribed from a Spanish diocesan parish record; unverified."
+}

--- a/eval/tests/e2e/juan-rodriguez-son/starting-research.json
+++ b/eval/tests/e2e/juan-rodriguez-son/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_juan_rodriguez_son",
+    "objective": "Did Juan Rodríguez Martínez and his wife Marcelina Garcia of Pozuelo, Albacete, Spain have a son also named Juan, who died in infancy in 1801, in addition to their eight known children (b. 1799-1822)?",
+    "subject_person_ids": [
+      "9634-PS9"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/juan-rodriguez-son/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/juan-rodriguez-son/starting-tree.gedcomx.json
@@ -1,0 +1,818 @@
+{
+  "persons": [
+    {
+      "id": "9634-PS9",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Juan",
+          "surname": "Rodríguez Martínez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "05efd440-d752-4e8b-9b16-043c51003b3b",
+          "type": "Birth",
+          "date": "16 November 1777",
+          "standard_date": "16 Nov 1777",
+          "place": "Pozuelo, Albacete, Castilla-La Mancha, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "e3157663-21fb-4571-a340-3af655ac5d15",
+          "type": "Death"
+        },
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "19 November 1777",
+          "standard_date": "19 Nov 1777",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "d0f1d84c-0b11-4d6f-b33c-7b3687142d76",
+          "type": "Burial",
+          "date": "18 Jan 1855",
+          "standard_date": "18 Jan 1855",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        }
+      ]
+    },
+    {
+      "id": "963H-88B",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Francisco",
+          "surname": "Rodriguez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "4 December 1801",
+          "standard_date": "4 Dec 1801",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GVZQ-RY9",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Severiano",
+          "surname": "Rodríguez García"
+        }
+      ],
+      "facts": [
+        {
+          "id": "65957105-c1d2-406c-a075-3bb1e6508e48",
+          "type": "Birth",
+          "date": "8 Nov 1817",
+          "standard_date": "8 Nov 1817"
+        },
+        {
+          "id": "85f17424-bd99-4240-979a-45cb043657f6",
+          "type": "Christening",
+          "date": "9 Nov 1817",
+          "standard_date": "9 Nov 1817",
+          "place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, España",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "800cebd9-a7f7-4966-b7d8-7952e2f4edc1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "963H-WVN",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Francisca",
+          "surname": "Rodriguez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "09 Mar 1822",
+          "standard_date": "9 Mar 1822",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "10 Mar 1822",
+          "standard_date": "10 Mar 1822",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "13868ee3-9275-4f38-a04d-f40418b7d8d1",
+          "type": "Baptism",
+          "date": "10 Mar 1822",
+          "standard_date": "10 Mar 1822",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LZZ6-NHR",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Antonio",
+          "surname": "Rodriguez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "26aaaf0d-0a64-40f2-bc34-686f9eac94f6",
+          "type": "Residence",
+          "date": "1728",
+          "standard_date": "1728",
+          "place": "Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "09e3fb6a-98ff-4de8-a86f-88e22156f3b1",
+          "type": "Birth",
+          "date": "08 Aug 1728",
+          "standard_date": "8 Aug 1728",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "88a94a0d-c37f-45c5-9b2c-1c95d34b379e",
+          "type": "Baptism",
+          "date": "12 Sep 1728",
+          "standard_date": "12 Sep 1728",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "359e3f55-c055-4509-8741-0a9821fb5c37",
+          "type": "Christening",
+          "date": "12 Sep 1728",
+          "standard_date": "12 Sep 1728",
+          "place": "SAN BARTOLOME, POZUELO, ALBACETE, SPAIN",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "c8b9936b-2d3f-4d6b-b88e-9212f43ce9af",
+          "type": "Unknown",
+          "date": "13 ene 1752",
+          "standard_date": "13 1752"
+        },
+        {
+          "id": "8f634477-7913-4497-840a-c08908a5c028",
+          "type": "Burial",
+          "date": "3 de agosto de 1797",
+          "standard_date": "3 Aug 1797",
+          "place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, España",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "9634-VXH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Juana",
+          "surname": "Rodríguez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "06 May 1799",
+          "standard_date": "6 May 1799",
+          "place": "Pozuelo, Albacete, España",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "6 May 1799",
+          "standard_date": "6 May 1799",
+          "place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, España",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "963H-MBM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Marcelina",
+          "surname": "Garcia"
+        }
+      ],
+      "facts": [
+        {
+          "id": "05efd440-d752-4e8b-9b16-043c51003b3b",
+          "type": "Birth",
+          "date": "25 April 1779",
+          "standard_date": "25 Apr 1779",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "f27d2591-78d8-4d89-a5d0-b6dd615a37eb",
+          "type": "Baptism",
+          "date": "03 May 1779",
+          "standard_date": "3 May 1779",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "03 May 1779",
+          "standard_date": "3 May 1779",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "8f93d182-5bb4-44a0-8c5d-f40c9d18713d",
+          "type": "Residence",
+          "date": "1779",
+          "standard_date": "1779",
+          "place": "Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "e3157663-21fb-4571-a340-3af655ac5d15",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "9634-JLQ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Bicenta",
+          "surname": "Martinez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "a4d6a635-d933-48b9-8d1c-874be9c52d4f",
+          "type": "Birth",
+          "date": "24 May 1735",
+          "standard_date": "24 May 1735",
+          "place": "Peñas de San Pedro, Albacete, Castilla-La Mancha, España",
+          "standard_place": "Peñas de San Pedro, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "cb5a0364-d166-4918-a46f-a5d39fbb7acd",
+          "type": "Baptism",
+          "date": "06 Jun 1735",
+          "standard_date": "6 Jun 1735",
+          "place": "Nuestra Señora de la Esperanza, Peñas de San Pedro, Albacete, Spain",
+          "standard_place": "Nuestra Señora de la Esperanza, Peñas de San Pedro, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "fda82379-4ad8-4f00-b4a0-62e3385468f5",
+          "type": "Christening",
+          "date": "06 Jun 1735",
+          "standard_date": "6 Jun 1735",
+          "place": "Santa Maria De La Esparanza, Penas De San Pedro, Albacete, Spain",
+          "standard_place": "Peñas de San Pedro, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "1a5387c9-43fa-4c59-9aee-a9f8606da763",
+          "type": "Residence",
+          "date": "1735",
+          "standard_date": "1735",
+          "place": "Penas de San Pedro, Albacete, Spain",
+          "standard_place": "Peñas de San Pedro, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "17720ed8-564e-479e-a95e-508d4a5e65e1",
+          "type": "Residence",
+          "date": "1735",
+          "standard_date": "1735",
+          "place": "Peñas de San Pedro, Albacete, Spain",
+          "standard_place": "Peñas de San Pedro, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "5256e017-3809-44a2-8f44-8db9c93fe8c1",
+          "type": "Death",
+          "date": "2 de diciembre de 1801",
+          "standard_date": "2 Dec 1801",
+          "place": "Pozuelo, Albacete, Castilla-La Mancha, España",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "5c741325-142b-4833-938b-286fc688e0df",
+          "type": "Burial",
+          "date": "3 de diciembre de 1801",
+          "standard_date": "3 Dec 1801",
+          "place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, España",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        }
+      ]
+    },
+    {
+      "id": "9634-P9Y",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Maria",
+          "surname": "Rodriguez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "02 Jul 1804",
+          "standard_date": "2 Jul 1804",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "04 Jul 1804",
+          "standard_date": "4 Jul 1804",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "fa7b2941-62d0-4727-b56f-dd5d539d5492",
+          "type": "Baptism",
+          "date": "04 Jul 1804",
+          "standard_date": "4 Jul 1804",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GS51-S1P",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "Ana Juana",
+          "surname": "Rodriguez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "e419c4cd-9bfa-4bff-b0ac-0a311131a757",
+          "type": "Birth",
+          "date": "12 Jul 1811",
+          "standard_date": "12 Jul 1811",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "9f0760ac-b58a-4176-9a40-664fe821f3f9",
+          "type": "Christening",
+          "date": "13 Jul 1811",
+          "standard_date": "13 Jul 1811",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "ddc22ece-fd5e-4518-ae7e-4228bc32f367",
+          "type": "Baptism",
+          "date": "13 Jul 1811",
+          "standard_date": "13 Jul 1811",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "ef943380-5fd8-48b1-9222-dc96fa754bc3",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "963H-MYP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N11",
+          "given": "Vicenta",
+          "surname": "Rodriguez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "26 Oct 1815",
+          "standard_date": "26 Oct 1815",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "26 Oct 1815",
+          "standard_date": "26 Oct 1815",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "1c636ec9-6c31-4b2a-94e9-3b1cfe072022",
+          "type": "Baptism",
+          "date": "26 Oct 1815",
+          "standard_date": "26 Oct 1815",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "9634-PS9",
+      "person2": "963H-MBM",
+      "facts": [
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "4 AGO 1798",
+          "standard_date": "4 1798",
+          "place": "San Bartolomé, Pozuelo, Albacete, España",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "14fa5ec2-daa1-47a3-8b0f-a7a37ec3a3e0",
+          "type": "Marriage",
+          "date": "04 Aug 1798",
+          "standard_date": "4 Aug 1798",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "LZZ6-NHR",
+      "person2": "9634-JLQ",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "13 Jan 1752",
+          "standard_date": "13 Jan 1752",
+          "place": "Nuestra Señora de la Esperanza, Peñas de San Pedro, Albacete, Castilla-La Mancha, España",
+          "standard_place": "Nuestra Señora de la Esperanza, Peñas de San Pedro, Albacete, Castilla-La Mancha, Spain"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "LZZ6-NHR",
+      "child": "9634-PS9",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "9634-JLQ",
+      "child": "9634-PS9",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "9634-PS9",
+      "child": "9634-VXH",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "963H-MBM",
+      "child": "9634-VXH",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "9634-PS9",
+      "child": "963H-88B",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "963H-MBM",
+      "child": "963H-88B",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "9634-PS9",
+      "child": "9634-P9Y",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "963H-MBM",
+      "child": "9634-P9Y",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "9634-PS9",
+      "child": "GS51-S1P",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "963H-MBM",
+      "child": "GS51-S1P",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "9634-PS9",
+      "child": "963H-MYP",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "963H-MBM",
+      "child": "963H-MYP",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "9634-PS9",
+      "child": "GVZQ-RY9"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "963H-MBM",
+      "child": "GVZQ-RY9"
+    },
+    {
+      "id": "R17",
+      "type": "ParentChild",
+      "parent": "9634-PS9",
+      "child": "963H-WVN",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R18",
+      "type": "ParentChild",
+      "parent": "963H-MBM",
+      "child": "963H-WVN",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "99CB-RRQ",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FRZL-GHF : Wed Mar 05 00:32:19 UTC 2025), Entry for Juana Rodriguez and Juan Rodriguez, 6 May 1799.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FRZL-GHN"
+    },
+    {
+      "id": "Q3NT-D6X",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N3QL-PZ5 : Sat Aug 31 09:19:55 UTC 2024), Entry for Pascuala Rivera and Antonio Rivera, 24 Dec 1829.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N3QL-PZ1"
+    },
+    {
+      "id": "Q646-BS8",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N39M-Z3P : Sat Aug 31 08:18:23 UTC 2024), Entry for Francisca Rodriguez and Juan Rodriguez, 10 Mar 1822.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N39M-Z35"
+    },
+    {
+      "id": "Q3VF-GK8",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5F5-P29 : Wed Mar 05 02:19:48 UTC 2025), Entry for Teresa Rivera Rodriguez and Antonio Rivera, 29 Aug 1832.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H8V3-G33Z"
+    },
+    {
+      "id": "QHCJ-DL2",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5JD-DJR : Wed Mar 05 02:18:32 UTC 2025), Entry for Tomas Lopez Rodriguez and Juan Lopez, 9 Mar 1853.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H8V9-JYN2"
+    },
+    {
+      "id": "9M42-GW4",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FRZL-RX8 : Wed Mar 05 00:06:58 UTC 2025), Entry for Francisca Rodriguez and Juan Rodriguez, 10 Mar 1822.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FRZL-RXD"
+    },
+    {
+      "id": "9M6L-PBH",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FRZL-P58 : Wed Mar 05 00:06:27 UTC 2025), Entry for Ana Juana Rodriguez and Juan Rodriguez, 13 Jul 1811.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FRZL-P5D"
+    },
+    {
+      "id": "99S9-WY6",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FRZL-P9G : Wed Mar 05 00:32:30 UTC 2025), Entry for Maria Rodriguez and Juan Rodriguez, 4 Jul 1804.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FRZL-P9P"
+    },
+    {
+      "id": "Q3VF-VBP",
+      "title": "Juan Rodrigues, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5F5-6BW : Wed Mar 05 02:18:16 UTC 2025), Entry for Severiano Rivera Rodrigues and Antonio Rivera, 10 Feb 1837.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H8V7-RX3Z"
+    },
+    {
+      "id": "QHVM-WKB",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N39M-M1F : Sat Aug 31 08:24:48 UTC 2024), Entry for Maria Rodriguez and Juan Rodriguez, 04 Jul 1804.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N39M-M1N"
+    },
+    {
+      "id": "9926-XZV",
+      "title": "Juan Rodriguez, \"Spain, Marriages, 1565-1950\"",
+      "citation": "\"España, matrimonios, 1565-1950\", database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:FFLR-65S : 16 February 2020), Juan Rodriguez, 1798.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FFLR-65S"
+    },
+    {
+      "id": "Q3VV-MK6",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VTJQ-SRM : Sat Aug 31 09:27:46 UTC 2024), Entry for Juan Rodriguez and Marcelina Garcia, 18 Jan 1855.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VTJQ-SRM"
+    },
+    {
+      "id": "Q3VV-9SV",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5FP-KRG : Wed Mar 05 02:51:35 UTC 2025), Entry for Severiano Rodriguez Garcia and Juan Rodriguez, 9 Nov 1817.",
+      "url": "https://familysearch.org/ark:/61903/1:1:F5FP-KRP"
+    },
+    {
+      "id": "QHCJ-6QV",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5FP-BC3 : Wed Mar 05 02:51:20 UTC 2025), Entry for Ana Juana Rodriguez Garcia and Juan Rodriguez, 13 Jul 1811.",
+      "url": "https://familysearch.org/ark:/61903/1:1:F5FP-BCQ"
+    },
+    {
+      "id": "QFV8-MDR",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N39M-4DV : Sat Aug 31 09:22:47 UTC 2024), Entry for Severiano Rodriguez and Juan Rodriguez, 09 Nov 1817.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N39M-4DK"
+    },
+    {
+      "id": "S2T3-MQ4",
+      "title": "Juan Rodriguez Martinez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5FP-DXJ : Wed Mar 05 01:18:43 UTC 2025), Entry for Juan Rodriguez Martinez and Antonio Rodriguez, 19 Nov 1777.",
+      "url": "https://familysearch.org/ark:/61903/1:1:F5FP-DXJ"
+    },
+    {
+      "id": "Q3NT-3L1",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5F5-DZL : Wed Mar 05 02:18:34 UTC 2025), Entry for Pascuala Rivera Rodriguez and Antonio Rivera, 24 Dec 1829.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H8VS-N52M"
+    },
+    {
+      "id": "Q3VN-SS3",
+      "title": "Marcelina Garcia, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5F5-PGM : Wed Mar 05 01:18:55 UTC 2025), Entry for Juan Antonio Rivera Rodriguez and Antonio Rivera, 22 Jan 1826.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H8VS-SL6Z"
+    },
+    {
+      "id": "Q3VN-XTY",
+      "title": "Juan, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N39M-DRK : Sat Aug 31 09:22:35 UTC 2024), Entry for Juan Antonio Rivera and Antonio Rivera, 22 Jan 1826.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N39M-DR5"
+    },
+    {
+      "id": "Q3VN-N7B",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5T4-X57 : Wed Mar 05 01:18:56 UTC 2025), Entry for Juana Rodriguez Garcia and Juan Rodriguez, 6 May 1799.",
+      "url": "https://familysearch.org/ark:/61903/1:1:F5T4-X5W"
+    },
+    {
+      "id": "QHCJ-D3R",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N39M-3P8 : Sat Aug 31 09:22:49 UTC 2024), Entry for Ana Juana Rodriguez and Juan Rodriguez, 13 Jul 1811.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N39M-3PD"
+    },
+    {
+      "id": "Q2S8-3DF",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N3QT-SHK : Sat Aug 31 09:22:49 UTC 2024), Entry for Juan Rodriguez and Antonio, 04 Aug 1798.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N3QT-SHK"
+    },
+    {
+      "id": "S2TQ-9YS",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N3M1-VMG : Sat Aug 31 09:21:03 UTC 2024), Entry for Juan Rodriguez and Antonio Rodriguez, 19 Nov 1777.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N3M1-VMG"
+    },
+    {
+      "id": "Q3VN-9NV",
+      "title": "Juan, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5F5-PGM : Wed Mar 05 01:18:55 UTC 2025), Entry for Juan Antonio Rivera Rodriguez and Antonio Rivera, 22 Jan 1826.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H8VS-SLZM"
+    },
+    {
+      "id": "QJ1V-QC3",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N39M-WCH : Sat Aug 31 08:31:34 UTC 2024), Entry for Vicenta Rodriguez and Juan Rodriguez, 26 Oct 1815.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N39M-WCC"
+    },
+    {
+      "id": "9MRS-PZS",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FRZL-561 : Wed Mar 05 00:06:52 UTC 2025), Entry for Vicenta Rodriguez and Juan Rodriguez, 26 Oct 1815.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FRZL-5XM"
+    },
+    {
+      "id": "Q3VN-CD1",
+      "title": "Juan Rodrigues, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N3QL-BRK : Sat Aug 31 08:23:00 UTC 2024), Entry for Severiano Rivera and Antonio Rivera, 10 Feb 1837.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N3QL-BR5"
+    },
+    {
+      "id": "Q3VN-8DV",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N3QL-R6R : Sat Aug 31 08:23:00 UTC 2024), Entry for Teresa Rivera and Antonio Rivera, 29 Aug 1832.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N3QL-RXM"
+    },
+    {
+      "id": "Q3VN-2R3",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N3M1-BS8 : Sat Aug 31 08:28:51 UTC 2024), Entry for Juana Rodriguez and Juan Rodriguez, 06 May 1799.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N3M1-BSD"
+    }
+  ]
+}

--- a/eval/tests/e2e/juan-rodriguez-son/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/juan-rodriguez-son/unstripped-tree.gedcomx.json
@@ -1,0 +1,818 @@
+{
+  "persons": [
+    {
+      "id": "9634-PS9",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Juan",
+          "surname": "Rodríguez Martínez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "05efd440-d752-4e8b-9b16-043c51003b3b",
+          "type": "Birth",
+          "date": "16 November 1777",
+          "standard_date": "16 Nov 1777",
+          "place": "Pozuelo, Albacete, Castilla-La Mancha, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "e3157663-21fb-4571-a340-3af655ac5d15",
+          "type": "Death"
+        },
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "19 November 1777",
+          "standard_date": "19 Nov 1777",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "d0f1d84c-0b11-4d6f-b33c-7b3687142d76",
+          "type": "Burial",
+          "date": "18 Jan 1855",
+          "standard_date": "18 Jan 1855",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        }
+      ]
+    },
+    {
+      "id": "963H-88B",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Francisco",
+          "surname": "Rodriguez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "4 December 1801",
+          "standard_date": "4 Dec 1801",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GVZQ-RY9",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Severiano",
+          "surname": "Rodríguez García"
+        }
+      ],
+      "facts": [
+        {
+          "id": "65957105-c1d2-406c-a075-3bb1e6508e48",
+          "type": "Birth",
+          "date": "8 Nov 1817",
+          "standard_date": "8 Nov 1817"
+        },
+        {
+          "id": "85f17424-bd99-4240-979a-45cb043657f6",
+          "type": "Christening",
+          "date": "9 Nov 1817",
+          "standard_date": "9 Nov 1817",
+          "place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, España",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "800cebd9-a7f7-4966-b7d8-7952e2f4edc1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "963H-WVN",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Francisca",
+          "surname": "Rodriguez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "09 Mar 1822",
+          "standard_date": "9 Mar 1822",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "10 Mar 1822",
+          "standard_date": "10 Mar 1822",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "13868ee3-9275-4f38-a04d-f40418b7d8d1",
+          "type": "Baptism",
+          "date": "10 Mar 1822",
+          "standard_date": "10 Mar 1822",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LZZ6-NHR",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Antonio",
+          "surname": "Rodriguez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "26aaaf0d-0a64-40f2-bc34-686f9eac94f6",
+          "type": "Residence",
+          "date": "1728",
+          "standard_date": "1728",
+          "place": "Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "09e3fb6a-98ff-4de8-a86f-88e22156f3b1",
+          "type": "Birth",
+          "date": "08 Aug 1728",
+          "standard_date": "8 Aug 1728",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "88a94a0d-c37f-45c5-9b2c-1c95d34b379e",
+          "type": "Baptism",
+          "date": "12 Sep 1728",
+          "standard_date": "12 Sep 1728",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "359e3f55-c055-4509-8741-0a9821fb5c37",
+          "type": "Christening",
+          "date": "12 Sep 1728",
+          "standard_date": "12 Sep 1728",
+          "place": "SAN BARTOLOME, POZUELO, ALBACETE, SPAIN",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "c8b9936b-2d3f-4d6b-b88e-9212f43ce9af",
+          "type": "Unknown",
+          "date": "13 ene 1752",
+          "standard_date": "13 1752"
+        },
+        {
+          "id": "8f634477-7913-4497-840a-c08908a5c028",
+          "type": "Burial",
+          "date": "3 de agosto de 1797",
+          "standard_date": "3 Aug 1797",
+          "place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, España",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "9634-VXH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Juana",
+          "surname": "Rodríguez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "06 May 1799",
+          "standard_date": "6 May 1799",
+          "place": "Pozuelo, Albacete, España",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "6 May 1799",
+          "standard_date": "6 May 1799",
+          "place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, España",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "963H-MBM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Marcelina",
+          "surname": "Garcia"
+        }
+      ],
+      "facts": [
+        {
+          "id": "05efd440-d752-4e8b-9b16-043c51003b3b",
+          "type": "Birth",
+          "date": "25 April 1779",
+          "standard_date": "25 Apr 1779",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "f27d2591-78d8-4d89-a5d0-b6dd615a37eb",
+          "type": "Baptism",
+          "date": "03 May 1779",
+          "standard_date": "3 May 1779",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "03 May 1779",
+          "standard_date": "3 May 1779",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "8f93d182-5bb4-44a0-8c5d-f40c9d18713d",
+          "type": "Residence",
+          "date": "1779",
+          "standard_date": "1779",
+          "place": "Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "e3157663-21fb-4571-a340-3af655ac5d15",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "9634-JLQ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Bicenta",
+          "surname": "Martinez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "a4d6a635-d933-48b9-8d1c-874be9c52d4f",
+          "type": "Birth",
+          "date": "24 May 1735",
+          "standard_date": "24 May 1735",
+          "place": "Peñas de San Pedro, Albacete, Castilla-La Mancha, España",
+          "standard_place": "Peñas de San Pedro, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "cb5a0364-d166-4918-a46f-a5d39fbb7acd",
+          "type": "Baptism",
+          "date": "06 Jun 1735",
+          "standard_date": "6 Jun 1735",
+          "place": "Nuestra Señora de la Esperanza, Peñas de San Pedro, Albacete, Spain",
+          "standard_place": "Nuestra Señora de la Esperanza, Peñas de San Pedro, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "fda82379-4ad8-4f00-b4a0-62e3385468f5",
+          "type": "Christening",
+          "date": "06 Jun 1735",
+          "standard_date": "6 Jun 1735",
+          "place": "Santa Maria De La Esparanza, Penas De San Pedro, Albacete, Spain",
+          "standard_place": "Peñas de San Pedro, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "1a5387c9-43fa-4c59-9aee-a9f8606da763",
+          "type": "Residence",
+          "date": "1735",
+          "standard_date": "1735",
+          "place": "Penas de San Pedro, Albacete, Spain",
+          "standard_place": "Peñas de San Pedro, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "17720ed8-564e-479e-a95e-508d4a5e65e1",
+          "type": "Residence",
+          "date": "1735",
+          "standard_date": "1735",
+          "place": "Peñas de San Pedro, Albacete, Spain",
+          "standard_place": "Peñas de San Pedro, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "5256e017-3809-44a2-8f44-8db9c93fe8c1",
+          "type": "Death",
+          "date": "2 de diciembre de 1801",
+          "standard_date": "2 Dec 1801",
+          "place": "Pozuelo, Albacete, Castilla-La Mancha, España",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "5c741325-142b-4833-938b-286fc688e0df",
+          "type": "Burial",
+          "date": "3 de diciembre de 1801",
+          "standard_date": "3 Dec 1801",
+          "place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, España",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        }
+      ]
+    },
+    {
+      "id": "9634-P9Y",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Maria",
+          "surname": "Rodriguez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "02 Jul 1804",
+          "standard_date": "2 Jul 1804",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "04 Jul 1804",
+          "standard_date": "4 Jul 1804",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "fa7b2941-62d0-4727-b56f-dd5d539d5492",
+          "type": "Baptism",
+          "date": "04 Jul 1804",
+          "standard_date": "4 Jul 1804",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GS51-S1P",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "Ana Juana",
+          "surname": "Rodriguez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "e419c4cd-9bfa-4bff-b0ac-0a311131a757",
+          "type": "Birth",
+          "date": "12 Jul 1811",
+          "standard_date": "12 Jul 1811",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "9f0760ac-b58a-4176-9a40-664fe821f3f9",
+          "type": "Christening",
+          "date": "13 Jul 1811",
+          "standard_date": "13 Jul 1811",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "ddc22ece-fd5e-4518-ae7e-4228bc32f367",
+          "type": "Baptism",
+          "date": "13 Jul 1811",
+          "standard_date": "13 Jul 1811",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "ef943380-5fd8-48b1-9222-dc96fa754bc3",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "963H-MYP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N11",
+          "given": "Vicenta",
+          "surname": "Rodriguez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "26 Oct 1815",
+          "standard_date": "26 Oct 1815",
+          "place": "San Bartolome, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "26 Oct 1815",
+          "standard_date": "26 Oct 1815",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "1c636ec9-6c31-4b2a-94e9-3b1cfe072022",
+          "type": "Baptism",
+          "date": "26 Oct 1815",
+          "standard_date": "26 Oct 1815",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "9634-PS9",
+      "person2": "963H-MBM",
+      "facts": [
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "4 AGO 1798",
+          "standard_date": "4 1798",
+          "place": "San Bartolomé, Pozuelo, Albacete, España",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        },
+        {
+          "id": "14fa5ec2-daa1-47a3-8b0f-a7a37ec3a3e0",
+          "type": "Marriage",
+          "date": "04 Aug 1798",
+          "standard_date": "4 Aug 1798",
+          "place": "San Bartolomé, Pozuelo, Albacete, Spain",
+          "standard_place": "San Bartolomé, Pozuelo, Albacete, Castilla-La Mancha, Spain"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "LZZ6-NHR",
+      "person2": "9634-JLQ",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "13 Jan 1752",
+          "standard_date": "13 Jan 1752",
+          "place": "Nuestra Señora de la Esperanza, Peñas de San Pedro, Albacete, Castilla-La Mancha, España",
+          "standard_place": "Nuestra Señora de la Esperanza, Peñas de San Pedro, Albacete, Castilla-La Mancha, Spain"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "LZZ6-NHR",
+      "child": "9634-PS9",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "9634-JLQ",
+      "child": "9634-PS9",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "9634-PS9",
+      "child": "9634-VXH",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "963H-MBM",
+      "child": "9634-VXH",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "9634-PS9",
+      "child": "963H-88B",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "963H-MBM",
+      "child": "963H-88B",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "9634-PS9",
+      "child": "9634-P9Y",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "963H-MBM",
+      "child": "9634-P9Y",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "9634-PS9",
+      "child": "GS51-S1P",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "963H-MBM",
+      "child": "GS51-S1P",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "9634-PS9",
+      "child": "963H-MYP",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "963H-MBM",
+      "child": "963H-MYP",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "9634-PS9",
+      "child": "GVZQ-RY9"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "963H-MBM",
+      "child": "GVZQ-RY9"
+    },
+    {
+      "id": "R17",
+      "type": "ParentChild",
+      "parent": "9634-PS9",
+      "child": "963H-WVN",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R18",
+      "type": "ParentChild",
+      "parent": "963H-MBM",
+      "child": "963H-WVN",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "99CB-RRQ",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FRZL-GHF : Wed Mar 05 00:32:19 UTC 2025), Entry for Juana Rodriguez and Juan Rodriguez, 6 May 1799.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FRZL-GHN"
+    },
+    {
+      "id": "Q3NT-D6X",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N3QL-PZ5 : Sat Aug 31 09:19:55 UTC 2024), Entry for Pascuala Rivera and Antonio Rivera, 24 Dec 1829.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N3QL-PZ1"
+    },
+    {
+      "id": "Q646-BS8",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N39M-Z3P : Sat Aug 31 08:18:23 UTC 2024), Entry for Francisca Rodriguez and Juan Rodriguez, 10 Mar 1822.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N39M-Z35"
+    },
+    {
+      "id": "Q3VF-GK8",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5F5-P29 : Wed Mar 05 02:19:48 UTC 2025), Entry for Teresa Rivera Rodriguez and Antonio Rivera, 29 Aug 1832.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H8V3-G33Z"
+    },
+    {
+      "id": "QHCJ-DL2",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5JD-DJR : Wed Mar 05 02:18:32 UTC 2025), Entry for Tomas Lopez Rodriguez and Juan Lopez, 9 Mar 1853.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H8V9-JYN2"
+    },
+    {
+      "id": "9M42-GW4",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FRZL-RX8 : Wed Mar 05 00:06:58 UTC 2025), Entry for Francisca Rodriguez and Juan Rodriguez, 10 Mar 1822.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FRZL-RXD"
+    },
+    {
+      "id": "9M6L-PBH",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FRZL-P58 : Wed Mar 05 00:06:27 UTC 2025), Entry for Ana Juana Rodriguez and Juan Rodriguez, 13 Jul 1811.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FRZL-P5D"
+    },
+    {
+      "id": "99S9-WY6",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FRZL-P9G : Wed Mar 05 00:32:30 UTC 2025), Entry for Maria Rodriguez and Juan Rodriguez, 4 Jul 1804.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FRZL-P9P"
+    },
+    {
+      "id": "Q3VF-VBP",
+      "title": "Juan Rodrigues, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5F5-6BW : Wed Mar 05 02:18:16 UTC 2025), Entry for Severiano Rivera Rodrigues and Antonio Rivera, 10 Feb 1837.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H8V7-RX3Z"
+    },
+    {
+      "id": "QHVM-WKB",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N39M-M1F : Sat Aug 31 08:24:48 UTC 2024), Entry for Maria Rodriguez and Juan Rodriguez, 04 Jul 1804.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N39M-M1N"
+    },
+    {
+      "id": "9926-XZV",
+      "title": "Juan Rodriguez, \"Spain, Marriages, 1565-1950\"",
+      "citation": "\"España, matrimonios, 1565-1950\", database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:FFLR-65S : 16 February 2020), Juan Rodriguez, 1798.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FFLR-65S"
+    },
+    {
+      "id": "Q3VV-MK6",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VTJQ-SRM : Sat Aug 31 09:27:46 UTC 2024), Entry for Juan Rodriguez and Marcelina Garcia, 18 Jan 1855.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VTJQ-SRM"
+    },
+    {
+      "id": "Q3VV-9SV",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5FP-KRG : Wed Mar 05 02:51:35 UTC 2025), Entry for Severiano Rodriguez Garcia and Juan Rodriguez, 9 Nov 1817.",
+      "url": "https://familysearch.org/ark:/61903/1:1:F5FP-KRP"
+    },
+    {
+      "id": "QHCJ-6QV",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5FP-BC3 : Wed Mar 05 02:51:20 UTC 2025), Entry for Ana Juana Rodriguez Garcia and Juan Rodriguez, 13 Jul 1811.",
+      "url": "https://familysearch.org/ark:/61903/1:1:F5FP-BCQ"
+    },
+    {
+      "id": "QFV8-MDR",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N39M-4DV : Sat Aug 31 09:22:47 UTC 2024), Entry for Severiano Rodriguez and Juan Rodriguez, 09 Nov 1817.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N39M-4DK"
+    },
+    {
+      "id": "S2T3-MQ4",
+      "title": "Juan Rodriguez Martinez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5FP-DXJ : Wed Mar 05 01:18:43 UTC 2025), Entry for Juan Rodriguez Martinez and Antonio Rodriguez, 19 Nov 1777.",
+      "url": "https://familysearch.org/ark:/61903/1:1:F5FP-DXJ"
+    },
+    {
+      "id": "Q3NT-3L1",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5F5-DZL : Wed Mar 05 02:18:34 UTC 2025), Entry for Pascuala Rivera Rodriguez and Antonio Rivera, 24 Dec 1829.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H8VS-N52M"
+    },
+    {
+      "id": "Q3VN-SS3",
+      "title": "Marcelina Garcia, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5F5-PGM : Wed Mar 05 01:18:55 UTC 2025), Entry for Juan Antonio Rivera Rodriguez and Antonio Rivera, 22 Jan 1826.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H8VS-SL6Z"
+    },
+    {
+      "id": "Q3VN-XTY",
+      "title": "Juan, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N39M-DRK : Sat Aug 31 09:22:35 UTC 2024), Entry for Juan Antonio Rivera and Antonio Rivera, 22 Jan 1826.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N39M-DR5"
+    },
+    {
+      "id": "Q3VN-N7B",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5T4-X57 : Wed Mar 05 01:18:56 UTC 2025), Entry for Juana Rodriguez Garcia and Juan Rodriguez, 6 May 1799.",
+      "url": "https://familysearch.org/ark:/61903/1:1:F5T4-X5W"
+    },
+    {
+      "id": "QHCJ-D3R",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N39M-3P8 : Sat Aug 31 09:22:49 UTC 2024), Entry for Ana Juana Rodriguez and Juan Rodriguez, 13 Jul 1811.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N39M-3PD"
+    },
+    {
+      "id": "Q2S8-3DF",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N3QT-SHK : Sat Aug 31 09:22:49 UTC 2024), Entry for Juan Rodriguez and Antonio, 04 Aug 1798.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N3QT-SHK"
+    },
+    {
+      "id": "S2TQ-9YS",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N3M1-VMG : Sat Aug 31 09:21:03 UTC 2024), Entry for Juan Rodriguez and Antonio Rodriguez, 19 Nov 1777.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N3M1-VMG"
+    },
+    {
+      "id": "Q3VN-9NV",
+      "title": "Juan, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:F5F5-PGM : Wed Mar 05 01:18:55 UTC 2025), Entry for Juan Antonio Rivera Rodriguez and Antonio Rivera, 22 Jan 1826.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H8VS-SLZM"
+    },
+    {
+      "id": "QJ1V-QC3",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N39M-WCH : Sat Aug 31 08:31:34 UTC 2024), Entry for Vicenta Rodriguez and Juan Rodriguez, 26 Oct 1815.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N39M-WCC"
+    },
+    {
+      "id": "9MRS-PZS",
+      "title": "Juan Rodriguez, \"España, bautismos, 1502-1940\"",
+      "citation": "\"España, bautismos, 1502-1940\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FRZL-561 : Wed Mar 05 00:06:52 UTC 2025), Entry for Vicenta Rodriguez and Juan Rodriguez, 26 Oct 1815.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FRZL-5XM"
+    },
+    {
+      "id": "Q3VN-CD1",
+      "title": "Juan Rodrigues, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N3QL-BRK : Sat Aug 31 08:23:00 UTC 2024), Entry for Severiano Rivera and Antonio Rivera, 10 Feb 1837.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N3QL-BR5"
+    },
+    {
+      "id": "Q3VN-8DV",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N3QL-R6R : Sat Aug 31 08:23:00 UTC 2024), Entry for Teresa Rivera and Antonio Rivera, 29 Aug 1832.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N3QL-RXM"
+    },
+    {
+      "id": "Q3VN-2R3",
+      "title": "Juan Rodriguez, \"España, Diócesis de Albacete, registros parroquiales, 1504-1979\"",
+      "citation": "\"España, Diócesis de Albacete, registros parroquiales, 1504-1979\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N3M1-BS8 : Sat Aug 31 08:28:51 UTC 2024), Entry for Juana Rodriguez and Juan Rodriguez, 06 May 1799.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N3M1-BSD"
+    }
+  ]
+}

--- a/eval/tests/e2e/katalin-horak-son/README.md
+++ b/eval/tests/e2e/katalin-horak-son/README.md
@@ -1,0 +1,34 @@
+# Katalin Horák — additional son János (b. 1844)
+
+**Source PID:** `LDSJ-SXL`
+**Katalin Horák is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+not recorded in the tree; died not recorded in the tree.
+
+## Research question
+
+> Did Katalin Horák and her husband István Banyári of Kľak, Nová Baňa, Slovakia have a son named János, baptized 1 September 1844?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `LDSJ-SXL` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+hard — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 20, flag `adds_son`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Slovakia, Church and Synagogue Books, 1592-1935: baptismal entry, 1 September 1844, Kľak, Nová Baňa, naming parents István Banyári and Káti Liskovics. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming the 1844 János baptism, plus a `required` finding that the report documents the rejection.
+
+**Strong reason to doubt this match**: the mother's surname in the hint record is "**Liskovics**", which bears no resemblance at all to the subject's tree surname "**Horák**" — a materially weaker name link than almost any other record in this batch (most others are routine spelling variants of the same surname). The father's name "István Banyári" does match the tree spouse's name, and the parish (Kľak) and era (a son baptized 1844, one to two years before the tree's existing son István, christened 1846) are both plausible. This fixture is a strong candidate for outcome (c) (false match — likely a different woman married to a same-named István Banyári in the same small parish, given how common the surname Banyári appears to be there) but is left as a recover-type draft finding pending the genealogist's review.

--- a/eval/tests/e2e/katalin-horak-son/expected-findings.json
+++ b/eval/tests/e2e/katalin-horak-son/expected-findings.json
@@ -1,0 +1,21 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Katalin Horák (recorded in the hint as Káti Liskovics) and István Banyári had a son, János Banyári, baptized 1 September 1844 in Kľak, Nová Baňa, close in time to the tree's existing son István (christened 15 April 1846).",
+      "details": {
+        "subject_person": "Katalin Horák (LDSJ-SXL)",
+        "relation": "child",
+        "target_person": {
+          "name": "János Banyári",
+          "birth": "baptized 1 September 1844, Kľak, Nová Baňa, Slovakia"
+        }
+      },
+      "supporting_sources": [
+        "Slovakia, Church and Synagogue Books, 1592-1935 — baptismal entry, 1 Sep 1844, Kľak, Nová Baňa, naming parents István Banyári and Káti Liskovics"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/katalin-horak-son/fixture.json
+++ b/eval/tests/e2e/katalin-horak-son/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "katalin-horak-son",
+  "name": "Katalin Horák — additional son János (b. 1844)",
+  "genre": "record-hint",
+  "source_pid": "LDSJ-SXL",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Katalin Horák and her husband István Banyári of Kľak, Nová Baňa, Slovakia have a son named János, baptized 1 September 1844?",
+  "tags": {
+    "question_type": "children",
+    "era": "1840s",
+    "geography": "SK"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 20, flag adds_son, confidence 3). Draft transcribed from a Slovak church/synagogue record; unverified."
+}

--- a/eval/tests/e2e/katalin-horak-son/starting-research.json
+++ b/eval/tests/e2e/katalin-horak-son/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_katalin_horak_son",
+    "objective": "Did Katalin Horák and her husband István Banyári of Kľak, Nová Baňa, Slovakia have a son named János, baptized 1 September 1844?",
+    "subject_person_ids": [
+      "LDSJ-SXL"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/katalin-horak-son/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/katalin-horak-son/starting-tree.gedcomx.json
@@ -1,0 +1,151 @@
+{
+  "persons": [
+    {
+      "id": "LDSJ-SXL",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Katalin",
+          "surname": "Horák"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LDSJ-SXK",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "István",
+          "surname": "Banyari"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "15 Apr 1846",
+          "standard_date": "15 Apr 1846",
+          "place": "Kľak, Nová Baňa, Slovakia",
+          "standard_place": "Kľak, Žarnovica, Slovakia"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LDSJ-SX2",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "István",
+          "surname": "Banyari"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GGCQ-1B6",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "István",
+          "surname": "Banyári"
+        }
+      ],
+      "facts": [
+        {
+          "id": "6efbdfd9-bbdb-46e9-9bfd-e153455d6010",
+          "type": "Birth",
+          "date": "1938",
+          "standard_date": "1938",
+          "place": "Mohol",
+          "standard_place": "Mohol, Solapur, Maharashtra, India"
+        },
+        {
+          "id": "7bdd64e6-68e9-4477-bd04-0d4740850575",
+          "type": "Death",
+          "place": "Dunaújváros, Fejér, Magyarország",
+          "standard_place": "Dunaújváros, Fejér, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "GGC7-K79",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "István",
+          "surname": "Banyári"
+        }
+      ],
+      "facts": [
+        {
+          "id": "219ac861-9e2e-4815-889d-8c5aa0a6fe97",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GGC7-K79",
+      "person2": "LDSJ-SXL"
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "LDSJ-SX2",
+      "person2": "LDSJ-SXL"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "LDSJ-SX2",
+      "child": "LDSJ-SXK"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "LDSJ-SXL",
+      "child": "LDSJ-SXK"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GGC7-K79",
+      "child": "GGCQ-1B6"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "LDSJ-SXL",
+      "child": "GGCQ-1B6"
+    }
+  ],
+  "sources": []
+}

--- a/eval/tests/e2e/katalin-horak-son/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/katalin-horak-son/unstripped-tree.gedcomx.json
@@ -1,0 +1,151 @@
+{
+  "persons": [
+    {
+      "id": "LDSJ-SXL",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Katalin",
+          "surname": "Horák"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LDSJ-SXK",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "István",
+          "surname": "Banyari"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "15 Apr 1846",
+          "standard_date": "15 Apr 1846",
+          "place": "Kľak, Nová Baňa, Slovakia",
+          "standard_place": "Kľak, Žarnovica, Slovakia"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LDSJ-SX2",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "István",
+          "surname": "Banyari"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GGCQ-1B6",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "István",
+          "surname": "Banyári"
+        }
+      ],
+      "facts": [
+        {
+          "id": "6efbdfd9-bbdb-46e9-9bfd-e153455d6010",
+          "type": "Birth",
+          "date": "1938",
+          "standard_date": "1938",
+          "place": "Mohol",
+          "standard_place": "Mohol, Solapur, Maharashtra, India"
+        },
+        {
+          "id": "7bdd64e6-68e9-4477-bd04-0d4740850575",
+          "type": "Death",
+          "place": "Dunaújváros, Fejér, Magyarország",
+          "standard_place": "Dunaújváros, Fejér, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "GGC7-K79",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "István",
+          "surname": "Banyári"
+        }
+      ],
+      "facts": [
+        {
+          "id": "219ac861-9e2e-4815-889d-8c5aa0a6fe97",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GGC7-K79",
+      "person2": "LDSJ-SXL"
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "LDSJ-SX2",
+      "person2": "LDSJ-SXL"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "LDSJ-SX2",
+      "child": "LDSJ-SXK"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "LDSJ-SXL",
+      "child": "LDSJ-SXK"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GGC7-K79",
+      "child": "GGCQ-1B6"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "LDSJ-SXL",
+      "child": "GGCQ-1B6"
+    }
+  ],
+  "sources": []
+}

--- a/eval/tests/e2e/manoel-oliveira-daughter/README.md
+++ b/eval/tests/e2e/manoel-oliveira-daughter/README.md
@@ -1,0 +1,34 @@
+# Manoel Melquiades de Oliveira — additional daughter Josefa (m. 1926)
+
+**Source PID:** `GHJ6-2WV`
+**Manoel Melquiades de Oliveira is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+not recorded in the tree; died not recorded in the tree.
+
+## Research question
+
+> Did Manoel Melquiades de Oliveira and his wife Cândida Damasceno de Oliveira of Rio Grande do Norte, Brazil have a daughter named Josefa, married 1926, in addition to their known children Abel and Maria Lila (b. 1901)?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `GHJ6-2WV` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+hard — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 8, flag `adds_daughter`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019: marriage registration, 12 March 1926, Natal, for Elfridio Justino Da Silva and Josefa Dias Da Conceição, naming the bride's parents as Manuel Melchiades de Oliveira and Candida de Oliveira. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Josefa Dias Da Conceição as the subject's daughter, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh **against** the match: the proposed daughter's surname, "Dias Da Conceição", bears no resemblance to the father's surname "de Oliveira" — Brazilian naming customs of the era sometimes drew a child's surname from a godparent or the mother's line, but this is a materially weaker surname link than most of this batch's other candidates. The parents' given names (Manuel Melchiades / Manoel Melquiades, and Candida / Cândida Damasceno) match closely, and the record is from the same state (Rio Grande do Norte) and era as the tree's known daughter Maria Lila (b. 1901, d. 1995, Natal).

--- a/eval/tests/e2e/manoel-oliveira-daughter/expected-findings.json
+++ b/eval/tests/e2e/manoel-oliveira-daughter/expected-findings.json
@@ -1,0 +1,22 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Manoel Melquiades de Oliveira and Cândida de Oliveira had a daughter, Josefa Dias Da Conceição, who married Elfridio Justino Da Silva on 12 March 1926 in Natal, Rio Grande do Norte, in addition to their children Abel and Maria Lila already in the tree.",
+      "details": {
+        "subject_person": "Manoel Melquiades de Oliveira (GHJ6-2WV)",
+        "relation": "child",
+        "target_person": {
+          "name": "Josefa Dias Da Conceição",
+          "birth": "unknown, likely Rio Grande do Norte, Brazil",
+          "marriage": "12 March 1926, Natal, Rio Grande do Norte, to Elfridio Justino Da Silva"
+        }
+      },
+      "supporting_sources": [
+        "Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019 — marriage registration, 12 Mar 1926, Natal, naming the bride's parents as Manuel Melchiades de Oliveira and Candida de Oliveira"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/manoel-oliveira-daughter/fixture.json
+++ b/eval/tests/e2e/manoel-oliveira-daughter/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "manoel-oliveira-daughter",
+  "name": "Manoel Melquiades de Oliveira — additional daughter Josefa (m. 1926)",
+  "genre": "record-hint",
+  "source_pid": "GHJ6-2WV",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Manoel Melquiades de Oliveira and his wife Cândida Damasceno de Oliveira of Rio Grande do Norte, Brazil have a daughter named Josefa, married 1926, in addition to their known children Abel and Maria Lila (b. 1901)?",
+  "tags": {
+    "question_type": "children",
+    "era": "1900s",
+    "geography": "BR"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 8, flag adds_daughter, confidence 3). Draft transcribed from a Brazilian Catholic marriage record; unverified."
+}

--- a/eval/tests/e2e/manoel-oliveira-daughter/starting-research.json
+++ b/eval/tests/e2e/manoel-oliveira-daughter/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_manoel_oliveira_daughter",
+    "objective": "Did Manoel Melquiades de Oliveira and his wife Cândida Damasceno de Oliveira of Rio Grande do Norte, Brazil have a daughter named Josefa, married 1926, in addition to their known children Abel and Maria Lila (b. 1901)?",
+    "subject_person_ids": [
+      "GHJ6-2WV"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/manoel-oliveira-daughter/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/manoel-oliveira-daughter/starting-tree.gedcomx.json
@@ -1,0 +1,162 @@
+{
+  "persons": [
+    {
+      "id": "GHJ6-2WV",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Manoel Melquiades",
+          "surname": "de Oliveira"
+        }
+      ],
+      "facts": [
+        {
+          "id": "551b43a4-80c8-410e-a058-5ee18d305576",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GHJ6-L4F",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Cândida",
+          "surname": "Damasceno de Oliveira"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4febaec9-2c76-484c-a8f3-25271f4abe77",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GHJ6-2BB",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Abel",
+          "surname": "de Oliveira"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1c8f0e31-2cef-472f-b882-96e143fd9219",
+          "type": "Death",
+          "date": "6 de março de 1967",
+          "standard_date": "6 Mar 1967",
+          "place": "Monrovia, Montserrado, Libéria",
+          "standard_place": "Monrovia, Greater Monrovia, Montserrado, Liberia"
+        }
+      ]
+    },
+    {
+      "id": "GHJQ-G8N",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Maria Lila",
+          "surname": "de Oliveira Serrano"
+        }
+      ],
+      "facts": [
+        {
+          "id": "3c5e1fce-7a8f-44b2-b720-756e2370c3ba",
+          "type": "Birth",
+          "date": "7 de novembro de 1901",
+          "standard_date": "7 Nov 1901",
+          "place": "Paraíba, Brasil",
+          "standard_place": "Paraíba, Brazil"
+        },
+        {
+          "id": "f64447f6-16b4-435f-9f99-e572c6d02c54",
+          "type": "Death",
+          "date": "20 de outubro de 1995",
+          "standard_date": "20 Oct 1995",
+          "place": "Natal, Rio Grande do Norte, Brasil",
+          "standard_place": "Natal, Rio Grande do Norte, Brazil"
+        },
+        {
+          "id": "a8ce3147-17ec-4d92-8ca9-1a6ad531e45b",
+          "type": "Death Registration",
+          "date": "24 Oct 1995",
+          "standard_date": "24 Oct 1995"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GHJ6-2WV",
+      "person2": "GHJ6-L4F"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "GHJ6-2WV",
+      "child": "GHJQ-G8N"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GHJ6-L4F",
+      "child": "GHJQ-G8N"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GHJ6-2WV",
+      "child": "GHJ6-2BB"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GHJ6-L4F",
+      "child": "GHJ6-2BB"
+    }
+  ],
+  "sources": [
+    {
+      "id": "3Y5P-3LQ",
+      "title": "Manuel Melchiades de Oliveira, “Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019”",
+      "citation": "\"Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6XWC-93R5 : Sat Mar 09 11:03:27 UTC 2024), Entry for Carlos Vieira de Andrade Serrano and Antonio Serrano Gonçalves de Andrade, 20 Nov 1926.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6XWC-93RB"
+    },
+    {
+      "id": "QKN1-CXG",
+      "title": "Manuel Melchiades de Oliveira, “Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019”",
+      "citation": "\"Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6XWC-DTH1 : Sat Mar 09 04:59:39 UTC 2024), Entry for Carlos Vieira de Andrade Serrano and Antonio Serrano Gonçalves de Andrade, 20 May 1931.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6XWC-DTC7"
+    },
+    {
+      "id": "3Y5W-3F8",
+      "title": "Manoel Melquiades de Oliveira, “Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019”",
+      "citation": "\"Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6XWH-CL2C : Sat Mar 09 19:51:51 UTC 2024), Entry for Maria Lila de Oliveira Serrano and Manoel Melquiades de Oliveira, 24 Oct 1995.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6XWH-CL2Z"
+    },
+    {
+      "id": "3Y5W-T8F",
+      "title": "Manuel Melchiades de Oliveira, “Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019”",
+      "citation": "\"Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6XWC-QXK1 : Sun Mar 10 20:54:00 UTC 2024), Entry for Carlos Vieira de Andrade Serrano and Antonio Serrano Gonçalves de Andrade, 30 Dec 1922.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6XWC-DSZQ"
+    },
+    {
+      "id": "QKN1-NV6",
+      "title": "Manoel Melquiades de Oliveira, “Brasil, Rio Grande do Norte, Registro Civil, 1803-2021”",
+      "citation": "\"Brasil, Rio Grande do Norte, Registro Civil, 1803-2021\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:62MV-LNKP : Wed May 27 06:45:44 UTC 2026), Entry for Lucy de Oliveira Serrano and Carlos Vieira de Andrade Serrano, setembro de 1923.",
+      "url": "https://familysearch.org/ark:/61903/1:1:62MV-LNK1"
+    }
+  ]
+}

--- a/eval/tests/e2e/manoel-oliveira-daughter/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/manoel-oliveira-daughter/unstripped-tree.gedcomx.json
@@ -1,0 +1,162 @@
+{
+  "persons": [
+    {
+      "id": "GHJ6-2WV",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Manoel Melquiades",
+          "surname": "de Oliveira"
+        }
+      ],
+      "facts": [
+        {
+          "id": "551b43a4-80c8-410e-a058-5ee18d305576",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GHJ6-L4F",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Cândida",
+          "surname": "Damasceno de Oliveira"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4febaec9-2c76-484c-a8f3-25271f4abe77",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GHJ6-2BB",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Abel",
+          "surname": "de Oliveira"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1c8f0e31-2cef-472f-b882-96e143fd9219",
+          "type": "Death",
+          "date": "6 de março de 1967",
+          "standard_date": "6 Mar 1967",
+          "place": "Monrovia, Montserrado, Libéria",
+          "standard_place": "Monrovia, Greater Monrovia, Montserrado, Liberia"
+        }
+      ]
+    },
+    {
+      "id": "GHJQ-G8N",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Maria Lila",
+          "surname": "de Oliveira Serrano"
+        }
+      ],
+      "facts": [
+        {
+          "id": "3c5e1fce-7a8f-44b2-b720-756e2370c3ba",
+          "type": "Birth",
+          "date": "7 de novembro de 1901",
+          "standard_date": "7 Nov 1901",
+          "place": "Paraíba, Brasil",
+          "standard_place": "Paraíba, Brazil"
+        },
+        {
+          "id": "f64447f6-16b4-435f-9f99-e572c6d02c54",
+          "type": "Death",
+          "date": "20 de outubro de 1995",
+          "standard_date": "20 Oct 1995",
+          "place": "Natal, Rio Grande do Norte, Brasil",
+          "standard_place": "Natal, Rio Grande do Norte, Brazil"
+        },
+        {
+          "id": "a8ce3147-17ec-4d92-8ca9-1a6ad531e45b",
+          "type": "Death Registration",
+          "date": "24 Oct 1995",
+          "standard_date": "24 Oct 1995"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GHJ6-2WV",
+      "person2": "GHJ6-L4F"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "GHJ6-2WV",
+      "child": "GHJQ-G8N"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GHJ6-L4F",
+      "child": "GHJQ-G8N"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GHJ6-2WV",
+      "child": "GHJ6-2BB"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GHJ6-L4F",
+      "child": "GHJ6-2BB"
+    }
+  ],
+  "sources": [
+    {
+      "id": "3Y5P-3LQ",
+      "title": "Manuel Melchiades de Oliveira, “Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019”",
+      "citation": "\"Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6XWC-93R5 : Sat Mar 09 11:03:27 UTC 2024), Entry for Carlos Vieira de Andrade Serrano and Antonio Serrano Gonçalves de Andrade, 20 Nov 1926.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6XWC-93RB"
+    },
+    {
+      "id": "QKN1-CXG",
+      "title": "Manuel Melchiades de Oliveira, “Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019”",
+      "citation": "\"Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6XWC-DTH1 : Sat Mar 09 04:59:39 UTC 2024), Entry for Carlos Vieira de Andrade Serrano and Antonio Serrano Gonçalves de Andrade, 20 May 1931.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6XWC-DTC7"
+    },
+    {
+      "id": "3Y5W-3F8",
+      "title": "Manoel Melquiades de Oliveira, “Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019”",
+      "citation": "\"Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6XWH-CL2C : Sat Mar 09 19:51:51 UTC 2024), Entry for Maria Lila de Oliveira Serrano and Manoel Melquiades de Oliveira, 24 Oct 1995.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6XWH-CL2Z"
+    },
+    {
+      "id": "3Y5W-T8F",
+      "title": "Manuel Melchiades de Oliveira, “Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019”",
+      "citation": "\"Brasil, Rio Grande do Norte, Registros da Igreja Católica, 1755-2019\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6XWC-QXK1 : Sun Mar 10 20:54:00 UTC 2024), Entry for Carlos Vieira de Andrade Serrano and Antonio Serrano Gonçalves de Andrade, 30 Dec 1922.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6XWC-DSZQ"
+    },
+    {
+      "id": "QKN1-NV6",
+      "title": "Manoel Melquiades de Oliveira, “Brasil, Rio Grande do Norte, Registro Civil, 1803-2021”",
+      "citation": "\"Brasil, Rio Grande do Norte, Registro Civil, 1803-2021\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:62MV-LNKP : Wed May 27 06:45:44 UTC 2026), Entry for Lucy de Oliveira Serrano and Carlos Vieira de Andrade Serrano, setembro de 1923.",
+      "url": "https://familysearch.org/ark:/61903/1:1:62MV-LNK1"
+    }
+  ]
+}

--- a/eval/tests/e2e/mary-dwyer-father/README.md
+++ b/eval/tests/e2e/mary-dwyer-father/README.md
@@ -1,0 +1,34 @@
+# Mary Dwyer — father Patrick Dwyer
+
+**Source PID:** `MNFL-T24`
+**Mary Dwyer is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+May 1840, Ireland; died not recorded in the tree (immigrated 1856; last residence 1900, South Windsor, Connecticut).
+
+## Research question
+
+> Who was the father of Mary Dwyer, wife of Michael Dwyer of South Windsor, Connecticut?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `MNFL-T24` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+hard — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 3, flag `adds_father`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Massachusetts, State Vital Records, 1638-1927: marriage entry, 21 April 1854, Chicopee, Hampden, Massachusetts, for Michael Dwyer (b. 1831, Ireland, son of John Dwyer) and Mary Dwyer (b. 1832, Ireland, daughter of Patrick Dwyer). The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Patrick Dwyer, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the tree's marriage date for Michael and Mary Dwyer is **20 April 1854 in Greenfield, Franklin, Massachusetts** — one day off and in a different town/county than the hint record's 21 April 1854, Chicopee, Hampden. A one-day marriage-date discrepancy is a common transcription variant, but the town/county mismatch (Chicopee/Hampden vs. Greenfield/Franklin — not neighboring counties) is a more serious divergence a reviewer should weigh against the exact-name, exact-year, same-country-of-origin (Ireland) match. The tree also records the groom's birth year as 1837, six years later than the hint record's 1831 — another point against a confident match. "Michael Dwyer" and "Mary Dwyer" are common Irish immigrant names, raising the odds of a same-name, different-family coincidence.

--- a/eval/tests/e2e/mary-dwyer-father/expected-findings.json
+++ b/eval/tests/e2e/mary-dwyer-father/expected-findings.json
@@ -1,0 +1,21 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Mary Dwyer's father was Patrick Dwyer, per a Massachusetts marriage record naming Mary Dwyer (b. 1832, Ireland) marrying Michael Dwyer (b. 1831, Ireland) on 21 April 1854 in Chicopee, Hampden, Massachusetts.",
+      "details": {
+        "subject_person": "Mary Dwyer (MNFL-T24)",
+        "relation": "parent",
+        "target_person": {
+          "name": "Patrick Dwyer",
+          "birth": "unknown, Ireland"
+        }
+      },
+      "supporting_sources": [
+        "Massachusetts, State Vital Records, 1638-1927 — marriage entry, 21 Apr 1854, Chicopee, Hampden, Massachusetts, for Michael Dwyer (son of John Dwyer) and Mary Dwyer (daughter of Patrick Dwyer)"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/mary-dwyer-father/fixture.json
+++ b/eval/tests/e2e/mary-dwyer-father/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "mary-dwyer-father",
+  "name": "Mary Dwyer — father Patrick Dwyer",
+  "genre": "record-hint",
+  "source_pid": "MNFL-T24",
+  "captured": "2026-07-24",
+  "researcher_question": "Who was the father of Mary Dwyer, wife of Michael Dwyer of South Windsor, Connecticut?",
+  "tags": {
+    "question_type": "parents",
+    "era": "1850s",
+    "geography": "US-CT"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 3, flag adds_father, confidence 3). Draft transcribed from a Massachusetts marriage record; unverified."
+}

--- a/eval/tests/e2e/mary-dwyer-father/starting-research.json
+++ b/eval/tests/e2e/mary-dwyer-father/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_mary_dwyer_father",
+    "objective": "Who was the father of Mary Dwyer, wife of Michael Dwyer of South Windsor, Connecticut?",
+    "subject_person_ids": [
+      "MNFL-T24"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/mary-dwyer-father/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/mary-dwyer-father/starting-tree.gedcomx.json
@@ -1,0 +1,311 @@
+{
+  "persons": [
+    {
+      "id": "MNFL-T24",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Mary",
+          "surname": "Dwyer"
+        }
+      ],
+      "facts": [
+        {
+          "id": "207c832c-53a8-427c-8a37-3b45253d5229",
+          "type": "Birth",
+          "date": "May 1840",
+          "standard_date": "May 1840",
+          "place": "Ireland",
+          "standard_place": "Ireland"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        },
+        {
+          "id": "6c91fe28-3d2c-4441-b8e9-42e46d914c58",
+          "type": "Immigration",
+          "date": "1856",
+          "standard_date": "1856"
+        },
+        {
+          "id": "0504a34a-3a2a-41ed-853e-61dbedb5f612",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "South Windsor, Hartford, Connecticut, United States",
+          "standard_place": "South Windsor, Hartford, Connecticut, United States"
+        }
+      ]
+    },
+    {
+      "id": "MNFL-TKV",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Michael",
+          "surname": "Dwyer"
+        }
+      ],
+      "facts": [
+        {
+          "id": "851fb39e-12dc-46e2-b7f2-c23256a09652",
+          "type": "Birth",
+          "date": "1837",
+          "standard_date": "1837",
+          "place": "Ireland",
+          "standard_place": "Ireland"
+        },
+        {
+          "id": "3bde05ae-9fab-4aca-ab33-df6950218fa3",
+          "type": "Immigration",
+          "date": "1856",
+          "standard_date": "1856"
+        },
+        {
+          "id": "be17d602-a21e-4b3b-9238-681e42f689f3",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "South Windsor, Hartford, Connecticut, United States",
+          "standard_place": "South Windsor, Hartford, Connecticut, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "G2X4-PKP",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Edward F",
+          "surname": "Dwyer"
+        }
+      ],
+      "facts": [
+        {
+          "id": "e2ad07f1-64b8-4187-8fec-5c398476199f",
+          "type": "Birth",
+          "date": "February 1878",
+          "standard_date": "Feb 1878",
+          "place": "Massachusetts, United States",
+          "standard_place": "Massachusetts, United States"
+        },
+        {
+          "id": "d4af8910-e482-4d34-a5b7-10add6af07b4",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "South Windsor, Hartford, Connecticut, United States",
+          "standard_place": "South Windsor, Hartford, Connecticut, United States"
+        },
+        {
+          "id": "00446f5c-9464-43df-96c2-74ac3f1b1438",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "G2XH-CFT",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Ellen E",
+          "surname": "Dwyer"
+        }
+      ],
+      "facts": [
+        {
+          "id": "f3d4e4af-9c2f-4da8-9aec-7b36fe98082d",
+          "type": "Birth",
+          "date": "March 1869",
+          "standard_date": "Mar 1869",
+          "place": "Connecticut, United States",
+          "standard_place": "Connecticut, United States"
+        },
+        {
+          "id": "2874aa9b-8fe5-4d80-aec7-3f97aacfff99",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "South Windsor, Hartford, Connecticut, United States",
+          "standard_place": "South Windsor, Hartford, Connecticut, United States"
+        },
+        {
+          "id": "ad69f8e9-4901-4231-b773-55d6e91ce28a",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GTRF-K4G",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "John Ralph",
+          "surname": "Dwyer"
+        }
+      ],
+      "facts": [
+        {
+          "id": "b7764bdf-074d-4500-9d14-b2d65e165652",
+          "type": "Birth",
+          "date": "1882",
+          "standard_date": "1882",
+          "place": "Massachusetts, United States",
+          "standard_place": "Massachusetts, United States"
+        },
+        {
+          "id": "8d4dc44a-e1e4-4a66-996d-4915c63594bb",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "South Windsor, Hartford, Connecticut, United States",
+          "standard_place": "South Windsor, Hartford, Connecticut, United States"
+        },
+        {
+          "id": "4c75969c-a3dd-4ba6-8e1c-670190a82584",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Manchester, Hartford, Connecticut, United States",
+          "standard_place": "Manchester, Hartford, Connecticut, United States"
+        },
+        {
+          "id": "1e6009a0-e0d8-41eb-8480-798279c317f8",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Hartford, Connecticut, United States",
+          "standard_place": "Hartford, Connecticut, United States"
+        },
+        {
+          "id": "981736d4-d032-42d7-a89a-fa27773b9075",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Manchester, Hartford, Connecticut, United States",
+          "standard_place": "Manchester, Hartford, Connecticut, United States"
+        },
+        {
+          "id": "bbed8c53-66a8-4174-a173-aa6220fb1749",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Same Place"
+        },
+        {
+          "id": "64f5c0e9-4453-48d8-b098-8422de9c0659",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Manchester, Hartford, Connecticut, United States",
+          "standard_place": "Manchester, Hartford, Connecticut, United States"
+        },
+        {
+          "id": "9b30c0c5-35e3-4734-8008-0d5548064ee1",
+          "type": "Death",
+          "date": "1963",
+          "standard_date": "1963"
+        },
+        {
+          "id": "6d724af4-2eb1-4cc9-a5bd-e6ab60de732f",
+          "type": "Marital Status",
+          "value": "Widowed"
+        },
+        {
+          "id": "2b54c6e3-91b2-40da-a905-9fe50fdcff97",
+          "type": "Ethnicity",
+          "value": "White"
+        },
+        {
+          "id": "33e9ea34-40f6-44ef-896d-ba89ff6f579f",
+          "type": "Burial",
+          "place": "Manchester, Hartford, Connecticut, United States",
+          "standard_place": "Manchester, Hartford, Connecticut, United States"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "MNFL-TKV",
+      "person2": "MNFL-T24",
+      "facts": [
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "20 APR 1854",
+          "standard_date": "20 Apr 1854",
+          "place": "Greenfield,Franklin,Massachusetts",
+          "standard_place": "Greenfield, Franklin, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "MNFL-TKV",
+      "child": "G2XH-CFT"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "MNFL-T24",
+      "child": "G2XH-CFT"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "MNFL-TKV",
+      "child": "G2X4-PKP"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "MNFL-T24",
+      "child": "G2X4-PKP"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "MNFL-TKV",
+      "child": "GTRF-K4G"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "MNFL-T24",
+      "child": "GTRF-K4G"
+    }
+  ],
+  "sources": [
+    {
+      "id": "MWFQ-MFS",
+      "title": "Mary Dwyer, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FC61-HMS : Thu May 23 00:30:37 UTC 2024), Entry for Michael Dwyer and Mary Dwyer, 20 Apr 1854.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FC61-HM9"
+    },
+    {
+      "id": "Q8HW-NV3",
+      "title": "Mary J Dwyer, \"United States, Census, 1900\"",
+      "citation": "\"United States, Census, 1900\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:M9QT-WW5 : Wed Jan 22 14:32:13 UTC 2025), Entry for Michael Dwyer and Mary J Dwyer, 1900.",
+      "url": "https://familysearch.org/ark:/61903/1:1:M9QT-WWR"
+    }
+  ]
+}

--- a/eval/tests/e2e/mary-dwyer-father/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/mary-dwyer-father/unstripped-tree.gedcomx.json
@@ -1,0 +1,311 @@
+{
+  "persons": [
+    {
+      "id": "MNFL-T24",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Mary",
+          "surname": "Dwyer"
+        }
+      ],
+      "facts": [
+        {
+          "id": "207c832c-53a8-427c-8a37-3b45253d5229",
+          "type": "Birth",
+          "date": "May 1840",
+          "standard_date": "May 1840",
+          "place": "Ireland",
+          "standard_place": "Ireland"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        },
+        {
+          "id": "6c91fe28-3d2c-4441-b8e9-42e46d914c58",
+          "type": "Immigration",
+          "date": "1856",
+          "standard_date": "1856"
+        },
+        {
+          "id": "0504a34a-3a2a-41ed-853e-61dbedb5f612",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "South Windsor, Hartford, Connecticut, United States",
+          "standard_place": "South Windsor, Hartford, Connecticut, United States"
+        }
+      ]
+    },
+    {
+      "id": "MNFL-TKV",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Michael",
+          "surname": "Dwyer"
+        }
+      ],
+      "facts": [
+        {
+          "id": "851fb39e-12dc-46e2-b7f2-c23256a09652",
+          "type": "Birth",
+          "date": "1837",
+          "standard_date": "1837",
+          "place": "Ireland",
+          "standard_place": "Ireland"
+        },
+        {
+          "id": "3bde05ae-9fab-4aca-ab33-df6950218fa3",
+          "type": "Immigration",
+          "date": "1856",
+          "standard_date": "1856"
+        },
+        {
+          "id": "be17d602-a21e-4b3b-9238-681e42f689f3",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "South Windsor, Hartford, Connecticut, United States",
+          "standard_place": "South Windsor, Hartford, Connecticut, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "G2X4-PKP",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Edward F",
+          "surname": "Dwyer"
+        }
+      ],
+      "facts": [
+        {
+          "id": "e2ad07f1-64b8-4187-8fec-5c398476199f",
+          "type": "Birth",
+          "date": "February 1878",
+          "standard_date": "Feb 1878",
+          "place": "Massachusetts, United States",
+          "standard_place": "Massachusetts, United States"
+        },
+        {
+          "id": "d4af8910-e482-4d34-a5b7-10add6af07b4",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "South Windsor, Hartford, Connecticut, United States",
+          "standard_place": "South Windsor, Hartford, Connecticut, United States"
+        },
+        {
+          "id": "00446f5c-9464-43df-96c2-74ac3f1b1438",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "G2XH-CFT",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Ellen E",
+          "surname": "Dwyer"
+        }
+      ],
+      "facts": [
+        {
+          "id": "f3d4e4af-9c2f-4da8-9aec-7b36fe98082d",
+          "type": "Birth",
+          "date": "March 1869",
+          "standard_date": "Mar 1869",
+          "place": "Connecticut, United States",
+          "standard_place": "Connecticut, United States"
+        },
+        {
+          "id": "2874aa9b-8fe5-4d80-aec7-3f97aacfff99",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "South Windsor, Hartford, Connecticut, United States",
+          "standard_place": "South Windsor, Hartford, Connecticut, United States"
+        },
+        {
+          "id": "ad69f8e9-4901-4231-b773-55d6e91ce28a",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GTRF-K4G",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "John Ralph",
+          "surname": "Dwyer"
+        }
+      ],
+      "facts": [
+        {
+          "id": "b7764bdf-074d-4500-9d14-b2d65e165652",
+          "type": "Birth",
+          "date": "1882",
+          "standard_date": "1882",
+          "place": "Massachusetts, United States",
+          "standard_place": "Massachusetts, United States"
+        },
+        {
+          "id": "8d4dc44a-e1e4-4a66-996d-4915c63594bb",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "South Windsor, Hartford, Connecticut, United States",
+          "standard_place": "South Windsor, Hartford, Connecticut, United States"
+        },
+        {
+          "id": "4c75969c-a3dd-4ba6-8e1c-670190a82584",
+          "type": "Residence",
+          "date": "1910",
+          "standard_date": "1910",
+          "place": "Manchester, Hartford, Connecticut, United States",
+          "standard_place": "Manchester, Hartford, Connecticut, United States"
+        },
+        {
+          "id": "1e6009a0-e0d8-41eb-8480-798279c317f8",
+          "type": "Residence",
+          "date": "1920",
+          "standard_date": "1920",
+          "place": "Hartford, Connecticut, United States",
+          "standard_place": "Hartford, Connecticut, United States"
+        },
+        {
+          "id": "981736d4-d032-42d7-a89a-fa27773b9075",
+          "type": "Residence",
+          "date": "1930",
+          "standard_date": "1930",
+          "place": "Manchester, Hartford, Connecticut, United States",
+          "standard_place": "Manchester, Hartford, Connecticut, United States"
+        },
+        {
+          "id": "bbed8c53-66a8-4174-a173-aa6220fb1749",
+          "type": "Residence",
+          "date": "1935",
+          "standard_date": "1935",
+          "place": "Same Place"
+        },
+        {
+          "id": "64f5c0e9-4453-48d8-b098-8422de9c0659",
+          "type": "Residence",
+          "date": "1940",
+          "standard_date": "1940",
+          "place": "Manchester, Hartford, Connecticut, United States",
+          "standard_place": "Manchester, Hartford, Connecticut, United States"
+        },
+        {
+          "id": "9b30c0c5-35e3-4734-8008-0d5548064ee1",
+          "type": "Death",
+          "date": "1963",
+          "standard_date": "1963"
+        },
+        {
+          "id": "6d724af4-2eb1-4cc9-a5bd-e6ab60de732f",
+          "type": "Marital Status",
+          "value": "Widowed"
+        },
+        {
+          "id": "2b54c6e3-91b2-40da-a905-9fe50fdcff97",
+          "type": "Ethnicity",
+          "value": "White"
+        },
+        {
+          "id": "33e9ea34-40f6-44ef-896d-ba89ff6f579f",
+          "type": "Burial",
+          "place": "Manchester, Hartford, Connecticut, United States",
+          "standard_place": "Manchester, Hartford, Connecticut, United States"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "MNFL-TKV",
+      "person2": "MNFL-T24",
+      "facts": [
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "20 APR 1854",
+          "standard_date": "20 Apr 1854",
+          "place": "Greenfield,Franklin,Massachusetts",
+          "standard_place": "Greenfield, Franklin, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "MNFL-TKV",
+      "child": "G2XH-CFT"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "MNFL-T24",
+      "child": "G2XH-CFT"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "MNFL-TKV",
+      "child": "G2X4-PKP"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "MNFL-T24",
+      "child": "G2X4-PKP"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "MNFL-TKV",
+      "child": "GTRF-K4G"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "MNFL-T24",
+      "child": "GTRF-K4G"
+    }
+  ],
+  "sources": [
+    {
+      "id": "MWFQ-MFS",
+      "title": "Mary Dwyer, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FC61-HMS : Thu May 23 00:30:37 UTC 2024), Entry for Michael Dwyer and Mary Dwyer, 20 Apr 1854.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FC61-HM9"
+    },
+    {
+      "id": "Q8HW-NV3",
+      "title": "Mary J Dwyer, \"United States, Census, 1900\"",
+      "citation": "\"United States, Census, 1900\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:M9QT-WW5 : Wed Jan 22 14:32:13 UTC 2025), Entry for Michael Dwyer and Mary J Dwyer, 1900.",
+      "url": "https://familysearch.org/ark:/61903/1:1:M9QT-WWR"
+    }
+  ]
+}

--- a/eval/tests/e2e/mary-kavanaugh-son/README.md
+++ b/eval/tests/e2e/mary-kavanaugh-son/README.md
@@ -1,0 +1,34 @@
+# Mary E. Kavanaugh — additional son James (b. 1872, Cohasset)
+
+**Source PID:** `G95C-GFP`
+**Mary E. Kavanaugh is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+1843, Manchester, England; died 10 December 1904, Whitman, Plymouth, Massachusetts.
+
+## Research question
+
+> Did Mary E. Kavanaugh and her husband Charles H. Williston of Cohasset, Massachusetts have a son born before their four known children (1877-1880), in addition to the four already in the tree?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `G95C-GFP` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+hard — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 2, flag `adds_son`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Massachusetts, State Vital Records, 1638-1927: death entry for James A. Welliston, born 1872, died 1876, Cohasset, Massachusetts, parents Charles H. Welliston and Mary Kavanagh. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming the 1872-1876 James A. Welliston claim, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the tree already has a son **James B. Williston, b./d. 1880** — if this hint is a true match the family named two sons James (a common necronym pattern after an infant death, as in the committed `heinrich-dewus-children-death` fixture's 'Walter'), which is plausible but not confirmed. The spelling **Welliston** vs. the tree's **Williston** is a routine period variant. The place (Cohasset, Norfolk, Massachusetts) matches the tree family's residence and the birthplace of the 1880 twins exactly. Against the match: 1872 predates the earliest tree-recorded child's birthplace evidence only by five years with no gap issue, but the mother's maiden name is recorded as **Kavanagh** in the hint vs. **Kavanaugh** in the tree — another routine variant, not by itself disqualifying.

--- a/eval/tests/e2e/mary-kavanaugh-son/expected-findings.json
+++ b/eval/tests/e2e/mary-kavanaugh-son/expected-findings.json
@@ -1,0 +1,22 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Mary E. Kavanaugh and Charles H. Williston had a son, James A. Welliston, born 1872 and died 1876 in Cohasset, Massachusetts, in addition to the four children already in the tree (Mary Augusta b. 1877, William F. b. 1878, James B. b./d. 1880, Fredrick L. b. 1880).",
+      "details": {
+        "subject_person": "Mary E. Kavanaugh (G95C-GFP)",
+        "relation": "child",
+        "target_person": {
+          "name": "James A. Welliston",
+          "birth": "1872, Cohasset, Massachusetts",
+          "death": "1876, Cohasset, Massachusetts"
+        }
+      },
+      "supporting_sources": [
+        "Massachusetts, State Vital Records, 1638-1927 — death entry for James A. Welliston, 1876, naming parents Charles H. Welliston and Mary Kavanagh"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/mary-kavanaugh-son/fixture.json
+++ b/eval/tests/e2e/mary-kavanaugh-son/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "mary-kavanaugh-son",
+  "name": "Mary E. Kavanaugh — additional son James (b. 1872, Cohasset)",
+  "genre": "record-hint",
+  "source_pid": "G95C-GFP",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Mary E. Kavanaugh and her husband Charles H. Williston of Cohasset, Massachusetts have a son born before their four known children (1877-1880), in addition to the four already in the tree?",
+  "tags": {
+    "question_type": "children",
+    "era": "1870s",
+    "geography": "US-MA"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 2, flag adds_son, confidence 3). Draft transcribed from a Massachusetts vital record; unverified."
+}

--- a/eval/tests/e2e/mary-kavanaugh-son/starting-research.json
+++ b/eval/tests/e2e/mary-kavanaugh-son/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_mary_kavanaugh_son",
+    "objective": "Did Mary E. Kavanaugh and her husband Charles H. Williston of Cohasset, Massachusetts have a son born before their four known children (1877-1880), in addition to the four already in the tree?",
+    "subject_person_ids": [
+      "G95C-GFP"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/mary-kavanaugh-son/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/mary-kavanaugh-son/starting-tree.gedcomx.json
@@ -1,0 +1,472 @@
+{
+  "persons": [
+    {
+      "id": "G95C-GFP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Mary E.",
+          "surname": "Kavanaugh"
+        }
+      ],
+      "facts": [
+        {
+          "id": "e9abe8ab-e95d-438d-afef-1c717e3845c8",
+          "type": "Birth",
+          "date": "1843",
+          "standard_date": "1843",
+          "place": "Manchester, England",
+          "standard_place": "Greater Manchester, England, United Kingdom"
+        },
+        {
+          "id": "6675959b-4464-4668-ae84-3030fe7304d5",
+          "type": "Death",
+          "date": "10 Dec 1904",
+          "standard_date": "10 Dec 1904",
+          "place": "Whitman, Massachusetts",
+          "standard_place": "Whitman, Plymouth, Massachusetts, United States"
+        },
+        {
+          "id": "f51e70e6-c4b3-4139-b36b-c858fb886d0d",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Cohasset, Norfolk, Massachusetts, United States",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "b170a33a-1215-46ef-9465-bbecb2a350b9",
+          "type": "Residence",
+          "date": "10 December 1904",
+          "standard_date": "10 Dec 1904",
+          "place": "Whitman, Plymouth, Massachusetts, United States",
+          "standard_place": "Whitman, Plymouth, Massachusetts, United States"
+        },
+        {
+          "id": "48520b4b-45a1-4f55-8d6d-5cff66fbd7fa",
+          "type": "Burial",
+          "date": "13 December 1904",
+          "standard_date": "13 Dec 1904",
+          "place": "Rockland, Plymouth, Massachusetts, United States",
+          "standard_place": "Rockland, Plymouth, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "GHWK-LLH",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "James B.",
+          "surname": "Williston"
+        }
+      ],
+      "facts": [
+        {
+          "id": "188307b8-350a-40dd-978d-4ac3adcfdb37",
+          "type": "Birth",
+          "date": "23 Jun 1880",
+          "standard_date": "23 Jun 1880",
+          "place": "Cohasset, Norfolk, Massachusetts",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "c8268c48-f4c8-4e80-a555-e000247f2939",
+          "type": "Death",
+          "date": "13 Sep 1880",
+          "standard_date": "13 Sep 1880",
+          "place": "Cohasset, Norfolk, Massachusetts, United States",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "9669-1T2",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Anthony",
+          "surname": "Kavanagh"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "G95Z-7K2",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Charles H.",
+          "surname": "Williston"
+        }
+      ],
+      "facts": [
+        {
+          "id": "304d9ac5-3f1c-4a4a-9e1c-829445c4a3a0",
+          "type": "Birth",
+          "date": "February 1848",
+          "standard_date": "Feb 1848",
+          "place": "Massachusetts, United States",
+          "standard_place": "Massachusetts, United States"
+        },
+        {
+          "id": "199e41c0-72fa-459e-82a8-4f6f1da5a47b",
+          "type": "Residence",
+          "date": "1855",
+          "standard_date": "1855",
+          "place": "Cohasset, Norfolk, Massachusetts, United States",
+          "standard_place": "Nantucket, Nantucket, Nantucket, Massachusetts, United States"
+        },
+        {
+          "id": "e96b575c-1c35-4af5-b66f-94d84d56c829",
+          "type": "Residence",
+          "date": "1865",
+          "standard_date": "1865",
+          "place": "Cohasset, Norfolk, Massachusetts, United States",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "5008962c-492e-4bc2-86c2-290723a23075",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Cohasset, Norfolk, Massachusetts, United States",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "4e9695fd-2432-4f63-a144-0c5ae08dfa5b",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Orange Town (north part), Franklin, Massachusetts, United States",
+          "standard_place": "Orange, Franklin, Massachusetts, United States"
+        },
+        {
+          "id": "9275eaf1-c5dd-453b-9a1d-b1d7a290a623",
+          "type": "Death",
+          "date": "1 January 1919",
+          "standard_date": "1 Jan 1919",
+          "place": "Whitman, Plymouth, Massachusetts, United States",
+          "standard_place": "Whitman, Plymouth, Massachusetts, United States"
+        },
+        {
+          "id": "7b5e0061-51d3-47b0-ad04-b77e63fca6c5",
+          "type": "Burial",
+          "date": "January 1919",
+          "standard_date": "Jan 1919",
+          "place": "Rockland, Plymouth, Massachusetts, United States of America",
+          "standard_place": "Rockland, Plymouth, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "KGZ6-T3S",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Mary Augusta",
+          "surname": "Williston"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "11 Jul 1877",
+          "standard_date": "11 Jul 1877",
+          "place": "Cohasset, Norfolk, Massachusetts",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "fbdac9d6-4f5c-492a-82d2-31bd4f5cb696",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Cohasset, Norfolk, Massachusetts, United States",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LWVJ-S8P",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "William F",
+          "surname": "Williston"
+        }
+      ],
+      "facts": [
+        {
+          "id": "33f46f95-dd94-4b74-9a1b-73f8f05a0ae2",
+          "type": "Birth",
+          "date": "10 Sep 1878",
+          "standard_date": "10 Sep 1878",
+          "place": "Cohasset, Norfolk, Massachusetts",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "123fb733-7e5e-4e33-83ba-e9754ed531e6",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Cohasset, Norfolk, Massachusetts, United States",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "b76a6116-7ff0-4f67-b31a-5b5362fde975",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Orange Town (north part), Franklin, Massachusetts, United States",
+          "standard_place": "Orange, Franklin, Massachusetts, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "13 Dec 1918",
+          "standard_date": "13 Dec 1918",
+          "place": "Whitman, Plymouth, Massachusetts, United States",
+          "standard_place": "Whitman, Plymouth, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "9669-1TL",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Mary",
+          "surname": "Coward"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GHWK-63F",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Fredrick L.",
+          "surname": "Williston"
+        }
+      ],
+      "facts": [
+        {
+          "id": "47f2bc3c-a4da-4b15-9c16-5ddbd8f6373b",
+          "type": "Birth",
+          "date": "23 Jun 1880",
+          "standard_date": "23 Jun 1880",
+          "place": "Cohasset, Norfolk, Massachusetts",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "b6749404-9a85-4d00-a8dd-bf06ed646323",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "G95Z-7K2",
+      "person2": "G95C-GFP",
+      "facts": [
+        {
+          "id": "923240f6-1b0b-4e09-bc38-8c494800d034",
+          "type": "Marriage",
+          "date": "5 Nov 1868",
+          "standard_date": "5 Nov 1868",
+          "place": "Boston, Suffolk, Massachusetts, United States",
+          "standard_place": "Boston, Suffolk, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "9669-1T2",
+      "person2": "9669-1TL"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "9669-1T2",
+      "child": "G95C-GFP",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "9669-1TL",
+      "child": "G95C-GFP",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "G95Z-7K2",
+      "child": "KGZ6-T3S"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "G95C-GFP",
+      "child": "KGZ6-T3S"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "G95Z-7K2",
+      "child": "LWVJ-S8P"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "G95C-GFP",
+      "child": "LWVJ-S8P"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "G95Z-7K2",
+      "child": "GHWK-LLH"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "G95C-GFP",
+      "child": "GHWK-LLH"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "G95Z-7K2",
+      "child": "GHWK-63F"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "G95C-GFP",
+      "child": "GHWK-63F"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7C2C-XY1",
+      "title": "Mary Kavanagh, \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FH3C-W5H : Sun Mar 10 17:23:50 UTC 2024), Entry for Charles Milliston and Henry Milliston, 5 November 1868.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FH3C-W57"
+    },
+    {
+      "id": "MW2D-HPS",
+      "title": "Mary Kavanagh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FC7R-QN5 : Thu Jul 24 15:35:15 UTC 2025), Entry for Charles Milliston and Henry Milliston, 5 Nov 1868.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FC7R-QNL"
+    },
+    {
+      "id": "3MPL-QFX",
+      "title": "Mary J. Williston, \"United States, Census, 1880\"",
+      "citation": "\"United States, Census, 1880\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:MHX4-F86 : Mon Jan 20 23:17:12 UTC 2025), Entry for Charles H. Williston and Mary J. Williston, 1880.",
+      "url": "https://familysearch.org/ark:/61903/1:1:MHX4-F8X"
+    },
+    {
+      "id": "3MPL-3DN",
+      "title": "Mary E. Cavenaugh, \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FH5M-R1V : Fri Mar 08 12:50:03 UTC 2024), Entry for William F. Williston and Charles H. Williston, 21 June 1904.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FH5M-R12"
+    },
+    {
+      "id": "3MPL-SXS",
+      "title": "Mary J., \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FHZ7-638 : Sun Mar 10 21:17:15 UTC 2024), Entry for James B. Williston and Charles H. Williston, 13 September 1880.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FHZ7-636"
+    },
+    {
+      "id": "3MPL-MVH",
+      "title": "Mary J. Kavanagh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FX8Y-FX4 : Fri Jul 25 23:54:14 UTC 2025), Entry for Fredrick L. Williston and Charles H. Williston, 1880.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FX8Y-FXW"
+    },
+    {
+      "id": "3MP2-13V",
+      "title": "Mary J. Kavanagh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FX8Y-FXZ : Thu Jul 24 17:41:35 UTC 2025), Entry for James B. Williston and Charles H. Williston, 1880.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FX8Y-FXC"
+    },
+    {
+      "id": "3MP2-VW7",
+      "title": "Mary Cavanaugh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KB86-XTZ : Fri Jul 25 22:18:26 UTC 2025), Entry for Charles H Williston and Henry Williston, 1 January 1919.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KB86-XT6"
+    },
+    {
+      "id": "3MP2-X1F",
+      "title": "Mary J Kavanagh Williston, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FX8V-82J : Thu May 23 01:44:37 UTC 2024), Entry for Willie Franklin Williston and Charles H Williston, 10 Sep 1878.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FX8V-82N"
+    },
+    {
+      "id": "3MP2-XHP",
+      "title": "Mary E. Kavanaugh Williston, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:NWP3-VVK : Wed May 22 20:48:16 UTC 2024), Entry for Mary E. Kavanaugh Williston and Antony Kavanaugh, 1904.",
+      "url": "https://familysearch.org/ark:/61903/1:1:NWP3-VVK"
+    },
+    {
+      "id": "3MP2-6CQ",
+      "title": "Mary J Kavanaugh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FX86-VGR : Thu May 23 00:03:48 UTC 2024), Entry for Mary Augusta Williston and Charles H Williston, 11 Jul 1877.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FX86-VG5"
+    },
+    {
+      "id": "3MP2-458",
+      "title": "Mary E Cavanagh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:23TC-Q6G : Thu Jul 24 17:23:29 UTC 2025), Entry for William F Williston and Charles H Williston, 13 December 1918.",
+      "url": "https://familysearch.org/ark:/61903/1:1:23TC-Q65"
+    },
+    {
+      "id": "SHW4-KYD",
+      "title": "Mary E. Cavanaugh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N4HW-KJ7 : Wed May 22 23:58:39 UTC 2024), Entry for William F. Williston and Anabel B. Witt, 21 Jun 1904.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N4HW-KJ4"
+    },
+    {
+      "id": "SHW4-8MK",
+      "title": "Mary E. Kavanaugh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N4CM-KQ7 : Thu May 23 01:23:17 UTC 2024), Entry for William F. Williston and Annabell D. Witt, 21 Jun 1904.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N4CM-KQ4"
+    }
+  ]
+}

--- a/eval/tests/e2e/mary-kavanaugh-son/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/mary-kavanaugh-son/unstripped-tree.gedcomx.json
@@ -1,0 +1,472 @@
+{
+  "persons": [
+    {
+      "id": "G95C-GFP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Mary E.",
+          "surname": "Kavanaugh"
+        }
+      ],
+      "facts": [
+        {
+          "id": "e9abe8ab-e95d-438d-afef-1c717e3845c8",
+          "type": "Birth",
+          "date": "1843",
+          "standard_date": "1843",
+          "place": "Manchester, England",
+          "standard_place": "Greater Manchester, England, United Kingdom"
+        },
+        {
+          "id": "6675959b-4464-4668-ae84-3030fe7304d5",
+          "type": "Death",
+          "date": "10 Dec 1904",
+          "standard_date": "10 Dec 1904",
+          "place": "Whitman, Massachusetts",
+          "standard_place": "Whitman, Plymouth, Massachusetts, United States"
+        },
+        {
+          "id": "f51e70e6-c4b3-4139-b36b-c858fb886d0d",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Cohasset, Norfolk, Massachusetts, United States",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "b170a33a-1215-46ef-9465-bbecb2a350b9",
+          "type": "Residence",
+          "date": "10 December 1904",
+          "standard_date": "10 Dec 1904",
+          "place": "Whitman, Plymouth, Massachusetts, United States",
+          "standard_place": "Whitman, Plymouth, Massachusetts, United States"
+        },
+        {
+          "id": "48520b4b-45a1-4f55-8d6d-5cff66fbd7fa",
+          "type": "Burial",
+          "date": "13 December 1904",
+          "standard_date": "13 Dec 1904",
+          "place": "Rockland, Plymouth, Massachusetts, United States",
+          "standard_place": "Rockland, Plymouth, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "GHWK-LLH",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "James B.",
+          "surname": "Williston"
+        }
+      ],
+      "facts": [
+        {
+          "id": "188307b8-350a-40dd-978d-4ac3adcfdb37",
+          "type": "Birth",
+          "date": "23 Jun 1880",
+          "standard_date": "23 Jun 1880",
+          "place": "Cohasset, Norfolk, Massachusetts",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "c8268c48-f4c8-4e80-a555-e000247f2939",
+          "type": "Death",
+          "date": "13 Sep 1880",
+          "standard_date": "13 Sep 1880",
+          "place": "Cohasset, Norfolk, Massachusetts, United States",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "9669-1T2",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Anthony",
+          "surname": "Kavanagh"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "G95Z-7K2",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Charles H.",
+          "surname": "Williston"
+        }
+      ],
+      "facts": [
+        {
+          "id": "304d9ac5-3f1c-4a4a-9e1c-829445c4a3a0",
+          "type": "Birth",
+          "date": "February 1848",
+          "standard_date": "Feb 1848",
+          "place": "Massachusetts, United States",
+          "standard_place": "Massachusetts, United States"
+        },
+        {
+          "id": "199e41c0-72fa-459e-82a8-4f6f1da5a47b",
+          "type": "Residence",
+          "date": "1855",
+          "standard_date": "1855",
+          "place": "Cohasset, Norfolk, Massachusetts, United States",
+          "standard_place": "Nantucket, Nantucket, Nantucket, Massachusetts, United States"
+        },
+        {
+          "id": "e96b575c-1c35-4af5-b66f-94d84d56c829",
+          "type": "Residence",
+          "date": "1865",
+          "standard_date": "1865",
+          "place": "Cohasset, Norfolk, Massachusetts, United States",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "5008962c-492e-4bc2-86c2-290723a23075",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Cohasset, Norfolk, Massachusetts, United States",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "4e9695fd-2432-4f63-a144-0c5ae08dfa5b",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Orange Town (north part), Franklin, Massachusetts, United States",
+          "standard_place": "Orange, Franklin, Massachusetts, United States"
+        },
+        {
+          "id": "9275eaf1-c5dd-453b-9a1d-b1d7a290a623",
+          "type": "Death",
+          "date": "1 January 1919",
+          "standard_date": "1 Jan 1919",
+          "place": "Whitman, Plymouth, Massachusetts, United States",
+          "standard_place": "Whitman, Plymouth, Massachusetts, United States"
+        },
+        {
+          "id": "7b5e0061-51d3-47b0-ad04-b77e63fca6c5",
+          "type": "Burial",
+          "date": "January 1919",
+          "standard_date": "Jan 1919",
+          "place": "Rockland, Plymouth, Massachusetts, United States of America",
+          "standard_place": "Rockland, Plymouth, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "KGZ6-T3S",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Mary Augusta",
+          "surname": "Williston"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "11 Jul 1877",
+          "standard_date": "11 Jul 1877",
+          "place": "Cohasset, Norfolk, Massachusetts",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "fbdac9d6-4f5c-492a-82d2-31bd4f5cb696",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Cohasset, Norfolk, Massachusetts, United States",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LWVJ-S8P",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "William F",
+          "surname": "Williston"
+        }
+      ],
+      "facts": [
+        {
+          "id": "33f46f95-dd94-4b74-9a1b-73f8f05a0ae2",
+          "type": "Birth",
+          "date": "10 Sep 1878",
+          "standard_date": "10 Sep 1878",
+          "place": "Cohasset, Norfolk, Massachusetts",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "123fb733-7e5e-4e33-83ba-e9754ed531e6",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Cohasset, Norfolk, Massachusetts, United States",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "b76a6116-7ff0-4f67-b31a-5b5362fde975",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Orange Town (north part), Franklin, Massachusetts, United States",
+          "standard_place": "Orange, Franklin, Massachusetts, United States"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death",
+          "date": "13 Dec 1918",
+          "standard_date": "13 Dec 1918",
+          "place": "Whitman, Plymouth, Massachusetts, United States",
+          "standard_place": "Whitman, Plymouth, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "9669-1TL",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Mary",
+          "surname": "Coward"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GHWK-63F",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Fredrick L.",
+          "surname": "Williston"
+        }
+      ],
+      "facts": [
+        {
+          "id": "47f2bc3c-a4da-4b15-9c16-5ddbd8f6373b",
+          "type": "Birth",
+          "date": "23 Jun 1880",
+          "standard_date": "23 Jun 1880",
+          "place": "Cohasset, Norfolk, Massachusetts",
+          "standard_place": "Cohasset, Norfolk, Massachusetts, United States"
+        },
+        {
+          "id": "b6749404-9a85-4d00-a8dd-bf06ed646323",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "G95Z-7K2",
+      "person2": "G95C-GFP",
+      "facts": [
+        {
+          "id": "923240f6-1b0b-4e09-bc38-8c494800d034",
+          "type": "Marriage",
+          "date": "5 Nov 1868",
+          "standard_date": "5 Nov 1868",
+          "place": "Boston, Suffolk, Massachusetts, United States",
+          "standard_place": "Boston, Suffolk, Massachusetts, United States"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "9669-1T2",
+      "person2": "9669-1TL"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "9669-1T2",
+      "child": "G95C-GFP",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "9669-1TL",
+      "child": "G95C-GFP",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "G95Z-7K2",
+      "child": "KGZ6-T3S"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "G95C-GFP",
+      "child": "KGZ6-T3S"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "G95Z-7K2",
+      "child": "LWVJ-S8P"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "G95C-GFP",
+      "child": "LWVJ-S8P"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "G95Z-7K2",
+      "child": "GHWK-LLH"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "G95C-GFP",
+      "child": "GHWK-LLH"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "G95Z-7K2",
+      "child": "GHWK-63F"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "G95C-GFP",
+      "child": "GHWK-63F"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7C2C-XY1",
+      "title": "Mary Kavanagh, \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FH3C-W5H : Sun Mar 10 17:23:50 UTC 2024), Entry for Charles Milliston and Henry Milliston, 5 November 1868.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FH3C-W57"
+    },
+    {
+      "id": "MW2D-HPS",
+      "title": "Mary Kavanagh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FC7R-QN5 : Thu Jul 24 15:35:15 UTC 2025), Entry for Charles Milliston and Henry Milliston, 5 Nov 1868.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FC7R-QNL"
+    },
+    {
+      "id": "3MPL-QFX",
+      "title": "Mary J. Williston, \"United States, Census, 1880\"",
+      "citation": "\"United States, Census, 1880\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:MHX4-F86 : Mon Jan 20 23:17:12 UTC 2025), Entry for Charles H. Williston and Mary J. Williston, 1880.",
+      "url": "https://familysearch.org/ark:/61903/1:1:MHX4-F8X"
+    },
+    {
+      "id": "3MPL-3DN",
+      "title": "Mary E. Cavenaugh, \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FH5M-R1V : Fri Mar 08 12:50:03 UTC 2024), Entry for William F. Williston and Charles H. Williston, 21 June 1904.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FH5M-R12"
+    },
+    {
+      "id": "3MPL-SXS",
+      "title": "Mary J., \"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\"",
+      "citation": "\"Massachusetts, Town Clerk, Vital and Town Records, 1626-2001\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FHZ7-638 : Sun Mar 10 21:17:15 UTC 2024), Entry for James B. Williston and Charles H. Williston, 13 September 1880.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FHZ7-636"
+    },
+    {
+      "id": "3MPL-MVH",
+      "title": "Mary J. Kavanagh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FX8Y-FX4 : Fri Jul 25 23:54:14 UTC 2025), Entry for Fredrick L. Williston and Charles H. Williston, 1880.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FX8Y-FXW"
+    },
+    {
+      "id": "3MP2-13V",
+      "title": "Mary J. Kavanagh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FX8Y-FXZ : Thu Jul 24 17:41:35 UTC 2025), Entry for James B. Williston and Charles H. Williston, 1880.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FX8Y-FXC"
+    },
+    {
+      "id": "3MP2-VW7",
+      "title": "Mary Cavanaugh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KB86-XTZ : Fri Jul 25 22:18:26 UTC 2025), Entry for Charles H Williston and Henry Williston, 1 January 1919.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KB86-XT6"
+    },
+    {
+      "id": "3MP2-X1F",
+      "title": "Mary J Kavanagh Williston, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FX8V-82J : Thu May 23 01:44:37 UTC 2024), Entry for Willie Franklin Williston and Charles H Williston, 10 Sep 1878.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FX8V-82N"
+    },
+    {
+      "id": "3MP2-XHP",
+      "title": "Mary E. Kavanaugh Williston, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:NWP3-VVK : Wed May 22 20:48:16 UTC 2024), Entry for Mary E. Kavanaugh Williston and Antony Kavanaugh, 1904.",
+      "url": "https://familysearch.org/ark:/61903/1:1:NWP3-VVK"
+    },
+    {
+      "id": "3MP2-6CQ",
+      "title": "Mary J Kavanaugh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FX86-VGR : Thu May 23 00:03:48 UTC 2024), Entry for Mary Augusta Williston and Charles H Williston, 11 Jul 1877.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FX86-VG5"
+    },
+    {
+      "id": "3MP2-458",
+      "title": "Mary E Cavanagh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:23TC-Q6G : Thu Jul 24 17:23:29 UTC 2025), Entry for William F Williston and Charles H Williston, 13 December 1918.",
+      "url": "https://familysearch.org/ark:/61903/1:1:23TC-Q65"
+    },
+    {
+      "id": "SHW4-KYD",
+      "title": "Mary E. Cavanaugh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N4HW-KJ7 : Wed May 22 23:58:39 UTC 2024), Entry for William F. Williston and Anabel B. Witt, 21 Jun 1904.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N4HW-KJ4"
+    },
+    {
+      "id": "SHW4-8MK",
+      "title": "Mary E. Kavanaugh, \"Massachusetts, State Vital Records, 1638-1927\"",
+      "citation": "\"Massachusetts, State Vital Records, 1638-1927\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N4CM-KQ7 : Thu May 23 01:23:17 UTC 2024), Entry for William F. Williston and Annabell D. Witt, 21 Jun 1904.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N4CM-KQ4"
+    }
+  ]
+}

--- a/eval/tests/e2e/matyas-muck-son/README.md
+++ b/eval/tests/e2e/matyas-muck-son/README.md
@@ -1,0 +1,34 @@
+# Muck Mátyás — second son named András (b. 1881)
+
+**Source PID:** `97M5-6H8`
+**Mátyás Muck is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+25 August 1844, Bikács, Tolna, Hungary; died 31 December 1921, Bikács, Tolna, Hungary.
+
+## Research question
+
+> Did Mátyás Muck and his first wife Erzsébet Wolf of Bikács, Tolna, Hungary have a second son named András, baptized about 1881, after their first son András died in infancy in 1873?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `97M5-6H8` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+hard — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 19, flag `adds_son`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Hungary, Reformed Church Christenings, 1624-1895: baptismal entry for András Muck, naming parents Mátyás Muck and Erzsébet Farkas. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming a second András Muck, plus a `required` finding that the report documents the rejection.
+
+The tree **already has a son named András Muck**, born 5 February 1873 and died 1 April 1873 (in infancy) — so if this hint is a true match, the family named a later child after the one who died, exactly the necronym pattern already documented in the committed `heinrich-dewus-children-death` fixture. In favor: the mother's name "Erzsébet Farkas" in the hint is a literal Hungarian translation of "Erzsébet **Wolf**" ("farkas" = "wolf" in Hungarian), a specific and distinctive linguistic clue pointing to the same woman recorded under a translated form of her German surname. Mátyás Muck's first marriage (to Erzsébet Wolf, 1866) lasted until her death in 1900, so an 1881 birth falls comfortably within that marriage. Because the family already used the name András once, distinguishing this record from the 1873 infant (rather than accidentally double-counting the same child) is the crux of the adjudication.

--- a/eval/tests/e2e/matyas-muck-son/expected-findings.json
+++ b/eval/tests/e2e/matyas-muck-son/expected-findings.json
@@ -1,0 +1,21 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Mátyás Muck and Erzsébet Farkas (recorded in the tree as Erzsébet Wolf — Farkas is the Hungarian translation of the German surname Wolf) had a second son named András, baptized about 1881 in Bogyiszló, Pest-Pilis-Solt-Kis-Kun — a necronym for their first son András, who died in infancy in 1873 (also already in the tree).",
+      "details": {
+        "subject_person": "Mátyás Muck (97M5-6H8)",
+        "relation": "child",
+        "target_person": {
+          "name": "András Muck",
+          "birth": "about 1881, Bogyiszló, Pest-Pilis-Solt-Kis-Kun, Hungary"
+        }
+      },
+      "supporting_sources": [
+        "Hungary, Reformed Church Christenings, 1624-1895 — baptismal entry for András Muck, naming parents Mátyás Muck and Erzsébet Farkas"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/matyas-muck-son/fixture.json
+++ b/eval/tests/e2e/matyas-muck-son/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "matyas-muck-son",
+  "name": "Muck Mátyás — second son named András (b. 1881)",
+  "genre": "record-hint",
+  "source_pid": "97M5-6H8",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Mátyás Muck and his first wife Erzsébet Wolf of Bikács, Tolna, Hungary have a second son named András, baptized about 1881, after their first son András died in infancy in 1873?",
+  "tags": {
+    "question_type": "children",
+    "era": "1880s",
+    "geography": "HU"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 19, flag adds_son, confidence 3). Draft transcribed from a Hungarian Reformed church record; unverified."
+}

--- a/eval/tests/e2e/matyas-muck-son/starting-research.json
+++ b/eval/tests/e2e/matyas-muck-son/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_matyas_muck_son",
+    "objective": "Did Mátyás Muck and his first wife Erzsébet Wolf of Bikács, Tolna, Hungary have a second son named András, baptized about 1881, after their first son András died in infancy in 1873?",
+    "subject_person_ids": [
+      "97M5-6H8"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/matyas-muck-son/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/matyas-muck-son/starting-tree.gedcomx.json
@@ -1,0 +1,482 @@
+{
+  "persons": [
+    {
+      "id": "97M5-6H8",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Mátyás",
+          "surname": "Muck"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "25 AUG 1844",
+          "standard_date": "25 Aug 1844",
+          "place": "Bikacs,Tolna,Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "31 December 1921",
+          "standard_date": "31 Dec 1921",
+          "place": "Bikács, Tolna, Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "a5fe4330-b89f-478b-9daf-db948a0523d1",
+          "type": "Christening",
+          "date": "1844. augusztus 25.",
+          "standard_date": "25 1844",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "KZ89-SYT",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Rosina",
+          "surname": "Blaser"
+        }
+      ],
+      "facts": [
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "11 JAN 1814",
+          "standard_date": "11 Jan 1814",
+          "place": "Bikacs,Tolna,Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1814. január 11.",
+          "standard_date": "11 Jan 1814",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LZX9-R6W",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Éva",
+          "surname": "Muck"
+        }
+      ],
+      "facts": [
+        {
+          "id": "20fda514-259e-4267-ad99-aef2f834ca60",
+          "type": "Birth",
+          "date": "1874. január 20.",
+          "standard_date": "20 Jan 1874",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "21 Jan 1874",
+          "standard_date": "21 Jan 1874",
+          "place": "Bogyiszló, Pest-Pilis-Solt-Kis-Kun, Hungary",
+          "standard_place": "Bogyiszló, Pest-Pilis-Solt-Kiskun, Hungary"
+        },
+        {
+          "id": "82519556-945e-495a-822c-5daadf09df13",
+          "type": "Baptism",
+          "date": "21 Jan 1874",
+          "standard_date": "21 Jan 1874",
+          "place": "Bogyiszló, Pest-Pilis-Solt-Kis-Kun, Hungary",
+          "standard_place": "Bogyiszló, Pest-Pilis-Solt-Kiskun, Hungary"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death",
+          "date": "1942. június 18.",
+          "standard_date": "18 1942",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "L6TX-ZXD",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Erzsébet",
+          "surname": "Stamp"
+        }
+      ],
+      "facts": [
+        {
+          "id": "fdfedcdb-ce17-44db-8469-41b2896e1919",
+          "type": "Birth",
+          "date": "1856. szeptember 8.",
+          "standard_date": "8 1856",
+          "place": "Paks, Tolna, Magyarország",
+          "standard_place": "Paks, Tolna, Hungary"
+        },
+        {
+          "id": "1e83d2d6-2594-44a8-9558-267ca40f51a6",
+          "type": "Christening",
+          "date": "09 Sep 1856",
+          "standard_date": "9 Sep 1856",
+          "place": "Paks, Tolna, Hungary",
+          "standard_place": "Paks, Tolna, Hungary"
+        },
+        {
+          "id": "4fc8c82a-e9bb-4ae6-bf26-0a0a2bb969a1",
+          "type": "Marriage Registration",
+          "date": "1905. május 11.",
+          "standard_date": "11 1905",
+          "place": "Paks, Tolna, Magyarország",
+          "standard_place": "Paks, Tolna, Hungary"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death",
+          "date": "1928. augusztus 4.",
+          "standard_date": "4 1928"
+        }
+      ]
+    },
+    {
+      "id": "L8WW-KBJ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Matyas",
+          "surname": "Muck"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1 Abril 1879",
+          "standard_date": "1 Apr 1879",
+          "place": "Bikács, Tolna, Hungría",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "5a0adb92-6ca0-420b-bebd-8c4be27bbb9c",
+          "type": "Christening",
+          "date": "2 de abril de 1879",
+          "standard_date": "2 Apr 1879",
+          "place": "Bogyiszló, Pest-Pilis-Solt-Kiskun, Hungria",
+          "standard_place": "Bogyiszló, Pest-Pilis-Solt-Kiskun, Hungary"
+        },
+        {
+          "id": "f5c31ed1-1ded-40f5-bcc8-0940d7699173",
+          "type": "Marriage Registration",
+          "date": "4 de fevereiro de 1904",
+          "standard_date": "4 Feb 1904",
+          "place": "Hungria",
+          "standard_place": "Hungary"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death",
+          "date": "before 1906",
+          "standard_date": "Bef 1906",
+          "place": "Bikács, Tolna, Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "LZX9-R6H",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Erzsébet",
+          "surname": "Wolf"
+        }
+      ],
+      "facts": [
+        {
+          "id": "75f4ea28-21ae-402b-9783-f9fd81ac75f8",
+          "type": "Birth",
+          "date": "1848. március 8.",
+          "standard_date": "8 1848",
+          "place": "Bikács, Tolna, Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "0a3773c3-3456-433f-9812-bdd7e3b1bcc3",
+          "type": "Baptism",
+          "date": "1848. március 8.",
+          "standard_date": "8 1848",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "1900. július 3.",
+          "standard_date": "3 1900",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "dcde45e2-55b0-43b7-b59e-edc9aad5756e",
+          "type": "Death Registration",
+          "date": "1900. július 4.",
+          "standard_date": "4 1900",
+          "place": "Magyarország",
+          "standard_place": "Hungary"
+        }
+      ]
+    },
+    {
+      "id": "GP8V-B53",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "András",
+          "surname": "Muck"
+        }
+      ],
+      "facts": [
+        {
+          "id": "29ca0878-7fbb-42e0-a75a-35acd0800648",
+          "type": "Birth",
+          "date": "1873. február 5.",
+          "standard_date": "5 Feb 1873",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "07520aba-0b83-4de2-888e-bbd720e8b9b3",
+          "type": "Death",
+          "date": "1873. április 1.",
+          "standard_date": "1 1873",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "KCQX-DZ6",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Paulus",
+          "surname": "Muck"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "21 JAN 1811",
+          "standard_date": "21 Jan 1811",
+          "place": "Bikacs,Tolna,Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "625b9d6f-fc44-4bd1-ab9b-40838c73db76",
+          "type": "Christening",
+          "date": "21 JAN 1811",
+          "standard_date": "21 Jan 1811",
+          "place": "Bikacs,Tolna,Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "1365cf01-dcde-4c49-80df-8bd67e2543eb",
+          "type": "Death",
+          "date": "04 NOV 1899",
+          "standard_date": "4 Nov 1899"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "97M5-6H8",
+      "person2": "LZX9-R6H",
+      "facts": [
+        {
+          "id": "905cc378-bd79-40ec-9cbc-f86a9be34616",
+          "type": "Marriage",
+          "date": "16 January 1866",
+          "standard_date": "16 Jan 1866",
+          "place": "Bikács, Tolna, Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "97M5-6H8",
+      "person2": "L6TX-ZXD",
+      "facts": [
+        {
+          "id": "92ca5d6c-1d70-4c21-8a9f-2a156de9ab8a",
+          "type": "Marriage",
+          "date": "1905. május 11.",
+          "standard_date": "11 1905",
+          "place": "Paks, Tolna, Magyarország",
+          "standard_place": "Paks, Tolna, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "Couple",
+      "person1": "KCQX-DZ6",
+      "person2": "KZ89-SYT",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "22 Nov 1831",
+          "standard_date": "22 Nov 1831",
+          "place": "Bikats,Tolna,Hungary",
+          "standard_place": "Tolna, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "KCQX-DZ6",
+      "child": "97M5-6H8",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "KZ89-SYT",
+      "child": "97M5-6H8",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "97M5-6H8",
+      "child": "GP8V-B53"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "LZX9-R6H",
+      "child": "GP8V-B53"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "97M5-6H8",
+      "child": "LZX9-R6W"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "LZX9-R6H",
+      "child": "LZX9-R6W"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "97M5-6H8",
+      "child": "L8WW-KBJ",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "LZX9-R6H",
+      "child": "L8WW-KBJ",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "QLPL-T3L",
+      "title": "Muck Éva szül. anyakönyv",
+      "citation": "\"Hungary, Reformed Church Christenings, 1624-1895,\" database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/3:1:9392-9ZKJ-F?cc=1858355 : 24 May 2019),  > image 1 of 1; Országos Leveltár, Budapest (Hungary National Archives, Budapest).",
+      "url": "https://familysearch.org/ark:/61903/3:1:9392-9ZKJ-F?view=explore"
+    },
+    {
+      "id": "Q171-5HD",
+      "title": "Mük Mátyós, \"Hungary, Civil Registration, 1895-1980\"",
+      "citation": "\"Hungary, Civil Registration, 1895-1980\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6VY1-S1HS : Sun Mar 10 05:04:58 UTC 2024), Entry for Stumpt Erzsébet and Mük Mátyós, 5 Aug 1928.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6VY1-S1H4"
+    },
+    {
+      "id": "SL2S-3W8",
+      "title": "Mátyás Muck, \"Hungary, Reformed Church Christenings, 1624-1895\"",
+      "citation": "\"Hungary, Reformed Church Christenings, 1624-1895\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VJRW-T78 : Wed Jul 24 01:32:51 UTC 2024), Entry for Éva Muck and Mátyás Muck, 21 Jan 1874.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VJRW-T7C"
+    },
+    {
+      "id": "QPFV-HJM",
+      "title": "Muck Mátyás, \"Hungary, Civil Registration, 1895-1980\"",
+      "citation": "\"Hungary, Civil Registration, 1895-1980\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6JYB-B4NH : Fri Mar 08 22:55:22 UTC 2024), Entry for Wolf Erzsébet and Wolf János, 4 Jul 1900.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6JYB-B4NV"
+    },
+    {
+      "id": "Q171-X4C",
+      "title": "Muck Mátyás, \"Hungary, Civil Registration, 1895-1980\"",
+      "citation": "\"Hungary, Civil Registration, 1895-1980\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6VBM-VRM9 : Sat Mar 09 02:28:50 UTC 2024), Entry for Muck Mátyás and Muck Pál, 11 May 1905.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6VBM-VRM9"
+    },
+    {
+      "id": "Q171-6KF",
+      "title": "Muk Máttyás, \"Hungary, Church Books, 1624-1950\"",
+      "citation": "\"Hungary, Church Books, 1624-1950\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6NSP-WMTK : Sun Mar 10 20:31:57 UTC 2024), Entry for Muk Máttyás and Muk Páll, 25 Aug 1844.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6NSP-WMTK"
+    },
+    {
+      "id": "Q171-PRQ",
+      "title": "Mük Mátyás, \"Hungary, Civil Registration, 1895-1980\"",
+      "citation": "\"Hungary, Civil Registration, 1895-1980\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6VBM-7ZGJ : Fri Mar 08 06:49:19 UTC 2024), Entry for Stúmpf Erzsébet and Mük Mátyás, 5 Aug 1928.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6VBM-7ZGL"
+    },
+    {
+      "id": "Q171-P1J",
+      "title": "Muk Mátyás, \"Hungary, Civil Registration, 1895-1980\"",
+      "citation": "\"Hungary, Civil Registration, 1895-1980\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6VY1-RVM7 : Fri Mar 08 23:42:12 UTC 2024), Entry for Stumpf Erzsébet and Muk Mátyás, 5 Aug 1928.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6VY1-RVMH"
+    },
+    {
+      "id": "7MJN-CKQ",
+      "title": "Mátyás Muck, \"Hungary, Reformed Church Christenings, 1624-1895\"",
+      "citation": "\"Hungary, Reformed Church Christenings, 1624-1895\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VJRW-NT1 : Sat Mar 09 00:45:07 UTC 2024), Entry for Mátyás Muck and Mátyás Muck, 02 Apr 1879.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VJRW-NTY"
+    }
+  ]
+}

--- a/eval/tests/e2e/matyas-muck-son/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/matyas-muck-son/unstripped-tree.gedcomx.json
@@ -1,0 +1,482 @@
+{
+  "persons": [
+    {
+      "id": "97M5-6H8",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Mátyás",
+          "surname": "Muck"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "25 AUG 1844",
+          "standard_date": "25 Aug 1844",
+          "place": "Bikacs,Tolna,Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "31 December 1921",
+          "standard_date": "31 Dec 1921",
+          "place": "Bikács, Tolna, Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "a5fe4330-b89f-478b-9daf-db948a0523d1",
+          "type": "Christening",
+          "date": "1844. augusztus 25.",
+          "standard_date": "25 1844",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "KZ89-SYT",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Rosina",
+          "surname": "Blaser"
+        }
+      ],
+      "facts": [
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "11 JAN 1814",
+          "standard_date": "11 Jan 1814",
+          "place": "Bikacs,Tolna,Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1814. január 11.",
+          "standard_date": "11 Jan 1814",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LZX9-R6W",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Éva",
+          "surname": "Muck"
+        }
+      ],
+      "facts": [
+        {
+          "id": "20fda514-259e-4267-ad99-aef2f834ca60",
+          "type": "Birth",
+          "date": "1874. január 20.",
+          "standard_date": "20 Jan 1874",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "21 Jan 1874",
+          "standard_date": "21 Jan 1874",
+          "place": "Bogyiszló, Pest-Pilis-Solt-Kis-Kun, Hungary",
+          "standard_place": "Bogyiszló, Pest-Pilis-Solt-Kiskun, Hungary"
+        },
+        {
+          "id": "82519556-945e-495a-822c-5daadf09df13",
+          "type": "Baptism",
+          "date": "21 Jan 1874",
+          "standard_date": "21 Jan 1874",
+          "place": "Bogyiszló, Pest-Pilis-Solt-Kis-Kun, Hungary",
+          "standard_place": "Bogyiszló, Pest-Pilis-Solt-Kiskun, Hungary"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death",
+          "date": "1942. június 18.",
+          "standard_date": "18 1942",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "L6TX-ZXD",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Erzsébet",
+          "surname": "Stamp"
+        }
+      ],
+      "facts": [
+        {
+          "id": "fdfedcdb-ce17-44db-8469-41b2896e1919",
+          "type": "Birth",
+          "date": "1856. szeptember 8.",
+          "standard_date": "8 1856",
+          "place": "Paks, Tolna, Magyarország",
+          "standard_place": "Paks, Tolna, Hungary"
+        },
+        {
+          "id": "1e83d2d6-2594-44a8-9558-267ca40f51a6",
+          "type": "Christening",
+          "date": "09 Sep 1856",
+          "standard_date": "9 Sep 1856",
+          "place": "Paks, Tolna, Hungary",
+          "standard_place": "Paks, Tolna, Hungary"
+        },
+        {
+          "id": "4fc8c82a-e9bb-4ae6-bf26-0a0a2bb969a1",
+          "type": "Marriage Registration",
+          "date": "1905. május 11.",
+          "standard_date": "11 1905",
+          "place": "Paks, Tolna, Magyarország",
+          "standard_place": "Paks, Tolna, Hungary"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death",
+          "date": "1928. augusztus 4.",
+          "standard_date": "4 1928"
+        }
+      ]
+    },
+    {
+      "id": "L8WW-KBJ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Matyas",
+          "surname": "Muck"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "1 Abril 1879",
+          "standard_date": "1 Apr 1879",
+          "place": "Bikács, Tolna, Hungría",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "5a0adb92-6ca0-420b-bebd-8c4be27bbb9c",
+          "type": "Christening",
+          "date": "2 de abril de 1879",
+          "standard_date": "2 Apr 1879",
+          "place": "Bogyiszló, Pest-Pilis-Solt-Kiskun, Hungria",
+          "standard_place": "Bogyiszló, Pest-Pilis-Solt-Kiskun, Hungary"
+        },
+        {
+          "id": "f5c31ed1-1ded-40f5-bcc8-0940d7699173",
+          "type": "Marriage Registration",
+          "date": "4 de fevereiro de 1904",
+          "standard_date": "4 Feb 1904",
+          "place": "Hungria",
+          "standard_place": "Hungary"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death",
+          "date": "before 1906",
+          "standard_date": "Bef 1906",
+          "place": "Bikács, Tolna, Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "LZX9-R6H",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Erzsébet",
+          "surname": "Wolf"
+        }
+      ],
+      "facts": [
+        {
+          "id": "75f4ea28-21ae-402b-9783-f9fd81ac75f8",
+          "type": "Birth",
+          "date": "1848. március 8.",
+          "standard_date": "8 1848",
+          "place": "Bikács, Tolna, Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "0a3773c3-3456-433f-9812-bdd7e3b1bcc3",
+          "type": "Baptism",
+          "date": "1848. március 8.",
+          "standard_date": "8 1848",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "1900. július 3.",
+          "standard_date": "3 1900",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "dcde45e2-55b0-43b7-b59e-edc9aad5756e",
+          "type": "Death Registration",
+          "date": "1900. július 4.",
+          "standard_date": "4 1900",
+          "place": "Magyarország",
+          "standard_place": "Hungary"
+        }
+      ]
+    },
+    {
+      "id": "GP8V-B53",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "András",
+          "surname": "Muck"
+        }
+      ],
+      "facts": [
+        {
+          "id": "29ca0878-7fbb-42e0-a75a-35acd0800648",
+          "type": "Birth",
+          "date": "1873. február 5.",
+          "standard_date": "5 Feb 1873",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "07520aba-0b83-4de2-888e-bbd720e8b9b3",
+          "type": "Death",
+          "date": "1873. április 1.",
+          "standard_date": "1 1873",
+          "place": "Bikács, Tolna, Magyarország",
+          "standard_place": "Bikács, Tolna, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "KCQX-DZ6",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Paulus",
+          "surname": "Muck"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "21 JAN 1811",
+          "standard_date": "21 Jan 1811",
+          "place": "Bikacs,Tolna,Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "625b9d6f-fc44-4bd1-ab9b-40838c73db76",
+          "type": "Christening",
+          "date": "21 JAN 1811",
+          "standard_date": "21 Jan 1811",
+          "place": "Bikacs,Tolna,Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        },
+        {
+          "id": "1365cf01-dcde-4c49-80df-8bd67e2543eb",
+          "type": "Death",
+          "date": "04 NOV 1899",
+          "standard_date": "4 Nov 1899"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "97M5-6H8",
+      "person2": "LZX9-R6H",
+      "facts": [
+        {
+          "id": "905cc378-bd79-40ec-9cbc-f86a9be34616",
+          "type": "Marriage",
+          "date": "16 January 1866",
+          "standard_date": "16 Jan 1866",
+          "place": "Bikács, Tolna, Hungary",
+          "standard_place": "Bikács, Tolna, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "97M5-6H8",
+      "person2": "L6TX-ZXD",
+      "facts": [
+        {
+          "id": "92ca5d6c-1d70-4c21-8a9f-2a156de9ab8a",
+          "type": "Marriage",
+          "date": "1905. május 11.",
+          "standard_date": "11 1905",
+          "place": "Paks, Tolna, Magyarország",
+          "standard_place": "Paks, Tolna, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "Couple",
+      "person1": "KCQX-DZ6",
+      "person2": "KZ89-SYT",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "22 Nov 1831",
+          "standard_date": "22 Nov 1831",
+          "place": "Bikats,Tolna,Hungary",
+          "standard_place": "Tolna, Hungary"
+        }
+      ]
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "KCQX-DZ6",
+      "child": "97M5-6H8",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "KZ89-SYT",
+      "child": "97M5-6H8",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "97M5-6H8",
+      "child": "GP8V-B53"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "LZX9-R6H",
+      "child": "GP8V-B53"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "97M5-6H8",
+      "child": "LZX9-R6W"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "LZX9-R6H",
+      "child": "LZX9-R6W"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "97M5-6H8",
+      "child": "L8WW-KBJ",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "LZX9-R6H",
+      "child": "L8WW-KBJ",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "QLPL-T3L",
+      "title": "Muck Éva szül. anyakönyv",
+      "citation": "\"Hungary, Reformed Church Christenings, 1624-1895,\" database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/3:1:9392-9ZKJ-F?cc=1858355 : 24 May 2019),  > image 1 of 1; Országos Leveltár, Budapest (Hungary National Archives, Budapest).",
+      "url": "https://familysearch.org/ark:/61903/3:1:9392-9ZKJ-F?view=explore"
+    },
+    {
+      "id": "Q171-5HD",
+      "title": "Mük Mátyós, \"Hungary, Civil Registration, 1895-1980\"",
+      "citation": "\"Hungary, Civil Registration, 1895-1980\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6VY1-S1HS : Sun Mar 10 05:04:58 UTC 2024), Entry for Stumpt Erzsébet and Mük Mátyós, 5 Aug 1928.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6VY1-S1H4"
+    },
+    {
+      "id": "SL2S-3W8",
+      "title": "Mátyás Muck, \"Hungary, Reformed Church Christenings, 1624-1895\"",
+      "citation": "\"Hungary, Reformed Church Christenings, 1624-1895\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VJRW-T78 : Wed Jul 24 01:32:51 UTC 2024), Entry for Éva Muck and Mátyás Muck, 21 Jan 1874.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VJRW-T7C"
+    },
+    {
+      "id": "QPFV-HJM",
+      "title": "Muck Mátyás, \"Hungary, Civil Registration, 1895-1980\"",
+      "citation": "\"Hungary, Civil Registration, 1895-1980\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6JYB-B4NH : Fri Mar 08 22:55:22 UTC 2024), Entry for Wolf Erzsébet and Wolf János, 4 Jul 1900.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6JYB-B4NV"
+    },
+    {
+      "id": "Q171-X4C",
+      "title": "Muck Mátyás, \"Hungary, Civil Registration, 1895-1980\"",
+      "citation": "\"Hungary, Civil Registration, 1895-1980\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6VBM-VRM9 : Sat Mar 09 02:28:50 UTC 2024), Entry for Muck Mátyás and Muck Pál, 11 May 1905.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6VBM-VRM9"
+    },
+    {
+      "id": "Q171-6KF",
+      "title": "Muk Máttyás, \"Hungary, Church Books, 1624-1950\"",
+      "citation": "\"Hungary, Church Books, 1624-1950\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6NSP-WMTK : Sun Mar 10 20:31:57 UTC 2024), Entry for Muk Máttyás and Muk Páll, 25 Aug 1844.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6NSP-WMTK"
+    },
+    {
+      "id": "Q171-PRQ",
+      "title": "Mük Mátyás, \"Hungary, Civil Registration, 1895-1980\"",
+      "citation": "\"Hungary, Civil Registration, 1895-1980\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6VBM-7ZGJ : Fri Mar 08 06:49:19 UTC 2024), Entry for Stúmpf Erzsébet and Mük Mátyás, 5 Aug 1928.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6VBM-7ZGL"
+    },
+    {
+      "id": "Q171-P1J",
+      "title": "Muk Mátyás, \"Hungary, Civil Registration, 1895-1980\"",
+      "citation": "\"Hungary, Civil Registration, 1895-1980\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6VY1-RVM7 : Fri Mar 08 23:42:12 UTC 2024), Entry for Stumpf Erzsébet and Muk Mátyás, 5 Aug 1928.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6VY1-RVMH"
+    },
+    {
+      "id": "7MJN-CKQ",
+      "title": "Mátyás Muck, \"Hungary, Reformed Church Christenings, 1624-1895\"",
+      "citation": "\"Hungary, Reformed Church Christenings, 1624-1895\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VJRW-NT1 : Sat Mar 09 00:45:07 UTC 2024), Entry for Mátyás Muck and Mátyás Muck, 02 Apr 1879.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VJRW-NTY"
+    }
+  ]
+}

--- a/eval/tests/e2e/micaela-salgado-son/README.md
+++ b/eval/tests/e2e/micaela-salgado-son/README.md
@@ -1,0 +1,34 @@
+# Micaela Salgado — additional son Guillermo (b. 1889)
+
+**Source PID:** `9XGG-PW4`
+**Micaela Salgado is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+1854, Tegucigalpa, Honduras; died not recorded in the tree.
+
+## Research question
+
+> Did Micaela Salgado of Tegucigalpa, Honduras have a son named Guillermo, baptized 1889, in addition to her two known daughters (b. 1874 and 1884)?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `9XGG-PW4` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 18, flag `adds_son`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Honduras, Catholic Church Records, 1633-1978: baptismal entry, 20 October 1889, San Miguel, Tegucigalpa, for Guillermo Salgado, naming mother Micaila Salgado with no father recorded. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Guillermo Salgado as the subject's son, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the tree does not record a spouse for Micaela Salgado at all, and the hint baptismal record likewise names no father — an internally consistent pattern (a single mother's baptismal entry) rather than a contradiction. The parish (Tegucigalpa, Francisco Morazán) matches the tree's other children exactly, and a 1889 baptism fits neatly after the tree's two known daughters (1874, 1884) as a later child. The surname "Salgado" alone, without a father to cross-check, leaves some risk of a different same-named Micaela Salgado in the same parish.

--- a/eval/tests/e2e/micaela-salgado-son/expected-findings.json
+++ b/eval/tests/e2e/micaela-salgado-son/expected-findings.json
@@ -1,0 +1,21 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Micaela Salgado had a son, Guillermo Salgado, baptized 20 October 1889 in San Miguel, Tegucigalpa, Francisco Morazán — no father is named in the record, consistent with the tree not recording a spouse for Micaela — in addition to her two daughters already in the tree (Raimunda b. 1874, Maria Norberta b. 1884).",
+      "details": {
+        "subject_person": "Micaela Salgado (9XGG-PW4)",
+        "relation": "child",
+        "target_person": {
+          "name": "Guillermo Salgado",
+          "birth": "baptized 20 October 1889, San Miguel, Tegucigalpa, Francisco Morazán, Honduras"
+        }
+      },
+      "supporting_sources": [
+        "Honduras, Catholic Church Records, 1633-1978 — baptismal entry, 20 Oct 1889, San Miguel, Tegucigalpa, naming mother Micaila Salgado, no father recorded"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/micaela-salgado-son/fixture.json
+++ b/eval/tests/e2e/micaela-salgado-son/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "micaela-salgado-son",
+  "name": "Micaela Salgado — additional son Guillermo (b. 1889)",
+  "genre": "record-hint",
+  "source_pid": "9XGG-PW4",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Micaela Salgado of Tegucigalpa, Honduras have a son named Guillermo, baptized 1889, in addition to her two known daughters (b. 1874 and 1884)?",
+  "tags": {
+    "question_type": "children",
+    "era": "1880s",
+    "geography": "HN"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 18, flag adds_son, confidence 3). Draft transcribed from a Honduran parish baptismal record; unverified."
+}

--- a/eval/tests/e2e/micaela-salgado-son/starting-research.json
+++ b/eval/tests/e2e/micaela-salgado-son/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_micaela_salgado_son",
+    "objective": "Did Micaela Salgado of Tegucigalpa, Honduras have a son named Guillermo, baptized 1889, in addition to her two known daughters (b. 1874 and 1884)?",
+    "subject_person_ids": [
+      "9XGG-PW4"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/micaela-salgado-son/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/micaela-salgado-son/starting-tree.gedcomx.json
@@ -1,0 +1,209 @@
+{
+  "persons": [
+    {
+      "id": "9XGG-PW4",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Micaela",
+          "surname": "Salgado"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4dea1a87-2d26-4744-8daa-3a88485c0235",
+          "type": "Birth",
+          "date": "1854",
+          "standard_date": "1854",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        },
+        {
+          "id": "f02b576e-1f7f-4a1b-8daa-5841b3b676d9",
+          "type": "Christening",
+          "date": "14 de mayo de 1854",
+          "standard_date": "14 May 1854",
+          "place": "Catedral San Miguel Arcángel, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Catedral San Miguel Arcángel, Distrito Central, Francisco Morazán, Honduras"
+        },
+        {
+          "id": "4189ff9a-d501-43a6-8569-9ef06cc30241",
+          "type": "Birth Registration",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        }
+      ]
+    },
+    {
+      "id": "MHZ1-4X1",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Elena",
+          "surname": "Salgado"
+        }
+      ],
+      "facts": [
+        {
+          "id": "a2de889f-09de-408a-82b6-26c29861ec63",
+          "type": "Birth",
+          "date": "1834",
+          "standard_date": "1834",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        },
+        {
+          "id": "eb2bf9a6-5393-4511-95cd-197e7e7074a6",
+          "type": "Christening",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        }
+      ]
+    },
+    {
+      "id": "PS4K-GN8",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Maria Norberta",
+          "surname": "Salgado"
+        }
+      ],
+      "facts": [
+        {
+          "id": "81e5f5b5-6451-4799-b453-e0764c583859",
+          "type": "Birth",
+          "date": "10 de diciembre de 1884",
+          "standard_date": "10 Dec 1884",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        },
+        {
+          "id": "5d9df6a9-a66b-4296-b34c-94323a218cf9",
+          "type": "Christening",
+          "date": "10 de febrero de 1885",
+          "standard_date": "10 Feb 1885",
+          "place": "Catedral San Miguel Arcángel, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Catedral San Miguel Arcángel, Distrito Central, Francisco Morazán, Honduras"
+        },
+        {
+          "id": "4d526f34-8380-47e4-b30e-0beded0dfe43",
+          "type": "Death",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        },
+        {
+          "id": "42468db6-2c94-4234-a3ff-03a1d67b54c7",
+          "type": "Birth Registration",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        }
+      ]
+    },
+    {
+      "id": "9XGG-PWW",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Raimunda De Jesus",
+          "surname": "Salgado"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "15 Mar 1874",
+          "standard_date": "15 Mar 1874"
+        },
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "12 Apr 1874",
+          "standard_date": "12 Apr 1874",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "ParentChild",
+      "parent": "MHZ1-4X1",
+      "child": "9XGG-PW4"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "9XGG-PW4",
+      "child": "9XGG-PWW",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "9XGG-PW4",
+      "child": "PS4K-GN8"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7J8S-549",
+      "title": "Micaela Salgado, \"Honduras, registros parroquiales y diocesanos, 1633-1978\"",
+      "citation": "\"Honduras, registros parroquiales y diocesanos, 1633-1978\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KXPM-NS3 : Sat Mar 09 07:02:56 UTC 2024), Entry for Raimunda de Jesus Salgado and Micaela Salgado, 12 Apr 1874.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KXPM-NSS"
+    },
+    {
+      "id": "7J8S-R2X",
+      "title": "Micaela Salgado, \"Honduras, registros parroquiales y diocesanos, 1633-1978\"",
+      "citation": "\"Honduras, registros parroquiales y diocesanos, 1633-1978\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KXP9-9KW : Sat Mar 09 11:26:46 UTC 2024), Entry for Maria Norberta Salgado and Micaela Salgado, 10 Feb 1885.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KXP9-9K7"
+    },
+    {
+      "id": "7J8S-PJ7",
+      "title": "Micaela Salgado, \"Honduras, registros parroquiales y diocesanos, 1633-1978\"",
+      "citation": "\"Honduras, registros parroquiales y diocesanos, 1633-1978\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KXG1-5MS : Sun Mar 10 09:12:35 UTC 2024), Entry for Micaela Salgado and Elena Salgado, 14 May 1854.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KXG1-5MS"
+    },
+    {
+      "id": "9M77-S7T",
+      "title": "Micaela Salgado in entry for Raimunda de Jesus Salgado, \"Honduras, Baptisms, 1730-1930\"",
+      "citation": "\"Honduras bautismos, 1730-1930\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:FLHH-R4H : 20 November 2025), Micaela Salgado in entry for Raimunda de Jesus Salgado, 1874.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FLHH-R4H"
+    },
+    {
+      "id": "7J8S-5GM",
+      "title": "Micaela Salgado, \"Honduras, Registro Civil, 1841-1968\"",
+      "citation": "\"Honduras, Registro Civil, 1841-1968\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKDY-H6Q1 : Tue Apr 28 13:23:43 UTC 2026), Entry for Maria Norberta Salgado and Micaela Salgado.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKDY-H67M"
+    },
+    {
+      "id": "7J8S-YH4",
+      "title": "Micaela Salgado, \"Honduras, Registro Civil, 1841-1968\"",
+      "citation": "\"Honduras, Registro Civil, 1841-1968\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QGTX-29PX : Tue Apr 28 13:52:46 UTC 2026), Entry for Micaela Salgado and Elena Salgado.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QGTX-29PX"
+    }
+  ]
+}

--- a/eval/tests/e2e/micaela-salgado-son/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/micaela-salgado-son/unstripped-tree.gedcomx.json
@@ -1,0 +1,209 @@
+{
+  "persons": [
+    {
+      "id": "9XGG-PW4",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Micaela",
+          "surname": "Salgado"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4dea1a87-2d26-4744-8daa-3a88485c0235",
+          "type": "Birth",
+          "date": "1854",
+          "standard_date": "1854",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        },
+        {
+          "id": "f02b576e-1f7f-4a1b-8daa-5841b3b676d9",
+          "type": "Christening",
+          "date": "14 de mayo de 1854",
+          "standard_date": "14 May 1854",
+          "place": "Catedral San Miguel Arcángel, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Catedral San Miguel Arcángel, Distrito Central, Francisco Morazán, Honduras"
+        },
+        {
+          "id": "4189ff9a-d501-43a6-8569-9ef06cc30241",
+          "type": "Birth Registration",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        }
+      ]
+    },
+    {
+      "id": "MHZ1-4X1",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Elena",
+          "surname": "Salgado"
+        }
+      ],
+      "facts": [
+        {
+          "id": "a2de889f-09de-408a-82b6-26c29861ec63",
+          "type": "Birth",
+          "date": "1834",
+          "standard_date": "1834",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        },
+        {
+          "id": "eb2bf9a6-5393-4511-95cd-197e7e7074a6",
+          "type": "Christening",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        }
+      ]
+    },
+    {
+      "id": "PS4K-GN8",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Maria Norberta",
+          "surname": "Salgado"
+        }
+      ],
+      "facts": [
+        {
+          "id": "81e5f5b5-6451-4799-b453-e0764c583859",
+          "type": "Birth",
+          "date": "10 de diciembre de 1884",
+          "standard_date": "10 Dec 1884",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        },
+        {
+          "id": "5d9df6a9-a66b-4296-b34c-94323a218cf9",
+          "type": "Christening",
+          "date": "10 de febrero de 1885",
+          "standard_date": "10 Feb 1885",
+          "place": "Catedral San Miguel Arcángel, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Catedral San Miguel Arcángel, Distrito Central, Francisco Morazán, Honduras"
+        },
+        {
+          "id": "4d526f34-8380-47e4-b30e-0beded0dfe43",
+          "type": "Death",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        },
+        {
+          "id": "42468db6-2c94-4234-a3ff-03a1d67b54c7",
+          "type": "Birth Registration",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        }
+      ]
+    },
+    {
+      "id": "9XGG-PWW",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Raimunda De Jesus",
+          "surname": "Salgado"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "15 Mar 1874",
+          "standard_date": "15 Mar 1874"
+        },
+        {
+          "id": "453dddf0-cce9-4ea8-bf89-7f0161420bc3",
+          "type": "Christening",
+          "date": "12 Apr 1874",
+          "standard_date": "12 Apr 1874",
+          "place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras",
+          "standard_place": "Tegucigalpa, Distrito Central, Francisco Morazán, Honduras"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "ParentChild",
+      "parent": "MHZ1-4X1",
+      "child": "9XGG-PW4"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "9XGG-PW4",
+      "child": "9XGG-PWW",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "9XGG-PW4",
+      "child": "PS4K-GN8"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7J8S-549",
+      "title": "Micaela Salgado, \"Honduras, registros parroquiales y diocesanos, 1633-1978\"",
+      "citation": "\"Honduras, registros parroquiales y diocesanos, 1633-1978\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KXPM-NS3 : Sat Mar 09 07:02:56 UTC 2024), Entry for Raimunda de Jesus Salgado and Micaela Salgado, 12 Apr 1874.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KXPM-NSS"
+    },
+    {
+      "id": "7J8S-R2X",
+      "title": "Micaela Salgado, \"Honduras, registros parroquiales y diocesanos, 1633-1978\"",
+      "citation": "\"Honduras, registros parroquiales y diocesanos, 1633-1978\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KXP9-9KW : Sat Mar 09 11:26:46 UTC 2024), Entry for Maria Norberta Salgado and Micaela Salgado, 10 Feb 1885.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KXP9-9K7"
+    },
+    {
+      "id": "7J8S-PJ7",
+      "title": "Micaela Salgado, \"Honduras, registros parroquiales y diocesanos, 1633-1978\"",
+      "citation": "\"Honduras, registros parroquiales y diocesanos, 1633-1978\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KXG1-5MS : Sun Mar 10 09:12:35 UTC 2024), Entry for Micaela Salgado and Elena Salgado, 14 May 1854.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KXG1-5MS"
+    },
+    {
+      "id": "9M77-S7T",
+      "title": "Micaela Salgado in entry for Raimunda de Jesus Salgado, \"Honduras, Baptisms, 1730-1930\"",
+      "citation": "\"Honduras bautismos, 1730-1930\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:FLHH-R4H : 20 November 2025), Micaela Salgado in entry for Raimunda de Jesus Salgado, 1874.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FLHH-R4H"
+    },
+    {
+      "id": "7J8S-5GM",
+      "title": "Micaela Salgado, \"Honduras, Registro Civil, 1841-1968\"",
+      "citation": "\"Honduras, Registro Civil, 1841-1968\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QKDY-H6Q1 : Tue Apr 28 13:23:43 UTC 2026), Entry for Maria Norberta Salgado and Micaela Salgado.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QKDY-H67M"
+    },
+    {
+      "id": "7J8S-YH4",
+      "title": "Micaela Salgado, \"Honduras, Registro Civil, 1841-1968\"",
+      "citation": "\"Honduras, Registro Civil, 1841-1968\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QGTX-29PX : Tue Apr 28 13:52:46 UTC 2026), Entry for Micaela Salgado and Elena Salgado.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QGTX-29PX"
+    }
+  ]
+}

--- a/eval/tests/e2e/pierre-desobry-spouse/README.md
+++ b/eval/tests/e2e/pierre-desobry-spouse/README.md
@@ -1,0 +1,34 @@
+# Pierre Henri DESOBRY — wife Clemence Sauselle and son Julien
+
+**Source PID:** `L6L3-BB8`
+**Pierre Henri DESOBRY is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+Pecquencourt, Nord, France (baptized 1753 and 1774 — two baptismal facts already conflict in the tree); died 11 October 1849, Aniche, Nord, France.
+
+## Research question
+
+> Who was the wife of Pierre Henri Désobry of Pecquencourt, France, and did they have a son named Julien who died in infancy in 1809?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `L6L3-BB8` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 17, flags `adds_spouse`/`adds_son`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — France, Nord, Parish and Civil Registration, 1524-1893: death registration, 8 September 1809, Pecquencourt, for Julien Désobri (infant), naming parents Pierre Henri Désobri and Clemence Sauselle. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Clemence Sauselle as the subject's wife, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: a son born 1808 and dying 1809 fits neatly between the tree's Philibert (b. 1800) and Jean Baptiste Aimé (b. 1813), and the parish (Pecquencourt) matches every other record for this family exactly. The tree oddly carries **two conflicting baptismal facts** for Pierre Henri Désobry himself (1753 and 1774, a 21-year gap, possibly two different men already conflated in the starting tree — a pre-existing tree data-quality issue, not something this fixture introduces or resolves), which should make a reviewer cautious about how reliable the existing tree profile is before trusting a new spouse/child hint against it. This is the family's first recorded spouse in the tree.

--- a/eval/tests/e2e/pierre-desobry-spouse/expected-findings.json
+++ b/eval/tests/e2e/pierre-desobry-spouse/expected-findings.json
@@ -1,0 +1,39 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Pierre Henri Désobry's wife was Clemence Sauselle. The tree currently records no spouse for him, though it records two children (Philibert b. 1800, Jean Baptiste Aimé b. 1813).",
+      "details": {
+        "subject_person": "Pierre Henri DESOBRY (L6L3-BB8)",
+        "relation": "spouse",
+        "target_person": {
+          "name": "Clemence Sauselle",
+          "birth": "unknown"
+        }
+      },
+      "supporting_sources": [
+        "France, Nord, Parish and Civil Registration, 1524-1893 — death registration, 8 Sep 1809, Pecquencourt, for Julien Désobri, naming parents Pierre Henri Désobri and Clemence Sauselle"
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "relationship",
+      "description": "Pierre Henri Désobry and Clemence Sauselle had a son, Julien Désobri, born 1808 and died in infancy 7 September 1809 in Pecquencourt — between the tree's two known children (Philibert b. 1800, Jean Baptiste Aimé b. 1813).",
+      "details": {
+        "subject_person": "Pierre Henri DESOBRY (L6L3-BB8)",
+        "relation": "child",
+        "target_person": {
+          "name": "Julien Désobri",
+          "birth": "1808, Pecquencourt, Nord, France",
+          "death": "7 September 1809, Pecquencourt, Nord, France"
+        }
+      },
+      "supporting_sources": [
+        "France, Nord, Parish and Civil Registration, 1524-1893 — death registration, 8 Sep 1809, Pecquencourt"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/pierre-desobry-spouse/fixture.json
+++ b/eval/tests/e2e/pierre-desobry-spouse/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "pierre-desobry-spouse",
+  "name": "Pierre Henri DESOBRY — wife Clemence Sauselle and son Julien",
+  "genre": "record-hint",
+  "source_pid": "L6L3-BB8",
+  "captured": "2026-07-24",
+  "researcher_question": "Who was the wife of Pierre Henri Désobry of Pecquencourt, France, and did they have a son named Julien who died in infancy in 1809?",
+  "tags": {
+    "question_type": "spouse",
+    "era": "1800s",
+    "geography": "FR"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 17, flags adds_spouse/adds_son, confidence 3). Draft transcribed from a French parish register; unverified."
+}

--- a/eval/tests/e2e/pierre-desobry-spouse/starting-research.json
+++ b/eval/tests/e2e/pierre-desobry-spouse/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_pierre_desobry_spouse",
+    "objective": "Who was the wife of Pierre Henri Désobry of Pecquencourt, France, and did they have a son named Julien who died in infancy in 1809?",
+    "subject_person_ids": [
+      "L6L3-BB8"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/pierre-desobry-spouse/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/pierre-desobry-spouse/starting-tree.gedcomx.json
@@ -1,0 +1,217 @@
+{
+  "persons": [
+    {
+      "id": "L6L3-BB8",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Pierre Henri",
+          "surname": "DESOBRY"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "place": "Pecquencourt, 59146, France",
+          "standard_place": "Pecquencourt, Nord, France"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death",
+          "date": "11 Oct 1849",
+          "standard_date": "11 Oct 1849",
+          "place": "Aniche, 59580, France",
+          "standard_place": "Aniche, Nord, France"
+        },
+        {
+          "id": "97badb51-7507-4c34-8b86-54ed87dd83b5",
+          "type": "Baptism",
+          "date": "7 juillet 1753",
+          "standard_date": "7 Jul 1753",
+          "place": "Pecquencourt, Nord, France",
+          "standard_place": "Pecquencourt, Nord, France"
+        },
+        {
+          "id": "c6372e95-12a3-40a9-a757-a38b3e4c9de9",
+          "type": "Baptism",
+          "date": "18 Sep 1774",
+          "standard_date": "18 Sep 1774",
+          "place": "Pecquencourt, Nord, France",
+          "standard_place": "Pecquencourt, Nord, France"
+        }
+      ]
+    },
+    {
+      "id": "GZ7S-4HG",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Marie Claire",
+          "surname": "Chartau"
+        }
+      ],
+      "facts": [
+        {
+          "id": "200e8efd-6521-4232-880e-19a0a3257644",
+          "type": "Birth",
+          "date": "1732",
+          "standard_date": "1732"
+        },
+        {
+          "id": "88d9122b-3c78-4d58-be72-965b3f6dab88",
+          "type": "Christening",
+          "date": "13 décembre 1732",
+          "standard_date": "13 Dec 1732",
+          "place": "Louvignies-Quesnoy, Nord, France",
+          "standard_place": "Louvignies-Quesnoy, Nord, France"
+        },
+        {
+          "id": "71d80ca3-b4e9-4615-9324-ddd4b2c86391",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GG4D-4NF",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Ubalde Joseph",
+          "surname": "Dezoubry"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4a02dc6b-612a-4ebd-a76d-ae4997131632",
+          "type": "Birth",
+          "date": "6 octobre 1726",
+          "standard_date": "6 Oct 1726",
+          "place": "Pecquencourt, Nord, France",
+          "standard_place": "Pecquencourt, Nord, France"
+        },
+        {
+          "id": "f6bef726-a378-40d8-bf4c-e684de9390ef",
+          "type": "Death"
+        },
+        {
+          "id": "047500e8-31be-4b0b-ba84-07682d1e979b",
+          "type": "Occupation",
+          "value": "Milicien"
+        }
+      ]
+    },
+    {
+      "id": "L6L3-569",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Philibert",
+          "surname": "DESOBRY"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "1800",
+          "standard_date": "1800",
+          "place": "Pecquencourt, 59146, France",
+          "standard_place": "Pecquencourt, Nord, France"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "L6L3-RHN",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Jean Baptiste Aimé",
+          "surname": "DESOBRY"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "19 Jan 1813",
+          "standard_date": "19 Jan 1813",
+          "place": "Pecquencourt, 59146, France",
+          "standard_place": "Pecquencourt, Nord, France"
+        },
+        {
+          "id": "7bdb9ee4-bc65-447c-be09-30dc275c872f",
+          "type": "Occupation",
+          "date": "1836",
+          "standard_date": "1836",
+          "place": "Mineur",
+          "standard_place": "Mineur, Baradères, Baradères, Nippes, Haiti"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GG4D-4NF",
+      "person2": "GZ7S-4HG"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "GG4D-4NF",
+      "child": "L6L3-BB8"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GZ7S-4HG",
+      "child": "L6L3-BB8"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "L6L3-BB8",
+      "child": "L6L3-569"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "L6L3-BB8",
+      "child": "L6L3-RHN"
+    }
+  ],
+  "sources": [
+    {
+      "id": "QGLK-TZT",
+      "title": "Pierre Henri Dezoubry, \"France, Nord, Parish and Civil Registration, 1524-1893\"",
+      "citation": "\"France, Nord, Parish and Civil Registration, 1524-1893\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:8NWP-366Z : Mon Mar 11 01:04:36 UTC 2024), Entry for Pierre Henri Dezoubry and Ubalde Joseph Dezoubry, 7 Jul 1753.",
+      "url": "https://familysearch.org/ark:/61903/1:1:8NWP-366Z"
+    },
+    {
+      "id": "QRPQ-KLZ",
+      "title": "Pierre Henry Dezoubry, \"France, Nord, Parish and Civil Registration, 1524-1893\"",
+      "citation": "\"France, Nord, Parish and Civil Registration, 1524-1893\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:8NWT-XMMM : Sat Mar 09 20:50:39 UTC 2024), Entry for Pierre Henry Dezoubry and Ubalde Joseph Dezoubry, 18 Sep 1774.",
+      "url": "https://familysearch.org/ark:/61903/1:1:8NWT-XMMM"
+    }
+  ]
+}

--- a/eval/tests/e2e/pierre-desobry-spouse/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/pierre-desobry-spouse/unstripped-tree.gedcomx.json
@@ -1,0 +1,217 @@
+{
+  "persons": [
+    {
+      "id": "L6L3-BB8",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Pierre Henri",
+          "surname": "DESOBRY"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "place": "Pecquencourt, 59146, France",
+          "standard_place": "Pecquencourt, Nord, France"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death",
+          "date": "11 Oct 1849",
+          "standard_date": "11 Oct 1849",
+          "place": "Aniche, 59580, France",
+          "standard_place": "Aniche, Nord, France"
+        },
+        {
+          "id": "97badb51-7507-4c34-8b86-54ed87dd83b5",
+          "type": "Baptism",
+          "date": "7 juillet 1753",
+          "standard_date": "7 Jul 1753",
+          "place": "Pecquencourt, Nord, France",
+          "standard_place": "Pecquencourt, Nord, France"
+        },
+        {
+          "id": "c6372e95-12a3-40a9-a757-a38b3e4c9de9",
+          "type": "Baptism",
+          "date": "18 Sep 1774",
+          "standard_date": "18 Sep 1774",
+          "place": "Pecquencourt, Nord, France",
+          "standard_place": "Pecquencourt, Nord, France"
+        }
+      ]
+    },
+    {
+      "id": "GZ7S-4HG",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Marie Claire",
+          "surname": "Chartau"
+        }
+      ],
+      "facts": [
+        {
+          "id": "200e8efd-6521-4232-880e-19a0a3257644",
+          "type": "Birth",
+          "date": "1732",
+          "standard_date": "1732"
+        },
+        {
+          "id": "88d9122b-3c78-4d58-be72-965b3f6dab88",
+          "type": "Christening",
+          "date": "13 décembre 1732",
+          "standard_date": "13 Dec 1732",
+          "place": "Louvignies-Quesnoy, Nord, France",
+          "standard_place": "Louvignies-Quesnoy, Nord, France"
+        },
+        {
+          "id": "71d80ca3-b4e9-4615-9324-ddd4b2c86391",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GG4D-4NF",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Ubalde Joseph",
+          "surname": "Dezoubry"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4a02dc6b-612a-4ebd-a76d-ae4997131632",
+          "type": "Birth",
+          "date": "6 octobre 1726",
+          "standard_date": "6 Oct 1726",
+          "place": "Pecquencourt, Nord, France",
+          "standard_place": "Pecquencourt, Nord, France"
+        },
+        {
+          "id": "f6bef726-a378-40d8-bf4c-e684de9390ef",
+          "type": "Death"
+        },
+        {
+          "id": "047500e8-31be-4b0b-ba84-07682d1e979b",
+          "type": "Occupation",
+          "value": "Milicien"
+        }
+      ]
+    },
+    {
+      "id": "L6L3-569",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Philibert",
+          "surname": "DESOBRY"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "1800",
+          "standard_date": "1800",
+          "place": "Pecquencourt, 59146, France",
+          "standard_place": "Pecquencourt, Nord, France"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "L6L3-RHN",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Jean Baptiste Aimé",
+          "surname": "DESOBRY"
+        }
+      ],
+      "facts": [
+        {
+          "id": "248eaba5-34ae-4182-9874-bfcc07166241",
+          "type": "Birth",
+          "date": "19 Jan 1813",
+          "standard_date": "19 Jan 1813",
+          "place": "Pecquencourt, 59146, France",
+          "standard_place": "Pecquencourt, Nord, France"
+        },
+        {
+          "id": "7bdb9ee4-bc65-447c-be09-30dc275c872f",
+          "type": "Occupation",
+          "date": "1836",
+          "standard_date": "1836",
+          "place": "Mineur",
+          "standard_place": "Mineur, Baradères, Baradères, Nippes, Haiti"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GG4D-4NF",
+      "person2": "GZ7S-4HG"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "GG4D-4NF",
+      "child": "L6L3-BB8"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GZ7S-4HG",
+      "child": "L6L3-BB8"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "L6L3-BB8",
+      "child": "L6L3-569"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "L6L3-BB8",
+      "child": "L6L3-RHN"
+    }
+  ],
+  "sources": [
+    {
+      "id": "QGLK-TZT",
+      "title": "Pierre Henri Dezoubry, \"France, Nord, Parish and Civil Registration, 1524-1893\"",
+      "citation": "\"France, Nord, Parish and Civil Registration, 1524-1893\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:8NWP-366Z : Mon Mar 11 01:04:36 UTC 2024), Entry for Pierre Henri Dezoubry and Ubalde Joseph Dezoubry, 7 Jul 1753.",
+      "url": "https://familysearch.org/ark:/61903/1:1:8NWP-366Z"
+    },
+    {
+      "id": "QRPQ-KLZ",
+      "title": "Pierre Henry Dezoubry, \"France, Nord, Parish and Civil Registration, 1524-1893\"",
+      "citation": "\"France, Nord, Parish and Civil Registration, 1524-1893\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:8NWT-XMMM : Sat Mar 09 20:50:39 UTC 2024), Entry for Pierre Henry Dezoubry and Ubalde Joseph Dezoubry, 18 Sep 1774.",
+      "url": "https://familysearch.org/ark:/61903/1:1:8NWT-XMMM"
+    }
+  ]
+}

--- a/eval/tests/e2e/pierre-tullier-son/README.md
+++ b/eval/tests/e2e/pierre-tullier-son/README.md
@@ -1,0 +1,34 @@
+# Pierre Albert Tullier — additional son Pierre Jacques Dominique (b. 1796)
+
+**Source PID:** `GPX7-28P`
+**Pierre Albert Tullier is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+4 March 1777, Stavele, Alveringem, West Flanders, Belgium; died 11 March 1846, Bambecque, Nord, France.
+
+## Research question
+
+> Did Pierre Albert Tullier and his wife Constance Dorothé Leys have a son, Pierre Jacques Dominique, born 1796, in addition to their five children recorded from 1805 onward?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `GPX7-28P` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+hard — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 6, flag `adds_son`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — France, Nord, Parish and Civil Registration, 1524-1893: marriage entry, 21 June 1825, Bambecque, for Pierre Jacques Dominique Tuilier (son of Pierre Tuilier and Constance Ley) and Constance Victoire Depuydt. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming the 1796 Pierre Jacques Dominique Tuilier birth, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh **against** the match: the tree records Pierre Albert Tullier's marriage to Constance Dorothé Leys as 24 September 1800 — but a son born in 1796 would predate that marriage by four years, which either means the couple had a child before their recorded marriage date, the tree's marriage date is wrong, or this is a different Pierre Tuilier/Tullier and Constance Leys/Ley pairing in the same small Bambecque parish ("Pierre" and "Constance" are common regional names, and "Tuilier"/"Tullier" is a spelling variant pair already present elsewhere in the tree, e.g. the subject's own name). In favor: same given names for both parents, and the same parish (Bambecque, Nord).

--- a/eval/tests/e2e/pierre-tullier-son/expected-findings.json
+++ b/eval/tests/e2e/pierre-tullier-son/expected-findings.json
@@ -1,0 +1,22 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Pierre Albert Tullier and Constance Dorothé Leys had a son, Pierre Jacques Dominique Tuilier, born 1796 and married 1825 in Bambecque, France, in addition to their five children already in the tree (born 1805-1816).",
+      "details": {
+        "subject_person": "Pierre Albert Tullier (GPX7-28P)",
+        "relation": "child",
+        "target_person": {
+          "name": "Pierre Jacques Dominique Tuilier",
+          "birth": "1796, France",
+          "marriage": "21 June 1825, Bambecque, Nord, France, to Constance Victoire Depuydt"
+        }
+      },
+      "supporting_sources": [
+        "France, Nord, Parish and Civil Registration, 1524-1893 — marriage entry, 21 Jun 1825, Bambecque, naming parents Pierre Tuilier and Constance Ley"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/pierre-tullier-son/fixture.json
+++ b/eval/tests/e2e/pierre-tullier-son/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "pierre-tullier-son",
+  "name": "Pierre Albert Tullier — additional son Pierre Jacques Dominique (b. 1796)",
+  "genre": "record-hint",
+  "source_pid": "GPX7-28P",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Pierre Albert Tullier and his wife Constance Dorothé Leys have a son, Pierre Jacques Dominique, born 1796, in addition to their five children recorded from 1805 onward?",
+  "tags": {
+    "question_type": "children",
+    "era": "1790s",
+    "geography": "FR"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 6, flag adds_son, confidence 3). Draft transcribed from a French parish/civil register; unverified."
+}

--- a/eval/tests/e2e/pierre-tullier-son/starting-research.json
+++ b/eval/tests/e2e/pierre-tullier-son/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_pierre_tullier_son",
+    "objective": "Did Pierre Albert Tullier and his wife Constance Dorothé Leys have a son, Pierre Jacques Dominique, born 1796, in addition to their five children recorded from 1805 onward?",
+    "subject_person_ids": [
+      "GPX7-28P"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/pierre-tullier-son/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/pierre-tullier-son/starting-tree.gedcomx.json
@@ -1,0 +1,367 @@
+{
+  "persons": [
+    {
+      "id": "GPX7-28P",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Pierre Albert",
+          "surname": "Tullier"
+        }
+      ],
+      "facts": [
+        {
+          "id": "22492e74-0f80-4205-a620-83aa568f4304",
+          "type": "Birth",
+          "date": "4 March 1777",
+          "standard_date": "4 Mar 1777",
+          "place": "Stavele, Alveringem, West Flanders, Belgium",
+          "standard_place": "Stavele, Alveringem, West Flanders, Belgium"
+        },
+        {
+          "id": "a6653a7d-c62f-4290-a221-c5104be378ef",
+          "type": "Death",
+          "date": "11 March 1846",
+          "standard_date": "11 Mar 1846",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        }
+      ]
+    },
+    {
+      "id": "G8QK-FXP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Constance Dorothé",
+          "surname": "Leys"
+        }
+      ],
+      "facts": [
+        {
+          "id": "dbe37865-a89c-469c-a368-36b3d2ab2f8c",
+          "type": "Birth",
+          "date": "1775",
+          "standard_date": "1775"
+        },
+        {
+          "id": "45e7d3ae-e75a-4a01-af93-836675607c34",
+          "type": "Death",
+          "date": "24 March 1831",
+          "standard_date": "24 Mar 1831"
+        }
+      ]
+    },
+    {
+      "id": "GPX4-WHM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Reine Sofie",
+          "surname": "Tullier"
+        }
+      ],
+      "facts": [
+        {
+          "id": "d7d6872f-0916-4b5c-a921-27c08d2595c2",
+          "type": "Birth",
+          "date": "26 December 1808",
+          "standard_date": "26 Dec 1808",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        },
+        {
+          "id": "95298767-b9f5-4c7c-a37b-d1643967c33f",
+          "type": "Death",
+          "date": "4 January 1809",
+          "standard_date": "4 Jan 1809",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        }
+      ]
+    },
+    {
+      "id": "GPXW-LB1",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Martin Dauphin",
+          "surname": "Tullier"
+        }
+      ],
+      "facts": [
+        {
+          "id": "663e91e9-2cc5-4433-8aff-1ea84b4f3a9b",
+          "type": "Birth",
+          "date": "10 November 1814",
+          "standard_date": "10 Nov 1814",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        },
+        {
+          "id": "af996fbb-dca6-4b33-8f6d-3263f13ebb44",
+          "type": "Death",
+          "date": "30 July 1852",
+          "standard_date": "30 Jul 1852",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        }
+      ]
+    },
+    {
+      "id": "GPX4-M4C",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Pierre Jacques Louis",
+          "surname": "Tullier"
+        }
+      ],
+      "facts": [
+        {
+          "id": "24916fd7-f82f-4df4-beca-1d8e5c6badbb",
+          "type": "Birth",
+          "date": "13 July 1816",
+          "standard_date": "13 Jul 1816",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        },
+        {
+          "id": "5c105fb7-77a5-4ee6-a99e-09a857d64a20",
+          "type": "Death",
+          "date": "19 January 1817",
+          "standard_date": "19 Jan 1817",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        }
+      ]
+    },
+    {
+      "id": "GPXW-BM8",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Barbe Henriette Constante",
+          "surname": "Tullier"
+        }
+      ],
+      "facts": [
+        {
+          "id": "5d4f851b-cb3e-48a5-b00a-53a3e851119a",
+          "type": "Birth",
+          "date": "17 April 1805",
+          "standard_date": "17 Apr 1805",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        },
+        {
+          "id": "da2a535f-1af3-4d9d-8b1f-d98451dfd9c3",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GPXW-Z79",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Jacobus",
+          "surname": "Tullier"
+        }
+      ],
+      "facts": [
+        {
+          "id": "54529076-86f8-4452-8648-3ba7999c9951",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GQ5B-TF6",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Anna Theresia",
+          "surname": "Devloo"
+        }
+      ],
+      "facts": [
+        {
+          "id": "33390d43-0c14-4fc2-8083-307b0d39c20b",
+          "type": "Birth",
+          "date": "8 July 1735",
+          "standard_date": "8 Jul 1735",
+          "place": "Oostvleteren, Vleteren, West Flanders, Belgium",
+          "standard_place": "Oostvleteren, Vleteren, West Flanders, Belgium"
+        },
+        {
+          "id": "35fedd79-926d-4425-a770-27d5133e15f6",
+          "type": "Death Registration",
+          "date": "8 Feb 1820",
+          "standard_date": "8 Feb 1820",
+          "place": "Bambecque, Nord, France",
+          "standard_place": "Bambecque, Nord, France"
+        },
+        {
+          "id": "66350e6c-0816-46f7-9516-caeeeac45435",
+          "type": "Death",
+          "date": "8 February 1820",
+          "standard_date": "8 Feb 1820",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        }
+      ]
+    },
+    {
+      "id": "GPXW-N8Z",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Charles Louis",
+          "surname": "Tullier"
+        }
+      ],
+      "facts": [
+        {
+          "id": "c22231f6-ccb7-4e21-b316-c45616a6aca9",
+          "type": "Birth",
+          "date": "11 October 1806",
+          "standard_date": "11 Oct 1806",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        },
+        {
+          "id": "a3e8d6ec-e4c4-475e-b716-ebc594aaf041",
+          "type": "Death",
+          "date": "9 February 1807",
+          "standard_date": "9 Feb 1807",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GPX7-28P",
+      "person2": "G8QK-FXP",
+      "facts": [
+        {
+          "id": "e5f824f0-6d85-4b35-bcc3-c6e4d20f5e4b",
+          "type": "Marriage",
+          "date": "24 September 1800",
+          "standard_date": "24 Sep 1800",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "GPXW-Z79",
+      "person2": "GQ5B-TF6",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "18 July 1769",
+          "standard_date": "18 Jul 1769"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GPXW-Z79",
+      "child": "GPX7-28P"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GQ5B-TF6",
+      "child": "GPX7-28P"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GPX7-28P",
+      "child": "GPXW-BM8"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "G8QK-FXP",
+      "child": "GPXW-BM8"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "GPX7-28P",
+      "child": "GPXW-N8Z"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "G8QK-FXP",
+      "child": "GPXW-N8Z"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "GPX7-28P",
+      "child": "GPX4-WHM"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "G8QK-FXP",
+      "child": "GPX4-WHM"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "GPX7-28P",
+      "child": "GPXW-LB1"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "G8QK-FXP",
+      "child": "GPXW-LB1"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "GPX7-28P",
+      "child": "GPX4-M4C"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "G8QK-FXP",
+      "child": "GPX4-M4C"
+    }
+  ],
+  "sources": []
+}

--- a/eval/tests/e2e/pierre-tullier-son/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/pierre-tullier-son/unstripped-tree.gedcomx.json
@@ -1,0 +1,367 @@
+{
+  "persons": [
+    {
+      "id": "GPX7-28P",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Pierre Albert",
+          "surname": "Tullier"
+        }
+      ],
+      "facts": [
+        {
+          "id": "22492e74-0f80-4205-a620-83aa568f4304",
+          "type": "Birth",
+          "date": "4 March 1777",
+          "standard_date": "4 Mar 1777",
+          "place": "Stavele, Alveringem, West Flanders, Belgium",
+          "standard_place": "Stavele, Alveringem, West Flanders, Belgium"
+        },
+        {
+          "id": "a6653a7d-c62f-4290-a221-c5104be378ef",
+          "type": "Death",
+          "date": "11 March 1846",
+          "standard_date": "11 Mar 1846",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        }
+      ]
+    },
+    {
+      "id": "G8QK-FXP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Constance Dorothé",
+          "surname": "Leys"
+        }
+      ],
+      "facts": [
+        {
+          "id": "dbe37865-a89c-469c-a368-36b3d2ab2f8c",
+          "type": "Birth",
+          "date": "1775",
+          "standard_date": "1775"
+        },
+        {
+          "id": "45e7d3ae-e75a-4a01-af93-836675607c34",
+          "type": "Death",
+          "date": "24 March 1831",
+          "standard_date": "24 Mar 1831"
+        }
+      ]
+    },
+    {
+      "id": "GPX4-WHM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Reine Sofie",
+          "surname": "Tullier"
+        }
+      ],
+      "facts": [
+        {
+          "id": "d7d6872f-0916-4b5c-a921-27c08d2595c2",
+          "type": "Birth",
+          "date": "26 December 1808",
+          "standard_date": "26 Dec 1808",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        },
+        {
+          "id": "95298767-b9f5-4c7c-a37b-d1643967c33f",
+          "type": "Death",
+          "date": "4 January 1809",
+          "standard_date": "4 Jan 1809",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        }
+      ]
+    },
+    {
+      "id": "GPXW-LB1",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Martin Dauphin",
+          "surname": "Tullier"
+        }
+      ],
+      "facts": [
+        {
+          "id": "663e91e9-2cc5-4433-8aff-1ea84b4f3a9b",
+          "type": "Birth",
+          "date": "10 November 1814",
+          "standard_date": "10 Nov 1814",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        },
+        {
+          "id": "af996fbb-dca6-4b33-8f6d-3263f13ebb44",
+          "type": "Death",
+          "date": "30 July 1852",
+          "standard_date": "30 Jul 1852",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        }
+      ]
+    },
+    {
+      "id": "GPX4-M4C",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Pierre Jacques Louis",
+          "surname": "Tullier"
+        }
+      ],
+      "facts": [
+        {
+          "id": "24916fd7-f82f-4df4-beca-1d8e5c6badbb",
+          "type": "Birth",
+          "date": "13 July 1816",
+          "standard_date": "13 Jul 1816",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        },
+        {
+          "id": "5c105fb7-77a5-4ee6-a99e-09a857d64a20",
+          "type": "Death",
+          "date": "19 January 1817",
+          "standard_date": "19 Jan 1817",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        }
+      ]
+    },
+    {
+      "id": "GPXW-BM8",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Barbe Henriette Constante",
+          "surname": "Tullier"
+        }
+      ],
+      "facts": [
+        {
+          "id": "5d4f851b-cb3e-48a5-b00a-53a3e851119a",
+          "type": "Birth",
+          "date": "17 April 1805",
+          "standard_date": "17 Apr 1805",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        },
+        {
+          "id": "da2a535f-1af3-4d9d-8b1f-d98451dfd9c3",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GPXW-Z79",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Jacobus",
+          "surname": "Tullier"
+        }
+      ],
+      "facts": [
+        {
+          "id": "54529076-86f8-4452-8648-3ba7999c9951",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GQ5B-TF6",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Anna Theresia",
+          "surname": "Devloo"
+        }
+      ],
+      "facts": [
+        {
+          "id": "33390d43-0c14-4fc2-8083-307b0d39c20b",
+          "type": "Birth",
+          "date": "8 July 1735",
+          "standard_date": "8 Jul 1735",
+          "place": "Oostvleteren, Vleteren, West Flanders, Belgium",
+          "standard_place": "Oostvleteren, Vleteren, West Flanders, Belgium"
+        },
+        {
+          "id": "35fedd79-926d-4425-a770-27d5133e15f6",
+          "type": "Death Registration",
+          "date": "8 Feb 1820",
+          "standard_date": "8 Feb 1820",
+          "place": "Bambecque, Nord, France",
+          "standard_place": "Bambecque, Nord, France"
+        },
+        {
+          "id": "66350e6c-0816-46f7-9516-caeeeac45435",
+          "type": "Death",
+          "date": "8 February 1820",
+          "standard_date": "8 Feb 1820",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        }
+      ]
+    },
+    {
+      "id": "GPXW-N8Z",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Charles Louis",
+          "surname": "Tullier"
+        }
+      ],
+      "facts": [
+        {
+          "id": "c22231f6-ccb7-4e21-b316-c45616a6aca9",
+          "type": "Birth",
+          "date": "11 October 1806",
+          "standard_date": "11 Oct 1806",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        },
+        {
+          "id": "a3e8d6ec-e4c4-475e-b716-ebc594aaf041",
+          "type": "Death",
+          "date": "9 February 1807",
+          "standard_date": "9 Feb 1807",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GPX7-28P",
+      "person2": "G8QK-FXP",
+      "facts": [
+        {
+          "id": "e5f824f0-6d85-4b35-bcc3-c6e4d20f5e4b",
+          "type": "Marriage",
+          "date": "24 September 1800",
+          "standard_date": "24 Sep 1800",
+          "place": "Bambecque, Nord, Hauts-de-France, France",
+          "standard_place": "Bambecque, Nord, France"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "GPXW-Z79",
+      "person2": "GQ5B-TF6",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "18 July 1769",
+          "standard_date": "18 Jul 1769"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GPXW-Z79",
+      "child": "GPX7-28P"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GQ5B-TF6",
+      "child": "GPX7-28P"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GPX7-28P",
+      "child": "GPXW-BM8"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "G8QK-FXP",
+      "child": "GPXW-BM8"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "GPX7-28P",
+      "child": "GPXW-N8Z"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "G8QK-FXP",
+      "child": "GPXW-N8Z"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "GPX7-28P",
+      "child": "GPX4-WHM"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "G8QK-FXP",
+      "child": "GPX4-WHM"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "GPX7-28P",
+      "child": "GPXW-LB1"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "G8QK-FXP",
+      "child": "GPXW-LB1"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "GPX7-28P",
+      "child": "GPX4-M4C"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "G8QK-FXP",
+      "child": "GPX4-M4C"
+    }
+  ],
+  "sources": []
+}

--- a/eval/tests/e2e/rafael-reyes-daughter/README.md
+++ b/eval/tests/e2e/rafael-reyes-daughter/README.md
@@ -1,0 +1,34 @@
+# Rafael Reyes — daughter Rita (b./d. 1913)
+
+**Source PID:** `MTNY-RXQ`
+**Rafael Reyes is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+not recorded in the tree; died not recorded in the tree.
+
+## Research question
+
+> Did Rafael Reyes and his wife Serapia Benavides Cueva of Usulután, El Salvador have a daughter named Rita, born and died in 1913?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `MTNY-RXQ` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+hard — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 16, flag `adds_daughter`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — El Salvador, Civil Registration, 1704-2001: death registration, 22 July 1932, Santa Elena, Usulután, for Rita Reyes (b./d. Jan 1913), naming parents Manuel Rafael Reyes and Serapia Benavides. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Rita Reyes as the subject's daughter, plus a `required` finding that the report documents the rejection.
+
+**Strong reason to doubt this match**: the tree records Rafael Reyes's marriage to Serapia Benavides Cueva as **19 January 1860** in Usulután. A daughter born in **1913** would be 53 years after that marriage — an implausible span for a single couple, and far more consistent with a grandson or great-grandson bearing the same repeated family names ("Rafael Reyes" + "Serapia Benavides" recurring in the same small Salvadoran community across generations is entirely plausible). The hint record's father is also named with a middle name, "**Manuel** Rafael Reyes", which the tree's "Rafael Reyes" does not carry — consistent with this being a different, later man of the same family. This fixture is a strong candidate for outcome (c) (false match, most likely a different, later generation) but is left as a recover-type draft finding pending the genealogist's review.

--- a/eval/tests/e2e/rafael-reyes-daughter/expected-findings.json
+++ b/eval/tests/e2e/rafael-reyes-daughter/expected-findings.json
@@ -1,0 +1,22 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Rafael Reyes and Serapia Benavides Cueva had a daughter, Rita Reyes, born and died in January 1913 (death registered 22 July 1932, Santa Elena, Usulután — the registration itself dated decades after the death).",
+      "details": {
+        "subject_person": "Rafael Reyes (MTNY-RXQ)",
+        "relation": "child",
+        "target_person": {
+          "name": "Rita Reyes",
+          "birth": "January 1913",
+          "death": "January 1913, Usulután, El Salvador"
+        }
+      },
+      "supporting_sources": [
+        "El Salvador, Civil Registration, 1704-2001 — death registration, 22 Jul 1932, Santa Elena, Usulután, naming parents Manuel Rafael Reyes and Serapia Benavides"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/rafael-reyes-daughter/fixture.json
+++ b/eval/tests/e2e/rafael-reyes-daughter/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "rafael-reyes-daughter",
+  "name": "Rafael Reyes — daughter Rita (b./d. 1913)",
+  "genre": "record-hint",
+  "source_pid": "MTNY-RXQ",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Rafael Reyes and his wife Serapia Benavides Cueva of Usulután, El Salvador have a daughter named Rita, born and died in 1913?",
+  "tags": {
+    "question_type": "children",
+    "era": "1910s",
+    "geography": "SV"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 16, flag adds_daughter, confidence 3). Draft transcribed from an El Salvador civil registration record; unverified."
+}

--- a/eval/tests/e2e/rafael-reyes-daughter/starting-research.json
+++ b/eval/tests/e2e/rafael-reyes-daughter/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_rafael_reyes_daughter",
+    "objective": "Did Rafael Reyes and his wife Serapia Benavides Cueva of Usulután, El Salvador have a daughter named Rita, born and died in 1913?",
+    "subject_person_ids": [
+      "MTNY-RXQ"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/rafael-reyes-daughter/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/rafael-reyes-daughter/starting-tree.gedcomx.json
@@ -1,0 +1,136 @@
+{
+  "persons": [
+    {
+      "id": "MTNY-RXQ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Rafael",
+          "surname": "Reyes"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MTNY-RFX",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Serapia",
+          "surname": "Benavides Cueva"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MTNY-RF1",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Cipriano",
+          "surname": "Reyes"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MTNY-RNH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Fermina",
+          "surname": "Lozano"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "MTNY-RXQ",
+      "person2": "MTNY-RFX",
+      "facts": [
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "19 JAN 1860",
+          "standard_date": "19 Jan 1860",
+          "place": "Santa Catarina,Usulutan,Usulutan,El Salvador",
+          "standard_place": "Usulután, Usulután, El Salvador"
+        },
+        {
+          "id": "e82ae229-a9f4-4ca2-911a-21c2569ec968",
+          "type": "Marriage",
+          "date": "19 Jan 1860",
+          "standard_date": "19 Jan 1860",
+          "place": "Santa Catarina de Alejandria, Usulután, Usulután, El Salvador",
+          "standard_place": "Santa Catarina de Alejandría, Usulután, Usulután Este, Usulután, El Salvador"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "MTNY-RF1",
+      "person2": "MTNY-RNH"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "MTNY-RF1",
+      "child": "MTNY-RXQ",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "MTNY-RNH",
+      "child": "MTNY-RXQ",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "71KV-X3T",
+      "title": "Rafael Reyes Lozano, \"El Salvador registros parroquiales y diocesanos, 1655-1977\"",
+      "citation": "\"El Salvador registros parroquiales y diocesanos, 1655-1977\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6N9V-VMQL : Wed Dec 17 03:18:40 UTC 2025), Entry for Rafael Reyes Lozano and Cipriano Reyes, 19 Jan 1860.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6N9V-VMQL"
+    },
+    {
+      "id": "9QFY-NSB",
+      "title": "Rafael Reyes, \"El Salvador, Marriages, 1810-1930\"",
+      "citation": "\"El Salvador matrimonios, 1810-1930\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:FGY7-TCL : 16 December 2025), Rafael Reyes, 1860.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FGY7-TCL"
+    }
+  ]
+}

--- a/eval/tests/e2e/rafael-reyes-daughter/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/rafael-reyes-daughter/unstripped-tree.gedcomx.json
@@ -1,0 +1,136 @@
+{
+  "persons": [
+    {
+      "id": "MTNY-RXQ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Rafael",
+          "surname": "Reyes"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MTNY-RFX",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Serapia",
+          "surname": "Benavides Cueva"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MTNY-RF1",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Cipriano",
+          "surname": "Reyes"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "MTNY-RNH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Fermina",
+          "surname": "Lozano"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "MTNY-RXQ",
+      "person2": "MTNY-RFX",
+      "facts": [
+        {
+          "id": "27913e02-f2f7-4653-9bc3-9a13a0896872",
+          "type": "Marriage",
+          "date": "19 JAN 1860",
+          "standard_date": "19 Jan 1860",
+          "place": "Santa Catarina,Usulutan,Usulutan,El Salvador",
+          "standard_place": "Usulután, Usulután, El Salvador"
+        },
+        {
+          "id": "e82ae229-a9f4-4ca2-911a-21c2569ec968",
+          "type": "Marriage",
+          "date": "19 Jan 1860",
+          "standard_date": "19 Jan 1860",
+          "place": "Santa Catarina de Alejandria, Usulután, Usulután, El Salvador",
+          "standard_place": "Santa Catarina de Alejandría, Usulután, Usulután Este, Usulután, El Salvador"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "MTNY-RF1",
+      "person2": "MTNY-RNH"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "MTNY-RF1",
+      "child": "MTNY-RXQ",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "MTNY-RNH",
+      "child": "MTNY-RXQ",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "71KV-X3T",
+      "title": "Rafael Reyes Lozano, \"El Salvador registros parroquiales y diocesanos, 1655-1977\"",
+      "citation": "\"El Salvador registros parroquiales y diocesanos, 1655-1977\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6N9V-VMQL : Wed Dec 17 03:18:40 UTC 2025), Entry for Rafael Reyes Lozano and Cipriano Reyes, 19 Jan 1860.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6N9V-VMQL"
+    },
+    {
+      "id": "9QFY-NSB",
+      "title": "Rafael Reyes, \"El Salvador, Marriages, 1810-1930\"",
+      "citation": "\"El Salvador matrimonios, 1810-1930\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:FGY7-TCL : 16 December 2025), Rafael Reyes, 1860.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FGY7-TCL"
+    }
+  ]
+}

--- a/eval/tests/e2e/rozal-sarman-daughter/README.md
+++ b/eval/tests/e2e/rozal-sarman-daughter/README.md
@@ -1,0 +1,34 @@
+# Sármán Rozál — additional daughter Viktoria (b. abt. 1892)
+
+**Source PID:** `P873-TWP`
+**Rozál Sármán is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+27 September 1872, Livada, Arad, Romania; died not recorded in the tree.
+
+## Research question
+
+> Did Rozál Sármán and her husband István Juhász of Torontál, Hungary have a daughter named Viktoria, baptized about 1892, in addition to their known daughter Ágnes (b. 1894)?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `P873-TWP` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+hard — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 28, flag `adds_daughter`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Hungary, Catholic Church Records, 1636-1895: baptismal entry, Kiszombor, Torontál, naming parents Istvan Juhasz and Rozal Szaz. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Viktoria Juhász as the subject's daughter, plus a `required` finding that the report documents the rejection.
+
+**Reason to doubt this match**: the mother's surname in the hint record is "**Szaz**", which does not resemble the subject's tree surname "**Sármán**" at all — similar to the row-20 Katalin Horák/Liskovics case, this is a materially weaker name link than most of this batch. The father's name "István Juhász" matches the tree's recorded spouse exactly, and a daughter baptized about 1892 fits neatly two years before the tree's known daughter Ágnes (b. 1894) — plausible as an older sibling. The place (Torontál) is consistent with the tree family's documented region. A reviewer should weigh the surname mismatch heavily against the otherwise-consistent father's name and timeline.

--- a/eval/tests/e2e/rozal-sarman-daughter/expected-findings.json
+++ b/eval/tests/e2e/rozal-sarman-daughter/expected-findings.json
@@ -1,0 +1,21 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Rozál Sármán (recorded in the hint as Rozal Szaz) and Istvan Juhasz had a daughter, Viktoria Juhász, baptized about 1892 in Kiszombor, Torontál, in addition to their daughter Ágnes already in the tree (b. 1894).",
+      "details": {
+        "subject_person": "Sármán Rozál (P873-TWP)",
+        "relation": "child",
+        "target_person": {
+          "name": "Viktoria Juhász",
+          "birth": "baptized about 1892, Kiszombor, Torontál, Hungary"
+        }
+      },
+      "supporting_sources": [
+        "Hungary, Catholic Church Records, 1636-1895 — baptismal entry, Kiszombor, Torontál, naming parents Istvan Juhasz and Rozal Szaz"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/rozal-sarman-daughter/fixture.json
+++ b/eval/tests/e2e/rozal-sarman-daughter/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "rozal-sarman-daughter",
+  "name": "Sármán Rozál — additional daughter Viktoria (b. abt. 1892)",
+  "genre": "record-hint",
+  "source_pid": "P873-TWP",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Rozál Sármán and her husband István Juhász of Torontál, Hungary have a daughter named Viktoria, baptized about 1892, in addition to their known daughter Ágnes (b. 1894)?",
+  "tags": {
+    "question_type": "children",
+    "era": "1890s",
+    "geography": "HU"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 28, flag adds_daughter, confidence 3). Draft transcribed from a Hungarian Catholic church record; unverified."
+}

--- a/eval/tests/e2e/rozal-sarman-daughter/starting-research.json
+++ b/eval/tests/e2e/rozal-sarman-daughter/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_rozal_sarman_daughter",
+    "objective": "Did Rozál Sármán and her husband István Juhász of Torontál, Hungary have a daughter named Viktoria, baptized about 1892, in addition to their known daughter Ágnes (b. 1894)?",
+    "subject_person_ids": [
+      "P873-TWP"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/rozal-sarman-daughter/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/rozal-sarman-daughter/starting-tree.gedcomx.json
@@ -1,0 +1,281 @@
+{
+  "persons": [
+    {
+      "id": "P873-TWP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Rozál",
+          "surname": "Sármán"
+        }
+      ],
+      "facts": [
+        {
+          "id": "0e92e801-02a2-4a75-94b9-d8976af1d996",
+          "type": "Birth",
+          "date": "1872. szeptember 27.",
+          "standard_date": "27 1872",
+          "place": "Livada, Arad, Románia",
+          "standard_place": "Livada, Arad, Romania"
+        },
+        {
+          "id": "c804071e-3ae0-4f5a-8db0-be54253f51dd",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PZ4D-4KF",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "István",
+          "surname": "Juhász"
+        }
+      ],
+      "facts": [
+        {
+          "id": "26101c6e-c112-46f0-b13d-5804903e95a0",
+          "type": "Birth",
+          "date": "1868. augusztus 14.",
+          "standard_date": "14 1868",
+          "place": "Torontál, Magyarország Limara",
+          "standard_place": "Torontál, Hungary"
+        },
+        {
+          "id": "f8123867-9526-4108-ac22-7f0aafc5096b",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PZH3-WD7",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "István",
+          "surname": "Juhász"
+        }
+      ],
+      "facts": [
+        {
+          "id": "11aaa817-b474-4615-985a-b0ac06bf4823",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P87Q-2VC",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Katalin",
+          "surname": "Majtényi"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ad67982e-58a2-4561-bc4b-6f44c19037cf",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GG3F-1XM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Ágnes",
+          "surname": "Juhász"
+        }
+      ],
+      "facts": [
+        {
+          "id": "6fefaab1-c44b-42eb-8a8e-dea07f9c5e72",
+          "type": "Birth",
+          "date": "1894. április 13.",
+          "standard_date": "13 1894",
+          "place": "Zimándudvar"
+        },
+        {
+          "id": "fd6a38d6-d2b1-4e55-8899-4e2a88a50193",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PZ4D-2LS",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Veronika",
+          "surname": "Juhász"
+        }
+      ],
+      "facts": [
+        {
+          "id": "2daadfc2-0214-4fa3-a914-06a03f4218c0",
+          "type": "Death"
+        },
+        {
+          "id": "3151750b-5b32-43e5-8009-3848a964ee4a",
+          "type": "LifeSketch",
+          "value": "Vera nénihez került csabai tata fiatal korában, ott lakott, Táncsics u. 41. (kb)laktak."
+        }
+      ]
+    },
+    {
+      "id": "PZ4D-W99",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Antal",
+          "surname": "Juhász"
+        }
+      ],
+      "facts": [
+        {
+          "id": "36e6515c-c3d4-49a0-ba65-2557e6de176a",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PZ4D-81P",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "János",
+          "surname": "Juhász"
+        }
+      ],
+      "facts": [
+        {
+          "id": "12e4feec-f67a-4843-993f-26a4d5c67e36",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P87Q-VF6",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "József",
+          "surname": "Sármán"
+        }
+      ],
+      "facts": [
+        {
+          "id": "3ce33561-bcab-448e-bc19-9238b949d349",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "PZ4D-4KF",
+      "person2": "P873-TWP"
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "P87Q-VF6",
+      "person2": "P87Q-2VC"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "P87Q-VF6",
+      "child": "P873-TWP"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "P87Q-2VC",
+      "child": "P873-TWP"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "PZ4D-4KF",
+      "child": "GG3F-1XM"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "P873-TWP",
+      "child": "GG3F-1XM"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "PZ4D-4KF",
+      "child": "PZ4D-W99"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "P873-TWP",
+      "child": "PZ4D-W99"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "PZ4D-4KF",
+      "child": "PZH3-WD7"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "P873-TWP",
+      "child": "PZH3-WD7"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "PZ4D-4KF",
+      "child": "PZ4D-81P"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "P873-TWP",
+      "child": "PZ4D-81P"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "PZ4D-4KF",
+      "child": "PZ4D-2LS"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "P873-TWP",
+      "child": "PZ4D-2LS"
+    }
+  ],
+  "sources": []
+}

--- a/eval/tests/e2e/rozal-sarman-daughter/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/rozal-sarman-daughter/unstripped-tree.gedcomx.json
@@ -1,0 +1,281 @@
+{
+  "persons": [
+    {
+      "id": "P873-TWP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Rozál",
+          "surname": "Sármán"
+        }
+      ],
+      "facts": [
+        {
+          "id": "0e92e801-02a2-4a75-94b9-d8976af1d996",
+          "type": "Birth",
+          "date": "1872. szeptember 27.",
+          "standard_date": "27 1872",
+          "place": "Livada, Arad, Románia",
+          "standard_place": "Livada, Arad, Romania"
+        },
+        {
+          "id": "c804071e-3ae0-4f5a-8db0-be54253f51dd",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PZ4D-4KF",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "István",
+          "surname": "Juhász"
+        }
+      ],
+      "facts": [
+        {
+          "id": "26101c6e-c112-46f0-b13d-5804903e95a0",
+          "type": "Birth",
+          "date": "1868. augusztus 14.",
+          "standard_date": "14 1868",
+          "place": "Torontál, Magyarország Limara",
+          "standard_place": "Torontál, Hungary"
+        },
+        {
+          "id": "f8123867-9526-4108-ac22-7f0aafc5096b",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PZH3-WD7",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "István",
+          "surname": "Juhász"
+        }
+      ],
+      "facts": [
+        {
+          "id": "11aaa817-b474-4615-985a-b0ac06bf4823",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P87Q-2VC",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Katalin",
+          "surname": "Majtényi"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ad67982e-58a2-4561-bc4b-6f44c19037cf",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GG3F-1XM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Ágnes",
+          "surname": "Juhász"
+        }
+      ],
+      "facts": [
+        {
+          "id": "6fefaab1-c44b-42eb-8a8e-dea07f9c5e72",
+          "type": "Birth",
+          "date": "1894. április 13.",
+          "standard_date": "13 1894",
+          "place": "Zimándudvar"
+        },
+        {
+          "id": "fd6a38d6-d2b1-4e55-8899-4e2a88a50193",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PZ4D-2LS",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Veronika",
+          "surname": "Juhász"
+        }
+      ],
+      "facts": [
+        {
+          "id": "2daadfc2-0214-4fa3-a914-06a03f4218c0",
+          "type": "Death"
+        },
+        {
+          "id": "3151750b-5b32-43e5-8009-3848a964ee4a",
+          "type": "LifeSketch",
+          "value": "Vera nénihez került csabai tata fiatal korában, ott lakott, Táncsics u. 41. (kb)laktak."
+        }
+      ]
+    },
+    {
+      "id": "PZ4D-W99",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Antal",
+          "surname": "Juhász"
+        }
+      ],
+      "facts": [
+        {
+          "id": "36e6515c-c3d4-49a0-ba65-2557e6de176a",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PZ4D-81P",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "János",
+          "surname": "Juhász"
+        }
+      ],
+      "facts": [
+        {
+          "id": "12e4feec-f67a-4843-993f-26a4d5c67e36",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P87Q-VF6",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "József",
+          "surname": "Sármán"
+        }
+      ],
+      "facts": [
+        {
+          "id": "3ce33561-bcab-448e-bc19-9238b949d349",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "PZ4D-4KF",
+      "person2": "P873-TWP"
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "P87Q-VF6",
+      "person2": "P87Q-2VC"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "P87Q-VF6",
+      "child": "P873-TWP"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "P87Q-2VC",
+      "child": "P873-TWP"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "PZ4D-4KF",
+      "child": "GG3F-1XM"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "P873-TWP",
+      "child": "GG3F-1XM"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "PZ4D-4KF",
+      "child": "PZ4D-W99"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "P873-TWP",
+      "child": "PZ4D-W99"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "PZ4D-4KF",
+      "child": "PZH3-WD7"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "P873-TWP",
+      "child": "PZH3-WD7"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "PZ4D-4KF",
+      "child": "PZ4D-81P"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "P873-TWP",
+      "child": "PZ4D-81P"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "PZ4D-4KF",
+      "child": "PZ4D-2LS"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "P873-TWP",
+      "child": "PZ4D-2LS"
+    }
+  ],
+  "sources": []
+}

--- a/eval/tests/e2e/santiago-gonzalez-son/README.md
+++ b/eval/tests/e2e/santiago-gonzalez-son/README.md
@@ -1,0 +1,34 @@
+# Santiago Gonzalez — additional son Manuel (b. 1915)
+
+**Source PID:** `G6MR-VHF`
+**Santiago Gonzalez is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+not recorded in the tree; died not recorded in the tree.
+
+## Research question
+
+> Did Santiago Gonzalez and his wife Petra Tumbaco of Guayaquil, Ecuador have a son named Manuel de Jesus, born 1915, in addition to their two known daughters (b. 1921 and 1934)?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `G6MR-VHF` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 15, flag `adds_son`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Ecuador, Cemetery Records, 1862-2020: burial entry for Manuel de Jesus Gonzalez Tumbaco (b. 1915, d. 5 Dec 1985, Ecuador), naming parents Santiago Gonzalez and Petita Tumbaco. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Manuel de Jesus Gonzalez Tumbaco as the subject's son, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the mother's name is recorded as "Petita Tumbaco" in the hint vs. "Petra Tumbaco" in the tree — a plausible diminutive/nickname variant ("Petita" from "Petra"), and the surname "Tumbaco" and father's given name "Santiago Gonzalez" both match exactly. A birth in 1915 predates the tree's two known daughters (1921, 1934), making Manuel the presumed eldest child — plausible but with no independent tree evidence (no marriage date, no other pre-1921 records) to corroborate the couple already having children by 1915.

--- a/eval/tests/e2e/santiago-gonzalez-son/expected-findings.json
+++ b/eval/tests/e2e/santiago-gonzalez-son/expected-findings.json
@@ -1,0 +1,22 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Santiago Gonzalez and Petra Tumbaco had a son, Manuel de Jesus Gonzalez Tumbaco, born 1915 and died 5 December 1985 in Ecuador, in addition to their two daughters already in the tree (Maria Angela b. 1921, Maria Bartola b. 1934).",
+      "details": {
+        "subject_person": "Santiago Gonzalez (G6MR-VHF)",
+        "relation": "child",
+        "target_person": {
+          "name": "Manuel de Jesus Gonzalez Tumbaco",
+          "birth": "1915, Ecuador",
+          "death": "5 December 1985, Ecuador"
+        }
+      },
+      "supporting_sources": [
+        "Ecuador, Cemetery Records, 1862-2020 — burial entry for Manuel de Jesus Gonzalez Tumbaco, naming parents Santiago Gonzalez and Petita Tumbaco"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/santiago-gonzalez-son/fixture.json
+++ b/eval/tests/e2e/santiago-gonzalez-son/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "santiago-gonzalez-son",
+  "name": "Santiago Gonzalez — additional son Manuel (b. 1915)",
+  "genre": "record-hint",
+  "source_pid": "G6MR-VHF",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Santiago Gonzalez and his wife Petra Tumbaco of Guayaquil, Ecuador have a son named Manuel de Jesus, born 1915, in addition to their two known daughters (b. 1921 and 1934)?",
+  "tags": {
+    "question_type": "children",
+    "era": "1910s",
+    "geography": "EC"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 15, flag adds_son, confidence 3). Draft transcribed from an Ecuadorian cemetery record; unverified."
+}

--- a/eval/tests/e2e/santiago-gonzalez-son/starting-research.json
+++ b/eval/tests/e2e/santiago-gonzalez-son/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_santiago_gonzalez_son",
+    "objective": "Did Santiago Gonzalez and his wife Petra Tumbaco of Guayaquil, Ecuador have a son named Manuel de Jesus, born 1915, in addition to their two known daughters (b. 1921 and 1934)?",
+    "subject_person_ids": [
+      "G6MR-VHF"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/santiago-gonzalez-son/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/santiago-gonzalez-son/starting-tree.gedcomx.json
@@ -1,0 +1,152 @@
+{
+  "persons": [
+    {
+      "id": "G6MR-VHF",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Santiago",
+          "surname": "Gonzalez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "20632850-49c3-437f-9213-b7ac09a8c64b",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "G6MT-HDQ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Petra",
+          "surname": "Tumbaco"
+        }
+      ],
+      "facts": [
+        {
+          "id": "b98bfed4-e327-4246-afe0-544f865eaf70",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GNZV-457",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Maria Angela",
+          "surname": "Gonzalez Tumbaco"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9c3cffdf-e56b-4848-b7e4-628141d89dca",
+          "type": "Birth",
+          "date": "1921",
+          "standard_date": "1921"
+        },
+        {
+          "id": "f80a454f-7f8b-4ca1-9dd4-1bfa2c2764d1",
+          "type": "Death",
+          "date": "25 Dec 1996",
+          "standard_date": "25 Dec 1996",
+          "place": "Guayaquil, Guayas, Ecuador",
+          "standard_place": "Guayaquil, Guayaquil, Guayas, Ecuador"
+        }
+      ]
+    },
+    {
+      "id": "GDL1-W4B",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Maria Bartola",
+          "surname": "González Tumbaco"
+        }
+      ],
+      "facts": [
+        {
+          "id": "82b670fa-961a-4167-a7ce-88b726e36349",
+          "type": "Birth",
+          "date": "1934",
+          "standard_date": "1934",
+          "place": "Guayaquil, Guayas, Ecuador",
+          "standard_place": "Guayaquil, Guayaquil, Guayas, Ecuador"
+        },
+        {
+          "id": "8c555545-7c7c-425f-ac76-1a182ded887f",
+          "type": "Death",
+          "date": "15 de marzo de 2003",
+          "standard_date": "15 Mar 2003",
+          "place": "Guayaquil, Guayas, Ecuador",
+          "standard_place": "Guayaquil, Guayaquil, Guayas, Ecuador"
+        },
+        {
+          "id": "deef7d4e-6a0c-4f13-a619-1df8e7453966",
+          "type": "Burial",
+          "date": "16 de marzo de 2003",
+          "standard_date": "16 Mar 2003",
+          "place": "Cementerio General de Guayaquil, Guayaquil, Guayaquil, Guayas, Ecuador",
+          "standard_place": "Cementerio General de Guayaquil, Guayaquil, Guayas, Ecuador"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "G6MR-VHF",
+      "person2": "G6MT-HDQ"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "G6MR-VHF",
+      "child": "GNZV-457"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "G6MT-HDQ",
+      "child": "GNZV-457"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "G6MR-VHF",
+      "child": "GDL1-W4B"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "G6MT-HDQ",
+      "child": "GDL1-W4B"
+    }
+  ],
+  "sources": [
+    {
+      "id": "3J4Q-1Y8",
+      "title": "Santiago Gonzalez, \"Ecuador, registros de cementerios, 1862-2020\"",
+      "citation": "\"Ecuador, registros de cementerios, 1862-2020\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:8YX3-T5N2 : Fri Mar 08 14:08:21 UTC 2024), Entry for Bartola Gonzalez Tumbaco and Santiago Gonzalez, 15 Mar 2003.",
+      "url": "https://familysearch.org/ark:/61903/1:1:8YX3-T52M"
+    },
+    {
+      "id": "WZ3V-2NF",
+      "title": "Santiago Gonzalez, \"Ecuador, registros de cementerios, 1862-2020\"",
+      "citation": "\"Ecuador, registros de cementerios, 1862-2020\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:DV3G-DKZM : Sun Mar 10 22:57:48 UTC 2024), Entry for Maria Angela Gonzalez Tumbaco and Santiago Gonzalez, 25 Dec 1996.",
+      "url": "https://familysearch.org/ark:/61903/1:1:DV3G-DK6Z"
+    }
+  ]
+}

--- a/eval/tests/e2e/santiago-gonzalez-son/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/santiago-gonzalez-son/unstripped-tree.gedcomx.json
@@ -1,0 +1,152 @@
+{
+  "persons": [
+    {
+      "id": "G6MR-VHF",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Santiago",
+          "surname": "Gonzalez"
+        }
+      ],
+      "facts": [
+        {
+          "id": "20632850-49c3-437f-9213-b7ac09a8c64b",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "G6MT-HDQ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Petra",
+          "surname": "Tumbaco"
+        }
+      ],
+      "facts": [
+        {
+          "id": "b98bfed4-e327-4246-afe0-544f865eaf70",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GNZV-457",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Maria Angela",
+          "surname": "Gonzalez Tumbaco"
+        }
+      ],
+      "facts": [
+        {
+          "id": "9c3cffdf-e56b-4848-b7e4-628141d89dca",
+          "type": "Birth",
+          "date": "1921",
+          "standard_date": "1921"
+        },
+        {
+          "id": "f80a454f-7f8b-4ca1-9dd4-1bfa2c2764d1",
+          "type": "Death",
+          "date": "25 Dec 1996",
+          "standard_date": "25 Dec 1996",
+          "place": "Guayaquil, Guayas, Ecuador",
+          "standard_place": "Guayaquil, Guayaquil, Guayas, Ecuador"
+        }
+      ]
+    },
+    {
+      "id": "GDL1-W4B",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Maria Bartola",
+          "surname": "González Tumbaco"
+        }
+      ],
+      "facts": [
+        {
+          "id": "82b670fa-961a-4167-a7ce-88b726e36349",
+          "type": "Birth",
+          "date": "1934",
+          "standard_date": "1934",
+          "place": "Guayaquil, Guayas, Ecuador",
+          "standard_place": "Guayaquil, Guayaquil, Guayas, Ecuador"
+        },
+        {
+          "id": "8c555545-7c7c-425f-ac76-1a182ded887f",
+          "type": "Death",
+          "date": "15 de marzo de 2003",
+          "standard_date": "15 Mar 2003",
+          "place": "Guayaquil, Guayas, Ecuador",
+          "standard_place": "Guayaquil, Guayaquil, Guayas, Ecuador"
+        },
+        {
+          "id": "deef7d4e-6a0c-4f13-a619-1df8e7453966",
+          "type": "Burial",
+          "date": "16 de marzo de 2003",
+          "standard_date": "16 Mar 2003",
+          "place": "Cementerio General de Guayaquil, Guayaquil, Guayaquil, Guayas, Ecuador",
+          "standard_place": "Cementerio General de Guayaquil, Guayaquil, Guayas, Ecuador"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "G6MR-VHF",
+      "person2": "G6MT-HDQ"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "G6MR-VHF",
+      "child": "GNZV-457"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "G6MT-HDQ",
+      "child": "GNZV-457"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "G6MR-VHF",
+      "child": "GDL1-W4B"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "G6MT-HDQ",
+      "child": "GDL1-W4B"
+    }
+  ],
+  "sources": [
+    {
+      "id": "3J4Q-1Y8",
+      "title": "Santiago Gonzalez, \"Ecuador, registros de cementerios, 1862-2020\"",
+      "citation": "\"Ecuador, registros de cementerios, 1862-2020\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:8YX3-T5N2 : Fri Mar 08 14:08:21 UTC 2024), Entry for Bartola Gonzalez Tumbaco and Santiago Gonzalez, 15 Mar 2003.",
+      "url": "https://familysearch.org/ark:/61903/1:1:8YX3-T52M"
+    },
+    {
+      "id": "WZ3V-2NF",
+      "title": "Santiago Gonzalez, \"Ecuador, registros de cementerios, 1862-2020\"",
+      "citation": "\"Ecuador, registros de cementerios, 1862-2020\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:DV3G-DKZM : Sun Mar 10 22:57:48 UTC 2024), Entry for Maria Angela Gonzalez Tumbaco and Santiago Gonzalez, 25 Dec 1996.",
+      "url": "https://familysearch.org/ark:/61903/1:1:DV3G-DK6Z"
+    }
+  ]
+}

--- a/eval/tests/e2e/sebastiana-sandoval-daughter/README.md
+++ b/eval/tests/e2e/sebastiana-sandoval-daughter/README.md
@@ -1,0 +1,34 @@
+# Sebastiana Sandoval — additional daughter Juana (b. 1876, d. 1879)
+
+**Source PID:** `K2GV-D61`
+**Sebastiana Sandoval is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+not recorded in the tree; died not recorded in the tree.
+
+## Research question
+
+> Did Sebastiana Sandoval and her husband Jose Aguilar of Oaxaca, Mexico have a daughter named Juana, born 1876 and died 1879, in addition to their four known children (b. 1877-1885)?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `K2GV-D61` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 23, flag `adds_daughter`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — México, Oaxaca, Registro Civil, 1861-2002: death registration, 28 October 1879, Tlaxiaco, for Juana Aguilar (b. 1876, d. 1879), naming parents Jose Maria Aguilar and Sebastiana Sandoval. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Juana Aguilar as the subject's daughter, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the father's name is recorded with a middle name, "Jose **Maria** Aguilar", in the hint vs. plain "Jose Aguilar" in the tree — a routine expansion, not a conflict. Juana's birth year (1876) is one year before the tree's earliest recorded child, Juan (b. 1877) — close enough to be a full sibling from the same set of pregnancies rather than a contradiction, though a reviewer should confirm the two aren't the same birth event misindexed under two names. The region (Oaxaca) matches the family's other records exactly.

--- a/eval/tests/e2e/sebastiana-sandoval-daughter/expected-findings.json
+++ b/eval/tests/e2e/sebastiana-sandoval-daughter/expected-findings.json
@@ -1,0 +1,22 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Sebastiana Sandoval and Jose Maria Aguilar (recorded in the tree as Jose Aguilar) had a daughter, Juana Aguilar, born 1876 and died 28 October 1879 in Tlaxiaco, Oaxaca (age about 3), in addition to their four children already in the tree (b. 1877-1885).",
+      "details": {
+        "subject_person": "Sebastiana Sandoval (K2GV-D61)",
+        "relation": "child",
+        "target_person": {
+          "name": "Juana Aguilar",
+          "birth": "1876",
+          "death": "28 October 1879, Tlaxiaco, Oaxaca, Mexico"
+        }
+      },
+      "supporting_sources": [
+        "México, Oaxaca, Registro Civil, 1861-2002 — death registration, 28 Oct 1879, Tlaxiaco, naming parents Jose Maria Aguilar and Sebastiana Sandoval"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/sebastiana-sandoval-daughter/fixture.json
+++ b/eval/tests/e2e/sebastiana-sandoval-daughter/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "sebastiana-sandoval-daughter",
+  "name": "Sebastiana Sandoval — additional daughter Juana (b. 1876, d. 1879)",
+  "genre": "record-hint",
+  "source_pid": "K2GV-D61",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Sebastiana Sandoval and her husband Jose Aguilar of Oaxaca, Mexico have a daughter named Juana, born 1876 and died 1879, in addition to their four known children (b. 1877-1885)?",
+  "tags": {
+    "question_type": "children",
+    "era": "1870s",
+    "geography": "MX"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 23, flag adds_daughter, confidence 3). Draft transcribed from a Mexican civil registration death record; unverified."
+}

--- a/eval/tests/e2e/sebastiana-sandoval-daughter/starting-research.json
+++ b/eval/tests/e2e/sebastiana-sandoval-daughter/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_sebastiana_sandoval_daughter",
+    "objective": "Did Sebastiana Sandoval and her husband Jose Aguilar of Oaxaca, Mexico have a daughter named Juana, born 1876 and died 1879, in addition to their four known children (b. 1877-1885)?",
+    "subject_person_ids": [
+      "K2GV-D61"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/sebastiana-sandoval-daughter/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/sebastiana-sandoval-daughter/starting-tree.gedcomx.json
@@ -1,0 +1,256 @@
+{
+  "persons": [
+    {
+      "id": "K2GV-D61",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Sebastiana",
+          "surname": "Sandoval"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "L4DP-TRJ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Juan",
+          "surname": "Aguilar Sandoval"
+        }
+      ],
+      "facts": [
+        {
+          "id": "8dddb0b5-4223-495c-9f1d-80f37098429e",
+          "type": "Birth",
+          "date": "1877",
+          "standard_date": "1877",
+          "place": "Magdalena Peñasco, Oaxaca, México",
+          "standard_place": "Magdalena Peñasco, Oaxaca, Mexico"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PHS7-Y7L",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Remigio",
+          "surname": "Aguilar"
+        }
+      ],
+      "facts": [
+        {
+          "id": "20e95df4-f747-4a26-8084-8d2a0f96d76c",
+          "type": "Birth",
+          "date": "30 de septiembre de 1879",
+          "standard_date": "30 Sep 1879",
+          "place": "Magdalena Peñasco, Oaxaca, México",
+          "standard_place": "Magdalena Peñasco, Oaxaca, Mexico"
+        },
+        {
+          "id": "e0d0f2ab-77ba-44d1-8332-61e91a798547",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "K2GV-D6B",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Jose",
+          "surname": "Aguilar"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "K2GV-D6Y",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Jose Casimiro Tomas",
+          "surname": "Aguilar Sandoval"
+        }
+      ],
+      "facts": [
+        {
+          "id": "d889f146-9ba7-4106-8597-a74ed0695461",
+          "type": "Birth",
+          "date": "2 de marzo de 1885",
+          "standard_date": "2 Mar 1885",
+          "place": "Santa María Asunción, Santa María Tlahuitoltepec, Oaxaca, México",
+          "standard_place": "Santa María Asunción, Santa María Tlahuitoltepec, Oaxaca, Mexico"
+        },
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "7 de marzo de 1885",
+          "standard_date": "7 Mar 1885",
+          "place": "Santa María Asunción, Santa María Tlahuitoltepec, Oaxaca, México",
+          "standard_place": "Santa María Asunción, Santa María Tlahuitoltepec, Oaxaca, Mexico"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PCQ2-MZX",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Carpio",
+          "surname": "Aguilar Sandoval"
+        }
+      ],
+      "facts": [
+        {
+          "id": "3f234f3b-52c6-4d13-abdd-81d7404298a7",
+          "type": "Birth",
+          "date": "1884",
+          "standard_date": "1884"
+        },
+        {
+          "id": "57809b1f-034b-47a4-89ef-7097abece845",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "K2GV-D6B",
+      "person2": "K2GV-D61"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "K2GV-D6B",
+      "child": "L4DP-TRJ"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "K2GV-D61",
+      "child": "L4DP-TRJ"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "K2GV-D6B",
+      "child": "PHS7-Y7L"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "K2GV-D61",
+      "child": "PHS7-Y7L"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "K2GV-D6B",
+      "child": "PCQ2-MZX"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "K2GV-D61",
+      "child": "PCQ2-MZX"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "K2GV-D6B",
+      "child": "K2GV-D6Y"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "K2GV-D61",
+      "child": "K2GV-D6Y"
+    }
+  ],
+  "sources": [
+    {
+      "id": "W8ND-NYL",
+      "title": "Sebastiana Sandoval, \"México bautismos, 1560-1950\"",
+      "citation": "\"México bautismos, 1560-1950\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N1JH-1HZ : Fri Mar 27 14:20:14 UTC 2026), Entry for Jose Casimiro Tomas Aguilar and Jose Aguilar, 7 Mar 1885.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N1JH-1HD"
+    },
+    {
+      "id": "W9S8-TZB",
+      "title": "Sebastiana Sandoval, \"México, Oaxaca, Registro Civil, 1861-2002\"",
+      "citation": "\"México, Oaxaca, Registro Civil, 1861-2002\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QG9P-1JRZ : Wed Mar 12 12:04:46 UTC 2025), Entry for Remigio Aguilar and José Maria Aguilar, 1 de octubre de 1879.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QG9P-1JRV"
+    },
+    {
+      "id": "W36H-L1F",
+      "title": "Sebastiana Sandova, \"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\"",
+      "citation": "\"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:D2M8-QYMM : Thu Oct 16 19:51:33 UTC 2025), Entry for Carpio Aguilar and Jose Aguilar, 7 Jul 1901.",
+      "url": "https://familysearch.org/ark:/61903/1:1:D2M8-QYW2"
+    },
+    {
+      "id": "WC7L-NSY",
+      "title": "Sebastiana Sandoval, \"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\"",
+      "citation": "\"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:DK7P-YBMM : Fri Jul 19 13:00:10 UTC 2024), Entry for Juan Aguilar and José Aguilar, 14 Jan 1906.",
+      "url": "https://familysearch.org/ark:/61903/1:1:DK75-W6PZ"
+    },
+    {
+      "id": "7HXT-68R",
+      "title": "Sebastiana Sandoval in entry for Juan Aguilar, \"Mexico, Marriages, 1570-1950\"",
+      "citation": "\"México matrimonios, 1570-1950\", database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:JHKV-6RT : 20 May 2021), Sebastiana Sandoval in entry for Juan Aguilar, 1892.",
+      "url": "https://familysearch.org/ark:/61903/1:1:JHKV-6RT"
+    },
+    {
+      "id": "WC7L-Z6P",
+      "title": "Sebastiana Sandoval, \"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\"",
+      "citation": "\"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:D2M8-6S3Z : Mon Jan 20 06:02:23 UTC 2025), Entry for Juan Aguilar and José, 24 Jul 1892.",
+      "url": "https://familysearch.org/ark:/61903/1:1:D2M8-6SZM"
+    },
+    {
+      "id": "7HXT-24Z",
+      "title": "Sebastiana Sandoval, \"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\"",
+      "citation": "\"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:DK7K-SD6Z : Mon Jan 20 03:00:47 UTC 2025), Entry for Juan Aguilarl and Jose, 24 Jul 1892.",
+      "url": "https://familysearch.org/ark:/61903/1:1:DK7K-SD2M"
+    },
+    {
+      "id": "WC7L-8QM",
+      "title": "Sebastiana Sandoval, \"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\"",
+      "citation": "\"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:D2MZ-243Z : Fri Jan 17 18:00:30 UTC 2025), Entry for Juan Aguilar and José Aguilar, 14 Jan 1906.",
+      "url": "https://familysearch.org/ark:/61903/1:1:D2MZ-24ZM"
+    }
+  ]
+}

--- a/eval/tests/e2e/sebastiana-sandoval-daughter/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/sebastiana-sandoval-daughter/unstripped-tree.gedcomx.json
@@ -1,0 +1,256 @@
+{
+  "persons": [
+    {
+      "id": "K2GV-D61",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Sebastiana",
+          "surname": "Sandoval"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "L4DP-TRJ",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Juan",
+          "surname": "Aguilar Sandoval"
+        }
+      ],
+      "facts": [
+        {
+          "id": "8dddb0b5-4223-495c-9f1d-80f37098429e",
+          "type": "Birth",
+          "date": "1877",
+          "standard_date": "1877",
+          "place": "Magdalena Peñasco, Oaxaca, México",
+          "standard_place": "Magdalena Peñasco, Oaxaca, Mexico"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PHS7-Y7L",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Remigio",
+          "surname": "Aguilar"
+        }
+      ],
+      "facts": [
+        {
+          "id": "20e95df4-f747-4a26-8084-8d2a0f96d76c",
+          "type": "Birth",
+          "date": "30 de septiembre de 1879",
+          "standard_date": "30 Sep 1879",
+          "place": "Magdalena Peñasco, Oaxaca, México",
+          "standard_place": "Magdalena Peñasco, Oaxaca, Mexico"
+        },
+        {
+          "id": "e0d0f2ab-77ba-44d1-8332-61e91a798547",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "K2GV-D6B",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Jose",
+          "surname": "Aguilar"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "K2GV-D6Y",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Jose Casimiro Tomas",
+          "surname": "Aguilar Sandoval"
+        }
+      ],
+      "facts": [
+        {
+          "id": "d889f146-9ba7-4106-8597-a74ed0695461",
+          "type": "Birth",
+          "date": "2 de marzo de 1885",
+          "standard_date": "2 Mar 1885",
+          "place": "Santa María Asunción, Santa María Tlahuitoltepec, Oaxaca, México",
+          "standard_place": "Santa María Asunción, Santa María Tlahuitoltepec, Oaxaca, Mexico"
+        },
+        {
+          "id": "40f0a628-7c4f-4a56-89af-dcdc1099d457",
+          "type": "Christening",
+          "date": "7 de marzo de 1885",
+          "standard_date": "7 Mar 1885",
+          "place": "Santa María Asunción, Santa María Tlahuitoltepec, Oaxaca, México",
+          "standard_place": "Santa María Asunción, Santa María Tlahuitoltepec, Oaxaca, Mexico"
+        },
+        {
+          "id": "9381f219-2889-4bfc-9b03-5527232282c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PCQ2-MZX",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Carpio",
+          "surname": "Aguilar Sandoval"
+        }
+      ],
+      "facts": [
+        {
+          "id": "3f234f3b-52c6-4d13-abdd-81d7404298a7",
+          "type": "Birth",
+          "date": "1884",
+          "standard_date": "1884"
+        },
+        {
+          "id": "57809b1f-034b-47a4-89ef-7097abece845",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "K2GV-D6B",
+      "person2": "K2GV-D61"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "K2GV-D6B",
+      "child": "L4DP-TRJ"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "K2GV-D61",
+      "child": "L4DP-TRJ"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "K2GV-D6B",
+      "child": "PHS7-Y7L"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "K2GV-D61",
+      "child": "PHS7-Y7L"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "K2GV-D6B",
+      "child": "PCQ2-MZX"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "K2GV-D61",
+      "child": "PCQ2-MZX"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "K2GV-D6B",
+      "child": "K2GV-D6Y"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "K2GV-D61",
+      "child": "K2GV-D6Y"
+    }
+  ],
+  "sources": [
+    {
+      "id": "W8ND-NYL",
+      "title": "Sebastiana Sandoval, \"México bautismos, 1560-1950\"",
+      "citation": "\"México bautismos, 1560-1950\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:N1JH-1HZ : Fri Mar 27 14:20:14 UTC 2026), Entry for Jose Casimiro Tomas Aguilar and Jose Aguilar, 7 Mar 1885.",
+      "url": "https://familysearch.org/ark:/61903/1:1:N1JH-1HD"
+    },
+    {
+      "id": "W9S8-TZB",
+      "title": "Sebastiana Sandoval, \"México, Oaxaca, Registro Civil, 1861-2002\"",
+      "citation": "\"México, Oaxaca, Registro Civil, 1861-2002\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QG9P-1JRZ : Wed Mar 12 12:04:46 UTC 2025), Entry for Remigio Aguilar and José Maria Aguilar, 1 de octubre de 1879.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QG9P-1JRV"
+    },
+    {
+      "id": "W36H-L1F",
+      "title": "Sebastiana Sandova, \"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\"",
+      "citation": "\"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:D2M8-QYMM : Thu Oct 16 19:51:33 UTC 2025), Entry for Carpio Aguilar and Jose Aguilar, 7 Jul 1901.",
+      "url": "https://familysearch.org/ark:/61903/1:1:D2M8-QYW2"
+    },
+    {
+      "id": "WC7L-NSY",
+      "title": "Sebastiana Sandoval, \"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\"",
+      "citation": "\"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:DK7P-YBMM : Fri Jul 19 13:00:10 UTC 2024), Entry for Juan Aguilar and José Aguilar, 14 Jan 1906.",
+      "url": "https://familysearch.org/ark:/61903/1:1:DK75-W6PZ"
+    },
+    {
+      "id": "7HXT-68R",
+      "title": "Sebastiana Sandoval in entry for Juan Aguilar, \"Mexico, Marriages, 1570-1950\"",
+      "citation": "\"México matrimonios, 1570-1950\", database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:JHKV-6RT : 20 May 2021), Sebastiana Sandoval in entry for Juan Aguilar, 1892.",
+      "url": "https://familysearch.org/ark:/61903/1:1:JHKV-6RT"
+    },
+    {
+      "id": "WC7L-Z6P",
+      "title": "Sebastiana Sandoval, \"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\"",
+      "citation": "\"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:D2M8-6S3Z : Mon Jan 20 06:02:23 UTC 2025), Entry for Juan Aguilar and José, 24 Jul 1892.",
+      "url": "https://familysearch.org/ark:/61903/1:1:D2M8-6SZM"
+    },
+    {
+      "id": "7HXT-24Z",
+      "title": "Sebastiana Sandoval, \"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\"",
+      "citation": "\"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:DK7K-SD6Z : Mon Jan 20 03:00:47 UTC 2025), Entry for Juan Aguilarl and Jose, 24 Jul 1892.",
+      "url": "https://familysearch.org/ark:/61903/1:1:DK7K-SD2M"
+    },
+    {
+      "id": "WC7L-8QM",
+      "title": "Sebastiana Sandoval, \"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\"",
+      "citation": "\"México, Oaxaca, registros parroquiales y diocesanos, 1559-2022\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:D2MZ-243Z : Fri Jan 17 18:00:30 UTC 2025), Entry for Juan Aguilar and José Aguilar, 14 Jan 1906.",
+      "url": "https://familysearch.org/ark:/61903/1:1:D2MZ-24ZM"
+    }
+  ]
+}

--- a/eval/tests/e2e/sebastiano-mingazzini-son/README.md
+++ b/eval/tests/e2e/sebastiano-mingazzini-son/README.md
@@ -1,0 +1,34 @@
+# Sebastiano Mingazzini — additional son Simone (b. 1860)
+
+**Source PID:** `GQSW-B3V`
+**Sebastiano Mingazzini is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+1826, Castel Bolognese, Ravenna, Italy; died not recorded in the tree.
+
+## Research question
+
+> Did Sebastiano Mingazzini and his wife Lucia Silvestrini of Castel Bolognese, Ravenna, Italy have a son named Simone, born 1860, in addition to their three known children (b. 1849-1853)?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `GQSW-B3V` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 22, flag `adds_son`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Italy, Ravenna, Ravenna, Civil Registration (Tribunale), 1866-1943: record for Simone Mingazzini (b. 1860 Faenza, d. 4 Jan 1933 Solarolo), naming parents Sebastiano and Lucia Silvestri. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Simone Mingazzini as the subject's son, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the mother's surname is recorded as "Silvestri" in the hint vs. "Silvestrini" in the tree — a routine Italian surname-suffix variant. The father's given name "Sebastiano" matches exactly, the region (Ravenna, Emilia-Romagna) matches, and a birth in 1860 fits neatly after the tree's three known children (1849, 1852, 1853) as a later child, though the birthplace shifts from Castel Bolognese (the other children) to nearby Faenza — a plausible short-distance move within the same district, but a difference worth noting.

--- a/eval/tests/e2e/sebastiano-mingazzini-son/expected-findings.json
+++ b/eval/tests/e2e/sebastiano-mingazzini-son/expected-findings.json
@@ -1,0 +1,22 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Sebastiano Mingazzini and Lucia Silvestri (recorded in the tree as Silvestrini) had a son, Simone Mingazzini, born 1860 in Faenza and died 4 January 1933 in Solarolo, Ravenna, in addition to their three children already in the tree (Giuseppe b. 1849, Giovanni b. 1852, Francesca b. 1853).",
+      "details": {
+        "subject_person": "Sebastiano Mingazzini (GQSW-B3V)",
+        "relation": "child",
+        "target_person": {
+          "name": "Simone Mingazzini",
+          "birth": "1860, Faenza, Ravenna, Italy",
+          "death": "4 January 1933, Solarolo, Ravenna, Italy"
+        }
+      },
+      "supporting_sources": [
+        "Italy, Ravenna, Ravenna, Civil Registration (Tribunale), 1866-1943 — record naming parents Sebastiano and Lucia Silvestri"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/sebastiano-mingazzini-son/fixture.json
+++ b/eval/tests/e2e/sebastiano-mingazzini-son/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "sebastiano-mingazzini-son",
+  "name": "Sebastiano Mingazzini — additional son Simone (b. 1860)",
+  "genre": "record-hint",
+  "source_pid": "GQSW-B3V",
+  "captured": "2026-07-24",
+  "researcher_question": "Did Sebastiano Mingazzini and his wife Lucia Silvestrini of Castel Bolognese, Ravenna, Italy have a son named Simone, born 1860, in addition to their three known children (b. 1849-1853)?",
+  "tags": {
+    "question_type": "children",
+    "era": "1860s",
+    "geography": "IT"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 22, flag adds_son, confidence 3). Draft transcribed from an Italian civil registration record; unverified."
+}

--- a/eval/tests/e2e/sebastiano-mingazzini-son/starting-research.json
+++ b/eval/tests/e2e/sebastiano-mingazzini-son/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_sebastiano_mingazzini_son",
+    "objective": "Did Sebastiano Mingazzini and his wife Lucia Silvestrini of Castel Bolognese, Ravenna, Italy have a son named Simone, born 1860, in addition to their three known children (b. 1849-1853)?",
+    "subject_person_ids": [
+      "GQSW-B3V"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/sebastiano-mingazzini-son/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/sebastiano-mingazzini-son/starting-tree.gedcomx.json
@@ -1,0 +1,273 @@
+{
+  "persons": [
+    {
+      "id": "GQSW-B3V",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Sebastiano",
+          "surname": "Mingazzini"
+        }
+      ],
+      "facts": [
+        {
+          "id": "dae0f327-22e8-48b7-af81-3efc253ddc00",
+          "type": "Birth",
+          "date": "1826",
+          "standard_date": "1826",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "f91497ba-0f77-4e63-a037-9da9e73463c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GQS4-DYG",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Teresa",
+          "surname": "Liverani"
+        }
+      ],
+      "facts": [
+        {
+          "id": "f8b3e084-fedd-4bb9-a61b-5b7fcdc4076f",
+          "type": "Birth",
+          "date": "circa 1790",
+          "standard_date": "Abt 1790",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "5123317b-6ae2-4ddd-9d47-df54602f68cf",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GQSW-B2K",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Battista",
+          "surname": "Mingazzini"
+        }
+      ],
+      "facts": [
+        {
+          "id": "256f9bbc-38de-4fc7-95fa-f3d9a8ba603d",
+          "type": "Birth",
+          "date": "1801",
+          "standard_date": "1801",
+          "place": "Faenza, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Faenza, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "5c295253-7c3e-4f25-9788-51d0ece952bf",
+          "type": "Death",
+          "date": "7 ottobre 1868",
+          "standard_date": "7 Oct 1868",
+          "place": "Faenza, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Faenza, Ravenna, Emilia-Romagna, Italy"
+        }
+      ]
+    },
+    {
+      "id": "GQS4-MGR",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Giuseppe",
+          "surname": "Mingazzini"
+        }
+      ],
+      "facts": [
+        {
+          "id": "8ad82d4b-f0e9-4048-af5e-61a99e27ad63",
+          "type": "Birth",
+          "date": "1849",
+          "standard_date": "1849",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "043d9df7-75e8-42d0-8093-f96fc8321b2b",
+          "type": "Death",
+          "date": "18 dicembre 1924",
+          "standard_date": "18 Dec 1924",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        }
+      ]
+    },
+    {
+      "id": "GQS4-95W",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Lucia",
+          "surname": "Silvestrini"
+        }
+      ],
+      "facts": [
+        {
+          "id": "c95be337-1d5b-4eec-babc-ac87f6b71937",
+          "type": "Birth",
+          "date": "circa 1830",
+          "standard_date": "Abt 1830",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "13fb19ec-b787-4aae-b030-07ebaa112591",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GQSW-TJW",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Francesca",
+          "surname": "Mingazzini"
+        }
+      ],
+      "facts": [
+        {
+          "id": "18f9453e-0669-4f95-83c3-4790213e559e",
+          "type": "Birth",
+          "date": "1853",
+          "standard_date": "1853",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "938653c4-f5f0-4b2e-85c8-71708823ac6b",
+          "type": "Death",
+          "date": "6 luglio 1938",
+          "standard_date": "6 Jul 1938",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "75baaaaf-36c0-457c-8792-93043062fea6",
+          "type": "Occupation",
+          "value": "Contadina"
+        }
+      ]
+    },
+    {
+      "id": "GQSW-B77",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Giovanni",
+          "surname": "Mingazzini"
+        }
+      ],
+      "facts": [
+        {
+          "id": "58f8367f-911c-40ad-b2ed-3f920054d941",
+          "type": "Birth",
+          "date": "26 febbraio 1852",
+          "standard_date": "26 Feb 1852",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "d8012573-801c-4b3a-8598-e1ff8d69dabd",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GQSW-B3V",
+      "person2": "GQS4-95W"
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "GQSW-B2K",
+      "person2": "GQS4-DYG"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GQSW-B2K",
+      "child": "GQSW-B3V"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GQS4-DYG",
+      "child": "GQSW-B3V"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GQSW-B3V",
+      "child": "GQS4-MGR"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "GQS4-95W",
+      "child": "GQS4-MGR"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "GQSW-B3V",
+      "child": "GQSW-B77"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "GQS4-95W",
+      "child": "GQSW-B77"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "GQSW-B3V",
+      "child": "GQSW-TJW"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "GQS4-95W",
+      "child": "GQSW-TJW"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7Y4G-PCY",
+      "title": "Sebastiano, “Italia, Ravenna, Ravenna, Stato Civile (Tribunale), 1866-1943”",
+      "citation": "\"Italia, Ravenna, Ravenna, Stato Civile (Tribunale), 1866-1943\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6JPZ-J7PF : Thu Apr 11 14:23:07 UTC 2024), Entry for Francesca Mingazzini and Sebastiano, 6 Jul 1938.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6JPZ-J7PN"
+    }
+  ]
+}

--- a/eval/tests/e2e/sebastiano-mingazzini-son/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/sebastiano-mingazzini-son/unstripped-tree.gedcomx.json
@@ -1,0 +1,273 @@
+{
+  "persons": [
+    {
+      "id": "GQSW-B3V",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Sebastiano",
+          "surname": "Mingazzini"
+        }
+      ],
+      "facts": [
+        {
+          "id": "dae0f327-22e8-48b7-af81-3efc253ddc00",
+          "type": "Birth",
+          "date": "1826",
+          "standard_date": "1826",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "f91497ba-0f77-4e63-a037-9da9e73463c1",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GQS4-DYG",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Teresa",
+          "surname": "Liverani"
+        }
+      ],
+      "facts": [
+        {
+          "id": "f8b3e084-fedd-4bb9-a61b-5b7fcdc4076f",
+          "type": "Birth",
+          "date": "circa 1790",
+          "standard_date": "Abt 1790",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "5123317b-6ae2-4ddd-9d47-df54602f68cf",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GQSW-B2K",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Battista",
+          "surname": "Mingazzini"
+        }
+      ],
+      "facts": [
+        {
+          "id": "256f9bbc-38de-4fc7-95fa-f3d9a8ba603d",
+          "type": "Birth",
+          "date": "1801",
+          "standard_date": "1801",
+          "place": "Faenza, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Faenza, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "5c295253-7c3e-4f25-9788-51d0ece952bf",
+          "type": "Death",
+          "date": "7 ottobre 1868",
+          "standard_date": "7 Oct 1868",
+          "place": "Faenza, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Faenza, Ravenna, Emilia-Romagna, Italy"
+        }
+      ]
+    },
+    {
+      "id": "GQS4-MGR",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Giuseppe",
+          "surname": "Mingazzini"
+        }
+      ],
+      "facts": [
+        {
+          "id": "8ad82d4b-f0e9-4048-af5e-61a99e27ad63",
+          "type": "Birth",
+          "date": "1849",
+          "standard_date": "1849",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "043d9df7-75e8-42d0-8093-f96fc8321b2b",
+          "type": "Death",
+          "date": "18 dicembre 1924",
+          "standard_date": "18 Dec 1924",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        }
+      ]
+    },
+    {
+      "id": "GQS4-95W",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Lucia",
+          "surname": "Silvestrini"
+        }
+      ],
+      "facts": [
+        {
+          "id": "c95be337-1d5b-4eec-babc-ac87f6b71937",
+          "type": "Birth",
+          "date": "circa 1830",
+          "standard_date": "Abt 1830",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "13fb19ec-b787-4aae-b030-07ebaa112591",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GQSW-TJW",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Francesca",
+          "surname": "Mingazzini"
+        }
+      ],
+      "facts": [
+        {
+          "id": "18f9453e-0669-4f95-83c3-4790213e559e",
+          "type": "Birth",
+          "date": "1853",
+          "standard_date": "1853",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "938653c4-f5f0-4b2e-85c8-71708823ac6b",
+          "type": "Death",
+          "date": "6 luglio 1938",
+          "standard_date": "6 Jul 1938",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "75baaaaf-36c0-457c-8792-93043062fea6",
+          "type": "Occupation",
+          "value": "Contadina"
+        }
+      ]
+    },
+    {
+      "id": "GQSW-B77",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Giovanni",
+          "surname": "Mingazzini"
+        }
+      ],
+      "facts": [
+        {
+          "id": "58f8367f-911c-40ad-b2ed-3f920054d941",
+          "type": "Birth",
+          "date": "26 febbraio 1852",
+          "standard_date": "26 Feb 1852",
+          "place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italia",
+          "standard_place": "Castel Bolognese, Ravenna, Emilia-Romagna, Italy"
+        },
+        {
+          "id": "d8012573-801c-4b3a-8598-e1ff8d69dabd",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GQSW-B3V",
+      "person2": "GQS4-95W"
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "GQSW-B2K",
+      "person2": "GQS4-DYG"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GQSW-B2K",
+      "child": "GQSW-B3V"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GQS4-DYG",
+      "child": "GQSW-B3V"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GQSW-B3V",
+      "child": "GQS4-MGR"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "GQS4-95W",
+      "child": "GQS4-MGR"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "GQSW-B3V",
+      "child": "GQSW-B77"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "GQS4-95W",
+      "child": "GQSW-B77"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "GQSW-B3V",
+      "child": "GQSW-TJW"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "GQS4-95W",
+      "child": "GQSW-TJW"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7Y4G-PCY",
+      "title": "Sebastiano, “Italia, Ravenna, Ravenna, Stato Civile (Tribunale), 1866-1943”",
+      "citation": "\"Italia, Ravenna, Ravenna, Stato Civile (Tribunale), 1866-1943\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6JPZ-J7PF : Thu Apr 11 14:23:07 UTC 2024), Entry for Francesca Mingazzini and Sebastiano, 6 Jul 1938.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6JPZ-J7PN"
+    }
+  ]
+}

--- a/eval/tests/e2e/susanna-dawson-marriage/README.md
+++ b/eval/tests/e2e/susanna-dawson-marriage/README.md
@@ -1,0 +1,34 @@
+# Susanna Dawson Kneale — marriage and father John Dawson
+
+**Source PID:** `9KNQ-8YB`
+**Susanna Dawson Kneale is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+1840, Lezayre, Isle of Man; died not recorded in the tree (last residence 1901, England).
+
+## Research question
+
+> When and where did Susanna Dawson marry John Kneale, and who was her father?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `9KNQ-8YB` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+easy — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 21, flags `adds_father`/`adds_marriage`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Isle of Man, Parish Registers, 1598-2009: marriage entry, 21 October 1860, Lezayre, for John Kneale (son of Thomas Kneale) and Susanna Dawson (daughter of John Dawson). The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard, plus a `required` finding that the report documents the rejection.
+
+This is one of the **stronger** candidate matches in the batch: the groom's name "John Kneale" matches the tree's recorded spouse exactly, the tree currently has **no** marriage date or father recorded for Susanna at all, and the marriage date (21 October 1860) falls almost exactly eleven months before the couple's first tree-recorded child (Thomas, b. 1861) — a textbook first-child interval. The father's name, John Dawson, matching the bride's surname "Dawson" (already part of the subject's full recorded name, "Susanna Dawson Kneale"), is an additional point in favor rather than a coincidence.

--- a/eval/tests/e2e/susanna-dawson-marriage/expected-findings.json
+++ b/eval/tests/e2e/susanna-dawson-marriage/expected-findings.json
@@ -1,0 +1,36 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "fact",
+      "description": "Susanna Dawson married John Kneale on 21 October 1860 in Lezayre, Isle of Man — eleven months before their first child Thomas was born (1861). The tree currently records this couple with no marriage date.",
+      "details": {
+        "subject_person": "Susanna Dawson Kneale (9KNQ-8YB)",
+        "fact_type": "Marriage",
+        "date": "21 October 1860",
+        "place": "Lezayre, Isle of Man"
+      },
+      "supporting_sources": [
+        "Isle of Man, Parish Registers, 1598-2009 — marriage entry, 21 Oct 1860, Lezayre, for John Kneale (son of Thomas Kneale) and Susanna Dawson (daughter of John Dawson)"
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "relationship",
+      "description": "Susanna Dawson Kneale's father was John Dawson, per the same marriage record.",
+      "details": {
+        "subject_person": "Susanna Dawson Kneale (9KNQ-8YB)",
+        "relation": "parent",
+        "target_person": {
+          "name": "John Dawson",
+          "birth": "unknown, likely Isle of Man"
+        }
+      },
+      "supporting_sources": [
+        "Isle of Man, Parish Registers, 1598-2009 — marriage entry, 21 Oct 1860, Lezayre"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/susanna-dawson-marriage/fixture.json
+++ b/eval/tests/e2e/susanna-dawson-marriage/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "susanna-dawson-marriage",
+  "name": "Susanna Dawson Kneale — marriage and father John Dawson",
+  "genre": "record-hint",
+  "source_pid": "9KNQ-8YB",
+  "captured": "2026-07-24",
+  "researcher_question": "When and where did Susanna Dawson marry John Kneale, and who was her father?",
+  "tags": {
+    "question_type": "marriage",
+    "era": "1860s",
+    "geography": "IM"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "easy",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 21, flags adds_father/adds_marriage, confidence 3). Draft transcribed from an Isle of Man parish marriage record; unverified."
+}

--- a/eval/tests/e2e/susanna-dawson-marriage/starting-research.json
+++ b/eval/tests/e2e/susanna-dawson-marriage/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_susanna_dawson_marriage",
+    "objective": "When and where did Susanna Dawson marry John Kneale, and who was her father?",
+    "subject_person_ids": [
+      "9KNQ-8YB"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/susanna-dawson-marriage/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/susanna-dawson-marriage/starting-tree.gedcomx.json
@@ -1,0 +1,708 @@
+{
+  "persons": [
+    {
+      "id": "9KNQ-8YB",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Susanna",
+          "surname": "Dawson Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "fb1277e7-d27c-481a-b158-aa13b3c7192d",
+          "type": "Birth",
+          "date": "1840",
+          "standard_date": "1840",
+          "place": "Lezayre, Isle of Man",
+          "standard_place": "Lezayre, Isle of Man"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        },
+        {
+          "id": "f8e9c1ca-a1ce-4d27-a383-905a0563be40",
+          "type": "Residence",
+          "date": "1871",
+          "standard_date": "1871",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "a4ace172-687f-458c-988b-a658b271b017",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "98e3766c-7a41-445c-9afd-40bf24be42db",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "England, United Kingdom",
+          "standard_place": "England, United Kingdom"
+        },
+        {
+          "id": "aff172f9-e444-4081-bd98-c44bfdf39941",
+          "type": "Marital Status",
+          "value": "Married"
+        }
+      ]
+    },
+    {
+      "id": "9KNQ-8YD",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "John",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "3dc100f0-2568-4015-a99e-537b61012221",
+          "type": "Birth",
+          "date": "1839",
+          "standard_date": "1839",
+          "place": "Andreas, Isle of Man",
+          "standard_place": "Andreas, Isle of Man"
+        },
+        {
+          "id": "148008bf-96ed-425b-9fa0-769f799665e5",
+          "type": "Residence",
+          "date": "1871",
+          "standard_date": "1871",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "ab7f11c0-8b82-40d4-8895-45b7721a5f0a",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "63479506-e5d4-46c4-9a7a-8c67bc9e0254",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "England, United Kingdom",
+          "standard_place": "England, United Kingdom"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        },
+        {
+          "id": "bf820ef7-8b57-48c4-b937-a113799fffa4",
+          "type": "Marital Status",
+          "value": "Married"
+        },
+        {
+          "id": "19d0f2e7-ed2a-422c-a35e-15185a167814",
+          "type": "Occupation",
+          "value": "SHOEMAKER JOURNEYMAN"
+        },
+        {
+          "id": "33ac1e89-a8b5-4228-9da2-e8055df97fef",
+          "type": "Occupation",
+          "value": "Shoemaker"
+        },
+        {
+          "id": "4ec40f61-e6d7-4f85-b054-bc5dae842bb1",
+          "type": "Occupation",
+          "value": "Boat Maker"
+        }
+      ]
+    },
+    {
+      "id": "GBSL-3WT",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Thomas",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "61670deb-1e01-49ff-a233-664f7251d1e5",
+          "type": "Birth",
+          "date": "1861",
+          "standard_date": "1861",
+          "place": "Lezayre, Isle of Man",
+          "standard_place": "Lezayre, Isle of Man"
+        },
+        {
+          "id": "88999a15-7b13-4e70-b722-72b2d75599ad",
+          "type": "Residence",
+          "date": "1871",
+          "standard_date": "1871",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "b37fb4bc-96a4-4468-b9cc-4550e4f6a3f5",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "b26675f8-484f-467c-92cd-99ef8508d48f",
+          "type": "Death"
+        },
+        {
+          "id": "5d0bd916-6217-4da4-b6c4-580c6ed75082",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "4e7349dc-102a-4bd0-8402-9ed3f341934a",
+          "type": "Occupation",
+          "value": "Shoemaker"
+        },
+        {
+          "id": "88daeb3f-c7d1-4cb2-aa05-a29805cf8b59",
+          "type": "Occupation",
+          "value": "Scholar"
+        }
+      ]
+    },
+    {
+      "id": "GBSS-G4Z",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Lenora M",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "cb99a426-c435-4cf6-ab5c-d79cae7a237c",
+          "type": "Birth",
+          "date": "1877",
+          "standard_date": "1877",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "361e83d2-ba6d-47ae-9b1f-d581b39e3fd5",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "England, United Kingdom",
+          "standard_place": "England, United Kingdom"
+        },
+        {
+          "id": "faa60387-133a-496b-bdc1-4aba921f2c61",
+          "type": "Death"
+        },
+        {
+          "id": "df5484b2-c571-4d8d-9063-227d2906108f",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "5da535b3-6da8-4e76-9e66-2dd02b1fdcec",
+          "type": "Occupation",
+          "value": "MILLINER ASSISTANT"
+        }
+      ]
+    },
+    {
+      "id": "GBSS-56D",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Edward D",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "0d595efa-6876-4d7c-aa77-6af2d118f06e",
+          "type": "Birth",
+          "date": "1874",
+          "standard_date": "1874",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "8f908f76-7df6-479e-b9d3-dc7d85d8ec71",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "444c7a4e-3987-4749-8d5d-3fc1e0b723f8",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "England, United Kingdom",
+          "standard_place": "England, United Kingdom"
+        },
+        {
+          "id": "3e93e372-f1a0-46a7-a8b8-7af9654caadc",
+          "type": "Death"
+        },
+        {
+          "id": "de3e4c1e-019d-4331-8559-7ed750e8c282",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "d26a0531-3dca-4ec3-b77c-9fcc11b57a4d",
+          "type": "Occupation",
+          "value": "CARPENTER JOURNEYMAN"
+        },
+        {
+          "id": "e2b59406-1ba6-4f10-a017-b60fb0cb8671",
+          "type": "Occupation",
+          "value": "Scholar"
+        }
+      ]
+    },
+    {
+      "id": "GBSS-HQJ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Jane",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "5cfe3491-c8dc-4d1e-aa71-4fdf3a70c211",
+          "type": "Birth",
+          "date": "1866",
+          "standard_date": "1866",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "8cc56d81-dafb-4c7f-ba56-f7aa2575b285",
+          "type": "Residence",
+          "date": "1871",
+          "standard_date": "1871",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "36177d04-6ad9-4663-82e0-7c1725a911f7",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "b5dd0e9d-27f2-47ad-abb3-550b63f3666c",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "England, United Kingdom",
+          "standard_place": "England, United Kingdom"
+        },
+        {
+          "id": "75028e21-fde4-4a20-a278-701a844f263e",
+          "type": "Death"
+        },
+        {
+          "id": "c1fcaf3b-a79b-49c6-be6c-ec91ed7c678f",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "8ace0790-0d11-4976-a188-8be89f4ff5bc",
+          "type": "Occupation",
+          "value": "DRESSMAKER"
+        },
+        {
+          "id": "3d5e8d09-30c4-4d31-b4fb-019b9e1c195e",
+          "type": "Occupation",
+          "value": "Scholar"
+        }
+      ]
+    },
+    {
+      "id": "GBSS-99Q",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Louisa",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "5c9ee662-d31b-4276-9bba-2cd0d1db77e5",
+          "type": "Residence",
+          "date": "1871",
+          "standard_date": "1871",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "4c0bd1b8-6af1-4b8c-bb47-2f27a9d76b6f",
+          "type": "Birth",
+          "date": "1872",
+          "standard_date": "1872",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "74c5d974-1c16-4a60-9bbc-15d5b2dbf143",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "bbaf8c21-b988-463b-a7f1-124da2c948a2",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "England, United Kingdom",
+          "standard_place": "England, United Kingdom"
+        },
+        {
+          "id": "189a82c0-f53b-4268-8885-55fd1608f7fc",
+          "type": "Death"
+        },
+        {
+          "id": "dc3d3b86-e4e1-4cce-b74e-88899ca59845",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "3fd53805-40fb-48d8-a554-874576113a17",
+          "type": "Occupation",
+          "value": "DRESSMAKER"
+        },
+        {
+          "id": "f91b6551-df96-4f58-b449-71568316c18d",
+          "type": "Occupation",
+          "value": "Scholar"
+        }
+      ]
+    },
+    {
+      "id": "GBSL-4KM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Mary",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "8dd16a84-ec60-4c20-adcc-437d67deafd3",
+          "type": "Birth",
+          "date": "1875",
+          "standard_date": "1875",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "c415e7b7-6bb7-45fc-a553-a7c8529dbf8e",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "baa2defa-a607-4e1f-93cb-407327b89fbd",
+          "type": "Death"
+        },
+        {
+          "id": "d9d98c61-ed28-4fa4-bfe0-380f7ad15df3",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "6efc8df3-5bc3-4faf-bc08-117d83efdc90",
+          "type": "Occupation",
+          "value": "Scholar"
+        }
+      ]
+    },
+    {
+      "id": "GBSL-M1Y",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Susannah",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "2efb40dd-2bd0-428c-97c7-1ae5ec98368c",
+          "type": "Birth",
+          "date": "1865",
+          "standard_date": "1865",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "c98efcfd-cbd0-4b1f-a09a-e19fc9c6ea72",
+          "type": "Residence",
+          "date": "1871",
+          "standard_date": "1871",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "0c191f9b-2a27-413b-9170-f58b561bceda",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "4c5e15bc-0cc6-4e47-835b-b98ed63f5745",
+          "type": "Death"
+        },
+        {
+          "id": "99e31768-cd1c-46a8-9f98-76417066e0ed",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "03956eea-1dac-47b0-97f0-14a67c26f9a8",
+          "type": "Occupation",
+          "value": "No Occupation"
+        },
+        {
+          "id": "0c96c9fd-c1fb-4702-aca9-61239f6d1f89",
+          "type": "Occupation",
+          "value": "Scholar"
+        }
+      ]
+    },
+    {
+      "id": "9KNQ-8T4",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "William",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "19 Oct 1878",
+          "standard_date": "19 Oct 1878",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "25d22f0e-8808-4764-9f9a-c6cc65a6f84b",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "fea46157-0ea1-409d-bc64-ee8790e2a272",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "England, United Kingdom",
+          "standard_place": "England, United Kingdom"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        },
+        {
+          "id": "776159d5-4750-453f-9975-84b9beca377b",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "37f27274-9d3d-4018-a27c-6e1328e2e295",
+          "type": "Occupation",
+          "value": "DRAPER'S ASSISTANT"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "9KNQ-8YD",
+      "person2": "9KNQ-8YB"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "GBSL-3WT"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "GBSL-3WT"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "GBSL-M1Y"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "GBSL-M1Y"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "GBSS-HQJ"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "GBSS-HQJ"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "GBSS-99Q"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "GBSS-99Q"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "GBSS-56D"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "GBSS-56D"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "GBSL-4KM"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "GBSL-4KM"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "GBSS-G4Z"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "GBSS-G4Z"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "9KNQ-8T4",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R17",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "9KNQ-8T4",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7QXM-QMJ",
+      "title": "Susannah Kneale, \"England and Wales, Census, 1881\"",
+      "citation": "\"England and Wales, Census, 1881\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q2WS-L64C : Tue Mar 05 17:54:12 UTC 2024), Entry for John Kneale and Susannah Kneale, 1881.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q2WS-L6HW"
+    },
+    {
+      "id": "7QNS-CDK",
+      "title": "Susannah Kneale, \"England and Wales, Census, 1871\"",
+      "citation": "\"England and Wales, Census, 1871\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VFTR-GNX : Tue Oct 08 14:36:48 UTC 2024), Entry for John Kneale and Susannah Kneale, 1871.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VFTR-GNF"
+    },
+    {
+      "id": "7QD4-YBC",
+      "title": "Susanna Kneale, \"England and Wales, Census, 1901\"",
+      "citation": "\"England and Wales, Census, 1901\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:X91V-6GY : Thu Feb 13 05:49:41 UTC 2025), Entry for John Kneale and Susanna Kneale, 31 Mar 1901.",
+      "url": "https://familysearch.org/ark:/61903/1:1:X91V-6GB"
+    },
+    {
+      "id": "M65Q-4P6",
+      "title": "Susanna Dawson Kneale in entry for William Kneale, \"Isle of Man, Births and Baptisms, 1607-1910\"",
+      "citation": "\"Isle of Man, Births and Baptisms, 1607-1910\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:X5PH-6S7 : 6 February 2020), Susanna Dawson Kneale in entry for William Kneale, 1878.",
+      "url": "https://familysearch.org/ark:/61903/1:1:X5PH-6S7"
+    },
+    {
+      "id": "937C-Z2F",
+      "title": "Susanna Dawson Kneale in entry for William Kneale, \"Isle of Man, Births and Baptisms, 1607-1910\"",
+      "citation": "\"Isle of Man, Births and Baptisms, 1607-1910\", database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:J33R-GB5 : 6 February 2020), Susanna Dawson Kneale in entry for William Kneale, 1878.",
+      "url": "https://familysearch.org/ark:/61903/1:1:J33R-GB5"
+    }
+  ]
+}

--- a/eval/tests/e2e/susanna-dawson-marriage/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/susanna-dawson-marriage/unstripped-tree.gedcomx.json
@@ -1,0 +1,708 @@
+{
+  "persons": [
+    {
+      "id": "9KNQ-8YB",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Susanna",
+          "surname": "Dawson Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "fb1277e7-d27c-481a-b158-aa13b3c7192d",
+          "type": "Birth",
+          "date": "1840",
+          "standard_date": "1840",
+          "place": "Lezayre, Isle of Man",
+          "standard_place": "Lezayre, Isle of Man"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        },
+        {
+          "id": "f8e9c1ca-a1ce-4d27-a383-905a0563be40",
+          "type": "Residence",
+          "date": "1871",
+          "standard_date": "1871",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "a4ace172-687f-458c-988b-a658b271b017",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "98e3766c-7a41-445c-9afd-40bf24be42db",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "England, United Kingdom",
+          "standard_place": "England, United Kingdom"
+        },
+        {
+          "id": "aff172f9-e444-4081-bd98-c44bfdf39941",
+          "type": "Marital Status",
+          "value": "Married"
+        }
+      ]
+    },
+    {
+      "id": "9KNQ-8YD",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "John",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "3dc100f0-2568-4015-a99e-537b61012221",
+          "type": "Birth",
+          "date": "1839",
+          "standard_date": "1839",
+          "place": "Andreas, Isle of Man",
+          "standard_place": "Andreas, Isle of Man"
+        },
+        {
+          "id": "148008bf-96ed-425b-9fa0-769f799665e5",
+          "type": "Residence",
+          "date": "1871",
+          "standard_date": "1871",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "ab7f11c0-8b82-40d4-8895-45b7721a5f0a",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "63479506-e5d4-46c4-9a7a-8c67bc9e0254",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "England, United Kingdom",
+          "standard_place": "England, United Kingdom"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        },
+        {
+          "id": "bf820ef7-8b57-48c4-b937-a113799fffa4",
+          "type": "Marital Status",
+          "value": "Married"
+        },
+        {
+          "id": "19d0f2e7-ed2a-422c-a35e-15185a167814",
+          "type": "Occupation",
+          "value": "SHOEMAKER JOURNEYMAN"
+        },
+        {
+          "id": "33ac1e89-a8b5-4228-9da2-e8055df97fef",
+          "type": "Occupation",
+          "value": "Shoemaker"
+        },
+        {
+          "id": "4ec40f61-e6d7-4f85-b054-bc5dae842bb1",
+          "type": "Occupation",
+          "value": "Boat Maker"
+        }
+      ]
+    },
+    {
+      "id": "GBSL-3WT",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Thomas",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "61670deb-1e01-49ff-a233-664f7251d1e5",
+          "type": "Birth",
+          "date": "1861",
+          "standard_date": "1861",
+          "place": "Lezayre, Isle of Man",
+          "standard_place": "Lezayre, Isle of Man"
+        },
+        {
+          "id": "88999a15-7b13-4e70-b722-72b2d75599ad",
+          "type": "Residence",
+          "date": "1871",
+          "standard_date": "1871",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "b37fb4bc-96a4-4468-b9cc-4550e4f6a3f5",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "b26675f8-484f-467c-92cd-99ef8508d48f",
+          "type": "Death"
+        },
+        {
+          "id": "5d0bd916-6217-4da4-b6c4-580c6ed75082",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "4e7349dc-102a-4bd0-8402-9ed3f341934a",
+          "type": "Occupation",
+          "value": "Shoemaker"
+        },
+        {
+          "id": "88daeb3f-c7d1-4cb2-aa05-a29805cf8b59",
+          "type": "Occupation",
+          "value": "Scholar"
+        }
+      ]
+    },
+    {
+      "id": "GBSS-G4Z",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Lenora M",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "cb99a426-c435-4cf6-ab5c-d79cae7a237c",
+          "type": "Birth",
+          "date": "1877",
+          "standard_date": "1877",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "361e83d2-ba6d-47ae-9b1f-d581b39e3fd5",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "England, United Kingdom",
+          "standard_place": "England, United Kingdom"
+        },
+        {
+          "id": "faa60387-133a-496b-bdc1-4aba921f2c61",
+          "type": "Death"
+        },
+        {
+          "id": "df5484b2-c571-4d8d-9063-227d2906108f",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "5da535b3-6da8-4e76-9e66-2dd02b1fdcec",
+          "type": "Occupation",
+          "value": "MILLINER ASSISTANT"
+        }
+      ]
+    },
+    {
+      "id": "GBSS-56D",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Edward D",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "0d595efa-6876-4d7c-aa77-6af2d118f06e",
+          "type": "Birth",
+          "date": "1874",
+          "standard_date": "1874",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "8f908f76-7df6-479e-b9d3-dc7d85d8ec71",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "444c7a4e-3987-4749-8d5d-3fc1e0b723f8",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "England, United Kingdom",
+          "standard_place": "England, United Kingdom"
+        },
+        {
+          "id": "3e93e372-f1a0-46a7-a8b8-7af9654caadc",
+          "type": "Death"
+        },
+        {
+          "id": "de3e4c1e-019d-4331-8559-7ed750e8c282",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "d26a0531-3dca-4ec3-b77c-9fcc11b57a4d",
+          "type": "Occupation",
+          "value": "CARPENTER JOURNEYMAN"
+        },
+        {
+          "id": "e2b59406-1ba6-4f10-a017-b60fb0cb8671",
+          "type": "Occupation",
+          "value": "Scholar"
+        }
+      ]
+    },
+    {
+      "id": "GBSS-HQJ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Jane",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "5cfe3491-c8dc-4d1e-aa71-4fdf3a70c211",
+          "type": "Birth",
+          "date": "1866",
+          "standard_date": "1866",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "8cc56d81-dafb-4c7f-ba56-f7aa2575b285",
+          "type": "Residence",
+          "date": "1871",
+          "standard_date": "1871",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "36177d04-6ad9-4663-82e0-7c1725a911f7",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "b5dd0e9d-27f2-47ad-abb3-550b63f3666c",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "England, United Kingdom",
+          "standard_place": "England, United Kingdom"
+        },
+        {
+          "id": "75028e21-fde4-4a20-a278-701a844f263e",
+          "type": "Death"
+        },
+        {
+          "id": "c1fcaf3b-a79b-49c6-be6c-ec91ed7c678f",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "8ace0790-0d11-4976-a188-8be89f4ff5bc",
+          "type": "Occupation",
+          "value": "DRESSMAKER"
+        },
+        {
+          "id": "3d5e8d09-30c4-4d31-b4fb-019b9e1c195e",
+          "type": "Occupation",
+          "value": "Scholar"
+        }
+      ]
+    },
+    {
+      "id": "GBSS-99Q",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Louisa",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "5c9ee662-d31b-4276-9bba-2cd0d1db77e5",
+          "type": "Residence",
+          "date": "1871",
+          "standard_date": "1871",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "4c0bd1b8-6af1-4b8c-bb47-2f27a9d76b6f",
+          "type": "Birth",
+          "date": "1872",
+          "standard_date": "1872",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "74c5d974-1c16-4a60-9bbc-15d5b2dbf143",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "bbaf8c21-b988-463b-a7f1-124da2c948a2",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "England, United Kingdom",
+          "standard_place": "England, United Kingdom"
+        },
+        {
+          "id": "189a82c0-f53b-4268-8885-55fd1608f7fc",
+          "type": "Death"
+        },
+        {
+          "id": "dc3d3b86-e4e1-4cce-b74e-88899ca59845",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "3fd53805-40fb-48d8-a554-874576113a17",
+          "type": "Occupation",
+          "value": "DRESSMAKER"
+        },
+        {
+          "id": "f91b6551-df96-4f58-b449-71568316c18d",
+          "type": "Occupation",
+          "value": "Scholar"
+        }
+      ]
+    },
+    {
+      "id": "GBSL-4KM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Mary",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "8dd16a84-ec60-4c20-adcc-437d67deafd3",
+          "type": "Birth",
+          "date": "1875",
+          "standard_date": "1875",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "c415e7b7-6bb7-45fc-a553-a7c8529dbf8e",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "baa2defa-a607-4e1f-93cb-407327b89fbd",
+          "type": "Death"
+        },
+        {
+          "id": "d9d98c61-ed28-4fa4-bfe0-380f7ad15df3",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "6efc8df3-5bc3-4faf-bc08-117d83efdc90",
+          "type": "Occupation",
+          "value": "Scholar"
+        }
+      ]
+    },
+    {
+      "id": "GBSL-M1Y",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Susannah",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "2efb40dd-2bd0-428c-97c7-1ae5ec98368c",
+          "type": "Birth",
+          "date": "1865",
+          "standard_date": "1865",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "c98efcfd-cbd0-4b1f-a09a-e19fc9c6ea72",
+          "type": "Residence",
+          "date": "1871",
+          "standard_date": "1871",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "0c191f9b-2a27-413b-9170-f58b561bceda",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "4c5e15bc-0cc6-4e47-835b-b98ed63f5745",
+          "type": "Death"
+        },
+        {
+          "id": "99e31768-cd1c-46a8-9f98-76417066e0ed",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "03956eea-1dac-47b0-97f0-14a67c26f9a8",
+          "type": "Occupation",
+          "value": "No Occupation"
+        },
+        {
+          "id": "0c96c9fd-c1fb-4702-aca9-61239f6d1f89",
+          "type": "Occupation",
+          "value": "Scholar"
+        }
+      ]
+    },
+    {
+      "id": "9KNQ-8T4",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N10",
+          "given": "William",
+          "surname": "Kneale"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "19 Oct 1878",
+          "standard_date": "19 Oct 1878",
+          "place": "Ramsey, Isle of Man",
+          "standard_place": "Ramsey, Isle of Man"
+        },
+        {
+          "id": "25d22f0e-8808-4764-9f9a-c6cc65a6f84b",
+          "type": "Residence",
+          "date": "1881",
+          "standard_date": "1881",
+          "place": "Maughold, Isle of Man",
+          "standard_place": "Maughold, Isle of Man"
+        },
+        {
+          "id": "fea46157-0ea1-409d-bc64-ee8790e2a272",
+          "type": "Residence",
+          "date": "31 March 1901",
+          "standard_date": "31 Mar 1901",
+          "place": "England, United Kingdom",
+          "standard_place": "England, United Kingdom"
+        },
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        },
+        {
+          "id": "776159d5-4750-453f-9975-84b9beca377b",
+          "type": "Marital Status",
+          "value": "Single"
+        },
+        {
+          "id": "37f27274-9d3d-4018-a27c-6e1328e2e295",
+          "type": "Occupation",
+          "value": "DRAPER'S ASSISTANT"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "9KNQ-8YD",
+      "person2": "9KNQ-8YB"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "GBSL-3WT"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "GBSL-3WT"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "GBSL-M1Y"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "GBSL-M1Y"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "GBSS-HQJ"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "GBSS-HQJ"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "GBSS-99Q"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "GBSS-99Q"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "GBSS-56D"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "GBSS-56D"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "GBSL-4KM"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "GBSL-4KM"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "GBSS-G4Z"
+    },
+    {
+      "id": "R15",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "GBSS-G4Z"
+    },
+    {
+      "id": "R16",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YD",
+      "child": "9KNQ-8T4",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R17",
+      "type": "ParentChild",
+      "parent": "9KNQ-8YB",
+      "child": "9KNQ-8T4",
+      "subtype": "Biological"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7QXM-QMJ",
+      "title": "Susannah Kneale, \"England and Wales, Census, 1881\"",
+      "citation": "\"England and Wales, Census, 1881\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q2WS-L64C : Tue Mar 05 17:54:12 UTC 2024), Entry for John Kneale and Susannah Kneale, 1881.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q2WS-L6HW"
+    },
+    {
+      "id": "7QNS-CDK",
+      "title": "Susannah Kneale, \"England and Wales, Census, 1871\"",
+      "citation": "\"England and Wales, Census, 1871\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:VFTR-GNX : Tue Oct 08 14:36:48 UTC 2024), Entry for John Kneale and Susannah Kneale, 1871.",
+      "url": "https://familysearch.org/ark:/61903/1:1:VFTR-GNF"
+    },
+    {
+      "id": "7QD4-YBC",
+      "title": "Susanna Kneale, \"England and Wales, Census, 1901\"",
+      "citation": "\"England and Wales, Census, 1901\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:X91V-6GY : Thu Feb 13 05:49:41 UTC 2025), Entry for John Kneale and Susanna Kneale, 31 Mar 1901.",
+      "url": "https://familysearch.org/ark:/61903/1:1:X91V-6GB"
+    },
+    {
+      "id": "M65Q-4P6",
+      "title": "Susanna Dawson Kneale in entry for William Kneale, \"Isle of Man, Births and Baptisms, 1607-1910\"",
+      "citation": "\"Isle of Man, Births and Baptisms, 1607-1910\", , <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:X5PH-6S7 : 6 February 2020), Susanna Dawson Kneale in entry for William Kneale, 1878.",
+      "url": "https://familysearch.org/ark:/61903/1:1:X5PH-6S7"
+    },
+    {
+      "id": "937C-Z2F",
+      "title": "Susanna Dawson Kneale in entry for William Kneale, \"Isle of Man, Births and Baptisms, 1607-1910\"",
+      "citation": "\"Isle of Man, Births and Baptisms, 1607-1910\", database, <i>FamilySearch</i> (https://familysearch.org/ark:/61903/1:1:J33R-GB5 : 6 February 2020), Susanna Dawson Kneale in entry for William Kneale, 1878.",
+      "url": "https://familysearch.org/ark:/61903/1:1:J33R-GB5"
+    }
+  ]
+}

--- a/eval/tests/e2e/susanna-szljacsan-spouse/README.md
+++ b/eval/tests/e2e/susanna-szljacsan-spouse/README.md
@@ -1,0 +1,34 @@
+# Susanna Szljacsan — husband Joannes Janeczky and daughter Susanna
+
+**Source PID:** `LDK6-6SH`
+**Susanna Szljacsan is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+5 March 1850, Lisková, Ružomberok, Slovakia; died not recorded in the tree.
+
+## Research question
+
+> Who did Susanna Szljacsan of Lisková, Ružomberok, Slovakia marry, and did she have a daughter named Susanna, baptized about 1884?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `LDK6-6SH` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+medium — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 29, flags `adds_spouse`/`adds_daughter`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Slovakia, Church and Synagogue Books, 1592-1935: baptismal entry for Susanna Janeczky, naming parents Joannes Janeczky and Susanna Szliacsan. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard naming Joannes Janeczky as the subject's husband, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the tree currently records no spouse or children at all for Susanna Szljacsan, so this record would be the first family data past her own baptism. The surname "Szliacsan" in the hint matches the tree's "Szljacsan" almost exactly (a one-letter transposition, a routine transcription variant), and the parish (Lisková, Ružomberok) matches her own baptismal parish exactly. A daughter baptized about 1884 would put Susanna at about age 34 — plausible, though there is no independent tree record of a marriage to cross-check the husband's name against.

--- a/eval/tests/e2e/susanna-szljacsan-spouse/expected-findings.json
+++ b/eval/tests/e2e/susanna-szljacsan-spouse/expected-findings.json
@@ -1,0 +1,38 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Susanna Szljacsan's husband was Joannes Janeczky. The tree currently records no spouse or children for her.",
+      "details": {
+        "subject_person": "Susanna Szljacsan (LDK6-6SH)",
+        "relation": "spouse",
+        "target_person": {
+          "name": "Joannes Janeczky",
+          "birth": "unknown, likely Lisková, Ružomberok, Slovakia"
+        }
+      },
+      "supporting_sources": [
+        "Slovakia, Church and Synagogue Books, 1592-1935 — baptismal entry for Susanna Janeczky, naming parents Joannes Janeczky and Susanna Szliacsan"
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "relationship",
+      "description": "Susanna Szljacsan and Joannes Janeczky had a daughter, Susanna Janeczky, baptized about 1884 in Lisková, Ružomberok.",
+      "details": {
+        "subject_person": "Susanna Szljacsan (LDK6-6SH)",
+        "relation": "child",
+        "target_person": {
+          "name": "Susanna Janeczky",
+          "birth": "baptized about 1884, Lisková, Ružomberok, Slovakia"
+        }
+      },
+      "supporting_sources": [
+        "Slovakia, Church and Synagogue Books, 1592-1935 — baptismal entry, Lisková, Ružomberok"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/susanna-szljacsan-spouse/fixture.json
+++ b/eval/tests/e2e/susanna-szljacsan-spouse/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "susanna-szljacsan-spouse",
+  "name": "Susanna Szljacsan — husband Joannes Janeczky and daughter Susanna",
+  "genre": "record-hint",
+  "source_pid": "LDK6-6SH",
+  "captured": "2026-07-24",
+  "researcher_question": "Who did Susanna Szljacsan of Lisková, Ružomberok, Slovakia marry, and did she have a daughter named Susanna, baptized about 1884?",
+  "tags": {
+    "question_type": "spouse",
+    "era": "1880s",
+    "geography": "SK"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "medium",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 29, flags adds_spouse/adds_daughter, confidence 3). Draft transcribed from a Slovak church/synagogue record; unverified."
+}

--- a/eval/tests/e2e/susanna-szljacsan-spouse/starting-research.json
+++ b/eval/tests/e2e/susanna-szljacsan-spouse/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_susanna_szljacsan_spouse",
+    "objective": "Who did Susanna Szljacsan of Lisková, Ružomberok, Slovakia marry, and did she have a daughter named Susanna, baptized about 1884?",
+    "subject_person_ids": [
+      "LDK6-6SH"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/susanna-szljacsan-spouse/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/susanna-szljacsan-spouse/starting-tree.gedcomx.json
@@ -1,0 +1,132 @@
+{
+  "persons": [
+    {
+      "id": "LDK6-6SH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Susanna",
+          "surname": "Szljacsan"
+        }
+      ],
+      "facts": [
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        },
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "05 Mar 1850",
+          "standard_date": "5 Mar 1850",
+          "place": "Lisková, Ružomberok, Slovakia",
+          "standard_place": "Lisková, Ružomberok, Slovakia"
+        },
+        {
+          "id": "c5650e22-d1cd-424c-b35a-0c1788e102b7",
+          "type": "Baptism",
+          "date": "05 Mar 1850",
+          "standard_date": "5 Mar 1850",
+          "place": "Lisková, Ružomberok, Slovakia",
+          "standard_place": "Lisková, Ružomberok, Slovakia"
+        }
+      ]
+    },
+    {
+      "id": "LDKF-RZK",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Maria",
+          "surname": "Munka"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LDKF-RZV",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "János",
+          "surname": "Szljacsan"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LDK6-6SZ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Maria",
+          "surname": "Boron Munka"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "LDKF-RZV",
+      "person2": "LDKF-RZK"
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "LDKF-RZV",
+      "person2": "LDK6-6SZ"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "LDKF-RZV",
+      "child": "LDK6-6SH"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "LDK6-6SZ",
+      "child": "LDK6-6SH"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "LDKF-RZK",
+      "child": "LDK6-6SH"
+    }
+  ],
+  "sources": [
+    {
+      "id": "SG4J-XT3",
+      "title": "Susanna Szljacsan, \"Slovakia, Church and Synagogue Books, 1592-1935\"",
+      "citation": "\"Slovakia, Church and Synagogue Books, 1592-1935\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KHQN-KC7 : Mon Mar 11 01:33:08 UTC 2024), Entry for Susanna Szljacsan and Joannes Szljacsan, 05 Mar 1850.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KHQN-KC7"
+    }
+  ]
+}

--- a/eval/tests/e2e/susanna-szljacsan-spouse/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/susanna-szljacsan-spouse/unstripped-tree.gedcomx.json
@@ -1,0 +1,132 @@
+{
+  "persons": [
+    {
+      "id": "LDK6-6SH",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Susanna",
+          "surname": "Szljacsan"
+        }
+      ],
+      "facts": [
+        {
+          "id": "689dd5f0-4e0e-47e7-9415-6db71c0d6dba",
+          "type": "Death"
+        },
+        {
+          "id": "4474d31c-e0d3-40af-a37a-d84e4555c04f",
+          "type": "Christening",
+          "date": "05 Mar 1850",
+          "standard_date": "5 Mar 1850",
+          "place": "Lisková, Ružomberok, Slovakia",
+          "standard_place": "Lisková, Ružomberok, Slovakia"
+        },
+        {
+          "id": "c5650e22-d1cd-424c-b35a-0c1788e102b7",
+          "type": "Baptism",
+          "date": "05 Mar 1850",
+          "standard_date": "5 Mar 1850",
+          "place": "Lisková, Ružomberok, Slovakia",
+          "standard_place": "Lisková, Ružomberok, Slovakia"
+        }
+      ]
+    },
+    {
+      "id": "LDKF-RZK",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Maria",
+          "surname": "Munka"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LDKF-RZV",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "János",
+          "surname": "Szljacsan"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LDK6-6SZ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Maria",
+          "surname": "Boron Munka"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "LDKF-RZV",
+      "person2": "LDKF-RZK"
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "LDKF-RZV",
+      "person2": "LDK6-6SZ"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "LDKF-RZV",
+      "child": "LDK6-6SH"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "LDK6-6SZ",
+      "child": "LDK6-6SH"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "LDKF-RZK",
+      "child": "LDK6-6SH"
+    }
+  ],
+  "sources": [
+    {
+      "id": "SG4J-XT3",
+      "title": "Susanna Szljacsan, \"Slovakia, Church and Synagogue Books, 1592-1935\"",
+      "citation": "\"Slovakia, Church and Synagogue Books, 1592-1935\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KHQN-KC7 : Mon Mar 11 01:33:08 UTC 2024), Entry for Susanna Szljacsan and Joannes Szljacsan, 05 Mar 1850.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KHQN-KC7"
+    }
+  ]
+}

--- a/eval/tests/e2e/victoriano-macatangay-parents/README.md
+++ b/eval/tests/e2e/victoriano-macatangay-parents/README.md
@@ -1,0 +1,34 @@
+# Victoriano Macatangay — parents and additional son Miguel (b. 1915)
+
+**Source PID:** `GV6J-VZC`
+**Victoriano Macatangay is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+not recorded in the tree; died not recorded in the tree.
+
+## Research question
+
+> Who were the parents of Victoriano Macatangay of Batangas, Philippines, and did he and his wife Gabina Sisquinto have a son named Miguel, born 1915, in addition to their six known children?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `GV6J-VZC` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+hard — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 26, flags `adds_father`/`adds_mother`/`adds_son`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Philippines, Catholic Church Records, 1520-2014: christening entry, 16 October 1915, Batangas City, for Miguel Macatangay Sisquinto, naming parents Victorino Macatangay and Gabina Sisquinto, and (via indirect grandparent-type relationship entries in the record) grandparents José and Bernardina Cabrera. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard, plus a `required` finding that the report documents the rejection.
+
+Points a reviewer should weigh: the record is unusually structured for this batch — rather than a simple parent-child baptismal entry, it carries several `http://familysearch.org/types/relationships/Grandparent` relationship entries connecting José, Bernardina Cabrera, Domingo, and María Dapal directly to the child Miguel, alongside the ordinary parent-child chain through Victorino and Gabina — a reviewer should confirm which persons are genuinely Victoriano's parents versus his wife's, since the indirect grandparent links could reflect a merged or over-linked FamilySearch index rather than a single clean source. In favor: the wife's name "Gabina Sisquinto" matches the tree's "Gabina Singamuto"/"Gabina Sinquino" (the tree itself records two spellings for her), the surname "Macatangay"/"Makatangay" matches, and a 1915 birth fits neatly among the tree's six known children (1904-1929).

--- a/eval/tests/e2e/victoriano-macatangay-parents/expected-findings.json
+++ b/eval/tests/e2e/victoriano-macatangay-parents/expected-findings.json
@@ -1,0 +1,55 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "Victoriano Macatangay's father was José, per a 1915 christening record for his son Miguel.",
+      "details": {
+        "subject_person": "Victoriano Macatangay (GV6J-VZC)",
+        "relation": "parent",
+        "target_person": {
+          "name": "José",
+          "birth": "unknown, likely Batangas, Philippines"
+        }
+      },
+      "supporting_sources": [
+        "Philippines, Catholic Church Records, 1520-2014 — christening entry for Miguel Macatangay Sisquinto, 16 Oct 1915, Batangas City, naming grandparents"
+      ],
+      "required": true
+    },
+    {
+      "id": "f2",
+      "type": "relationship",
+      "description": "Victoriano Macatangay's mother was Bernardina Cabrera, per the same christening record.",
+      "details": {
+        "subject_person": "Victoriano Macatangay (GV6J-VZC)",
+        "relation": "parent",
+        "target_person": {
+          "name": "Bernardina Cabrera",
+          "birth": "unknown, likely Batangas, Philippines"
+        }
+      },
+      "supporting_sources": [
+        "Philippines, Catholic Church Records, 1520-2014 — christening entry for Miguel Macatangay Sisquinto, 16 Oct 1915, Batangas City"
+      ],
+      "required": true
+    },
+    {
+      "id": "f3",
+      "type": "relationship",
+      "description": "Victoriano Macatangay and Gabina Sisquinto had a son, Miguel Macatangay Sisquinto, born 28 September 1915 and christened 16 October 1915 in Batangas City, in addition to their six children already in the tree (b. 1904-1929).",
+      "details": {
+        "subject_person": "Victoriano Macatangay (GV6J-VZC)",
+        "relation": "child",
+        "target_person": {
+          "name": "Miguel Macatangay Sisquinto",
+          "birth": "28 September 1915, Batangas City, Batangas, Philippines"
+        }
+      },
+      "supporting_sources": [
+        "Philippines, Catholic Church Records, 1520-2014 — christening entry, 16 Oct 1915, Batangas City, naming parents Victorino Macatangay and Gabina Sisquinto"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/victoriano-macatangay-parents/fixture.json
+++ b/eval/tests/e2e/victoriano-macatangay-parents/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "victoriano-macatangay-parents",
+  "name": "Victoriano Macatangay — parents and additional son Miguel (b. 1915)",
+  "genre": "record-hint",
+  "source_pid": "GV6J-VZC",
+  "captured": "2026-07-24",
+  "researcher_question": "Who were the parents of Victoriano Macatangay of Batangas, Philippines, and did he and his wife Gabina Sisquinto have a son named Miguel, born 1915, in addition to their six known children?",
+  "tags": {
+    "question_type": "parents",
+    "era": "1910s",
+    "geography": "PH"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 26, flags adds_father/adds_mother/adds_son, confidence 3). Draft transcribed from a Philippine Catholic church record; unverified."
+}

--- a/eval/tests/e2e/victoriano-macatangay-parents/starting-research.json
+++ b/eval/tests/e2e/victoriano-macatangay-parents/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_victoriano_macatangay_parents",
+    "objective": "Who were the parents of Victoriano Macatangay of Batangas, Philippines, and did he and his wife Gabina Sisquinto have a son named Miguel, born 1915, in addition to their six known children?",
+    "subject_person_ids": [
+      "GV6J-VZC"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/victoriano-macatangay-parents/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/victoriano-macatangay-parents/starting-tree.gedcomx.json
@@ -1,0 +1,423 @@
+{
+  "persons": [
+    {
+      "id": "GV6J-VZC",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Victoriano",
+          "surname": "Macatangay"
+        }
+      ],
+      "facts": [
+        {
+          "id": "44cf8b53-3e2b-4f1d-8b28-8f2f77f5d556",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GV6J-4B2",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Gabina",
+          "surname": "Singamuto"
+        }
+      ],
+      "facts": [
+        {
+          "id": "7197701a-db47-44fe-8995-e161828d9649",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PQRJ-SN7",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Juana",
+          "surname": "Macatangay"
+        }
+      ],
+      "facts": [
+        {
+          "id": "99a4827a-2a4e-47e4-be48-f6f9d59ce68d",
+          "type": "Birth",
+          "date": "1904",
+          "standard_date": "1904",
+          "place": "Batangas, Batangas, Philippines",
+          "standard_place": "Batangas, Batangas, Philippines"
+        },
+        {
+          "id": "bd8bfece-b5cf-40aa-b0f4-2eee6989a824",
+          "type": "Death"
+        },
+        {
+          "id": "98438740-3e08-4bfd-8a1f-06cf167eb044",
+          "type": "Marital Status",
+          "value": "Single"
+        }
+      ]
+    },
+    {
+      "id": "G79J-NXT",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Leonila Singamuto",
+          "surname": "Macatangay"
+        }
+      ],
+      "facts": [
+        {
+          "id": "52f329eb-8b4f-4024-a341-ad95c64f000b",
+          "type": "Birth",
+          "date": "1908",
+          "standard_date": "1908",
+          "place": "Batangas, Batangas, Philippines",
+          "standard_place": "Batangas, Batangas, Philippines"
+        },
+        {
+          "id": "4feff4de-518f-4564-a629-37450f5f3e54",
+          "type": "Death"
+        },
+        {
+          "id": "be244acf-ed1f-44c7-82d2-f29eba6cbf56",
+          "type": "Marital Status",
+          "value": "Single"
+        }
+      ]
+    },
+    {
+      "id": "P7SM-3PJ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Inés",
+          "surname": "Macatangay"
+        }
+      ],
+      "facts": [
+        {
+          "id": "354e91d5-021a-4f12-a9ef-5cb34b4df852",
+          "type": "Birth",
+          "date": "19 April 1920",
+          "standard_date": "19 Apr 1920",
+          "place": "Batangas, Batangas, Philippines",
+          "standard_place": "Batangas, Batangas, Philippines"
+        },
+        {
+          "id": "2dc81e05-86e5-453c-b0a9-bb3c4a19b117",
+          "type": "Christening",
+          "date": "25 April 1920",
+          "standard_date": "25 Apr 1920",
+          "place": "Batangas, Batangas, Philippines",
+          "standard_place": "Batangas, Batangas, Philippines"
+        },
+        {
+          "id": "26180fa7-05e9-4834-83bf-8c485e60a2e7",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P77P-RDD",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Arceli",
+          "surname": "Makatangay"
+        }
+      ],
+      "facts": [
+        {
+          "id": "deaa0050-ebca-481f-97bf-66329b212f8c",
+          "type": "Birth",
+          "date": "1929",
+          "standard_date": "1929"
+        },
+        {
+          "id": "b0aff423-789d-413e-a041-fbbdb5930649",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PW45-2BG",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Serafio",
+          "surname": "Makatangay"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1d57b42c-5b3e-4a7a-ae5d-a3462013d76d",
+          "type": "Birth",
+          "date": "1906",
+          "standard_date": "1906"
+        },
+        {
+          "id": "2aa4ee81-64d0-40c2-9bf2-a01d57dd1b06",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P7SM-2LY",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Gabina",
+          "surname": "Sinquino"
+        }
+      ],
+      "facts": [
+        {
+          "id": "8a0595aa-5b3d-4d0c-a31d-deaf25b388d7",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P7SM-B86",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Juan",
+          "surname": "Macatangay"
+        }
+      ],
+      "facts": [
+        {
+          "id": "7a6e04be-ddee-461c-9ddf-4d4e477abeef",
+          "type": "Birth",
+          "date": "1919",
+          "standard_date": "1919"
+        },
+        {
+          "id": "bad5fd7e-d5b2-48ef-bc8c-43a659421cf6",
+          "type": "Marriage Notice",
+          "date": "1944",
+          "standard_date": "1944",
+          "place": "Batangas, Batangas, Philippines",
+          "standard_place": "Batangas, Batangas, Philippines"
+        },
+        {
+          "id": "60d439b4-bdf2-4d96-88ad-14fefbe51d76",
+          "type": "Death"
+        },
+        {
+          "id": "46007428-3a3b-4285-8868-66b9271bd829",
+          "type": "Marital Status",
+          "value": "Single"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GV6J-VZC",
+      "person2": "GV6J-4B2"
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "GV6J-VZC",
+      "person2": "P7SM-2LY"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GV6J-VZC",
+      "child": "PQRJ-SN7"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GV6J-4B2",
+      "child": "PQRJ-SN7"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GV6J-VZC",
+      "child": "PW45-2BG"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "GV6J-4B2",
+      "child": "PW45-2BG"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "GV6J-VZC",
+      "child": "G79J-NXT"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "GV6J-4B2",
+      "child": "G79J-NXT"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "GV6J-VZC",
+      "child": "P7SM-B86"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "P7SM-2LY",
+      "child": "P7SM-B86"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "GV6J-VZC",
+      "child": "P7SM-3PJ"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "P7SM-2LY",
+      "child": "P7SM-3PJ"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "GV6J-VZC",
+      "child": "P77P-RDD"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "GV6J-4B2",
+      "child": "P77P-RDD"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7RS1-8V3",
+      "title": "Victorino Macatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6P5N-GHBM : Fri Jan 30 22:23:08 UTC 2026), Entry for Aurelio Bibiano Suares and Mariano Suares, 18 Oct 1931.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6P5N-GHBZ"
+    },
+    {
+      "id": "7R63-TH6",
+      "title": "Victorino Makatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QLYC-NJKN : Wed Jan 22 14:02:06 UTC 2025), Entry for Jose Torres and Arceli Makatangay, 29 Sep 1947.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QLYC-NJKJ"
+    },
+    {
+      "id": "7RFQ-VWT",
+      "title": "Victorino Macatangay, \"Philippines, Marriages, 1723-1957\"",
+      "citation": "\"Philippines, Marriages, 1723-1957\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:HBH3-H13Z : Sat Jan 31 08:20:06 UTC 2026), Entry for Hermogenes Macatangay Y Singuimoto and Virginia Salinas, 17 Jan 1949.",
+      "url": "https://familysearch.org/ark:/61903/1:1:HBH3-H1ZM"
+    },
+    {
+      "id": "76SS-TMV",
+      "title": "Victorino Macatangay, \"Philippines, Marriages, 1723-1957\"",
+      "citation": "\"Philippines, Marriages, 1723-1957\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FN8Z-DVT : Fri Jan 30 23:14:39 UTC 2026), Entry for Aurelio Bibiano Suares and Mariano Suares, 18 Oct 1931.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FN8Z-DV5"
+    },
+    {
+      "id": "7RS1-FLZ",
+      "title": "Victorino Macatangay, \"Philippines, Catholic Church Records, 1520-2014\"",
+      "citation": "\"Philippines, Catholic Church Records, 1520-2014\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6665-N586 : Thu Sep 04 17:16:25 UTC 2025), Entry for Inés and Victorino Macatangay, 25 de abril de 1920.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6665-N58X"
+    },
+    {
+      "id": "Q3BY-27J",
+      "title": "Victoriano Makatangay, \"Philippines, Marriages, 1723-1957\"",
+      "citation": "\"Philippines, Marriages, 1723-1957\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H1MG-92W2 : Tue Dec 09 08:58:32 UTC 2025), Entry for Jose, Jr. Torres and Jose Torres, 1947.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H1MG-922M"
+    },
+    {
+      "id": "7RFQ-NGY",
+      "title": "Victoriano Makatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QGP6-SHD8 : Fri Jan 17 23:42:48 UTC 2025), Entry for Jose Torres and Arceli Makatangay, 29 Sep 1947.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QGP6-SHDX"
+    },
+    {
+      "id": "Q3BY-5ZF",
+      "title": "Victorino Makatangay, \"Philippines, Marriages, 1723-1957\"",
+      "citation": "\"Philippines, Marriages, 1723-1957\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:HB7K-SQMM : Sat Jan 31 00:26:51 UTC 2026), Entry for Jose Jr. Torres and Arabell Makatangay, 29 Sep 1947.",
+      "url": "https://familysearch.org/ark:/61903/1:1:HB7K-SQ6Z"
+    },
+    {
+      "id": "75XG-T6H",
+      "title": "Victorino Macatangay, \"Philippines, Marriages, 1723-1957\"",
+      "citation": "\"Philippines, Marriages, 1723-1957\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FN8H-LYR : Fri Jan 30 18:38:34 UTC 2026), Entry for Miguel Ramos and Enlalio Ramos, 10 Jan 1924.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FN8H-LYP"
+    },
+    {
+      "id": "7RS1-GRB",
+      "title": "Victorino Makatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QLYC-NJKW : Wed Jan 22 11:11:07 UTC 2025), Entry for Jose Torres and Arceli Makatangay, 29 Sep 1947.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QLYC-NJKC"
+    },
+    {
+      "id": "7RFQ-JNB",
+      "title": "Victorino Macatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:8QVW-QRT2 : Thu Dec 26 17:31:31 UTC 2024), Entry for Hermogenes Macatangay Singuimoto and Victorino Macatangay, 1949.",
+      "url": "https://familysearch.org/ark:/61903/1:1:8QVW-QTMM"
+    },
+    {
+      "id": "Q3BY-RDX",
+      "title": "Victorino Mocatangay, \"Philippines, Marriages, 1723-1957\"",
+      "citation": "\"Philippines, Marriages, 1723-1957\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:HB7V-6TPZ : Thu Jan 29 03:31:02 UTC 2026), Entry for Jose Jr. Torres and Araceli Mocatangay, 29 Sep 1947.",
+      "url": "https://familysearch.org/ark:/61903/1:1:HB7V-6YW2"
+    },
+    {
+      "id": "75XG-T99",
+      "title": "Victorino Macatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6P5N-1RP8 : Fri Jan 30 22:21:15 UTC 2026), Entry for Miguel Ramos and Eulalio Ramos, 10 Jan 1924.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6P5N-1RPN"
+    },
+    {
+      "id": "7RS1-DGM",
+      "title": "Victorino Macatangay, \"Philippines, Marriages, 1723-1957\"",
+      "citation": "\"Philippines, Marriages, 1723-1957\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H1CK-J1N2 : Wed Dec 10 08:36:35 UTC 2025), Entry for Juan Macatangay and Victorino Macatangay, 1944.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H1CK-J12M"
+    },
+    {
+      "id": "7RS1-VSX",
+      "title": "Victorino Macatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6P5J-QM4D : Sat Jan 31 15:58:43 UTC 2026), Entry for Juan Macatangay and Victorino Macatangay, 14 Jan 1944.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6P5J-QM4X"
+    },
+    {
+      "id": "7Y24-5QS",
+      "title": "Victorino Makatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:84ZV-J7W2 : Sun Oct 05 06:24:12 UTC 2025), Entry for Serafio Makatangay and Victorino Makatangay, 1926.",
+      "url": "https://familysearch.org/ark:/61903/1:1:84ZV-J7ZM"
+    }
+  ]
+}

--- a/eval/tests/e2e/victoriano-macatangay-parents/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/victoriano-macatangay-parents/unstripped-tree.gedcomx.json
@@ -1,0 +1,423 @@
+{
+  "persons": [
+    {
+      "id": "GV6J-VZC",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Victoriano",
+          "surname": "Macatangay"
+        }
+      ],
+      "facts": [
+        {
+          "id": "44cf8b53-3e2b-4f1d-8b28-8f2f77f5d556",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "GV6J-4B2",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Gabina",
+          "surname": "Singamuto"
+        }
+      ],
+      "facts": [
+        {
+          "id": "7197701a-db47-44fe-8995-e161828d9649",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PQRJ-SN7",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Juana",
+          "surname": "Macatangay"
+        }
+      ],
+      "facts": [
+        {
+          "id": "99a4827a-2a4e-47e4-be48-f6f9d59ce68d",
+          "type": "Birth",
+          "date": "1904",
+          "standard_date": "1904",
+          "place": "Batangas, Batangas, Philippines",
+          "standard_place": "Batangas, Batangas, Philippines"
+        },
+        {
+          "id": "bd8bfece-b5cf-40aa-b0f4-2eee6989a824",
+          "type": "Death"
+        },
+        {
+          "id": "98438740-3e08-4bfd-8a1f-06cf167eb044",
+          "type": "Marital Status",
+          "value": "Single"
+        }
+      ]
+    },
+    {
+      "id": "G79J-NXT",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Leonila Singamuto",
+          "surname": "Macatangay"
+        }
+      ],
+      "facts": [
+        {
+          "id": "52f329eb-8b4f-4024-a341-ad95c64f000b",
+          "type": "Birth",
+          "date": "1908",
+          "standard_date": "1908",
+          "place": "Batangas, Batangas, Philippines",
+          "standard_place": "Batangas, Batangas, Philippines"
+        },
+        {
+          "id": "4feff4de-518f-4564-a629-37450f5f3e54",
+          "type": "Death"
+        },
+        {
+          "id": "be244acf-ed1f-44c7-82d2-f29eba6cbf56",
+          "type": "Marital Status",
+          "value": "Single"
+        }
+      ]
+    },
+    {
+      "id": "P7SM-3PJ",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Inés",
+          "surname": "Macatangay"
+        }
+      ],
+      "facts": [
+        {
+          "id": "354e91d5-021a-4f12-a9ef-5cb34b4df852",
+          "type": "Birth",
+          "date": "19 April 1920",
+          "standard_date": "19 Apr 1920",
+          "place": "Batangas, Batangas, Philippines",
+          "standard_place": "Batangas, Batangas, Philippines"
+        },
+        {
+          "id": "2dc81e05-86e5-453c-b0a9-bb3c4a19b117",
+          "type": "Christening",
+          "date": "25 April 1920",
+          "standard_date": "25 Apr 1920",
+          "place": "Batangas, Batangas, Philippines",
+          "standard_place": "Batangas, Batangas, Philippines"
+        },
+        {
+          "id": "26180fa7-05e9-4834-83bf-8c485e60a2e7",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P77P-RDD",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N6",
+          "given": "Arceli",
+          "surname": "Makatangay"
+        }
+      ],
+      "facts": [
+        {
+          "id": "deaa0050-ebca-481f-97bf-66329b212f8c",
+          "type": "Birth",
+          "date": "1929",
+          "standard_date": "1929"
+        },
+        {
+          "id": "b0aff423-789d-413e-a041-fbbdb5930649",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "PW45-2BG",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N7",
+          "given": "Serafio",
+          "surname": "Makatangay"
+        }
+      ],
+      "facts": [
+        {
+          "id": "1d57b42c-5b3e-4a7a-ae5d-a3462013d76d",
+          "type": "Birth",
+          "date": "1906",
+          "standard_date": "1906"
+        },
+        {
+          "id": "2aa4ee81-64d0-40c2-9bf2-a01d57dd1b06",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P7SM-2LY",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N8",
+          "given": "Gabina",
+          "surname": "Sinquino"
+        }
+      ],
+      "facts": [
+        {
+          "id": "8a0595aa-5b3d-4d0c-a31d-deaf25b388d7",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "P7SM-B86",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N9",
+          "given": "Juan",
+          "surname": "Macatangay"
+        }
+      ],
+      "facts": [
+        {
+          "id": "7a6e04be-ddee-461c-9ddf-4d4e477abeef",
+          "type": "Birth",
+          "date": "1919",
+          "standard_date": "1919"
+        },
+        {
+          "id": "bad5fd7e-d5b2-48ef-bc8c-43a659421cf6",
+          "type": "Marriage Notice",
+          "date": "1944",
+          "standard_date": "1944",
+          "place": "Batangas, Batangas, Philippines",
+          "standard_place": "Batangas, Batangas, Philippines"
+        },
+        {
+          "id": "60d439b4-bdf2-4d96-88ad-14fefbe51d76",
+          "type": "Death"
+        },
+        {
+          "id": "46007428-3a3b-4285-8868-66b9271bd829",
+          "type": "Marital Status",
+          "value": "Single"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "GV6J-VZC",
+      "person2": "GV6J-4B2"
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "GV6J-VZC",
+      "person2": "P7SM-2LY"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "GV6J-VZC",
+      "child": "PQRJ-SN7"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "GV6J-4B2",
+      "child": "PQRJ-SN7"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "GV6J-VZC",
+      "child": "PW45-2BG"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "GV6J-4B2",
+      "child": "PW45-2BG"
+    },
+    {
+      "id": "R7",
+      "type": "ParentChild",
+      "parent": "GV6J-VZC",
+      "child": "G79J-NXT"
+    },
+    {
+      "id": "R8",
+      "type": "ParentChild",
+      "parent": "GV6J-4B2",
+      "child": "G79J-NXT"
+    },
+    {
+      "id": "R9",
+      "type": "ParentChild",
+      "parent": "GV6J-VZC",
+      "child": "P7SM-B86"
+    },
+    {
+      "id": "R10",
+      "type": "ParentChild",
+      "parent": "P7SM-2LY",
+      "child": "P7SM-B86"
+    },
+    {
+      "id": "R11",
+      "type": "ParentChild",
+      "parent": "GV6J-VZC",
+      "child": "P7SM-3PJ"
+    },
+    {
+      "id": "R12",
+      "type": "ParentChild",
+      "parent": "P7SM-2LY",
+      "child": "P7SM-3PJ"
+    },
+    {
+      "id": "R13",
+      "type": "ParentChild",
+      "parent": "GV6J-VZC",
+      "child": "P77P-RDD"
+    },
+    {
+      "id": "R14",
+      "type": "ParentChild",
+      "parent": "GV6J-4B2",
+      "child": "P77P-RDD"
+    }
+  ],
+  "sources": [
+    {
+      "id": "7RS1-8V3",
+      "title": "Victorino Macatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6P5N-GHBM : Fri Jan 30 22:23:08 UTC 2026), Entry for Aurelio Bibiano Suares and Mariano Suares, 18 Oct 1931.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6P5N-GHBZ"
+    },
+    {
+      "id": "7R63-TH6",
+      "title": "Victorino Makatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QLYC-NJKN : Wed Jan 22 14:02:06 UTC 2025), Entry for Jose Torres and Arceli Makatangay, 29 Sep 1947.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QLYC-NJKJ"
+    },
+    {
+      "id": "7RFQ-VWT",
+      "title": "Victorino Macatangay, \"Philippines, Marriages, 1723-1957\"",
+      "citation": "\"Philippines, Marriages, 1723-1957\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:HBH3-H13Z : Sat Jan 31 08:20:06 UTC 2026), Entry for Hermogenes Macatangay Y Singuimoto and Virginia Salinas, 17 Jan 1949.",
+      "url": "https://familysearch.org/ark:/61903/1:1:HBH3-H1ZM"
+    },
+    {
+      "id": "76SS-TMV",
+      "title": "Victorino Macatangay, \"Philippines, Marriages, 1723-1957\"",
+      "citation": "\"Philippines, Marriages, 1723-1957\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FN8Z-DVT : Fri Jan 30 23:14:39 UTC 2026), Entry for Aurelio Bibiano Suares and Mariano Suares, 18 Oct 1931.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FN8Z-DV5"
+    },
+    {
+      "id": "7RS1-FLZ",
+      "title": "Victorino Macatangay, \"Philippines, Catholic Church Records, 1520-2014\"",
+      "citation": "\"Philippines, Catholic Church Records, 1520-2014\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6665-N586 : Thu Sep 04 17:16:25 UTC 2025), Entry for Inés and Victorino Macatangay, 25 de abril de 1920.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6665-N58X"
+    },
+    {
+      "id": "Q3BY-27J",
+      "title": "Victoriano Makatangay, \"Philippines, Marriages, 1723-1957\"",
+      "citation": "\"Philippines, Marriages, 1723-1957\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H1MG-92W2 : Tue Dec 09 08:58:32 UTC 2025), Entry for Jose, Jr. Torres and Jose Torres, 1947.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H1MG-922M"
+    },
+    {
+      "id": "7RFQ-NGY",
+      "title": "Victoriano Makatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QGP6-SHD8 : Fri Jan 17 23:42:48 UTC 2025), Entry for Jose Torres and Arceli Makatangay, 29 Sep 1947.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QGP6-SHDX"
+    },
+    {
+      "id": "Q3BY-5ZF",
+      "title": "Victorino Makatangay, \"Philippines, Marriages, 1723-1957\"",
+      "citation": "\"Philippines, Marriages, 1723-1957\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:HB7K-SQMM : Sat Jan 31 00:26:51 UTC 2026), Entry for Jose Jr. Torres and Arabell Makatangay, 29 Sep 1947.",
+      "url": "https://familysearch.org/ark:/61903/1:1:HB7K-SQ6Z"
+    },
+    {
+      "id": "75XG-T6H",
+      "title": "Victorino Macatangay, \"Philippines, Marriages, 1723-1957\"",
+      "citation": "\"Philippines, Marriages, 1723-1957\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:FN8H-LYR : Fri Jan 30 18:38:34 UTC 2026), Entry for Miguel Ramos and Enlalio Ramos, 10 Jan 1924.",
+      "url": "https://familysearch.org/ark:/61903/1:1:FN8H-LYP"
+    },
+    {
+      "id": "7RS1-GRB",
+      "title": "Victorino Makatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QLYC-NJKW : Wed Jan 22 11:11:07 UTC 2025), Entry for Jose Torres and Arceli Makatangay, 29 Sep 1947.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QLYC-NJKC"
+    },
+    {
+      "id": "7RFQ-JNB",
+      "title": "Victorino Macatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:8QVW-QRT2 : Thu Dec 26 17:31:31 UTC 2024), Entry for Hermogenes Macatangay Singuimoto and Victorino Macatangay, 1949.",
+      "url": "https://familysearch.org/ark:/61903/1:1:8QVW-QTMM"
+    },
+    {
+      "id": "Q3BY-RDX",
+      "title": "Victorino Mocatangay, \"Philippines, Marriages, 1723-1957\"",
+      "citation": "\"Philippines, Marriages, 1723-1957\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:HB7V-6TPZ : Thu Jan 29 03:31:02 UTC 2026), Entry for Jose Jr. Torres and Araceli Mocatangay, 29 Sep 1947.",
+      "url": "https://familysearch.org/ark:/61903/1:1:HB7V-6YW2"
+    },
+    {
+      "id": "75XG-T99",
+      "title": "Victorino Macatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6P5N-1RP8 : Fri Jan 30 22:21:15 UTC 2026), Entry for Miguel Ramos and Eulalio Ramos, 10 Jan 1924.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6P5N-1RPN"
+    },
+    {
+      "id": "7RS1-DGM",
+      "title": "Victorino Macatangay, \"Philippines, Marriages, 1723-1957\"",
+      "citation": "\"Philippines, Marriages, 1723-1957\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:H1CK-J1N2 : Wed Dec 10 08:36:35 UTC 2025), Entry for Juan Macatangay and Victorino Macatangay, 1944.",
+      "url": "https://familysearch.org/ark:/61903/1:1:H1CK-J12M"
+    },
+    {
+      "id": "7RS1-VSX",
+      "title": "Victorino Macatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:6P5J-QM4D : Sat Jan 31 15:58:43 UTC 2026), Entry for Juan Macatangay and Victorino Macatangay, 14 Jan 1944.",
+      "url": "https://familysearch.org/ark:/61903/1:1:6P5J-QM4X"
+    },
+    {
+      "id": "7Y24-5QS",
+      "title": "Victorino Makatangay, \"Philippines Civil Registration (National), 1945-1996\"",
+      "citation": "\"Philippines Civil Registration (National), 1945-1996\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:84ZV-J7W2 : Sun Oct 05 06:24:12 UTC 2025), Entry for Serafio Makatangay and Victorino Makatangay, 1926.",
+      "url": "https://familysearch.org/ark:/61903/1:1:84ZV-J7ZM"
+    }
+  ]
+}

--- a/eval/tests/e2e/wasyl-kapach-birth/README.md
+++ b/eval/tests/e2e/wasyl-kapach-birth/README.md
@@ -1,0 +1,34 @@
+# Wasyl Kapach — birth in Ukraine and immigration to Canada
+
+**Source PID:** `L17M-W4Q`
+**Wasyl Kapach is deceased.** (FamilySearch ToS requires
+all committed e2e fixtures to be about deceased persons.) Born
+not recorded in the tree; died not recorded in the tree.
+
+## Research question
+
+> When and where in Ukraine was Wasyl Kapach born, and when did he immigrate to Canada?
+
+## What was removed from the starting tree
+
+**Nothing.** This is a *record-hint* fixture, a different genre from the
+strip-based fixtures: the expected answer never appeared in the
+FamilySearch tree. The starting tree is the live snapshot as-is
+(captured 2026-07-24, PID `L17M-W4Q` with relatives). Nothing was
+stripped (`"genre": "record-hint"` in `fixture.json`):
+`starting-tree.gedcomx.json` is the snapshot as-is (written by
+`strip --none`), and `unstripped-tree.gedcomx.json` is committed
+identical to it so `snapshot --check` can audit upstream drift.
+`validate` enforces the equality and skips the presence mirror
+(spec §3.6).
+
+## Expected difficulty
+
+hard — see "Notes for reviewers" below for the reviewer's read on
+match strength.
+
+## Notes for reviewers
+
+**DRAFT PENDING ADJUDICATION.** This fixture comes from a hint batch (`filtered-list-samples.csv` row 32, flags `adds_daughter`/`adds_birth`, confidence 3) in which roughly half the hint records are **false matches**, and the authors do not know which. `expected-findings.json` was transcribed from the hint record — Canada, Prairie Provinces, Census, 1926: household entry for Wasyl Capach, Athabasca, Alberta, giving birth 1883 Ukraine and immigration 1906. The genealogist + developer teams must decide (a) true match — keep the findings; (b) different answer — edit `expected-findings.json`; or (c) no findable answer — replace the findings with a `"polarity": "avoid"` guard, plus a `required` finding that the report documents the rejection.
+
+**Note on the `adds_daughter` flag**: the CSV batch flags this hint record as `adds_daughter`, but the FamilySearch `record_read` response for this ark returned only a single indexed person (Wasyl Capach himself) with no household members or relationships — the 1926 census entry likely has other family members captured only in the underlying census image, not surfaced by this API call. No daughter's name is available to draft a finding around; a genealogist adjudicating this fixture should pull the actual census image (`image_read`) to see whether a daughter appears there before deciding how to handle that half of the hint. The tree's known son, Andrew Kapach, was born 1916 — a decade after this census subject's 1906 immigration, consistent with the same family. The wife's name, Tekla Doliney Kapach (d. 1915, Vegreville, Alberta — a different town than the 1926 census's Athabasca), predates this census by over a decade, so she would not appear as a household member in 1926 regardless.

--- a/eval/tests/e2e/wasyl-kapach-birth/expected-findings.json
+++ b/eval/tests/e2e/wasyl-kapach-birth/expected-findings.json
@@ -1,0 +1,19 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "fact",
+      "description": "Wasyl Kapach (recorded in the census as Wasyl Capach) was born 1883 in Ukraine and immigrated to Canada in 1906, per the 1926 Prairie Provinces census (Athabasca, Alberta). The tree currently has no birth fact for him.",
+      "details": {
+        "subject_person": "Wasyl Kapach (L17M-W4Q)",
+        "fact_type": "Birth",
+        "date": "1883",
+        "place": "Ukraine"
+      },
+      "supporting_sources": [
+        "Canada, Prairie Provinces, Census, 1926 — household entry for Wasyl Capach, Athabasca, Alberta"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/wasyl-kapach-birth/fixture.json
+++ b/eval/tests/e2e/wasyl-kapach-birth/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "wasyl-kapach-birth",
+  "name": "Wasyl Kapach — birth in Ukraine and immigration to Canada",
+  "genre": "record-hint",
+  "source_pid": "L17M-W4Q",
+  "captured": "2026-07-24",
+  "researcher_question": "When and where in Ukraine was Wasyl Kapach born, and when did he immigrate to Canada?",
+  "tags": {
+    "question_type": "birth_date",
+    "era": "1880s",
+    "geography": "CA"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "hard",
+  "notes": "Record-hint fixture (filtered-list-samples.csv row 32, flags adds_daughter/adds_birth, confidence 3). Draft transcribed from a 1926 Canadian census record; unverified."
+}

--- a/eval/tests/e2e/wasyl-kapach-birth/starting-research.json
+++ b/eval/tests/e2e/wasyl-kapach-birth/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_wasyl_kapach_birth",
+    "objective": "When and where in Ukraine was Wasyl Kapach born, and when did he immigrate to Canada?",
+    "subject_person_ids": [
+      "L17M-W4Q"
+    ],
+    "status": "active",
+    "created": "2026-07-24",
+    "updated": "2026-07-24"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/wasyl-kapach-birth/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/wasyl-kapach-birth/starting-tree.gedcomx.json
@@ -1,0 +1,121 @@
+{
+  "persons": [
+    {
+      "id": "L17M-W4Q",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Wasyl",
+          "surname": "Kapach"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4f5a7841-26b1-47c5-b4d4-aa4a5ebbcbf8",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LVFX-1PX",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Andrew",
+          "surname": "Kapach"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "20 December 1916",
+          "standard_date": "20 Dec 1916"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death",
+          "date": "13 April 1984",
+          "standard_date": "13 Apr 1984"
+        }
+      ]
+    },
+    {
+      "id": "L1K5-ZC3",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Tekla",
+          "surname": "Doliney Kapach"
+        }
+      ],
+      "facts": [
+        {
+          "id": "796b71b9-f635-462b-83c7-4d0f80af945f",
+          "type": "Death",
+          "date": "November 8, 1915",
+          "standard_date": "8 Nov 1915",
+          "place": "Vegreville, Alberta, Canada",
+          "standard_place": "Vegreville, County of Minburn No. 27, Alberta, Canada"
+        },
+        {
+          "id": "c19a5ccd-fad3-40f4-9caf-84a09f70c07b",
+          "type": "Birth",
+          "place": "Ukraine, Province Of Galicia",
+          "standard_place": "Ukraine"
+        }
+      ]
+    },
+    {
+      "id": "L17M-72G",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Mary",
+          "surname": "Antosko"
+        }
+      ],
+      "facts": [
+        {
+          "id": "7a6b5819-6c5d-4460-8148-a66b43180469",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "L17M-W4Q",
+      "person2": "L17M-72G"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "L1K5-ZC3",
+      "child": "L17M-W4Q"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "L17M-W4Q",
+      "child": "LVFX-1PX"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "L17M-72G",
+      "child": "LVFX-1PX"
+    }
+  ],
+  "sources": []
+}

--- a/eval/tests/e2e/wasyl-kapach-birth/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/wasyl-kapach-birth/unstripped-tree.gedcomx.json
@@ -1,0 +1,121 @@
+{
+  "persons": [
+    {
+      "id": "L17M-W4Q",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "Wasyl",
+          "surname": "Kapach"
+        }
+      ],
+      "facts": [
+        {
+          "id": "4f5a7841-26b1-47c5-b4d4-aa4a5ebbcbf8",
+          "type": "Death"
+        }
+      ]
+    },
+    {
+      "id": "LVFX-1PX",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Andrew",
+          "surname": "Kapach"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "20 December 1916",
+          "standard_date": "20 Dec 1916"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death",
+          "date": "13 April 1984",
+          "standard_date": "13 Apr 1984"
+        }
+      ]
+    },
+    {
+      "id": "L1K5-ZC3",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Tekla",
+          "surname": "Doliney Kapach"
+        }
+      ],
+      "facts": [
+        {
+          "id": "796b71b9-f635-462b-83c7-4d0f80af945f",
+          "type": "Death",
+          "date": "November 8, 1915",
+          "standard_date": "8 Nov 1915",
+          "place": "Vegreville, Alberta, Canada",
+          "standard_place": "Vegreville, County of Minburn No. 27, Alberta, Canada"
+        },
+        {
+          "id": "c19a5ccd-fad3-40f4-9caf-84a09f70c07b",
+          "type": "Birth",
+          "place": "Ukraine, Province Of Galicia",
+          "standard_place": "Ukraine"
+        }
+      ]
+    },
+    {
+      "id": "L17M-72G",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "Mary",
+          "surname": "Antosko"
+        }
+      ],
+      "facts": [
+        {
+          "id": "7a6b5819-6c5d-4460-8148-a66b43180469",
+          "type": "Death"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "L17M-W4Q",
+      "person2": "L17M-72G"
+    },
+    {
+      "id": "R2",
+      "type": "ParentChild",
+      "parent": "L1K5-ZC3",
+      "child": "L17M-W4Q"
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "L17M-W4Q",
+      "child": "LVFX-1PX"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "L17M-72G",
+      "child": "LVFX-1PX"
+    }
+  ],
+  "sources": []
+}


### PR DESCRIPTION
## Summary
- Adds 32 draft `record-hint` e2e fixtures under `eval/tests/e2e/`, one for each remaining row of `filtered-list-samples.csv` (row 1 / Heinrich Dewus already has a fixture + issue #638).
- Each fixture mirrors the `heinrich-dewus-children-death` / `mary-mcandrew-son` pattern: a live FamilySearch tree snapshot (`snapshot`/`strip --none`/`scaffold`), an `expected-findings.json` transcribed from the corresponding hint record, and a README documenting the DRAFT PENDING ADJUDICATION state plus reviewer notes on match strength.
- Opens a companion tracking issue per fixture (#852-#883), unassigned, in the project's Ready column, using the same template as #637/#638 (including the hint-record URL).
- All 32 fixtures pass `uv run python -m e2e.author validate`.

## Test plan
- [ ] Spot-check a few fixtures' `expected-findings.json` / README "Notes for reviewers" against the cited hint record before adjudicating.
- [ ] Confirm each linked issue (#852-#883) is visible in the project board's Ready column.
- [ ] Genealogist adjudication of each fixture (true match / different answer / false match) is separate follow-up work tracked by the linked issues, not part of this PR.

Generated with Claude Code
