### PR TITLE
Revert "allow Claude to edit runlog .json files when needed, but not .ann.json files"

### DIFF
--- a/eval/CLAUDE.md
+++ b/eval/CLAUDE.md
@@ -64,7 +64,8 @@ eval/
 > validates every correction against `ann.schema.json` before saving. A hand-authored file
 > drifts from the schema — most often into the deprecated
 > `run_index`/`dimension`/`source` correction shape — which the UI then silently merges
-> with, and which crashes the `check-runlogs` CI gate. If an annotation needs fixing, open
+> with, and which crashes the `check-runlogs` CI gate. The same goes for run-log `.json`
+> files: the **harness** writes those, never a human. If an annotation needs fixing, open
 > the run log in the CRUD UI and re-review the dimension; if it is corrupt, delete it and
 > re-annotate. The only correct way to produce either file is to run the tooling.
 >


### PR DESCRIPTION
Reverts 5080b1d7.

That commit dropped the sentence in `eval/CLAUDE.md` saying run-log `.json`
files are written by the harness, never a human. This restores it, so the
prohibition once again covers both `.ann.json` annotations and run-log
`.json` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)