### PR TITLE
docs: trim the e2e guide to the workflow for genealogists

### DIFF
--- a/.claude/skills/resolve-record-hint/SKILL.md
+++ b/.claude/skills/resolve-record-hint/SKILL.md
@@ -27,9 +27,13 @@ Get a GitHub issue number/URL or a fixture slug from the user; ask if you have
 neither.
 
 - Given an issue: `gh issue view <n> --json title,body`. Pull the slug (from
-  the title, `test <slug>`) and the hint record's `familysearch.org/ark:/...`
-  URL — that URL lives **only** in the issue body, never in the fixture
-  folder.
+  the title, `test <slug>`) and **both** links in the body: the tree person
+  (`familysearch.org/tree/person/details/<PID>`) and the hint record
+  (`familysearch.org/ark:/...`). The record URL lives **only** in the issue
+  body, never in the fixture folder. If either link is missing from the issue,
+  say so and stop — the genealogist can't do the research without them, and
+  `fixture.json`'s `source_pid` is the tree person's PID if you need to
+  reconstruct that half.
 - Read `eval/tests/e2e/<slug>/README.md`'s "Notes for reviewers" — what the
   original author already found (the tree's existing sources, the
   match-strength argument for and against).
@@ -37,13 +41,19 @@ neither.
 
 ## Step 2 — Send the genealogist to do the research
 
-Tell them to open the hint record at the issue's URL on **familysearch.org**,
-by hand, and look for corroborating or contradicting evidence the same way
-they would for any genealogical proof — reading the attached sources,
-searching independently for the person, checking dates and places against
-what the tree already has. This is the actual GPS work the benchmark exists
-to measure; there is no tool shortcut for it, and this skill does not fetch
-the record for them.
+Give them the two URLs from the issue and tell them to work in this order, by
+hand on **familysearch.org**:
+
+1. **The tree person first** — read the sources already attached to them. That
+   is the baseline the hint has to be consistent with, and it is how they catch
+   a hint that is only a re-indexing of a source the person already has.
+2. **The hint record** — look for corroborating or contradicting evidence the
+   same way they would for any genealogical proof: searching independently for
+   the person, checking dates, places and family members against what the tree
+   already has.
+
+This is the actual GPS work the benchmark exists to measure; there is no tool
+shortcut for it, and this skill does not fetch either page for them.
 
 If the call is borderline, tell them to ask a genealogist for a second
 opinion rather than guess alone.
@@ -72,9 +82,11 @@ becomes the README's new "Notes for reviewers."
     `supporting_sources` to the corrected answer.
   - Outcome 3: replace the findings with a `"polarity": "avoid"` finding
     naming the wrong claim, paired with a `required: true` finding
-    documenting the negative conclusion. Follow
-    `eval/tests/e2e/thomas-seaver-other-wife/expected-findings.json` as the
-    worked shape.
+    documenting the negative conclusion. Copy the JSON *shape* from
+    `eval/tests/e2e/thomas-seaver-other-wife/expected-findings.json` — that
+    file is a valid instance of the pair. (Its README is not a model for
+    yours: that fixture was authored in this shape from the start, not
+    resolved from a hint.)
 
   Only use the fields spec §3.4 defines: `id`, `type`, `description`,
   `details`, `polarity`, `supporting_sources`, `required`. **Never write
@@ -83,9 +95,12 @@ becomes the README's new "Notes for reviewers."
   it anyway.
 
 - **`README.md`** — replace the "DRAFT PENDING ADJUDICATION" paragraph under
-  "Notes for reviewers" with the genealogist's conclusion and reasoning.
-  Match the level of detail in `thomas-seaver-other-wife`'s or
-  `heinrich-dewus-children-death`'s README.
+  "Notes for reviewers" with the genealogist's conclusion and reasoning. No
+  fixture has been resolved yet, so there is no example to imitate; write the
+  paragraph so the next person can re-derive the call without redoing the
+  research — the verdict, what evidence decided it, and what was searched and
+  came up empty. Remove the marker text itself: it is the only signal that
+  distinguishes a resolved fixture from a draft.
 
 - **`fixture.json`** — update `notes` if it still describes the fixture as
   an unverified draft.

--- a/Makefile
+++ b/Makefile
@@ -481,6 +481,23 @@ mcpb: ## Build the .mcpb desktop extension
 plugin: ## Build the Cowork plugin .zip
 	node scripts/package-plugin.mjs
 
+.PHONY: cowork-install
+cowork-install: mcpb plugin ## Build BOTH artifacts and print the install click-path (Windows: eval\CoworkInstall.bat)
+	# One target because installing only one of the two is the most common way
+	# to spend an hour debugging a `/research` that is really just stale. The
+	# click-path is printed rather than automated: both installs are Claude
+	# Desktop UI actions with no CLI.
+	@printf '\n=== Built. Now install BOTH, then fully quit and reopen Claude Desktop ===\n\n'
+	@printf '1. MCP server (.mcpb):  Claude Desktop -> Settings -> Extensions ->\n'
+	@printf '   Advanced Settings -> Install extension -> releases/genealogy-mcp.mcpb\n'
+	@printf '   (install straight over the old copy -- no uninstall needed)\n\n'
+	@printf '2. Plugin (.zip):  Claude Desktop -> COWORK tab -> Customize ->\n'
+	@printf '   REMOVE any existing Genealogy Research plugin, then Add -> Upload\n'
+	@printf '   Plugin -> releases/genealogy-plugin.zip\n'
+	@printf '   (the Cowork tab and the Code tab keep separate plugin lists)\n\n'
+	@printf '3. Fully QUIT and reopen Claude Desktop.\n\n'
+	@ls -l releases/genealogy-mcp.mcpb releases/genealogy-plugin.zip 2>/dev/null || true
+
 # Marker recording the commit `make sandbox-image` last built the E2B template
 # from, so `deploy-preflight` can warn when in-sandbox agent code changed since.
 # Gitignored local build state, like the .make-installed dep stamps above.

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -1,12 +1,7 @@
 # E2E Testing Guide — authoring and running a benchmark fixture
 
