### PR TITLE
e2e: document record-hint adjudication (Step 1B); reject phantom finding fields

### DIFF
--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -144,6 +144,11 @@ choosing:
 > `source_pid` you resolve before landing. `/author-e2e-fixture` covers it;
 > everything below applies unchanged.
 
+> **Assigned a GitHub issue titled "test `<slug>`"** (numbered among
+> #852–883, or similar)? You're not authoring a fixture — one already
+> exists, drafted from an unverified FamilySearch record hint, and your job
+> is to adjudicate it. Skip Steps 1–2 and go to **Step 1B** below.
+
 ## Step 2 — Match the question to what you strip 🤖 Claude Code
 
 The research question is what the agent receives. The stripping decides what it
@@ -178,6 +183,77 @@ concluding from insufficient evidence, which is the failure that matters most
 in genealogy, because a wrong parent silently corrupts an entire upstream tree.
 Aim for the suite as a whole to cover both, across a spread of question types,
 eras and geographies. Details: spec §3.4.1.
+
+## Step 1B — Adjudicating an assigned draft record-hint fixture 🤖 Claude Code
+
+Skip this unless you were assigned one of these issues. If you were, skip
+Steps 1–2 — the fixture already exists — and rejoin the guide at Step 3 once
+you're done here.
+
+**What this is.** A `genre: "record-hint"` fixture (spec §3.6) inverts the
+normal shape: nothing was stripped, because the answer was never in the
+FamilySearch tree to begin with. It lives in a historical record that
+FamilySearch's own hinting matched to the tree person with *unverified*
+confidence. `filtered-list-samples.csv` — a batch of such hints — seeded 32
+of these fixtures (issues #852–883) plus two earlier ones (#637, #638), each
+one's README saying **DRAFT PENDING ADJUDICATION**. Adjudicating one means
+doing the actual genealogical work to decide whether the hint is true, then
+making `expected-findings.json` state the truth instead of the raw,
+unverified hint.
+
+**Start from the GitHub issue, not the fixture folder.** Unlike every other
+fixture in the repo, the source you're checking — a clickable
+`familysearch.org/ark:/...` URL to the specific hint record — lives *only* in
+the issue body. The fixture's own README paraphrases the hint as prose, with
+no link. Open the issue first.
+
+**Do the research.** Read the fixture's README "Notes for reviewers" section
+for what the original author already found (the tree's existing sources, the
+match-strength argument for and against). Then verify it yourself: open the
+hint record at the issue's URL, and use `record_search`/`record_read` (via the
+scratch workspace, Step 4 below, or by hand on familysearch.org) to check for
+corroborating or contradicting evidence the same way you would for any
+genealogical proof. You're doing the human GPS work the benchmark exists to
+measure — there's no shortcut command for this part.
+
+**Encode one of three outcomes in `expected-findings.json`:**
+
+1. **True match** — leave the findings as transcribed.
+2. **Answerable, but differently** — edit `expected-findings.json` to the
+   correct answer (different date, different record, different person).
+3. **False match, no findable substitute** — replace the findings with a
+   `"polarity": "avoid"` finding naming the claim the agent must **not**
+   assert, paired with a `required: true` finding that the agent's report
+   documented the negative conclusion. This is already spelled out correctly
+   in `/author-e2e-fixture`'s own "Record-hint fixtures" section, and
+   `thomas-seaver-other-wife` is the one already-adjudicated fixture in the
+   repo showing exactly what this looks like end to end — read it before you
+   write outcome 3.
+
+> **Ignore any issue text that tells you to write `"expectation":
+> "not_found"`.** That field does not exist — it isn't read by the judge, the
+> validator, or anywhere else, so a finding written that way silently grades
+> as an ordinary, never-satisfied recall finding instead of the restraint
+> test it's supposed to be. It shipped in the original issue text for
+> #852–883 by mistake. `make e2e-validate` now hard-fails on it (and on any
+> other unrecognized finding field) instead of staying silent — if you see
+> that error, it means an old copy of the issue instructions, not the guide.
+> Use outcome 3's `polarity: "avoid"` shape instead.
+
+**Guardrails:**
+
+- **Don't touch `starting-tree.gedcomx.json` or `starting-research.json`.**
+  This task only edits `expected-findings.json`, the README, and
+  `fixture.json`'s `notes`. The rest of the guide assumes you're building
+  those files; here they're already correct and immutable.
+- **Record your reasoning in the README's "Notes for reviewers"** — replace
+  "DRAFT PENDING ADJUDICATION" with what you concluded and why, following the
+  level of detail in `thomas-seaver-other-wife`'s or `heinrich-dewus-children-death`'s
+  README.
+
+Once `expected-findings.json` and the README reflect your adjudication,
+continue at **Step 3** — but read its record-hint note below first, since
+`make e2e-validate`'s checks differ slightly for this genre.
 
 ## Step 3 — Prove the answer is findable ⌨️ Terminal
 
