### PR TITLE
e2e: tag timeline entries with tool/skill names for per-skill latency analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,11 +410,13 @@ e2e-calibrate: ## Run judge calibration against committed run annotations (maint
 	cd eval/harness && uv run python -m e2e.calibrate_judge
 
 .PHONY: e2e-latency
-e2e-latency: ## Phase-0 latency breakdown of committed e2e runs: make e2e-latency (all) | TEST=<slug> | MD=1 for a Markdown table
+e2e-latency: ## Phase-0 latency breakdown of committed e2e runs: make e2e-latency (all) | TEST=<slug> | MD=1 for a Markdown table | BY_SKILL=1 for a per-skill phase breakdown
 	# Pure analysis over committed run JSONs — no live run, no API. Answers
 	# "how much of wall-clock is model generation vs tool execution?" (the
 	# Phase 0 gate). See docs/plan/research-latency-reduction-plan.md.
-	cd eval/harness && uv run python -m e2e.latency_report $(if $(TEST),--test $(TEST),--all) $(if $(MD),--markdown,)
+	# BY_SKILL needs a run committed after 2026-07-26 (timeline tool-name tagging);
+	# older runs report "no skill-phase data" rather than crashing.
+	cd eval/harness && uv run python -m e2e.latency_report $(if $(TEST),--test $(TEST),--all) $(if $(MD),--markdown,) $(if $(BY_SKILL),--by-skill,)
 
 .PHONY: skill-latency
 skill-latency: ## Per-skill output-token profile from unit runlogs: make skill-latency (all) | SKILL=<name> [VS_PREV=1] | BEFORE=a.json AFTER=b.json

--- a/eval/harness/e2e/latency_report.py
+++ b/eval/harness/e2e/latency_report.py
@@ -13,9 +13,17 @@ committed result JSON (see e2e/result.py):
   - ``usage.duration_api_ms``  — cumulative time awaiting the model API
   - ``usage.num_turns``        — assistant turns
   - ``usage.usage.output_tokens`` (and input / cache counters)
-  - ``usage.timeline``         — ``[[elapsed_s, kind], ...]`` per SDK message,
-                                 kind ∈ {assistant, tool_result, system:*, result}
-                                 (added after 2026-06; older runs lack it)
+  - ``usage.timeline``         — ``[[elapsed_s, kind, tool_names], ...]`` per SDK
+                                 message, kind ∈ {assistant, tool_result, system:*,
+                                 result}. ``tool_names`` (added 2026-07-26) is the
+                                 list of ``_timeline_tool_label``-formatted names
+                                 for any tool call in that message — a Skill call
+                                 is labeled ``"Skill:<skill-name>"`` rather than
+                                 the bare "Skill", so a run's Skill-phase
+                                 boundaries are readable directly off the
+                                 timeline. Runs from before that date have 2-element
+                                 rows (no ``tool_names``); ``--by-skill`` degrades
+                                 to "no data" rather than crashing on those.
 
 This module is pure analysis on top of that — it adds **no** instrumentation to
 a run. ``analyze_result`` is a pure function (unit-tested without a live run);
@@ -25,6 +33,7 @@ CLI (from eval/harness/):
   uv run python -m e2e.latency_report --test kenneth-quass-death
   uv run python -m e2e.latency_report --all
   uv run python -m e2e.latency_report --all --markdown > table.md
+  uv run python -m e2e.latency_report --test kenneth-quass-death --by-skill
   uv run python -m e2e.latency_report path/to/run-<ts>.json [more.json ...]
 
 Two independent decompositions are reported so they corroborate:
@@ -34,6 +43,14 @@ Two independent decompositions are reported so they corroborate:
      (``assistant`` + ``system:*``) is non-tool (model generation, plus any
      stall/resume idle — not separable within one session). Wall-clock beyond the
      timeline span is flagged separately as stall/idle.
+
+A third, optional decomposition — ``--by-skill`` — segments the run into
+per-Skill-invocation phases (e.g. how long ``person-evidence`` vs.
+``proof-conclusion`` ran) using the ``tool_names`` tags above. This used to
+require the raw SDK ``session.jsonl`` (gitignored, and only reliably present
+by accident — see ``docs/plan/tree-materialization-batching-plan.md`` §1.2);
+now every run committed after the tags were added carries what's needed, from
+any contributor's normal PR, with no extra step.
 """
 
 from __future__ import annotations
@@ -114,6 +131,11 @@ class LatencyBreakdown:
     # model deliberations.
     slowest_gen_gaps: list[tuple[float, float]] = field(default_factory=list)
 
+    # Per-Skill-invocation phases (--by-skill), from the timeline's tool_names
+    # tags (see _skill_phase_breakdown). Empty for a run committed before the
+    # tags existed, or a run with no Skill tool-use at all — never an error.
+    skill_phases: list[dict[str, Any]] = field(default_factory=list)
+
 
 def _timeline_decomposition(timeline: list[list[Any]]) -> dict[str, Any]:
     """Split inter-message wall-clock gaps into tool-execution vs everything-else.