-How to author and run an end-to-end research benchmark test, walked through
-**one real fixture end to end**. Written for the team
-doing the work.
-
-This page covers **the e2e benchmark only** — the expensive, live-FamilySearch
-runs that measure how much real research the agent can do on its own. Two
-things it deliberately does *not* cover:
+How to work an end-to-end research benchmark fixture: resolve one you've been
+assigned, or author a new one from a FamilySearch person.
 
 | You want to… | Go to |
 |---|---|
@@ -15,32 +10,36 @@ things it deliberately does *not* cover:
 
 ---
 
-## What e2e tests are
+## The workflow at a glance
 
-An e2e test snapshots a real, well-researched FamilySearch person's tree,
-strips a focused subset (the "answer"), and asks the agent — via
-`/research --autonomous` — to recover what was removed. The judge grades the
-final state `pass` / `partial` / `fail`.
+Which steps are yours depends on how you got here:
 
-They're a **stakeholder-facing benchmark, not a regression suite**. Per-PR
-regression coverage is the unit tests in `eval/tests/unit/`.
+- **Assigned a fixture** — a GitHub issue titled "test `<slug>`". This is the
+  normal case. Do steps **0, 1a, then 4–9**.
+- **Authoring a new fixture** — no issue, just a person you want to turn into a
+  test. Do **every** step.
 