@@ -239,6 +315,19 @@ file, a schema violation, a dangling relationship endpoint or source `ref`.
 Suspects are warn-only, by design — they're for the author to judge.
 
 Omit `TEST=` to lint every fixture.
+
+> **Coming from Step 1B (a record-hint fixture)?** Nothing was stripped, so
+> "is the answer still present" doesn't apply — `validate` instead enforces
+> that `starting-tree.gedcomx.json` and `unstripped-tree.gedcomx.json` are
+> byte-identical, and skips the presence check entirely (spec §3.6). The
+> name-overlap linter above still runs, though, and it's polarity-agnostic:
+> since the subject person is fully present in that (never-stripped) starting
+> tree, a `WARN` naming your own finding's subject is common and *expected*
+> here, not a sign something's wrong — `heinrich-dewus-children-death`'s
+> README documents exactly this. Judge each WARN on its merits rather than
+> trying to make it disappear. A hard `ERROR` is different: it means a
+> structural problem, now including an unrecognized field in
+> `expected-findings.json` (see Step 1B's note on `"expectation": "not_found"`).
 
 Field tables, the hand-authoring path, cascade rules, and `provided-documents/`
 detail: spec §§2–3, §6.2.
@@ -478,6 +567,14 @@ confirm `pass`, and commit that run log under `eval/runlogs/e2e/<slug>/`.
 > above. Landing an unproven fixture is a judgment call you should be able to
 > defend in review, not something the machine will stop.
 
+> **Adjudicated a record-hint fixture to a false-match/`avoid` outcome (Step
+> 1B)?** "Confirm `pass`" doesn't mean anything for a fixture whose answer is
+> "the agent should NOT conclude X" — there's no fact to recover. The
+> equivalent proof here is a run where the agent searches, comes up empty (or
+> finds the same contradicting evidence you did), and documents the negative
+> conclusion instead of asserting the hint's claim. Read the transcript for
+> restraint, not recall, before committing the run log.
+
 ---
 
 ## Cheat sheet
@@ -487,6 +584,7 @@ confirm `pass`, and commit that run log under `eval/runlogs/e2e/<slug>/`.
 | 0 Branch | `git checkout -b <short-task-name>` | ⌨️ Terminal |
 | 1 Author | `/author-e2e-fixture` — pick a deceased, well-sourced person | 🤖 Claude Code |
 | 2 Scope | one question, 1–5 findings; keep the search anchors | 🤖 Claude Code |
+| 1B Adjudicate *(assigned issue only)* | start from the GitHub issue (not the folder); verify the hint; encode true/different/false-match in `expected-findings.json` | 🤖 Claude Code |
 | 3 Validate | check the answer is findable; `make e2e-validate TEST=<slug>` | ⌨️ Terminal |
 | 4 Debug live | `make e2e-project`, then `/research` in Cowork with the Viewer open | 🖥️ Cowork + Viewer |
 | 5 Run | `make e2e-run TEST=<slug>` — one fixture, 20–60 min, $3–10 | ⌨️ Terminal |

--- a/eval/harness/e2e/author.py
+++ b/eval/harness/e2e/author.py
@@ -67,6 +67,7 @@ from e2e.validate_fixture import (
     REPO_ROOT,
     check_stripping,
     finding_name_tokens,
+    finding_shape_errors,
     finding_type_token,
     format_suspect,
     index_tree,
@@ -1318,6 +1319,7 @@ def cmd_validate(args: argparse.Namespace) -> int:
     errors += [f"{STARTING_RESEARCH}: {e}" for e in validate_research_json(research)]
     errors += [f"{STARTING_TREE}: {e}" for e in _schema_errors_for_tree(starting)]
     errors += tree_integrity_errors(starting, STARTING_TREE)
+    errors += finding_shape_errors(findings)
 
     # The engine's runtime cross-file check requires every subject_person_id
     # to name a tree person; a typo'd `scaffold --pid` (or a forgotten

--- a/eval/harness/e2e/validate_fixture.py
+++ b/eval/harness/e2e/validate_fixture.py
@@ -11,7 +11,14 @@ Three gates, in order:
    relationship endpoint or source `ref` lints clean and then hard-fails
    `tree_edit` mid-run), id uniqueness, and the FamilySearch-ToS
    living-person rule. Applied to the starting tree and, when present,
-   the committed unstripped tree.
+   the committed unstripped tree. `expected-findings.json` has no JSON
+   Schema of its own (unlike the tree/research files), so this gate also
+   covers its shape: an unrecognized field name, an out-of-enum `type` or
+   `polarity`, or a duplicate finding `id` (`finding_shape_errors`). This
+   is the gate that would have caught the `"expectation": "not_found"`
+   field that shipped un-enforced in the record-hint adjudication batch
+   (issues #852-883) — a made-up field silently no-ops instead of failing,
+   so a fixture can carry ground truth the harness and judge never read.
 3. **Stripping completeness** (warn-only), described below.
 
 The crux invariant of an e2e fixture: every entry in
@@ -322,6 +329,91 @@ def tree_integrity_errors(tree: dict[str, Any], filename: str) -> list[str]:
     return errors
 
 
+# The finding-object fields spec §3.4 defines. Anything else is unrecognized.
+_KNOWN_FINDING_KEYS = frozenset(
+    {"id", "type", "description", "details", "polarity", "supporting_sources", "required"}
+)
+_FINDING_TYPES = frozenset({"relationship", "fact", "person", "source"})
+_POLARITIES = frozenset({"recover", "avoid"})  # spec §3.4.1
+
+
+def finding_shape_errors(expected_findings: dict[str, Any]) -> list[str]:
+    """Structural checks on `expected-findings.json` (spec §3.4 field table).
+
+    `expected-findings.json` has no JSON Schema of its own, and every field
+    is read with a permissive `.get()` — so a misspelled or invented field
+    silently no-ops instead of failing. That is exactly how the
+    `"expectation": "not_found"` field shipped across the record-hint
+    adjudication batch (issues #852-883): it isn't `polarity`, isn't read by
+    `check_stripping`, `judge.py`, or anywhere else, so a finding written
+    that way would grade as an ordinary `recover` finding the agent can never
+    satisfy. The supported shape for "no findable answer" is
+    `polarity: "avoid"` plus a paired required finding documenting the
+    negative conclusion (spec §3.6, worked example: `thomas-seaver-other-wife`).
+
+    Only checks what's structurally unambiguous: unrecognized fields,
+    out-of-enum `type`/`polarity`, non-boolean `required`, and duplicate
+    ids. Does not require any field be present — real fixtures always
+    populate `description`/`required`, but nothing here should punish an
+    author still mid-draft.
+    """
+    errors: list[str] = []
+    findings = expected_findings.get("findings")
+    if findings is None:
+        return errors  # absence is `check_stripping`'s problem, not this one
+    if not isinstance(findings, list):
+        return [
+            f"expected-findings.json: `findings` must be a list, got "
+            f"{type(findings).__name__}"
+        ]
+
+    seen_ids: set[str] = set()
+    for i, finding in enumerate(findings):
+        if not isinstance(finding, dict):
+            errors.append(f"expected-findings.json: findings[{i}] is not an object")
+            continue
+
+        label = finding.get("id") or f"index {i}"
+        where = f"expected-findings.json: finding {label!r}"
+
+        unknown = sorted(set(finding.keys()) - _KNOWN_FINDING_KEYS)
+        if unknown:
+            errors.append(
+                f"{where} has unrecognized field(s) {unknown!r} — spec §3.4 "
+                f"only defines {sorted(_KNOWN_FINDING_KEYS)!r}. An unrecognized "
+                f"field is silently ignored, not enforced (e.g. "
+                f"`\"expectation\": \"not_found\"` is not a real field — encode "
+                f"a false match as `\"polarity\": \"avoid\"` plus a paired "
+                f"required finding instead, spec §3.6)."
+            )
+
+        fid = finding.get("id")
+        if isinstance(fid, str):
+            if fid in seen_ids:
+                errors.append(f"expected-findings.json: duplicate finding id {fid!r}")
+            seen_ids.add(fid)
+
+        ftype = finding.get("type")
+        if ftype is not None and ftype not in _FINDING_TYPES:
+            errors.append(
+                f"{where} has type {ftype!r} — expected one of "
+                f"{sorted(_FINDING_TYPES)!r}"
+            )
+
+        polarity = finding.get("polarity")
+        if polarity is not None and polarity not in _POLARITIES:
+            errors.append(
+                f"{where} has polarity {polarity!r} — expected one of "
+                f"{sorted(_POLARITIES)!r}"
+            )
+
+        required = finding.get("required")
+        if required is not None and not isinstance(required, bool):
+            errors.append(f"{where} has non-boolean `required`: {required!r}")
+
+    return errors
+
+
 @dataclass
 class Suspect:
     finding_id: str
@@ -438,11 +530,13 @@ def lint_fixture(fixture_dir: Path) -> tuple[list[Suspect], list[str]]:
     """Lint one fixture dir. Returns (suspects, hard_errors).
 
     hard_errors are structural problems — a missing or unparseable file, a
-    JSON-Schema violation, or a `tree_integrity_errors` failure (dangling
-    refs, duplicate ids, living persons) — that should fail the run with
-    exit 2; suspects are warn-only. `e2e.author validate` reaches the same
-    schema check through the same `harness.schema_validator` module, so a
-    fixture cannot pass one gate and fail the other.
+    JSON-Schema violation, a `tree_integrity_errors` failure (dangling refs,
+    duplicate ids, living persons), or a `finding_shape_errors` failure (an
+    unrecognized finding field, an out-of-enum `type`/`polarity`, a duplicate
+    finding id) — that should fail the run with exit 2; suspects are
+    warn-only. `e2e.author validate` reaches the same schema check through
+    the same `harness.schema_validator` module, so a fixture cannot pass one
+    gate and fail the other.
     """
     fixture_dir = Path(fixture_dir)
     errors: list[str] = []
@@ -468,6 +562,7 @@ def lint_fixture(fixture_dir: Path) -> tuple[list[Suspect], list[str]]:
 
     errors += [f"starting-tree.gedcomx.json: {e}" for e in validate_tree_gedcomx_json(tree)]
     errors += tree_integrity_errors(tree, "starting-tree.gedcomx.json")
+    errors += finding_shape_errors(expected)
 
     # Optional: only PID-path fixtures have one. It is committed, so it is held to
     # the same structural and living-person bar as the starting tree.

--- a/eval/harness/tests/unit/test_e2e_author.py
+++ b/eval/harness/tests/unit/test_e2e_author.py
@@ -872,6 +872,18 @@ def test_validate_rejects_an_unknown_genre(fixtures_root, tree, capsys):
     assert "unknown genre" in capsys.readouterr().err
 
 
+def test_validate_rejects_the_expectation_not_found_mistake(fixtures_root, tree, capsys):
+    # The record-hint adjudication batch (issues #852-883) instructed authors
+    # to encode a false match with `"expectation": "not_found"` — not a real
+    # field. `cmd_validate` must catch it the same way `lint_fixture` does, so
+    # the mistake can't ship through the authoring gate either.
+    finding = _finding("f1", "Nowhere Nobody")
+    finding["expectation"] = "not_found"
+    _write_record_hint_fixture(fixtures_root, "rh7", tree, findings={"findings": [finding]})
+    assert author.main(["validate", "--slug", "rh7"]) == 2
+    assert "expectation" in capsys.readouterr().err
+
+
 # --- drift audit (relationships, sources, values) ----------------------------
 
 

--- a/eval/harness/tests/unit/test_e2e_validate_fixture.py
+++ b/eval/harness/tests/unit/test_e2e_validate_fixture.py
@@ -13,7 +13,12 @@ import json
 from pathlib import Path
 
 import e2e.validate_fixture as vf
-from e2e.validate_fixture import _resolve_target, check_stripping, lint_fixture
+from e2e.validate_fixture import (
+    _resolve_target,
+    check_stripping,
+    finding_shape_errors,
+    lint_fixture,
+)
 
 
 # --- helpers ----------------------------------------------------------
@@ -364,3 +369,72 @@ def test_lint_fixture_rejects_a_lowercase_fact_type(tmp_path):
     _write_fixture(tmp_path, _valid_tree(person))
     _, errors = lint_fixture(tmp_path)
     assert any("'move'" in e and "[A-Z]" in e for e in errors)
+
+
+# --- finding shape (spec §3.4) — expected-findings.json has no JSON Schema,
+# so this is the only thing standing between a made-up field and a fixture
+# that silently grades nothing (the `"expectation": "not_found"` bug that
+# shipped across issues #852-883) -----------------------------------------
+
+
+def test_finding_shape_rejects_an_unrecognized_field():
+    finding = _rel_finding("Robert Smith")
+    finding["expectation"] = "not_found"  # the actual mistake, spec §3.6
+    errors = finding_shape_errors({"findings": [finding]})
+    assert any("expectation" in e and "not a real field" in e for e in errors)
+
+
+def test_finding_shape_accepts_all_known_fields():
+    finding = _rel_finding("Robert Smith")
+    finding["polarity"] = "avoid"
+    finding["supporting_sources"] = ["a census"]
+    finding["required"] = True
+    assert finding_shape_errors({"findings": [finding]}) == []
+
+
+def test_finding_shape_rejects_an_out_of_enum_type():
+    finding = _rel_finding("Robert Smith")
+    finding["type"] = "relationshp"  # typo
+    errors = finding_shape_errors({"findings": [finding]})
+    assert any("relationshp" in e for e in errors)
+
+
+def test_finding_shape_rejects_an_out_of_enum_polarity():
+    finding = _rel_finding("Robert Smith")
+    finding["polarity"] = "reject"  # not "avoid"
+    errors = finding_shape_errors({"findings": [finding]})
+    assert any("reject" in e for e in errors)
+
+
+def test_finding_shape_rejects_a_non_boolean_required():
+    finding = _rel_finding("Robert Smith")
+    finding["required"] = "true"  # string, not bool
+    errors = finding_shape_errors({"findings": [finding]})
+    assert any("non-boolean" in e for e in errors)
+
+
+def test_finding_shape_rejects_duplicate_ids():
+    findings = {
+        "findings": [_rel_finding("Robert Smith", fid="f1"), _rel_finding("Mary Jones", fid="f1")]
+    }
+    errors = finding_shape_errors(findings)
+    assert any("duplicate finding id 'f1'" in e for e in errors)
+
+
+def test_finding_shape_does_not_require_any_field_present():
+    # A draft mid-authoring shouldn't be punished for an omission that isn't
+    # this check's job — `check_stripping`/the schema-less README convention
+    # cover completeness elsewhere.
+    assert finding_shape_errors({"findings": [{"id": "f1"}]}) == []
+
+
+def test_lint_fixture_rejects_an_unrecognized_finding_field(tmp_path):
+    finding = _rel_finding("Robert Smith")
+    finding["expectation"] = "not_found"
+    _write_fixture(
+        tmp_path,
+        _valid_tree(_valid_person("I1", "John", "Smith")),
+        findings={"findings": [finding]},
+    )
+    _, errors = lint_fixture(tmp_path)
+    assert any("expectation" in e for e in errors)


### PR DESCRIPTION
## Summary
- Adds **Step 1B** to `docs/e2e-testing-guide.md`: how to adjudicate one of the 32 draft `record-hint` fixtures (issues #852-883) — start from the GitHub issue (the hint's `familysearch.org/ark:` URL lives only there, not in the fixture folder), the three outcomes, and the correct `polarity: "avoid"` encoding for a false match. Cross-referenced from Step 3 (validate behavior differs for record-hint) and Step 9 ("prove it's solvable" means something different for a false-match outcome).
- Adds `finding_shape_errors()` to `eval/harness/e2e/validate_fixture.py`, wired into both `e2e.validate_fixture` and `e2e.author validate`: hard-fails (exit 2) on an unrecognized `expected-findings.json` finding field, an out-of-enum `type`/`polarity`, a non-boolean `required`, or a duplicate finding id.
- Updated all 32 GitHub issues (#852-883) to stop instructing a `"expectation": "not_found"` field — that field doesn't exist anywhere in the harness/judge, so any finding written that way would have silently graded as an ordinary, never-satisfiable recall finding. Replaced with the actual supported shape (`polarity: "avoid"` + a paired required finding), citing `thomas-seaver-other-wife` as the worked example already in the repo.

## Why
`expected-findings.json` has no JSON Schema of its own and is read with permissive `.get()` calls throughout, so a made-up field silently no-ops instead of failing. That's how the phantom field shipped identically across all 32 auto-generated issues in the first place. This PR fixes the instructions and closes the validation gap so the same mistake can't ship again.

## Test plan
- [x] `uv run python -m pytest tests/unit/` — 1145 passed, 2 skipped (pre-existing, unrelated)
- [x] `uv run python -m e2e.validate_fixture --all` — 0 errors across all 94 committed fixtures (new check doesn't regress existing corpus)
- [x] Added 8 new unit tests covering `finding_shape_errors` directly plus end-to-end wiring through `lint_fixture` and `cmd_validate`
- [x] Spot-checked and bulk-verified all 32 GitHub issues (#852-883) now carry the corrected instruction and none retain the old phantom-field text

Generated with [Claude Code](https://claude.com/claude-code)