@@ -159,6 +181,49 @@ def _timeline_decomposition(timeline: list[list[Any]]) -> dict[str, Any]:
         "tool_time_pct": (tool / total) if total > 0 else None,
         "slowest_gen_gaps": gen_gaps[:5],
     }
+
+
+def _skill_phase_breakdown(timeline: list[list[Any]]) -> list[dict[str, Any]]:
+    """Segment a run into per-Skill-invocation phases using the timeline's
+    ``tool_names`` tags (orchestrator.py's ``_timeline_tool_label``).
+
+    A ``"Skill:<name>"`` tag marks a context switch, not a call-and-return —
+    the skill's actual work happens in the turns that follow, until the next
+    Skill invocation (or the run's end). So a phase's span is
+    [this Skill tag's elapsed_s, the NEXT Skill tag's elapsed_s (or the
+    timeline's last point)], not the gap to its own tool_result.
+
+    Runs committed before the tags existed have 2-element timeline rows (or
+    a 3rd element that's always ``[]``) and no ``"Skill:"``-prefixed names
+    anywhere — this returns ``[]`` for those, never raises. A run with a
+    tagged timeline but genuinely no Skill tool-use (crashed before routing)
+    also returns ``[]``.
+    """
+    boundaries: list[tuple[float, str]] = []
+    last_t = 0.0
+    for entry in timeline:
+        t = float(entry[0])
+        last_t = t
+        names = entry[2] if len(entry) > 2 else []
+        if not isinstance(names, list):
+            continue
+        for name in names:
+            if isinstance(name, str) and name.startswith("Skill:"):
+                boundaries.append((t, name[len("Skill:"):]))
+    if not boundaries:
+        return []
+    phases: list[dict[str, Any]] = []
+    for i, (start, skill) in enumerate(boundaries):
+        end = boundaries[i + 1][0] if i + 1 < len(boundaries) else last_t
+        phases.append(
+            {
+                "skill": skill,
+                "start_s": round(start, 1),
+                "end_s": round(end, 1),
+                "duration_s": round(max(0.0, end - start), 1),
+            }
+        )
+    return phases
 
 
 def analyze_result(result: dict[str, Any], source_file: str | None = None) -> LatencyBreakdown:
@@ -218,6 +283,7 @@ def analyze_result(result: dict[str, Any], source_file: str | None = None) -> La
         # Wall-clock beyond the timeline span is stall/resume/judge idle.
         if bd.timeline_span_s is not None:
             bd.stall_s = round(max(0.0, bd.wall_clock_s - bd.timeline_span_s), 1)
+        bd.skill_phases = _skill_phase_breakdown(timeline)
 
     return bd
 
@@ -286,6 +352,24 @@ def format_markdown_table(bds: list[LatencyBreakdown]) -> str:
     return "\n".join([header, *rows])
 
 
+def format_skill_phases(bd: LatencyBreakdown) -> str:
+    """A per-run block: how long each Skill invocation ran, in order."""
+    if not bd.skill_phases:
+        return (
+            f"=== {bd.test_id} — no skill-phase data "
+            "(run predates timeline tool-name tagging, or made no Skill tool-use) ==="
+        )
+    lines = [f"=== {bd.test_id} — per-skill phase breakdown ==="]
+    for p in bd.skill_phases:
+        share = (p["duration_s"] / bd.wall_clock_s * 100) if bd.wall_clock_s else None
+        share_str = f"{share:.0f}%" if share is not None else "n/a"
+        lines.append(
+            f"  {p['skill']:<28} {_fmt_min(p['duration_s']):>7}  "
+            f"({p['start_s']:.0f}s → {p['end_s']:.0f}s, {share_str} of wall-clock)"
+        )
+    return "\n".join(lines)
+
+
 # --- Run discovery + CLI ----------------------------------------------------
 
 def _is_result_json(p: Path) -> bool:
@@ -330,6 +414,12 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--test", help="latest committed run for this fixture slug")
     ap.add_argument("--all", action="store_true", help="latest run per fixture")
     ap.add_argument("--markdown", action="store_true", help="emit a Markdown table")