-**Runs are expensive: 20–60 minutes and $3–10 each. Run one at a time.**
-
-> **Before you quote a number to anyone outside the team.** The verdict
-> measures *fact recovery, not sound reasoning* — an agent can recover a right
-> answer from one weak hit and still `pass`. The advisory proof-quality score
-> partly closes that gap, and negative fixtures sample the agent's restraint
-> from over-claiming, but neither certifies it. This is a strong **capability
-> signal**, not a certification that the agent does sound, verifiable GPS
-> research. Don't describe it as the latter. Full framing: spec §1.
+| Step | What you do | Where |
+|---|---|---|
+| 0 Branch | `git checkout -b <short-task-name>` | ⌨️ Terminal |
+| 1 Choose your path | assigned a fixture → 1a; authoring a new one → 1b | 🤖 Claude Code |
+| 1a Resolve *(the norm)* | `/resolve-record-hint` — verify the hint, write the truth | 🤖 Claude Code |
+| 1b Author | `/author-e2e-fixture` — pick a deceased, stable person | 🤖 Claude Code |
+| 2 Scope *(1b only)* | one question, 1–5 findings; keep the search anchors | 🤖 Claude Code |
+| 3 Validate *(1b only)* | check the answer is findable; `make e2e-validate TEST=<slug>` | ⌨️ Terminal |
+| 4 Debug live | `make e2e-project`, then `/research` in Cowork with the Viewer open | 🖥️ Cowork + Viewer |
+| 5 Run | `make e2e-run TEST=<slug>` — one fixture, 20–60 min, $3–10 | ⌨️ Terminal |
+| 6 Read | `/interpret-e2e-result`; `make e2e-view` for the visual pass | 🤖 Claude Code |
+| 7 Attribute | read the transcript, fix in Step 4; `/mine-unit-test --e2e-run …` for a skill miss | 🤖 Claude Code |
+| 8 Grade | `/grade-e2e-run` → commit the `.ann.json` (CI-enforced) | 🤖 Claude Code |
+| 9 Land | commit fixture + run log + grade; open the PR | ⌨️ Terminal / GitHub |
 
 ## The three places you'll work
 
 | Icon | Place | What it is | You use it to… |
 |---|---|---|---|
 | ⌨️ | **Terminal** | A plain shell where you type `make …` (Windows: double-click the matching `.bat` in `eval\`). | Set up, validate, seed, run, view. |
-| 🤖 | **Claude Code** | The **Code tab** of the Claude desktop app opened on your **repo root**, or `claude` in a terminal there — either works, and the Code tab is the usual Windows path. **Not** Cowork. The `/`-commands below are repo-local dev skills under `.claude/skills/`, picked up automatically in this checkout. | Author the fixture, interpret the result, grade the run. |
+| 🤖 | **Claude Code** | The **Code tab** of the Claude desktop app opened on your **repo root**, or `claude` in a terminal there — either works, and the Code tab is the usual Windows path. **Not** Cowork. The `/`-commands below are repo-local dev skills under `.claude/skills/`, picked up automatically in this checkout and identical on every platform. | Author the fixture, interpret the result, grade the run. |
 | 🖥️ | **Cowork** | The shipping product, with the plugin + MCP extension installed. | Watch `/research` work on the fixture live, before you spend money on a headless run. |
 
 A fourth surface matters throughout: the **Research Viewer** (Electron,
@@ -48,10 +47,19 @@ A fourth surface matters throughout: the **Research Viewer** (Electron,
 sources of whichever project folder you point it at. It's how you *see* what the
 agent wrote instead of trusting the chat's summary of itself.
 
-> `author-e2e-fixture`, `resolve-record-hint`, `interpret-e2e-result`, and
-> `grade-e2e-run` are repo-local dev skills — **not** part of the shipped
-> Cowork plugin. The `/`-commands are typed into Claude Code and are
-> identical on every platform.
+## What e2e tests are
+
+An e2e test snapshots a real, well-researched FamilySearch person's tree,
+strips a focused subset (the "answer"), and asks the agent — via
+`/research --autonomous` — to recover what was removed. The judge grades the
+final state `pass` / `partial` / `fail`.
+
+**Runs are expensive: 20–60 minutes and $3–10 each. Run one at a time.**
+
+This is a capability benchmark, not a regression suite — per-PR regression
+coverage is the unit tests in `eval/tests/unit/`. The verdict measures *fact
+recovery, not sound reasoning*, so don't quote it outside the team as proof that
+the agent does sound, verifiable GPS research. Full framing: spec §1.
 
 ---
 
@@ -79,22 +87,6 @@ If it flags something:
 
 ---
 
-## The running example
-
-Everything below follows one fixture that's already in the repo:
-**`spriggs-parents-1898`** — Reuben Spencer Spriggs, FamilySearch PID
-`L64C-QQX`, born 1898 in Maddock, Benson County, North Dakota; died 1998. The
-research question is *"Who were the parents of Reuben Spencer Spriggs?"*, and
-the answer — his father John William Spriggs, his mother Charlotte Marie
-Westby, and the two census sources naming them — is what got stripped.
-
-Read `eval/tests/e2e/spriggs-parents-1898/` alongside this page; substitute your
-own slug as you go. It follows the self-authoring path (Step 1b). If you're
-adjudicating an assigned fixture instead (Step 1a), `thomas-seaver-other-wife`
-and `heinrich-dewus-children-death` are the worked examples to read instead.
-
----
-
 ## Step 0 — Branch ⌨️ Terminal
 
 One task, one branch, always cut from an up-to-date `main` — you open a PR from
@@ -109,8 +101,8 @@ git checkout -b spriggs-parents-fixture
 ```
 
 **GitHub Desktop:** Current Branch dropdown → select **main** and
-**Fetch/Pull** → **New branch…** → name it `spriggs-parents-fixture` → base it
-on `main` → **Create branch**.
+**Fetch/Pull** → **New branch…** → name it → base it on `main` → **Create
+branch**.
 
 Everything the rest of this produces — the fixture files, the run log, the
 grade — lands on this one branch.
@@ -119,55 +111,59 @@ grade — lands on this one branch.
 
 - **Assigned a fixture?** A GitHub issue titled "test `<slug>`" means the
   fixture already exists, drafted from an unverified FamilySearch record
-  hint. Go to **Step 1a**. This is the normal way fixtures get worked going
-  forward — most contributors start here, not by picking a new person.
+  hint. Go to **Step 1a**.
 - **Authoring a brand-new fixture?** No issue — just a person (or research
   document) you want to turn into a test. Go to **Step 1b**.
 
 ## Step 1a — Resolve an assigned fixture 🤖 Claude Code
 
-**What this is.** A `genre: "record-hint"` fixture (spec §3.6) inverts the
-normal shape: nothing was stripped, because the answer was never in the
-FamilySearch tree to begin with. It lives in a historical record that
-FamilySearch's own hinting matched to the tree person with *unverified*
-confidence. Adjudicating means doing the real genealogical work to decide
-whether the hint is true, then making `expected-findings.json` state the
-truth instead of the raw, unverified hint.
+**What this is.** The fixture's answer was never in the FamilySearch tree — it
+lives in a historical record that FamilySearch's own hinting matched to the tree
+person with *unverified* confidence, and about half of those matches are wrong.
+Your job is to decide whether this one is true, and leave the fixture stating
+what you found instead of the raw hint.
 
-**Start from the GitHub issue, not the fixture folder.** The source you're
-checking — a clickable `familysearch.org/ark:/...` URL to the specific hint
-record — lives *only* in the issue body. The fixture's own README
-paraphrases the hint as prose, with no link. Open the issue first.
+**Start from the GitHub issue, not the fixture folder.** It links the two things
+you need: the **tree person** on familysearch.org, and the **hint record** that
+was matched to them.
 
-**Do the research.** Read the fixture's README "Notes for reviewers" section
-for what the original author already found (the tree's existing sources, the
-match-strength argument for and against). Then open the hint record at the
-issue's URL on **familysearch.org** and look, by hand, for corroborating or
-contradicting evidence — the same way you would for any genealogical proof.
+**Do the research, in this order:**
+
+1. **Open the tree person first** and read the sources already attached to them.
+   That's the baseline the hint has to be consistent with — and it's how you
+   catch a hint that is really just a re-indexing of a source the person already
+   has.
+2. **Read the fixture's README**, "Notes for reviewers" section, for what the
+   original author already found (the tree's existing sources, the
+   match-strength argument for and against).
+3. **Open the hint record** and look, by hand, for corroborating or
+   contradicting evidence — the same way you would for any genealogical proof.
+
 This is the human GPS work the benchmark exists to measure; there's no tool
 shortcut for it. **Ask a genealogist for a second opinion** if the call is
 borderline — don't guess alone.
 
-**Write the outcome with the skill — don't hand-edit the JSON:**
+**Write the outcome with the skill — don't hand-edit the fixture files:**
 
 ```
 /resolve-record-hint
 ```
 
-Give it the issue (number or URL) or the slug. It walks you through the three
-possible outcomes, asks what you found, and writes `expected-findings.json`,
-the README's "Notes for reviewers", and `fixture.json`'s `notes` for you —
-then validates the result:
+Give it the issue (number or URL) or the slug. It asks what you found, writes
+the fixture files, and validates the result. The three outcomes:
 
-1. **True match** — findings stay as written.
-2. **Answerable, but differently** — the skill edits `expected-findings.json`
-   to the correct answer.
-3. **False match, no findable substitute** — the skill replaces the findings
-   with a `polarity: "avoid"` finding naming the wrong claim, paired with a
-   required finding documenting the negative conclusion.
+1. **The hint is right** — the fixture stays as it is.
+2. **The answer is something else** — the skill rewrites the fixture's expected
+   findings to the correct answer.
+3. **The hint is wrong, and no other record answers the question** — the skill
+   turns the fixture into a restraint test: the agent must *not* assert the
+   wrong claim, and must document the negative conclusion.
 
-Once the skill hands off, go straight to **Step 4** — Steps 2 and 3 don't
-apply here (nothing was stripped, and the skill already validated).
+`thomas-seaver-other-wife` and `heinrich-dewus-children-death` are the worked
+examples in the repo — read one alongside your own.
+
+Once the skill hands off, go straight to **Step 4** — Steps 2 and 3 don't apply
+here (nothing was stripped, and the skill already validated).
 
 ## Step 1b — Pick a person and author a new fixture 🤖 Claude Code
 
@@ -190,6 +186,11 @@ choosing:
   authoring tool refuses a person marked living, and refuses one whose `living`
   field is simply absent (absent is not deceased).
 - **Stable.** Older records, settled profiles — not ones being actively edited.
+
+`eval/tests/e2e/spriggs-parents-1898/` is the worked example to read alongside
+your own: *"Who were the parents of Reuben Spencer Spriggs?"* (PID `L64C-QQX`,
+born 1898 in Maddock, Benson County, North Dakota), where the stripped answer is
+his two parents and the census sources naming them.
 
 > There's a second, secondary path for when you have no FamilySearch access:
 > building PID-less from a bundled research document, with a placeholder
@@ -227,11 +228,10 @@ you'd search from measures nothing but frustration.
   matched when the agent correctly declined. (`hole-parents-negative` is the
   worked instance in the repo.)
 
-Negative fixtures are the only way this benchmark sees **over-claiming** —
-concluding from insufficient evidence, which is the failure that matters most
-in genealogy, because a wrong parent silently corrupts an entire upstream tree.
-Aim for the suite as a whole to cover both, across a spread of question types,
-eras and geographies. Details: spec §3.4.1.
+Negative fixtures are the only way this benchmark sees **over-claiming**, the
+failure that matters most in genealogy. Aim for the suite as a whole to cover
+both, across a spread of question types, eras and geographies. Details: spec
+§3.4.1.
 
 ## Step 3 — Prove the answer is findable ⌨️ Terminal
 
@@ -323,20 +323,10 @@ Full walkthrough: `eval/README.md` → "Debug a fixture interactively".
 ## Step 5 — Run it ⌨️ Terminal
 
 **This is the expensive confirmation at the *end* of the loop, not a debugging
-tool.**
+tool.** One fixture at a time:
 
 ```bash
 make e2e-run TEST=<slug>            # Windows: eval\RunE2E.bat
-```
-
-Takes one `TEST=<slug>` at a time — there's deliberately no full-suite flag,
-since a sweep is 4–10 hours and $30–100. If you genuinely need a batch, drive
-it with a shell loop and budget for it.
-
-For the full flag list, ask the tool rather than a doc:
-
-```bash
-cd eval/harness && uv run python -m e2e.run_e2e --help
 ```
 
 ## Step 6 — Read the result 🤖 Claude Code
@@ -388,10 +378,6 @@ for the Research Viewer (`make electron`, Windows: `eval\Viewer.bat`).
 | `cost_cap` | Hit the per-run cost limit |
 | `error` | SDK or harness exception; check `result.error` |
 
-One note on reading `blocked_tree_reads`: each entry carries a `blocked_by`
-field, because a block isn't always the universal tree-read rule — it may be the
-fixture's own `blocked_tools`. Read the field rather than assuming.
-
 Full field reference: spec §8.
 
 ## Step 7 — When it fails ⌨️ / 🤖
@@ -432,9 +418,8 @@ grade.)
 
 It shows you each expected finding plus the agent's evidence, and writes
 `run-<ts>.ann.json` with your labels. It reads the fixture and the run's final
