### PR TITLE
docs: restructure e2e guide around record-hint fixture resolution

### DIFF
--- a/.claude/skills/resolve-record-hint/SKILL.md
+++ b/.claude/skills/resolve-record-hint/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: resolve-record-hint
+model: claude-sonnet-4-6
+description: Resolves a draft `genre: "record-hint"` e2e fixture that was assigned via a GitHub issue titled "test <slug>". The fixture's expected-findings.json currently just transcribes an unverified FamilySearch hint record; this skill walks the genealogist through confirming or refuting the hint (the research itself is done by hand on familysearch.org — this skill never fetches anything), then writes the correct expected-findings.json, updates the README's "Notes for reviewers" and fixture.json's notes, and validates the result. Use when the user says "resolve this fixture", "adjudicate this fixture", "I was assigned test <slug>", "review this record hint", pastes a "test <slug>" GitHub issue, or asks to encode the outcome in expected-findings.json for a record-hint fixture. Do NOT use to author a brand-new fixture from a FamilySearch PID or research document (use author-e2e-fixture), to interpret or grade a completed e2e run (use interpret-e2e-result / grade-e2e-run), or to mine a unit test from a miss (use mine-unit-test).
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+---
+
+# Resolve Record Hint
+
+**Narration:** default to concise — this is developer/genealogist-facing fixture work, not research narration.
+
+A `record-hint` fixture starts as a guess: FamilySearch's own hinting matched a
+historical record to a tree person with unverified confidence, and
+`expected-findings.json` just transcribes that guess. Resolving it means doing
+the real genealogical work to confirm or refute it, then making the fixture
+state the truth. **The genealogist does the research and makes the call; this
+skill only does the writing**, so no one hand-edits the JSON.
+
+## Step 1 — Find the issue and the fixture
+
+Get a GitHub issue number/URL or a fixture slug from the user; ask if you have
+neither.
+
+- Given an issue: `gh issue view <n> --json title,body`. Pull the slug (from
+  the title, `test <slug>`) and the hint record's `familysearch.org/ark:/...`
+  URL — that URL lives **only** in the issue body, never in the fixture
+  folder.
+- Read `eval/tests/e2e/<slug>/README.md`'s "Notes for reviewers" — what the
+  original author already found (the tree's existing sources, the
+  match-strength argument for and against).
+- Read the fixture's current `expected-findings.json` and `fixture.json`.
+
+## Step 2 — Send the genealogist to do the research
+
+Tell them to open the hint record at the issue's URL on **familysearch.org**,
+by hand, and look for corroborating or contradicting evidence the same way
+they would for any genealogical proof — reading the attached sources,
+searching independently for the person, checking dates and places against
+what the tree already has. This is the actual GPS work the benchmark exists
+to measure; there is no tool shortcut for it, and this skill does not fetch
+the record for them.
+
+If the call is borderline, tell them to ask a genealogist for a second
+opinion rather than guess alone.
+
+Wait for their conclusion before continuing.
+
+## Step 3 — Get the outcome
+
+Ask which of the three applies, and collect only what that outcome needs:
+
+1. **True match** — nothing further needed.
+2. **Answerable, but differently** — what's actually true (a different date,
+   record, or person) in place of what's there now.
+3. **False match, no findable substitute** — the specific claim the agent
+   must not assert, plus confirmation that the search came up empty (or
+   turned up contradicting evidence).
+
+In all three cases, also ask for their reasoning in plain language — this
+becomes the README's new "Notes for reviewers."
+
+## Step 4 — Write the files
+
+- **`expected-findings.json`**
+  - Outcome 1: leave unchanged.
+  - Outcome 2: edit the existing finding(s)' `description` / `details` /
+    `supporting_sources` to the corrected answer.
+  - Outcome 3: replace the findings with a `"polarity": "avoid"` finding
+    naming the wrong claim, paired with a `required: true` finding
+    documenting the negative conclusion. Follow
+    `eval/tests/e2e/thomas-seaver-other-wife/expected-findings.json` as the
+    worked shape.
+
+  Only use the fields spec §3.4 defines: `id`, `type`, `description`,
+  `details`, `polarity`, `supporting_sources`, `required`. **Never write
+  `"expectation"`** — it isn't a real field. An unrecognized field silently
+  no-ops instead of grading anything, and `make e2e-validate` hard-fails on
+  it anyway.
+
+- **`README.md`** — replace the "DRAFT PENDING ADJUDICATION" paragraph under
+  "Notes for reviewers" with the genealogist's conclusion and reasoning.
+  Match the level of detail in `thomas-seaver-other-wife`'s or
+  `heinrich-dewus-children-death`'s README.
+
+- **`fixture.json`** — update `notes` if it still describes the fixture as
+  an unverified draft.
+
+**Never touch** `starting-tree.gedcomx.json`, `unstripped-tree.gedcomx.json`,
+or `starting-research.json` — this task only edits the three files above;
+those three are already correct and immutable.
+
+## Step 5 — Validate
+
+```bash
+cd eval/harness && uv run python -m e2e.validate_fixture <slug>
+# equivalently, from the repo root: make e2e-validate TEST=<slug>
+```
+
+This is a record-hint fixture, so a `WARN` naming the fixture's own subject
+person is **expected, not a problem** — the subject legitimately stays in
+the tree, since nothing was ever stripped. A hard `ERROR` means something
+structural is actually wrong — fix it before handing off.
+
+## Step 6 — Hand off
+
+Tell the user the fixture is resolved. The next step is **Step 4** of
+`docs/e2e-testing-guide.md` (debug live in Cowork) — Steps 2 and 3 don't
+apply to this genre, because nothing was stripped and Step 5 above already
+validated it.
+
+## What you do not do
+
+- Don't fetch or read the hint record yourself — the genealogist does that
+  research by hand; you write up their conclusion.
+- Don't touch `starting-tree.gedcomx.json`, `unstripped-tree.gedcomx.json`,
+  or `starting-research.json`.
+- Don't write any finding field spec §3.4 doesn't define.
+- Don't skip Step 5 — an unvalidated fixture can silently ship a structural
+  error.
+
+## Re-invocation behavior
+
+**Writes:** `expected-findings.json`, `README.md`'s "Notes for reviewers",
+and `fixture.json`'s `notes`, all under `eval/tests/e2e/<slug>/`.
+
+**On repeat invocation:** re-running re-resolves from the fixture's
+current state — safe, since the current state (not history) is always the
+starting point. If the fixture was already resolved (no "DRAFT PENDING
+ADJUDICATION" left), confirm with the user before overwriting a settled
+conclusion.

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -48,9 +48,10 @@ A fourth surface matters throughout: the **Research Viewer** (Electron,
 sources of whichever project folder you point it at. It's how you *see* what the
 agent wrote instead of trusting the chat's summary of itself.
 
-> `author-e2e-fixture`, `interpret-e2e-result`, and `grade-e2e-run` are
-> repo-local dev skills — **not** part of the shipped Cowork plugin. The
-> `/`-commands are typed into Claude Code and are identical on every platform.
+> `author-e2e-fixture`, `resolve-record-hint`, `interpret-e2e-result`, and
+> `grade-e2e-run` are repo-local dev skills — **not** part of the shipped
+> Cowork plugin. The `/`-commands are typed into Claude Code and are
+> identical on every platform.
 
 ---
 
@@ -88,7 +89,9 @@ the answer — his father John William Spriggs, his mother Charlotte Marie
 Westby, and the two census sources naming them — is what got stripped.
 
 Read `eval/tests/e2e/spriggs-parents-1898/` alongside this page; substitute your
-own slug as you go.
+own slug as you go. It follows the self-authoring path (Step 1b). If you're
+adjudicating an assigned fixture instead (Step 1a), `thomas-seaver-other-wife`
+and `heinrich-dewus-children-death` are the worked examples to read instead.
 
 ---
 
@@ -112,7 +115,61 @@ on `main` → **Create branch**.
 Everything the rest of this produces — the fixture files, the run log, the
 grade — lands on this one branch.
 
-## Step 1 — Pick a person and author the fixture 🤖 Claude Code
+## Step 1 — Choose your path 🤖 Claude Code
+
+- **Assigned a fixture?** A GitHub issue titled "test `<slug>`" means the
+  fixture already exists, drafted from an unverified FamilySearch record
+  hint. Go to **Step 1a**. This is the normal way fixtures get worked going
+  forward — most contributors start here, not by picking a new person.
+- **Authoring a brand-new fixture?** No issue — just a person (or research
+  document) you want to turn into a test. Go to **Step 1b**.
+
+## Step 1a — Resolve an assigned fixture 🤖 Claude Code
+
+**What this is.** A `genre: "record-hint"` fixture (spec §3.6) inverts the
+normal shape: nothing was stripped, because the answer was never in the
+FamilySearch tree to begin with. It lives in a historical record that
+FamilySearch's own hinting matched to the tree person with *unverified*
+confidence. Adjudicating means doing the real genealogical work to decide
+whether the hint is true, then making `expected-findings.json` state the
+truth instead of the raw, unverified hint.
+
+**Start from the GitHub issue, not the fixture folder.** The source you're
+checking — a clickable `familysearch.org/ark:/...` URL to the specific hint
+record — lives *only* in the issue body. The fixture's own README
+paraphrases the hint as prose, with no link. Open the issue first.
+
+**Do the research.** Read the fixture's README "Notes for reviewers" section
+for what the original author already found (the tree's existing sources, the
+match-strength argument for and against). Then open the hint record at the
+issue's URL on **familysearch.org** and look, by hand, for corroborating or
+contradicting evidence — the same way you would for any genealogical proof.
+This is the human GPS work the benchmark exists to measure; there's no tool
+shortcut for it. **Ask a genealogist for a second opinion** if the call is
+borderline — don't guess alone.
+
+**Write the outcome with the skill — don't hand-edit the JSON:**
+
+```
+/resolve-record-hint
+```
+
+Give it the issue (number or URL) or the slug. It walks you through the three
+possible outcomes, asks what you found, and writes `expected-findings.json`,
+the README's "Notes for reviewers", and `fixture.json`'s `notes` for you —
+then validates the result:
+
+1. **True match** — findings stay as written.
+2. **Answerable, but differently** — the skill edits `expected-findings.json`
+   to the correct answer.
+3. **False match, no findable substitute** — the skill replaces the findings
+   with a `polarity: "avoid"` finding naming the wrong claim, paired with a
+   required finding documenting the negative conclusion.
+
+Once the skill hands off, go straight to **Step 4** — Steps 2 and 3 don't
+apply here (nothing was stripped, and the skill already validated).
+
+## Step 1b — Pick a person and author a new fixture 🤖 Claude Code
 
 **The normal path is one command.** From a Claude Code session at the repo root,
 logged in to FamilySearch:
@@ -132,11 +189,6 @@ choosing:
 - **Deceased.** Required by FamilySearch's terms. This is *enforced* — the
   authoring tool refuses a person marked living, and refuses one whose `living`
   field is simply absent (absent is not deceased).
-- **Substantial, diverse sources.** At least 10 attached, spanning multiple
-  record types — census + vital + church or probate. Five censuses of the same
-  family across years doesn't count. (Reuben had 12; stripping took it to 10.)
-- **Reasonable size.** Over ~500 KB of snapshot, narrow the scope or pick
-  someone else.
 - **Stable.** Older records, settled profiles — not ones being actively edited.
 
 > There's a second, secondary path for when you have no FamilySearch access:
@@ -144,12 +196,9 @@ choosing:
 > `source_pid` you resolve before landing. `/author-e2e-fixture` covers it;
 > everything below applies unchanged.
 
-> **Assigned a GitHub issue titled "test `<slug>`"** (numbered among
-> #852–883, or similar)? You're not authoring a fixture — one already
-> exists, drafted from an unverified FamilySearch record hint, and your job
-> is to adjudicate it. Skip Steps 1–2 and go to **Step 1B** below.
-
 ## Step 2 — Match the question to what you strip 🤖 Claude Code
+
+*(Step 1b only — skip this and Step 3 if you came from Step 1a.)*
 
 The research question is what the agent receives. The stripping decides what it
 must recover. They have to line up:
@@ -184,119 +233,29 @@ in genealogy, because a wrong parent silently corrupts an entire upstream tree.
 Aim for the suite as a whole to cover both, across a spread of question types,
 eras and geographies. Details: spec §3.4.1.
 
-## Step 1B — Adjudicating an assigned draft record-hint fixture 🤖 Claude Code
-
-Skip this unless you were assigned one of these issues. If you were, skip
-Steps 1–2 — the fixture already exists — and rejoin the guide at Step 3 once
-you're done here.
-
-**What this is.** A `genre: "record-hint"` fixture (spec §3.6) inverts the
-normal shape: nothing was stripped, because the answer was never in the
-FamilySearch tree to begin with. It lives in a historical record that
-FamilySearch's own hinting matched to the tree person with *unverified*
-confidence. `filtered-list-samples.csv` — a batch of such hints — seeded 32
-of these fixtures (issues #852–883) plus two earlier ones (#637, #638), each
-one's README saying **DRAFT PENDING ADJUDICATION**. Adjudicating one means
-doing the actual genealogical work to decide whether the hint is true, then
-making `expected-findings.json` state the truth instead of the raw,
-unverified hint.
-
-**Start from the GitHub issue, not the fixture folder.** Unlike every other
-fixture in the repo, the source you're checking — a clickable
-`familysearch.org/ark:/...` URL to the specific hint record — lives *only* in
-the issue body. The fixture's own README paraphrases the hint as prose, with
-no link. Open the issue first.
-
-**Do the research.** Read the fixture's README "Notes for reviewers" section
-for what the original author already found (the tree's existing sources, the
-match-strength argument for and against). Then verify it yourself: open the
-hint record at the issue's URL, and use `record_search`/`record_read` (via the
-scratch workspace, Step 4 below, or by hand on familysearch.org) to check for
-corroborating or contradicting evidence the same way you would for any
-genealogical proof. You're doing the human GPS work the benchmark exists to
-measure — there's no shortcut command for this part.
-
-**Encode one of three outcomes in `expected-findings.json`:**
-
-1. **True match** — leave the findings as transcribed.
-2. **Answerable, but differently** — edit `expected-findings.json` to the
-   correct answer (different date, different record, different person).
-3. **False match, no findable substitute** — replace the findings with a
-   `"polarity": "avoid"` finding naming the claim the agent must **not**
-   assert, paired with a `required: true` finding that the agent's report
-   documented the negative conclusion. This is already spelled out correctly
-   in `/author-e2e-fixture`'s own "Record-hint fixtures" section, and
-   `thomas-seaver-other-wife` is the one already-adjudicated fixture in the
-   repo showing exactly what this looks like end to end — read it before you
-   write outcome 3.
-
-> **Ignore any issue text that tells you to write `"expectation":
-> "not_found"`.** That field does not exist — it isn't read by the judge, the
-> validator, or anywhere else, so a finding written that way silently grades
-> as an ordinary, never-satisfied recall finding instead of the restraint
-> test it's supposed to be. It shipped in the original issue text for
-> #852–883 by mistake. `make e2e-validate` now hard-fails on it (and on any
-> other unrecognized finding field) instead of staying silent — if you see
-> that error, it means an old copy of the issue instructions, not the guide.
-> Use outcome 3's `polarity: "avoid"` shape instead.
-
-**Guardrails:**
-
-- **Don't touch `starting-tree.gedcomx.json` or `starting-research.json`.**
-  This task only edits `expected-findings.json`, the README, and
-  `fixture.json`'s `notes`. The rest of the guide assumes you're building
-  those files; here they're already correct and immutable.
-- **Record your reasoning in the README's "Notes for reviewers"** — replace
-  "DRAFT PENDING ADJUDICATION" with what you concluded and why, following the
-  level of detail in `thomas-seaver-other-wife`'s or `heinrich-dewus-children-death`'s
-  README.
-
-Once `expected-findings.json` and the README reflect your adjudication,
-continue at **Step 3** — but read its record-hint note below first, since
-`make e2e-validate`'s checks differ slightly for this genre.
-
 ## Step 3 — Prove the answer is findable ⌨️ Terminal
 
+*(Step 1b only — Step 1a's skill already validated for you.)*
+
 Stripping your local copy isn't enough — **live FamilySearch still has the
-answer.** The harness closes that hole by blocking five tree-reading tools for
-the whole run, so the agent can't read the answer back off the tree:
+answer.** The harness blocks these tools for the whole run, so the agent can't
+read the answer back off the tree:
 
 ```
 person_read   person_search   person_ancestors
 person_record_matches   person_person_matches
 ```
 
-The principle is: block anything keyed off the **subject person** that surfaces
-the answer; allow tools keyed off a record the agent had to find first
-(`record_person_matches`, `record_record_matches`, `source_attachments`) and
-tools that read the *local* stripped tree (`person_warnings`). A fixture can
-also name extra tools in its own `blocked_tools` — used when one specific tool
-would hand over that fixture's ground truth, e.g. `wiki_search` on a fixture
-built from a wiki case study. Spec §6.1.
-
-Which means: pick a question whose answer is **recoverable by research**. Any of
-these routes counts — it does not have to be an indexed FamilySearch record:
+So the question you pick must be recoverable through **records** the agent can
+still reach:
 
 | Route | How the agent gets there |
 |---|---|
-| **Indexed records** | `record_search` → `record_read`. The default, and the Spriggs route: the 1910 and 1920 U.S. censuses both list Reuben in his parents' household. |
+| **Indexed records** | `record_search` → `record_read` — the default route |
 | **Full text** | `fulltext_search` over unindexed books, deeds, probate, newspapers |
 | **Images** | `image_search` / `image_read` / `image_transcribe` on an unindexed film |
-| **Off-FamilySearch sources** | Ancestry, FindAGrave, MyHeritage, FindMyPast, a county archive — `external_links_search` finds *where* the record lives |
-| **Indirect evidence** | No single source states the answer; the agent assembles it from several (a marriage-record age + a census + a burial) |
-
-One catch on the off-FamilySearch route: **the agent has no web browser during
-a run.** The harness allows exactly `Read`, `Write`, `Edit`, `Glob`, `Grep`,
-`Skill` and `Task` plus the genealogy MCP tools — `WebFetch` and `WebSearch`
-are not on that list, so a run that reaches for one gets back *"Permission to
-use WebFetch has been denied"*. That has happened in four committed runs, all
-of them trying to read a Norwegian or Québécois archive site directly.
-`external_links_search` can tell the agent a record exists on FindAGrave and
-where; it cannot read the page. So if the proof genuinely lives off
-FamilySearch, capture the document yourself and bundle it in the fixture's
-`provided-documents/`. The harness drops it into the workspace exactly where an
-uploaded capture lands and names it in the prompt, so the agent reads it with
-`Read` and the run stays reproducible. Spec §6.2.
+| **Off-FamilySearch sources** | `external_links_search` finds *where* a record lives (Ancestry, FindAGrave, a county archive) — the agent has no browser during a run, so if it needs to *read* the page, capture it yourself into the fixture's `provided-documents/` (spec §6.2) |
+| **Indirect evidence** | Assembled from several sources (e.g. a marriage-record age + a census + a burial) |
 
 If the only route to the answer runs through the live tree, the fixture can't
 measure anything and won't land.
@@ -307,27 +266,11 @@ measure anything and won't land.
 make e2e-validate TEST=<slug>       # Windows: eval\ValidateFixture.bat
 ```
 
-It warns when a finding's answer still looks present in the starting tree
-(which would let the agent get it for free and "pass" every run). A `WARN` is
-sometimes a legitimate name collision — review each rather than assuming. It
-**hard-fails (exit 2) only on structural problems**: a missing or unparseable
-file, a schema violation, a dangling relationship endpoint or source `ref`.
-Suspects are warn-only, by design — they're for the author to judge.
-
-Omit `TEST=` to lint every fixture.
-
-> **Coming from Step 1B (a record-hint fixture)?** Nothing was stripped, so
-> "is the answer still present" doesn't apply — `validate` instead enforces
-> that `starting-tree.gedcomx.json` and `unstripped-tree.gedcomx.json` are
-> byte-identical, and skips the presence check entirely (spec §3.6). The
-> name-overlap linter above still runs, though, and it's polarity-agnostic:
-> since the subject person is fully present in that (never-stripped) starting
-> tree, a `WARN` naming your own finding's subject is common and *expected*
-> here, not a sign something's wrong — `heinrich-dewus-children-death`'s
-> README documents exactly this. Judge each WARN on its merits rather than
-> trying to make it disappear. A hard `ERROR` is different: it means a
-> structural problem, now including an unrecognized field in
-> `expected-findings.json` (see Step 1B's note on `"expectation": "not_found"`).
+It **hard-fails (exit 2) only on structural problems**: a missing or
+unparseable file, a schema violation, a dangling relationship endpoint or
+source `ref`. A `WARN` about a finding's answer possibly still being present is
+for you to judge — sometimes it's a legitimate name collision, not a real
+problem. Omit `TEST=` to lint every fixture.
 
 Field tables, the hand-authoring path, cascade rules, and `provided-documents/`
 detail: spec §§2–3, §6.2.
@@ -335,10 +278,8 @@ detail: spec §§2–3, §6.2.
 ## Step 4 — Debug `/research` live, before you pay for a run 🖥️ Cowork + Viewer
 
 A headless run can't show you *why* the agent stopped or skipped a step — and
-it charges you 20–60 minutes to not tell you. Watch a run live, fix what you
-see, and save the headless run for the verdict.
-
-**Cowork + the Research Viewer** (recommended — structured output):
+it charges you 20–60 minutes to not tell you. Watch a run live in Cowork, fix
+what you see, and save the headless run for the verdict.
 
 1. **Build and install both artifacts**, so Cowork has the genealogy tools.
    This is the step that costs an hour when it's skipped:
@@ -354,10 +295,8 @@ see, and save the headless run for the verdict.
    Customize and upload the new `.zip` via Add → Upload Plugin, from the
    **Cowork** tab rather than the Code tab — they keep separate plugin lists.
    **Fully quit and reopen** Claude Desktop. Redo both after any MCP-server or
-   skill change; without them `/research` says things like
-   "validate_research_schema isn't available" and degrades to guessing, which
-   is a missing install, not a `/research` bug. (Canonical version of these
-   rules, including what does *not* need reinstalling:
+   skill change; without them `/research` degrades to guessing, which is a
+   missing install, not a `/research` bug. (Full rules:
    [`skill-lifecycle.md`](skill-lifecycle.md#rebuilding-and-reinstalling).)
 
 2. Seed an editable project from the fixture's starting state:
@@ -373,27 +312,10 @@ see, and save the headless run for the verdict.
 
 Full walkthrough: `eval/README.md` → "Debug a fixture interactively".
 
-**The scratch workspace** (lighter — Claude Code only, no Cowork install):
-
-```bash
-make e2e-scratch TEST=<slug>        # Windows: eval\ScratchResearch.bat
-```
-
-It seeds the fixture's starting state and the plugin skills into a throwaway
-directory **outside the repo**, reusing the harness's own `build_workspace` so
-it matches a real run, then drops you into `claude` there. In the session:
-
-```
-# Claude Code prompts ONCE to approve the project MCP server (.mcp.json).
-# Approve it, or /research has no FamilySearch tools and can't research.
-# Start WITHOUT --autonomous so you can watch it chain and nudge it:
-/research <the researcher question>
-```
-
-> **Neither live path blocks the tree-reading tools** the way a benchmark run
-> does. Calling them by hand reads the live tree — fine for debugging, but
-> don't let a hand-run "pass" that way convince you the fixture is solvable. A
-> real run can't do that.
+> **This doesn't block the tree-reading tools** the way a benchmark run does.
+> Calling them by hand reads the live tree — fine for debugging, but don't let
+> a hand-run "pass" that way convince you the fixture is solvable. A real run
+> can't do that.
 
 **Land any skill fixes this exposes before you run.** That's
 [`skill-lifecycle.md`](skill-lifecycle.md), not this page.
@@ -407,15 +329,11 @@ tool.**
 make e2e-run TEST=<slug>            # Windows: eval\RunE2E.bat
 ```
 
-**One fixture per run.** `make e2e-run` takes `TEST=<slug>` and nothing else,
-and the underlying `run_e2e.py` requires `--test` — there is deliberately no
-full-suite flag and no tag sweep. A 10-fixture sweep is 4–10 hours and $30–100,
-which is a budget decision, not something a one-word flag should make easy to
-trigger. If you genuinely need a batch, drive it with a shell loop and budget
-for it.
+Takes one `TEST=<slug>` at a time — there's deliberately no full-suite flag,
+since a sweep is 4–10 hours and $30–100. If you genuinely need a batch, drive
+it with a shell loop and budget for it.
 
-For the full flag list, ask the tool rather than a doc — the flags change and a
-copied list goes stale:
+For the full flag list, ask the tool rather than a doc:
 
 ```bash
 cd eval/harness && uv run python -m e2e.run_e2e --help
@@ -478,21 +396,14 @@ Full field reference: spec §8.
 
 ## Step 7 — When it fails ⌨️ / 🤖
 
-Read the transcript first — most failures are obvious from it. Then place the
-cause before changing anything, because the fix differs completely by cause:
-
-| Cause | Tell |
-|---|---|
-| **Agent reasoning regression** | Different decisions on the same evidence |
-| **`/research` regression** | A GPS step skipped, or the wrong sub-skill ran |
-| **Sub-skill regression** | Right sub-skill, worse output |
-| **FS data drift** | FS returned different records; the agent behaved correctly against changed inputs |
-| **Single-run jitter** | Small deltas, one finding flipping — re-run before concluding |
+Read the transcript first — most failures are obvious from it. If something
+needs fixing, fix it in **Step 4** (Cowork + Viewer) and re-run, rather than
+guessing blind from the run log alone.
 
 One trap worth naming: if the agent found the right answer but recorded it
 *only* in `research.json` and not in the tree, that is an **agent failure, not
-a judge miss**. Landing the answer in the tree is an explicit success criterion
-of the GPS flow.
+a judge miss** — landing the answer in the tree is a required GPS success
+criterion.
 
 **When it's a skill problem, capture it before you fix it.** In Claude Code:
 
@@ -500,14 +411,9 @@ of the GPS flow.
 /mine-unit-test --e2e-run eval/runlogs/e2e/<slug>
 ```
 
-That turns the miss into a unit test — cheap, runs on every PR — and drops you
-into [`skill-lifecycle.md`](skill-lifecycle.md) at step 3 (its step 1(b) is this
-very door). Classify the finding
-first, though: the lane rule there exists because most e2e findings are tooling
-or eval bugs, not skill-prose gaps.
-
-The full attribution procedure — what to diff, how to read `tool_calls`, and
-why the e2e run log has no `skills_invoked` field — is spec §15.
+That turns the miss into a unit test and drops you into
+[`skill-lifecycle.md`](skill-lifecycle.md) at step 3 — that's where the rest of
+the fix-and-verify loop lives; this guide doesn't repeat it.
 
 When a fixture's behavior shifts meaningfully, add a dated line to its
 `README.md` saying what changed. Next person to run it reads that first.
@@ -529,11 +435,6 @@ It shows you each expected finding plus the agent's evidence, and writes
 tree — deliberately **not** the judge's own grades — so you label blind. That
 independence is what makes the agreement number mean anything. Commit the
 `.ann.json`.
-
-**You never run `calibrate_judge`** — not even `--dry-run`. That's the
-maintainer's periodic step once a batch of grades exists, and it's the only
-thing that calls the judge API at scale. Collecting grades *before* the judge
-is calibrated is the intended bootstrap, not a problem.
 
 Annotation format, the ≥80% agreement gate, and how to read a calibration
 report: spec §7.4.
@@ -567,13 +468,13 @@ confirm `pass`, and commit that run log under `eval/runlogs/e2e/<slug>/`.
 > above. Landing an unproven fixture is a judgment call you should be able to
 > defend in review, not something the machine will stop.
 
-> **Adjudicated a record-hint fixture to a false-match/`avoid` outcome (Step
-> 1B)?** "Confirm `pass`" doesn't mean anything for a fixture whose answer is
-> "the agent should NOT conclude X" — there's no fact to recover. The
-> equivalent proof here is a run where the agent searches, comes up empty (or
-> finds the same contradicting evidence you did), and documents the negative
-> conclusion instead of asserting the hint's claim. Read the transcript for
-> restraint, not recall, before committing the run log.
+> **Adjudicated a fixture to a false-match/`avoid` outcome (Step 1a)?**
+> "Confirm `pass`" doesn't mean anything for a fixture whose answer is "the
+> agent should NOT conclude X" — there's no fact to recover. The equivalent
+> proof here is a run where the agent searches, comes up empty (or finds the
+> same contradicting evidence you did), and documents the negative conclusion
+> instead of asserting the hint's claim. Read the transcript for restraint,
+> not recall, before committing the run log.
 
 ---
 
@@ -582,14 +483,15 @@ confirm `pass`, and commit that run log under `eval/runlogs/e2e/<slug>/`.
 | Step | What you do | Where |
 |---|---|---|
 | 0 Branch | `git checkout -b <short-task-name>` | ⌨️ Terminal |
-| 1 Author | `/author-e2e-fixture` — pick a deceased, well-sourced person | 🤖 Claude Code |
-| 2 Scope | one question, 1–5 findings; keep the search anchors | 🤖 Claude Code |
-| 1B Adjudicate *(assigned issue only)* | start from the GitHub issue (not the folder); verify the hint; encode true/different/false-match in `expected-findings.json` | 🤖 Claude Code |
-| 3 Validate | check the answer is findable; `make e2e-validate TEST=<slug>` | ⌨️ Terminal |
+| 1 Choose your path | assigned a fixture → 1a; authoring a new one → 1b | 🤖 Claude Code |
+| 1a Resolve *(the norm)* | `/resolve-record-hint` — verify the hint, write the truth | 🤖 Claude Code |
+| 1b Author | `/author-e2e-fixture` — pick a deceased, stable person | 🤖 Claude Code |
+| 2 Scope *(1b only)* | one question, 1–5 findings; keep the search anchors | 🤖 Claude Code |
+| 3 Validate *(1b only)* | check the answer is findable; `make e2e-validate TEST=<slug>` | ⌨️ Terminal |
 | 4 Debug live | `make e2e-project`, then `/research` in Cowork with the Viewer open | 🖥️ Cowork + Viewer |
 | 5 Run | `make e2e-run TEST=<slug>` — one fixture, 20–60 min, $3–10 | ⌨️ Terminal |
 | 6 Read | `/interpret-e2e-result`; `make e2e-view` for the visual pass | 🤖 Claude Code |
-| 7 Attribute | place the cause; `/mine-unit-test --e2e-run …` for a skill miss | 🤖 Claude Code |
+| 7 Attribute | read the transcript, fix in Step 4; `/mine-unit-test --e2e-run …` for a skill miss | 🤖 Claude Code |
 | 8 Grade | `/grade-e2e-run` → commit the `.ann.json` (CI-enforced) | 🤖 Claude Code |
 | 9 Land | commit fixture + run log + grade; open the PR | ⌨️ Terminal / GitHub |
 
@@ -607,16 +509,15 @@ it from that folder; each prompts for what it needs instead of taking
 | `make plugin` | `eval\BuildPlugin.bat` |
 | `make e2e-validate TEST=<slug>` | `eval\ValidateFixture.bat` |
 | `make e2e-project TEST=<slug>` | `eval\SeedProject.bat` |
-| `make e2e-scratch TEST=<slug>` | `eval\ScratchResearch.bat` |
 | `make e2e-run TEST=<slug>` | `eval\RunE2E.bat` |
 | `make e2e-view TEST=<slug>` | `eval\ViewE2E.bat` |
 | `make electron` | `eval\Viewer.bat` |
 | `make e2e-calibrate` *(maintainer)* | `eval\RunCalibration.bat` |
 | `git checkout -b <short-task-name>` | GitHub Desktop → Current Branch → **New branch…** |
 
-The `/`-commands (`/author-e2e-fixture`, `/interpret-e2e-result`,
-`/grade-e2e-run`, `/mine-unit-test`) are typed into Claude Code and are the same
-everywhere.
+The `/`-commands (`/author-e2e-fixture`, `/resolve-record-hint`,
+`/interpret-e2e-result`, `/grade-e2e-run`, `/mine-unit-test`) are typed into
+Claude Code and are the same everywhere.
 
 ## Related docs
 


### PR DESCRIPTION
## Summary
- Reorders the e2e testing guide so resolving an assigned `record-hint` fixture is **Step 1a** (the norm going forward) and self-authoring a brand-new fixture is **Step 1b** — previously the reverse, with adjudication buried as an unusual "Step 1B" detour.
- Adds a new dev skill, `/resolve-record-hint`, so genealogists/developers never hand-edit `expected-findings.json` — it walks them through the three adjudication outcomes, writes the fixture files, and validates. The actual research (checking the hint record) is done by hand on familysearch.org, not via MCP tools.
- Drops the "substantial, diverse sources" / "reasonable size" bar for self-authored fixtures (Step 1b), removes the "ignore this stale issue text" warning (superseded by fixing the source), drops the manual JSON-editing guardrails section, and cuts the confusing hand-off note between the old Step 1B and Step 3.
- Shortens Steps 3, 4, 5, 7, and 8 substantially: drops the scratch-workspace alternative (standardizes on Cowork), cuts prose that duplicated `skill-lifecycle.md`'s failure-attribution loop, and removes reminders about things nobody was doing anyway (e.g. `calibrate_judge`).
- Updates GitHub issues #637 and #638 (the two pre-batch record-hint issues that still had the stale `"expectation": "not_found"` instruction) to match the corrected wording already in #852-883, and point at the new skill.

## Test plan
- [ ] Skim `docs/e2e-testing-guide.md` end to end for coherence (step numbering, cross-references to Step 4/7/8 still line up)
- [ ] Try `/resolve-record-hint` against one of the still-draft record-hint fixtures (e.g. `eval/tests/e2e/mary-kavanaugh-son`) and confirm it writes valid `expected-findings.json` + README + validates cleanly
- [ ] Confirm `make e2e-validate` still passes for existing record-hint fixtures (`thomas-seaver-other-wife`, `heinrich-dewus-children-death`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)