+    ap.add_argument(
+        "--by-skill",
+        action="store_true",
+        help="per-skill wall-clock phase breakdown instead of the whole-run summary "
+        "(needs a run committed after 2026-07-26's timeline tool-name tagging)",
+    )
     args = ap.parse_args(argv)
 
     paths: list[Path] = [Path(f) for f in args.files]
@@ -347,7 +437,11 @@ def main(argv: list[str] | None = None) -> int:
 
     bds = [_load(p) for p in paths]
 
-    if args.markdown:
+    if args.by_skill:
+        for bd in bds:
+            print(format_skill_phases(bd))
+            print()
+    elif args.markdown:
         print(format_markdown_table(bds))
     else:
         for bd in bds:

--- a/eval/harness/e2e/orchestrator.py
+++ b/eval/harness/e2e/orchestrator.py
@@ -404,6 +404,28 @@ def _summarize_tool_response(content: Any) -> str:
     return text
 
 
+def _timeline_tool_label(tool: str, args: dict | None) -> str:
+    """Human-legible label for a `timeline` entry's tool-names list.
+
+    `tool_calls` already has the bare name (and, for Skill, the skill it
+    launched, in `args["skill"]`) — but no timestamp. `timeline` has the
+    timestamp — but until this label existed, no tool identity, so a
+    per-skill wall-clock breakdown (e2e.latency_report --by-skill) could
+    only be reconstructed from the raw SDK session transcript, which is
+    gitignored and normally discarded once the run's tempdir is cleaned up
+    (not a reliable source for other contributors' PRs). Labeling the
+    timeline directly means every committed run carries it for free.
+
+    A Skill call is labeled with the skill it launches (e.g.
+    "Skill:person-evidence") rather than the bare "Skill" — that is the
+    actual phase-boundary signal callers need; the bare tool name alone
+    would require a second join against `tool_calls` to recover it.
+    """
+    if tool == "Skill":
+        return f"Skill:{(args or {}).get('skill', '?')}"
+    return _bare_tool_name(tool)
+
+
 _USAGE_FIELDS = (
     "input_tokens",
     "output_tokens",
@@ -526,9 +548,14 @@ async def _run_agent(
 
     run_started = time.monotonic()
 
-    # Per-message timeline for forensics: [elapsed_seconds, kind]. Lets a later
-    # analysis split a run into structural vs stall time and pinpoint a
-    # no-progress gap WITHOUT a session.jsonl (which isn't reliably copied).
+    # Per-message timeline for forensics: [elapsed_seconds, kind, tool_names].
+    # Lets a later analysis split a run into structural vs stall time, pinpoint
+    # a no-progress gap, AND segment a run by Skill-phase boundaries — all
+    # WITHOUT a session.jsonl (which isn't reliably copied, and is gitignored
+    # even when it is — see _timeline_tool_label). tool_names is the list of
+    # `_timeline_tool_label`-formatted names for any ToolUseBlock/ToolResultBlock
+    # in this message ([] for assistant messages with no tool call, and always
+    # [] for system:*/result kinds).
     timeline: list[list[Any]] = []
     # Stall detection tracks time since the last PROGRESS message (assistant
     # text, a tool call, or a tool result) — not since any message, because the
@@ -807,6 +834,7 @@ async def _run_agent(
                 progressed = False
 
                 if isinstance(message, AssistantMessage):
+                    assistant_tool_names: list[str] = []
                     for block in message.content:
                         if isinstance(block, TextBlock):
                             transcript.append(f"\n**assistant:** {block.text}\n")
@@ -822,6 +850,9 @@ async def _run_agent(
                             }
                             tool_calls.append(entry)
                             pending_tool_uses[block.id] = entry
+                            assistant_tool_names.append(
+                                _timeline_tool_label(block.name, block.input)
+                            )
                             args_short = _summarize_tool_response(block.input)
                             transcript.append(
                                 f"\n**tool_use** `{block.name}` — args: {args_short}\n"
@@ -834,10 +865,13 @@ async def _run_agent(
                     # Record before the timeline append so a message that
                     # arrives moments before a timeout still counts.
                     _accumulate_usage(streamed, message)
-                    timeline.append([round(now - run_started, 1), "assistant"])
+                    timeline.append(
+                        [round(now - run_started, 1), "assistant", assistant_tool_names]
+                    )
                 elif isinstance(message, UserMessage):
                     # Tool results return as UserMessages with ToolResultBlock content.
                     content = message.content
+                    tool_result_names: list[str] = []
                     if isinstance(content, list):
                         for block in content:
                             if isinstance(block, ToolResultBlock):
@@ -845,9 +879,14 @@ async def _run_agent(
                                 summary = _summarize_tool_response(block.content)
                                 if entry is not None:
                                     entry["response_summary"] = summary
+                                    tool_result_names.append(
+                                        _timeline_tool_label(entry["tool"], entry.get("args"))
+                                    )
                                 transcript.append(f"\n**tool_result:** {summary}\n")
                                 progressed = True
-                    timeline.append([round(now - run_started, 1), "tool_result"])
+                    timeline.append(
+                        [round(now - run_started, 1), "tool_result", tool_result_names]
+                    )
                 elif isinstance(message, SystemMessage):
                     # Init / config / hint messages. Capture the session id (for
                     # resume) and the CLI version (for the runlog); neither counts
@@ -860,10 +899,10 @@ async def _run_agent(
                     if ver:
                         cli_version["v"] = ver
                     timeline.append(
-                        [round(now - run_started, 1), f"system:{message.subtype}"]
+                        [round(now - run_started, 1), f"system:{message.subtype}", []]
                     )
                 elif isinstance(message, ResultMessage):
-                    timeline.append([round(now - run_started, 1), "result"])
+                    timeline.append([round(now - run_started, 1), "result", []])
                     usage = {
                         "duration_ms": message.duration_ms,
                         "duration_api_ms": message.duration_api_ms,

--- a/eval/harness/tests/unit/test_e2e_latency_report.py
+++ b/eval/harness/tests/unit/test_e2e_latency_report.py
@@ -12,6 +12,8 @@ from e2e.latency_report import (
     analyze_result,
     format_breakdown,
     format_markdown_table,
+    format_skill_phases,
+    _skill_phase_breakdown,
     _timeline_decomposition,
 )
 
@@ -146,4 +148,66 @@ def test_markdown_table_has_row_per_run():
     table = format_markdown_table(bds)
     assert table.count("\n") == 3  # header + separator + 2 rows
     assert "morris" in table
-    assert "kenneth-quass-death" in table
+
+
+# --- --by-skill (timeline tool-name tags, added 2026-07-26) ------------------
+
+_SKILL_TIMELINE = [
+    [0.0, "assistant", ["Skill:question-selection"]],
+    [5.0, "tool_result", []],
+    [8.0, "assistant", ["Skill:research-plan"]],
+    [15.0, "tool_result", []],
+    [20.0, "assistant", ["Skill:person-evidence"]],
+    [45.0, "tool_result", ["record_search"]],
+    [50.0, "assistant", []],
+]
+
+
+def test_skill_phase_breakdown_segments_by_skill_boundary():
+    phases = _skill_phase_breakdown(_SKILL_TIMELINE)
+    assert [p["skill"] for p in phases] == [
+        "question-selection",
+        "research-plan",
+        "person-evidence",
+    ]
+    # Each phase runs from its own Skill tag to the NEXT one's (not to its own
+    # tool_result) — the final phase runs to the timeline's last point.
+    assert phases[0] == {"skill": "question-selection", "start_s": 0.0, "end_s": 8.0, "duration_s": 8.0}
+    assert phases[1] == {"skill": "research-plan", "start_s": 8.0, "end_s": 20.0, "duration_s": 12.0}
+    assert phases[2] == {"skill": "person-evidence", "start_s": 20.0, "end_s": 50.0, "duration_s": 30.0}
+
+
+def test_skill_phase_breakdown_empty_for_legacy_timeline_rows():
+    """2-element rows (pre-2026-07-26, no tool_names at all) -> no crash, []."""
+    assert _skill_phase_breakdown(_result()["usage"]["timeline"]) == []
+
+
+def test_skill_phase_breakdown_empty_when_tagged_but_no_skill_calls():
+    """3-element rows present, but nothing is a Skill call (e.g. a run that
+    crashed before routing to any skill) -> []. not an error."""
+    timeline = [[0.0, "assistant", []], [3.0, "tool_result", ["record_search"]]]
+    assert _skill_phase_breakdown(timeline) == []
+
+
+def test_analyze_result_populates_skill_phases():
+    bd = analyze_result(_result(usage={**_result()["usage"], "timeline": _SKILL_TIMELINE}))
+    assert [p["skill"] for p in bd.skill_phases] == [
+        "question-selection",
+        "research-plan",
+        "person-evidence",
+    ]
+
+
+def test_format_skill_phases_renders_each_phase():
+    bd = analyze_result(_result(usage={**_result()["usage"], "timeline": _SKILL_TIMELINE}))
+    text = format_skill_phases(bd)
+    assert "question-selection" in text
+    assert "research-plan" in text
+    assert "person-evidence" in text
+
+
+def test_format_skill_phases_no_data_message_for_legacy_run():
+    bd = analyze_result(_result())  # legacy 2-element timeline, no tags
+    text = format_skill_phases(bd)
+    assert "no skill-phase data" in text
+    assert "kenneth-quass-death" in text

--- a/eval/harness/tests/unit/test_e2e_orchestrator.py
+++ b/eval/harness/tests/unit/test_e2e_orchestrator.py
@@ -18,6 +18,7 @@ from e2e.orchestrator import (
     _fallback_usage,
     _render_user_message,
     _summarize_tool_response,
+    _timeline_tool_label,
     build_workspace,
     load_fixture,
     provided_documents,
@@ -354,6 +355,31 @@ def test_summarize_tool_response_truncates_long_content():
     out = _summarize_tool_response(long)
     assert len(out) <= 500
     assert out.endswith("...")
+
+
+# --- timeline tool labeling ---------------------------------------------------
+# Regression cover for the per-skill wall-clock gap: usage.timeline carried
+# elapsed time + message kind but no tool identity, so a Skill-phase
+# breakdown could only be reconstructed from the raw session.jsonl (gitignored,
+# not reliably present for other contributors' PRs). _timeline_tool_label is
+# what timeline.append now calls to tag each entry.
+
+
+def test_timeline_tool_label_skill_call_names_the_skill():
+    assert _timeline_tool_label("Skill", {"skill": "person-evidence"}) == "Skill:person-evidence"
+
+
+def test_timeline_tool_label_skill_call_missing_skill_arg():
+    assert _timeline_tool_label("Skill", {}) == "Skill:?"
+    assert _timeline_tool_label("Skill", None) == "Skill:?"
+
+
+def test_timeline_tool_label_mcp_tool_strips_prefix():
+    assert _timeline_tool_label("mcp__genealogy__record_search", {}) == "record_search"
+
+
+def test_timeline_tool_label_non_mcp_tool_passthrough():
+    assert _timeline_tool_label("Read", {"file_path": "x"}) == "Read"
 
 
 # --- streamed-usage fallback -------------------------------------------------


### PR DESCRIPTION
## Summary

- `usage.timeline` (`[elapsed_s, kind]`) has timestamps but no tool identity, and `tool_calls` has tool identity but no timestamps — so a per-skill wall-clock breakdown (which phase of a run is slow) could only be reconstructed from the raw SDK `session.jsonl`, which is gitignored and normally discarded once a run's tempdir is cleaned up. That made it a lucky accident whenever the data needed for a performance investigation happened to survive (only ever observed once, by accident, in `spriggs-marriage-1926`).
- Tags each `timeline` entry with the tool name(s) involved (a `Skill` call is labeled `"Skill:<skill-name>"` rather than the bare `"Skill"`, so a Skill-phase boundary is readable directly off the timeline without a second join against `tool_calls`).
- Adds `--by-skill` to `e2e.latency_report` (and `make e2e-latency BY_SKILL=1`) to segment a run into per-Skill-invocation phases from those tags — e.g. how long `person-evidence` vs. `proof-conclusion` ran, without needing the raw transcript.
- Every e2e run committed from now on carries this for free, through the normal PR flow (`run-<ts>.json` + `.ann.json`). No change to the `.session.jsonl` gitignore policy, no new discipline required of contributors.
- Backward compatible: runs committed before this land with 2-element timeline rows (or a 3rd element that's always `[]`); `--by-skill` reports "no skill-phase data" for those rather than crashing, and the existing whole-run analysis (`_timeline_decomposition`, tool/non-tool split) is untouched.

Follow-up from `docs/plan/tree-materialization-batching-plan.md` §8 (a `--by-skill` mode was flagged there as a nice-to-have once that plan's investigation needed per-skill timing it couldn't reliably get).

## Test plan

- [x] `eval/harness`'s full test suite passes (1147 passed, 2 skipped)
- [x] New unit tests for `_timeline_tool_label` (orchestrator.py): Skill-call labeling, missing skill arg, mcp-prefix stripping, passthrough
- [x] New unit tests for `_skill_phase_breakdown` / `format_skill_phases` (latency_report.py): boundary segmentation, legacy 2-element-row backward compatibility, tagged-but-no-Skill-calls case
- [x] Manually verified `make e2e-latency TEST=kenneth-quass-death BY_SKILL=1` degrades cleanly on a real historical (pre-tagging) run
- [x] Manually verified normal `make e2e-latency` output is byte-identical in shape (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)