-tree — deliberately **not** the judge's own grades — so you label blind. That
-independence is what makes the agreement number mean anything. Commit the
-`.ann.json`.
+tree — deliberately **not** the judge's own grades — so you label blind. Commit
+the `.ann.json`.
 
 Annotation format, the ≥80% agreement gate, and how to read a calibration
 report: spec §7.4.
@@ -458,42 +443,20 @@ tick the fixture directory plus the run log **and** its `.ann.json`, type a
 summary, **Commit to `<your-branch>`**, then **Push origin** and **Create Pull
 Request** (it opens GitHub in your browser with the branch pre-filled).
 
-**Prove it's solvable.** Stripping proves the answer isn't *in* the starting
-tree; only a run proves it's *recoverable from live FS*. So run the fixture,
-confirm `pass`, and commit that run log under `eval/runlogs/e2e/<slug>/`.
+**Commit a passing run, from the branch you're landing.** Stripping proves the
+answer isn't *in* the starting tree; only a run proves it's *recoverable from
+live FS*. If you fixed something in Step 7 and re-ran, the earlier run log is
+stale — commit the new one. Landing a fixture without a passing run is a
+judgment call you should be able to defend in review.
 
-> This is a **strong convention, not a CI check** — `check_e2e_fixtures.py`
-> deliberately does not gate it, because draft and PID-less fixtures routinely
-> land without a passing run first. What CI *does* block is the grading rule
-> above. Landing an unproven fixture is a judgment call you should be able to
-> defend in review, not something the machine will stop.
-
-> **Adjudicated a fixture to a false-match/`avoid` outcome (Step 1a)?**
-> "Confirm `pass`" doesn't mean anything for a fixture whose answer is "the
-> agent should NOT conclude X" — there's no fact to recover. The equivalent
-> proof here is a run where the agent searches, comes up empty (or finds the
-> same contradicting evidence you did), and documents the negative conclusion
-> instead of asserting the hint's claim. Read the transcript for restraint,
-> not recall, before committing the run log.
+> **Resolved a fixture to "the hint is wrong" (Step 1a)?** "Passing" means
+> something different there: there's no fact to recover, so what you're looking
+> for in the run is **restraint** — the agent searched, came up empty (or found
+> the same contradicting evidence you did), and documented that negative
+> conclusion instead of asserting the hint's claim. Read the transcript for
+> restraint, not recall, before committing the run log.
 
 ---
-
-## Cheat sheet
-
-| Step | What you do | Where |
-|---|---|---|
-| 0 Branch | `git checkout -b <short-task-name>` | ⌨️ Terminal |
-| 1 Choose your path | assigned a fixture → 1a; authoring a new one → 1b | 🤖 Claude Code |
-| 1a Resolve *(the norm)* | `/resolve-record-hint` — verify the hint, write the truth | 🤖 Claude Code |
-| 1b Author | `/author-e2e-fixture` — pick a deceased, stable person | 🤖 Claude Code |
-| 2 Scope *(1b only)* | one question, 1–5 findings; keep the search anchors | 🤖 Claude Code |
-| 3 Validate *(1b only)* | check the answer is findable; `make e2e-validate TEST=<slug>` | ⌨️ Terminal |
-| 4 Debug live | `make e2e-project`, then `/research` in Cowork with the Viewer open | 🖥️ Cowork + Viewer |
-| 5 Run | `make e2e-run TEST=<slug>` — one fixture, 20–60 min, $3–10 | ⌨️ Terminal |
-| 6 Read | `/interpret-e2e-result`; `make e2e-view` for the visual pass | 🤖 Claude Code |
-| 7 Attribute | read the transcript, fix in Step 4; `/mine-unit-test --e2e-run …` for a skill miss | 🤖 Claude Code |
-| 8 Grade | `/grade-e2e-run` → commit the `.ann.json` (CI-enforced) | 🤖 Claude Code |
-| 9 Land | commit fixture + run log + grade; open the PR | ⌨️ Terminal / GitHub |
 
 ## Windows equivalents
 
