### PR TITLE
docs: plugin agents keep reference material inline (closes #702)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,36 @@ load path there. Search by bare tool name — `query: "+research_append"` —
 which matches whatever prefix the session exposes. The same packaging test
 fails any `select:mcp__…` in a plugin body.
 
+**No playbook/reference files for agents — an agent body is self-contained.**
+Everything an agent needs at runtime lives inline in its `.md`. Do **not**
+split per-topic reference material (e.g. per-record-type extraction tables)
+into sibling files for the agent to `Read` on demand, and do **not** assemble
+them into the body at build time. Decided 2026-07-27 after measuring both;
+tried on `record-extractor` (issue #702, closed) and reverted.
+
+*Why not on-demand `Read`:* it is unreliable in a way nothing catches. Across
+a full `record-extraction` suite run with the files provably reachable, the
+agent read the playbook on some tests, ignored it on others (every assertion
+fell back to `informant_proximity: "unknown"`), and over-applied it on others
+(`witness` on all 16) — pass rate 6/19 against a 12–14/19 baseline, fails up
+from 0–1 to 6. Every one of those modes is silent: no error, and the unit
+harness only records MCP tool calls (`skill_runner.py` filters on `mcp__`),
+so a skipped `Read` leaves no trace at all. This is behavioral, not
+environmental — it persisted after the harness was made to load the plugin
+the way both production paths do.
+
+*Why not build-time assembly:* it works mechanically but splits the reviewed
+artifact from the executed one. In this repo the prompt **is** the product —
+whoever edits a fragment must be able to see the whole body it lands in
+(contradictions 400 lines up, the total context budget). Seeing the real size
+is also the pressure that produces a smaller prompt; hiding it removes the
+incentive.
+
+*What this costs, knowingly:* there is no per-record-type ownership surface,
+so a probate specialist edits the same file as everyone else. That need is
+declined, not disproven — revisit only with a mechanism that cannot silently
+skip, and re-read this note first.
+
 ## Handling user feedback submissions
 
 When a user submits a feedback zip via the Cowork viewer, the workflow


### PR DESCRIPTION
Records a convention in `CLAUDE.md` § "Cowork plugin agents": **an agent body is self-contained** — no sibling reference/playbook files read at runtime, and no build-time assembly of them either.

This is the outcome of building the split on `record-extractor` (the four record-type informant tables → `agents/record-extractor-playbooks/*.md`), measuring it, and reverting. **Docs only — no code change; the agent body is unchanged from `main`.**

## Why not on-demand `Read`

Unreliable, and every failure mode is silent.

| record-extraction suite | pass | partial | fail |
|---|---|---|---|
| baseline (4 runs, 07-24) | 12–14 | 4–7 | 0–1 |
| playbooks, files unreachable | 6 | 11 | 2 |
| playbooks, files provably reachable | 6 | 7 | 6 |

No recovery once the files were reachable. Within a single run the agent **read** the playbook on some tests, **ignored** it on others (every assertion fell back to `informant_proximity: "unknown"`), and **over-applied** it on others (`witness` ×16).

Nothing catches any of that: no error is raised, and the unit harness records only MCP tool calls (`skill_runner.py` filters on `mcp__`), so a skipped `Read` leaves no trace in the run log.

It is behavioral, not environmental — it persisted after the harness was changed to load the plugin the way both production paths already do (Cowork's installed `.mcpb`; `real_agent.py:97` `plugins=[{"type":"local"}]`).

## Why not build-time assembly

It works mechanically but splits the reviewed artifact from the executed one. In this repo the prompt *is* the product: whoever edits a fragment must be able to see the whole body it lands in (a contradiction 400 lines up, the total context budget), and seeing the real size is the pressure that produces a smaller prompt.

## What this costs, knowingly

There is no per-record-type ownership surface — a probate specialist edits the same file as everyone else. That need is **declined, not disproven**. At four tables / ~120 lines, pre-customer, it is not worth the reliability or reviewability cost. Revisit only with a mechanism that cannot silently skip.

Closes #702 (also closed on the issue itself, with the same evidence).

## Note for reviewers

One unexplained observation, now moot but worth knowing if the harness-fidelity change is ever revived on its own branch: `ut_record_extraction_002` passed in all five prior runs and failed in the run where the harness loaded the plugin via `plugins=`, with no validator failures (a judge-dimension failure). That harness change is **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)