@@ -512,7 +475,6 @@ it from that folder; each prompts for what it needs instead of taking
 | `make e2e-run TEST=<slug>` | `eval\RunE2E.bat` |
 | `make e2e-view TEST=<slug>` | `eval\ViewE2E.bat` |
 | `make electron` | `eval\Viewer.bat` |
-| `make e2e-calibrate` *(maintainer)* | `eval\RunCalibration.bat` |
 | `git checkout -b <short-task-name>` | GitHub Desktop → Current Branch → **New branch…** |
 
 The `/`-commands (`/author-e2e-fixture`, `/resolve-record-hint`,

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -159,11 +159,12 @@ the fixture files, and validates the result. The three outcomes:
    turns the fixture into a restraint test: the agent must *not* assert the
    wrong claim, and must document the negative conclusion.
 
-`thomas-seaver-other-wife` and `heinrich-dewus-children-death` are the worked
-examples in the repo — read one alongside your own.
-
 Once the skill hands off, go straight to **Step 4** — Steps 2 and 3 don't apply
 here (nothing was stripped, and the skill already validated).
+
+> No fixture of this genre has been resolved and run end to end yet, so there's
+> no finished one to copy. You are working an unexercised path: if a step doesn't
+> behave the way this page says, that's worth reporting, not working around.
 
 ## Step 1b — Pick a person and author a new fixture 🤖 Claude Code
 
@@ -285,18 +286,18 @@ what you see, and save the headless run for the verdict.
    This is the step that costs an hour when it's skipped:
 
    ```bash
-   make mcpb                       # Windows: eval\BuildMcpb.bat
-   make plugin                     # Windows: eval\BuildPlugin.bat
+   make cowork-install             # Windows: eval\CoworkInstall.bat
    ```
 
-   Install the `.mcpb` in Claude Desktop → Settings → Extensions → Advanced
-   Settings → Install extension (straight over the old copy — no uninstall
-   needed). Then **remove any existing Genealogy Research plugin** in Cowork →
-   Customize and upload the new `.zip` via Add → Upload Plugin, from the
-   **Cowork** tab rather than the Code tab — they keep separate plugin lists.
-   **Fully quit and reopen** Claude Desktop. Redo both after any MCP-server or
-   skill change; without them `/research` degrades to guessing, which is a
-   missing install, not a `/research` bug. (Full rules:
+   It builds both and prints where to install each: the `.mcpb` in Claude
+   Desktop → Settings → Extensions → Advanced Settings → Install extension
+   (straight over the old copy — no uninstall needed), and the `.zip` in Cowork
+   → Customize, **removing any existing Genealogy Research plugin first**, via
+   Add → Upload Plugin — from the **Cowork** tab rather than the Code tab, since
+   they keep separate plugin lists. Then **fully quit and reopen** Claude
+   Desktop. Redo this after any MCP-server or skill change; without it
+   `/research` degrades to guessing, which is a missing install, not a
+   `/research` bug. (Full rules:
    [`skill-lifecycle.md`](skill-lifecycle.md#rebuilding-and-reinstalling).)
 
 2. Seed an editable project from the fixture's starting state:
@@ -468,8 +469,9 @@ it from that folder; each prompts for what it needs instead of taking
 |---|---|
 | `make e2e-preflight` | `eval\CheckSetup.bat` |
 | `make e2e-login` | `eval\Login.bat` |
-| `make mcpb` | `eval\BuildMcpb.bat` |
-| `make plugin` | `eval\BuildPlugin.bat` |
+| `make cowork-install` | `eval\CoworkInstall.bat` |
+| `make mcpb` *(one artifact only)* | `eval\BuildMcpb.bat` |
+| `make plugin` *(one artifact only)* | `eval\BuildPlugin.bat` |
 | `make e2e-validate TEST=<slug>` | `eval\ValidateFixture.bat` |
 | `make e2e-project TEST=<slug>` | `eval\SeedProject.bat` |
 | `make e2e-run TEST=<slug>` | `eval\RunE2E.bat` |

--- a/eval/CLAUDE.md
+++ b/eval/CLAUDE.md
@@ -173,13 +173,14 @@ The same workflow also runs `eval/harness/scripts/check_tool_coverage.py` (warn-
 
 ### E2E checks (`check-e2e-fixtures.yml`)
 
-A **separate** workflow, triggered on `eval/tests/e2e/**`, `eval/runlogs/e2e/**`, and its own script, runs `check_e2e_fixtures.py` — one blocking check:
+A **separate** workflow, triggered on `eval/tests/e2e/**`, `eval/runlogs/e2e/**`, and its own script, runs `check_e2e_fixtures.py` — one blocking check plus one warn:
 
 | Check | Severity | What |
 |---|---|---|
 | Grading gate | **block** | Every `run-<ts>.json` **added in the PR** that produced a final tree (`run-<ts>.final-tree.gedcomx.json` present) must ship its `run-<ts>.ann.json` sibling in the same PR. Grading is same-PR. Treeless runs (crash/skip before a tree) are exempt. Scoped to PR-added logs via `git diff --diff-filter=A` (`BASE_SHA`/`HEAD_SHA`); presence only — content validity is the maintainer's `calibrate_judge --dry-run`, not CI. |
+| Unresolved draft | warn | A PR-added run log whose fixture README still carries `DRAFT PENDING ADJUDICATION` — the run scored an unverified record hint rather than a genealogist-resolved answer, so its verdict and grade mean less than they appear to. One warning per fixture. Cleared by `/resolve-record-hint` (e2e-testing-guide.md Step 1a) removing the marker. |
 
-**Fixture validity is not CI-gated.** Whether a fixture has a committed *passing* run log (proof it is solvable from live FamilySearch — spec §14) is a recommended authoring practice surfaced in the docs, not a check. A fixture can land without one (draft/PID-less fixtures routinely do). This used to be an advisory warning; it was removed because it re-flagged every un-run fixture in the repo on every e2e PR — pure noise.
+**Fixture validity is not CI-gated.** Whether a fixture has a committed *passing* run log (proof it is solvable from live FamilySearch — spec §14) is a recommended authoring practice surfaced in the docs, not a check. A fixture can land without one (draft/PID-less fixtures routinely do). This used to be an advisory warning; it was removed because it re-flagged every un-run fixture in the repo on every e2e PR — pure noise. The unresolved-draft warn above avoids that trap by firing only on fixtures the PR itself committed a run for.
 
 The e2e `.ann.json` is written by the `/grade-e2e-run` skill (blind grading), **not** the CRUD UI — see the "never hand-write" note above, which is scoped to *unit* annotations.
 

--- a/eval/CoworkInstall.bat
+++ b/eval/CoworkInstall.bat
@@ -1,0 +1,63 @@
+@echo off
+cd %~dp0
+
+echo === Cowork Genealogy - Build BOTH artifacts for Cowork ===
+echo.
+echo Builds releases\genealogy-mcp.mcpb (the tools, runs on your machine) AND
+echo releases\genealogy-plugin.zip (the skills and agents Cowork runs), then
+echo prints exactly where to install each one.
+echo.
+echo Installing only ONE of the two is the most common way to lose an hour to a
+echo /research that is really just running stale code. Do both, every time an
+echo MCP tool or a skill changes.
+echo.
+echo Same as "make cowork-install" on Mac. Runs the two Node build scripts. No
+echo bash or zip needed -- just Node, which Setup.bat already installs.
+echo.
+
+where node >nul 2>nul
+if errorlevel 1 (
+  echo ERROR: 'node' was not found on PATH. Install Node.js, or run Setup.bat
+  echo        first -- the eval setup installs the dependencies this needs.
+  pause
+  exit /b 1
+)
+
+cd ..
+
+echo --- Building the MCP server (.mcpb) ---
+call node scripts\build-mcpb.mjs
+if errorlevel 1 (
+  echo.
+  echo Build FAILED on the .mcpb. Scroll up for the error; nothing was installed.
+  pause
+  exit /b 1
+)
+
+echo.
+echo --- Building the Cowork plugin (.zip) ---
+call node scripts\package-plugin.mjs
+if errorlevel 1 (
+  echo.
+  echo Build FAILED on the plugin .zip. The .mcpb above did build, but install
+  echo BOTH or neither -- a half install is worse than none.
+  pause
+  exit /b 1
+)
+
+echo.
+echo === Built. Now install BOTH, then fully quit and reopen Claude Desktop ===
+echo.
+echo 1. MCP server ^(.mcpb^): Claude Desktop -^> Settings -^> Extensions -^>
+echo    Advanced Settings -^> Install extension -^> releases\genealogy-mcp.mcpb
+echo    Install straight over the old copy -- no uninstall needed.
+echo.
+echo 2. Plugin ^(.zip^): Claude Desktop -^> COWORK tab -^> Customize -^>
+echo    REMOVE any existing Genealogy Research plugin, then
+echo    Add -^> Upload Plugin -^> releases\genealogy-plugin.zip
+echo    Upload from the COWORK tab, not the Code tab -- they keep separate
+echo    plugin lists, and a plugin added in Code will not appear in Cowork.
+echo.
+echo 3. Fully QUIT and reopen Claude Desktop.
+echo.
+pause

--- a/eval/README.md
+++ b/eval/README.md
@@ -37,8 +37,9 @@ eval/
   ScratchResearch.bat     Windows: set up a throwaway dir to debug /research by hand
   SeedProject.bat         Windows: seed an editable Cowork project from a fixture (debug /research live)
   Viewer.bat              Windows: launch the Research Viewer (Electron)
-  BuildMcpb.bat           Windows: build the .mcpb desktop extension (for the Cowork debug loop)
-  BuildPlugin.bat         Windows: build the Cowork plugin .zip (for the Cowork debug loop)
+  CoworkInstall.bat       Windows: build BOTH artifacts + print the install click-path (start here)
+  BuildMcpb.bat           Windows: build only the .mcpb desktop extension
+  BuildPlugin.bat         Windows: build only the Cowork plugin .zip
   RunCalibration.bat      Windows: run judge calibration (maintainer only)
 ```
 
@@ -331,16 +332,16 @@ for debugging *why* the agent did or didn't do something, and it keeps the
 test-improve loop fast: you watch the fix work in minutes instead of waiting
 20–60 min for a headless verdict.
 
-**First time (and after any skill or MCP-server change):** build and install
-the two artifacts so Cowork has the genealogy tools — `eval\BuildMcpb.bat`
-(`make mcpb`), then install the `.mcpb` in Claude Desktop → Settings →
-Extensions → Advanced Settings → Install extension (over the old copy — no
-uninstall needed); and `eval\BuildPlugin.bat` (`make plugin`), then **remove any
-existing Genealogy Research plugin** in Cowork → Customize and upload the new
-one via Add → Upload Plugin. Upload it from the **Cowork** tab, not the Code tab
-— they keep separate plugin lists. **Fully quit and reopen** Claude Desktop
-after installing. The headless `RunE2E.bat` path doesn't use these (it runs the
-compiled engine directly), so this is only for the live Cowork loop.
+**First time (and after any skill or MCP-server change):** run
+`eval\CoworkInstall.bat` (`make cowork-install`). It builds **both** artifacts
+and prints where each one goes — install the `.mcpb` in Claude Desktop →
+Settings → Extensions → Advanced Settings → Install extension (over the old copy
+— no uninstall needed), and the `.zip` in Cowork → Customize, **removing any
+existing Genealogy Research plugin first**, via Add → Upload Plugin. Upload it
+from the **Cowork** tab, not the Code tab — they keep separate plugin lists.
+**Fully quit and reopen** Claude Desktop after installing. The headless
+`RunE2E.bat` path doesn't use these (it runs the compiled engine directly), so
+this is only for the live Cowork loop.
 
 1. `eval\SeedProject.bat` → enter the slug (`make e2e-project TEST=<slug>`).
    Copies the fixture's starting state into `eval\e2e-project\<slug>\` as a

--- a/eval/harness/scripts/check_e2e_fixtures.py
+++ b/eval/harness/scripts/check_e2e_fixtures.py
@@ -16,6 +16,21 @@ incomplete / malformed) is the maintainer's ``calibrate_judge --dry-run`` step
 and the loader's own classification — kept out of CI so this check stays
 stdlib-only and never needs the harness venv.
 
+## Unresolved-draft check (WARN only)
+
+A `genre: "record-hint"` fixture ships as a draft: its README carries
+``DRAFT PENDING ADJUDICATION`` until a genealogist resolves the hint
+(Step 1a of docs/e2e-testing-guide.md), and `/resolve-record-hint` clearing
+that marker is what makes it resolved. Committing a *run* for a fixture whose
+marker is still there means the run scored the unverified hint rather than the
+truth — the run is not wrong to exist, but its grade means much less, so the
+reviewer should know. Warn-only: never blocks.
+
+Scoped to **PR-added run logs**, deliberately. An earlier fixture-validity
+warning was removed for re-flagging every un-run fixture in the repo on every
+e2e PR; this one can only fire on a fixture the PR itself committed a run for,
+so it stays silent until someone actually does the thing worth flagging.
+
 ## Not gated: fixture validity
 
 Whether a fixture has a committed *passing* run log (proof it is solvable from
@@ -37,6 +52,10 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parents[2]
 RUNLOGS_DIR = REPO_ROOT / "eval" / "runlogs" / "e2e"
+
+# The marker `/resolve-record-hint` strips from a record-hint fixture's README
+# when a genealogist resolves it. Its presence == still an unverified draft.
+DRAFT_MARKER = "DRAFT PENDING ADJUDICATION"
 
 
 # --------------------------------------------------------------------------- #
@@ -115,6 +134,36 @@ def check_added_runlogs_graded(added: list[Path]) -> list[str]:
 
 
 # --------------------------------------------------------------------------- #
+# Unresolved-draft check (warn only): a run committed for a still-draft fixture
+# --------------------------------------------------------------------------- #
+
+def check_added_runlogs_resolved(added: list[Path]) -> list[str]:
+    """Warn-only: a PR-added run log whose fixture README still carries
+    ``DRAFT PENDING ADJUDICATION``.
+
+    The run scored an unverified hint rather than a genealogist-confirmed
+    answer, so its verdict and its grade both mean less than they look like
+    they do. One warning per fixture, not per run log.
+    """
+    warnings: list[str] = []
+    for slug in sorted({rel.parts[3] for rel in added if len(rel.parts) >= 4}):
+        # Resolved against REPO_ROOT at call time, like check_added_runlogs_graded.
+        readme = REPO_ROOT / "eval" / "tests" / "e2e" / slug / "README.md"
+        if not readme.exists():
+            continue
+        if DRAFT_MARKER in readme.read_text(encoding="utf-8"):
+            warnings.append(
+                f"fixture '{slug}' still carries '{DRAFT_MARKER}' in its "
+                "README, but this PR commits a run for it. The run scored the "
+                "unverified hint, not a resolved answer — resolve the hint "
+                "first (/resolve-record-hint, e2e-testing-guide.md Step 1a) "
+                "and re-run, or say in the PR why the draft run is worth "
+                "committing."
+            )
+    return warnings
+
+
+# --------------------------------------------------------------------------- #
 # CLI
 # --------------------------------------------------------------------------- #
 
@@ -124,6 +173,12 @@ def main() -> int:
     if added is None:
         print("E2E grading gate skipped (no PR context: BASE_SHA/HEAD_SHA unset).")
         return 0
+
+    # --- Unresolved-draft check (warn only) — runs first so its output is
+    # --- visible even when the blocking gate below fails the job.
+    for w in check_added_runlogs_resolved(added):
+        print(f"::warning::{w}")
+        print(f"  ! {w}", file=sys.stderr)
 
     grade_violations = check_added_runlogs_graded(added)
     if grade_violations:

--- a/eval/harness/tests/unit/test_check_e2e_fixtures.py
+++ b/eval/harness/tests/unit/test_check_e2e_fixtures.py
@@ -87,6 +87,54 @@ def test_git_added_filters_to_primary_e2e_runlogs(monkeypatch):
     ]
 
 
+# --- Unresolved-draft check (warn only) -----------------------------------
+
+
+def _write_fixture_readme(repo_root: Path, slug: str, *, draft: bool) -> None:
+    d = repo_root / "eval" / "tests" / "e2e" / slug
+    d.mkdir(parents=True, exist_ok=True)
+    marker = "**DRAFT PENDING ADJUDICATION.** Transcribed from an unverified hint."
+    body = f"# {slug}\n\n## Notes for reviewers\n\n"
+    (d / "README.md").write_text(
+        body + (marker if draft else "Resolved: the hint is a true match."),
+        encoding="utf-8",
+    )
+
+
+def test_draft_fixture_with_committed_run_warns(tmp_path, monkeypatch):
+    monkeypatch.setattr(check_e2e_fixtures, "REPO_ROOT", tmp_path)
+    rel = _make_e2e_run(tmp_path, "smith", "2026-06-15_10-00-00", tree=True, ann=True)
+    _write_fixture_readme(tmp_path, "smith", draft=True)
+    warnings = check_e2e_fixtures.check_added_runlogs_resolved([rel])
+    assert len(warnings) == 1
+    assert "smith" in warnings[0]
+    assert check_e2e_fixtures.DRAFT_MARKER in warnings[0]
+
+
+def test_resolved_fixture_does_not_warn(tmp_path, monkeypatch):
+    monkeypatch.setattr(check_e2e_fixtures, "REPO_ROOT", tmp_path)
+    rel = _make_e2e_run(tmp_path, "smith", "2026-06-15_10-00-00", tree=True, ann=True)
+    _write_fixture_readme(tmp_path, "smith", draft=False)
+    assert check_e2e_fixtures.check_added_runlogs_resolved([rel]) == []
+
+
+def test_missing_fixture_readme_does_not_warn(tmp_path, monkeypatch):
+    """A run log with no fixture dir (renamed/removed) is silent, not a crash."""
+    monkeypatch.setattr(check_e2e_fixtures, "REPO_ROOT", tmp_path)
+    rel = _make_e2e_run(tmp_path, "smith", "2026-06-15_10-00-00", tree=True, ann=True)
+    assert check_e2e_fixtures.check_added_runlogs_resolved([rel]) == []
+
+
+def test_two_runs_of_one_draft_fixture_warn_once(tmp_path, monkeypatch):
+    monkeypatch.setattr(check_e2e_fixtures, "REPO_ROOT", tmp_path)
+    rels = [
+        _make_e2e_run(tmp_path, "smith", "2026-06-15_10-00-00", tree=True, ann=True),
+        _make_e2e_run(tmp_path, "smith", "2026-06-15_18-00-00", tree=True, ann=True),
+    ]
+    _write_fixture_readme(tmp_path, "smith", draft=True)
+    assert len(check_e2e_fixtures.check_added_runlogs_resolved(rels)) == 1
+
+
 # --- main() exit-code behavior --------------------------------------------
 
 
@@ -109,3 +157,14 @@ def test_main_skips_without_pr_context(monkeypatch):
     """No PR env (BASE_SHA/HEAD_SHA unset) → gate is skipped, exit 0."""
     monkeypatch.setattr(check_e2e_fixtures, "git_added_e2e_runlogs", lambda: None)
     assert check_e2e_fixtures.main() == 0
+
+
+def test_main_draft_warning_does_not_fail_the_job(tmp_path, monkeypatch, capsys):
+    """An unresolved-draft fixture warns but must never change the exit code —
+    20 people working drafts in parallel can't have this blocking their PRs."""
+    monkeypatch.setattr(check_e2e_fixtures, "REPO_ROOT", tmp_path)
+    rel = _make_e2e_run(tmp_path, "smith", "2026-06-15_10-00-00", tree=True, ann=True)
+    _write_fixture_readme(tmp_path, "smith", draft=True)
+    monkeypatch.setattr(check_e2e_fixtures, "git_added_e2e_runlogs", lambda: [rel])
+    assert check_e2e_fixtures.main() == 0
+    assert "::warning::" in capsys.readouterr().out


### PR DESCRIPTION
Prepares the e2e record-hint workflow for 20 people starting on the assigned issues. Two commits: the guide trim, then exercising the path they'll actually walk.

## Why the second commit exists

No record-hint fixture has ever been resolved or run. 35 exist, 34 still carry `DRAFT PENDING ADJUDICATION`, and **zero** have a committed run log (53 strip fixtures do). `thomas-seaver-other-wife` was authored directly in the resolved shape rather than worked as an assignment. So this is an unexercised path — verified what could be verified without spending a run.

**Verified locally**
- `validate_fixture --all` — record-hint fixtures lint `OK`; `thomas-seaver`'s `avoid` findings throw exactly the WARNs its README documents.
- `e2e.project --test joseph-david-daughter` — seeds a `strip --none` fixture correctly. Never run for this genre before.
- The judge's `avoid` path is wired: `apply_avoid_guard` + subject-name exemption + polarity-agnostic `derive_verdict`.
- `make cowork-install` end to end; harness suite `1162 passed`; `check_e2e_fixtures` tests `14 passed` (9 existing + 5 new).

## Changes

**Guide trim (first commit).** 538 → 435 lines. Cheat sheet + route map to the top (assigned → 0, 1a, 4–9; new fixture → every step). Step 1a: open the tree person *before* the hint record. Three outcomes in plain language, not JSON field names. `adjudicate` → `resolve`. Step 5 loses the no-full-suite rationale and `--help`; Step 9 loses the CI-convention blockquote and gains "commit a passing run from the branch you're landing." Running-example section replaced by per-path pointers.

**Worked-example references removed.** There's no resolved fixture to imitate, so neither the guide nor the skill offers one, and Step 1a says plainly that this is an unexercised path worth reporting problems from. The skill still copies the JSON *shape* from `thomas-seaver-other-wife/expected-findings.json` — a valid instance of the avoid/required pair — but no longer points at either README as a model write-up.

**`/resolve-record-hint`:** research order (tree person first, and why), and both URLs pulled from the issue with a stop if either is missing. The 35 issue bodies were rewritten out-of-band to carry a tree-person link, which none of them had — the PID previously lived only in `fixture.json`.

**Unresolved-draft CI warn.** A PR-added run log whose fixture README still says DRAFT means the run scored the unverified hint rather than a resolved answer. **Warn only, never blocks** — a test pins `main()` at exit 0 — and scoped to PR-added logs so it can't repeat the noise that got the old fixture-validity warning deleted.

**`make cowork-install` + `eval\CoworkInstall.bat`.** Installing one artifact and not the other is the standing way to lose an hour to a stale `/research`. Both installs are Desktop UI actions with no CLI, so the target builds both and prints the click-path. Collapses eight manual steps in Step 4 to one command; Windows batch equivalent since most of the team is on Windows.

## Known gaps, deliberately not closed here

- **#638 `heinrich-dewus-children-death`** has no hint-record URL anywhere — the batch source (`filtered-list-samples.csv` row 1) isn't in the repo. Owner is taking it.
- **#639 `test spriggs-marriage-1925`** — slug typo (fixture is `-1926`) *and* its body is the record-hint template while the fixture is a plain strip fixture, so its instructions don't apply. Owner is taking it.
- No fixture of this genre has completed a run. The first one to land becomes the worked example the docs can point at again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)