### PR TITLE
fix(web): stop the chat yanking to the bottom while the user reads

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -1,10 +1,115 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import type { SessionConnection, WsMessage } from '../transport/SessionConnection'
 import { api, ApiError } from '../api'
 
 const OPENING_TURN = "Let's start a new genealogy research project."
+
+// How close to the bottom still counts as "at the bottom". Deliberately not an
+// equality check: fractional device pixel ratios and sub-pixel scrollHeight
+// leave scrollTop + clientHeight a pixel or two short even when fully pinned.
+const STICK_THRESHOLD_PX = 64
+
+/**
+ * Follow the bottom of a scroll container while the user is pinned there, and
+ * stop the moment they scroll up to read.
+ *
+ * Detaching is driven by *input events*, never by comparing scroll positions
+ * across renders. While a turn streams, the document grows underneath the
+ * viewport many times a second, and position-only logic cannot tell "the user
+ * scrolled up" apart from "the content got taller" — which is how the old
+ * unconditional scroll-to-bottom yanked the view away mid-read. Re-attaching is
+ * the reverse: only a real `scroll` event that lands inside the threshold does
+ * it, so growth alone never re-arms following.
+ *
+ * The caller drives `follow()` from its own effect, so the "content changed"
+ * dependencies stay visible at the call site.
+ */
+function useStickToBottom(ref: React.RefObject<HTMLDivElement | null>): {
+  detached: boolean
+  follow: () => void
+  scrollToBottom: (smooth?: boolean) => void
+} {
+  // Mirrored in a ref as well as state: the event handlers below read it
+  // without re-subscribing, while the arrow button renders off the state.
+  const stickingRef = useRef(true)
+  const [detached, setDetached] = useState(false)
+
+  const setSticking = useCallback((next: boolean): void => {
+    if (stickingRef.current === next) return
+    stickingRef.current = next
+    setDetached(!next)
+  }, [])
+
+  const scrollToBottom = useCallback(
+    (smooth = false): void => {
+      const el = ref.current
+      if (!el) return
+      el.scrollTo({ top: el.scrollHeight, behavior: smooth ? 'smooth' : 'auto' })
+      setSticking(true)
+    },
+    [ref, setSticking]
+  )
+
+  // Instant, never smooth: at delta granularity a smooth scroll is still
+  // animating when the next chunk lands, so the view lags behind the text and
+  // rubber-bands. Smooth is reserved for the explicit arrow click.
+  const follow = useCallback((): void => {
+    if (!stickingRef.current) return
+    const el = ref.current
+    if (!el) return
+    el.scrollTo({ top: el.scrollHeight })
+  }, [ref])
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    // Any upward gesture is an explicit "let me read" — detach at once, before
+    // the scroll it causes has even been applied. Testing "is anything below
+    // me" here would be wrong for exactly that reason: the gesture fires while
+    // still pinned at the bottom, so the only thing worth asking is whether the
+    // transcript can scroll at all. On one too short to overflow the gesture
+    // moves nothing, and an arrow pointing at no content is worse than none.
+    const detach = (): void => {
+      if (el.scrollHeight > el.clientHeight + STICK_THRESHOLD_PX) setSticking(false)
+    }
+    const onWheel = (e: WheelEvent): void => {
+      if (e.deltaY < 0) detach()
+    }
+    const onTouchMove = (): void => detach()
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (['PageUp', 'ArrowUp', 'Home'].includes(e.key)) detach()
+    }
+    // Scrollbar drag: a pointerdown past the content box is on the gutter, which
+    // produces no wheel or touch event of its own.
+    const onPointerDown = (e: PointerEvent): void => {
+      if (e.offsetX > el.clientWidth) detach()
+    }
+    // The only way back. Content growing while detached moves no scrollTop, so
+    // it fires nothing here and cannot silently re-arm following.
+    const onScroll = (): void => {
+      if (el.scrollHeight - el.scrollTop - el.clientHeight <= STICK_THRESHOLD_PX)
+        setSticking(true)
+    }
+
+    el.addEventListener('wheel', onWheel, { passive: true })
+    el.addEventListener('touchmove', onTouchMove, { passive: true })
+    el.addEventListener('keydown', onKeyDown)
+    el.addEventListener('pointerdown', onPointerDown)
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      el.removeEventListener('wheel', onWheel)
+      el.removeEventListener('touchmove', onTouchMove)
+      el.removeEventListener('keydown', onKeyDown)
+      el.removeEventListener('pointerdown', onPointerDown)
+      el.removeEventListener('scroll', onScroll)
+    }
+  }, [ref, setSticking])
+
+  return { detached, follow, scrollToBottom }
+}
 
 interface ToolChip {
   tool: string
@@ -64,6 +169,7 @@ export default function ChatPane({
   const turnStartRef = useRef(0)
   const [activity, setActivity] = useState<AgentActivity | null>(null)
   const [connState, setConnState] = useState<'open' | 'reconnecting'>('open')
+  const { detached, follow, scrollToBottom } = useStickToBottom(scrollRef)
 
   // Append agent_event content onto the last assistant message (the streaming one).
   const applyEvent = (ev: Record<string, unknown>): void => {
@@ -171,9 +277,12 @@ export default function ChatPane({
     return off
   }, [conn])
 
+  // Follow new content only while the user is pinned to the bottom. Note there
+  // is deliberately no scroll on turn_done: finishing a response is not a
+  // reason to yank someone out of the passage they scrolled up to read.
   useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight })
-  }, [messages, busy])
+    follow()
+  }, [messages, busy, follow])
 
   // Tick a visible "working… Ns" while a turn is in flight, so a long tool call
   // reads as alive rather than hung.
@@ -195,6 +304,9 @@ export default function ChatPane({
     conn.send({ type: 'user_msg', text: trimmed })
     setBusy(true)
     setInput('')
+    // Sending is an unambiguous "I'm back at the live edge" — re-attach even if
+    // the user had scrolled up to compose against something further back.
+    scrollToBottom()
   }
 
   // Ask the agent to abort the running turn. The runner forwards this to the SDK
@@ -235,68 +347,93 @@ export default function ChatPane({
 
   return (
     <div className="chatBody">
-      <div className="chatMessages" ref={scrollRef}>
-        {messages.length === 0 && (
-          <div className="chatPlaceholder">
-            <p className="muted small">
-              {ready ? 'Say hello to start.' : 'Connecting to the agent…'}
-            </p>
-          </div>
-        )}
-        {messages.map((m, i) => (
-          <div key={i} className={m.role === 'user' ? 'msgUser' : 'msgAssistant'}>
-            {m.tools.length > 0 && (
-              <div className="toolChips">
-                {m.tools.map((t, j) => (
-                  <span key={j} className={`toolChip ${t.done ? 'toolDone' : 'toolRunning'}`}>
-                    {t.done ? '✓' : '⟳'} {t.agent ? `${t.agent} · ` : ''}
-                    {t.tool}: {t.summary}
-                  </span>
-                ))}
-              </div>
-            )}
-            {(m.thinking || m.streamThinking) && (
-              <details className="thinkingBlock" style={{ margin: '4px 0' }}>
-                <summary className="muted small" style={{ cursor: 'pointer' }}>💭 Thinking</summary>
-                <div className="muted small" style={{ whiteSpace: 'pre-wrap', marginTop: 4 }}>
-                  {m.thinking}
-                  {m.streamThinking}
-                </div>
-              </details>
-            )}
-            {m.text && (
-              <div className={`msgText ${m.error ? 'msgError' : ''}`}>
-                <Markdown remarkPlugins={[remarkGfm]}>{m.text}</Markdown>
-              </div>
-            )}
-            {/* In-flight text, rendered as plain preformatted text: markdown is
-                routinely mid-token at delta granularity, and re-parsing a partial
-                document every frame makes list/code blocks flicker as they close. */}
-            {m.streamText && (
-              <div className={`msgText ${m.error ? 'msgError' : ''}`} style={{ whiteSpace: 'pre-wrap' }}>
-                {m.streamText}
-              </div>
-            )}
-          </div>
-        ))}
-        {/* One status line, three distinct states. Reconnecting is shown even
-            when a turn wasn't running, because a dropped socket is worth knowing
-            about; it takes priority over "working" so a stall never masquerades
-            as progress (the failure mode that hid the 2026-07-20 disconnect). */}
-        {connState === 'reconnecting' ? (
-          <div className="typing">●●● Reconnecting…</div>
-        ) : (
-          busy && (
-            <div className="typing">
-              ●●●{' '}
-              {activity
-                ? `${activity.agent}${activity.lastTool ? ` · ${activity.lastTool}` : ''}${
-                    activity.toolUses ? ` · ${activity.toolUses} tools` : ''
-                  }`
-                : 'working…'}{' '}
-              {elapsed}s
+      <div className="chatScrollArea">
+        <div className="chatMessages" ref={scrollRef}>
+          {messages.length === 0 && (
+            <div className="chatPlaceholder">
+              <p className="muted small">
+                {ready ? 'Say hello to start.' : 'Connecting to the agent…'}
+              </p>
             </div>
-          )
+          )}
+          {messages.map((m, i) => (
+            <div key={i} className={m.role === 'user' ? 'msgUser' : 'msgAssistant'}>
+              {m.tools.length > 0 && (
+                <div className="toolChips">
+                  {m.tools.map((t, j) => (
+                    <span key={j} className={`toolChip ${t.done ? 'toolDone' : 'toolRunning'}`}>
+                      {t.done ? '✓' : '⟳'} {t.agent ? `${t.agent} · ` : ''}
+                      {t.tool}: {t.summary}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {(m.thinking || m.streamThinking) && (
+                <details className="thinkingBlock" style={{ margin: '4px 0' }}>
+                  <summary className="muted small" style={{ cursor: 'pointer' }}>💭 Thinking</summary>
+                  <div className="muted small" style={{ whiteSpace: 'pre-wrap', marginTop: 4 }}>
+                    {m.thinking}
+                    {m.streamThinking}
+                  </div>
+                </details>
+              )}
+              {m.text && (
+                <div className={`msgText ${m.error ? 'msgError' : ''}`}>
+                  <Markdown remarkPlugins={[remarkGfm]}>{m.text}</Markdown>
+                </div>
+              )}
+              {/* In-flight text, rendered as plain preformatted text: markdown is
+                  routinely mid-token at delta granularity, and re-parsing a partial
+                  document every frame makes list/code blocks flicker as they close. */}
+              {m.streamText && (
+                <div className={`msgText ${m.error ? 'msgError' : ''}`} style={{ whiteSpace: 'pre-wrap' }}>
+                  {m.streamText}
+                </div>
+              )}
+            </div>
+          ))}
+          {/* One status line, three distinct states. Reconnecting is shown even
+              when a turn wasn't running, because a dropped socket is worth knowing
+              about; it takes priority over "working" so a stall never masquerades
+              as progress (the failure mode that hid the 2026-07-20 disconnect). */}
+          {connState === 'reconnecting' ? (
+            <div className="typing">●●● Reconnecting…</div>
+          ) : (
+            busy && (
+              <div className="typing">
+                ●●●{' '}
+                {activity
+                  ? `${activity.agent}${activity.lastTool ? ` · ${activity.lastTool}` : ''}${
+                      activity.toolUses ? ` · ${activity.toolUses} tools` : ''
+                    }`
+                  : 'working…'}{' '}
+                {elapsed}s
+              </div>
+            )
+          )}
+        </div>
+
+        {/* Shown only while detached, so during normal "watch it work" reading
+            it never appears. Smooth here — this one is a deliberate click, not
+            a per-token follow. */}
+        {detached && (
+          <button
+            type="button"
+            className="chatJumpLatest"
+            onClick={() => scrollToBottom(true)}
+            title="Scroll to latest"
+            aria-label="Scroll to latest"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path
+                d="M6 9.5 12 15.5 18 9.5"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
         )}
       </div>
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -523,6 +523,15 @@ button {
 }
 
 /* ── Chat ─────────────────────────────────────────────── */
+/* Positioning context for the jump-to-latest button, so it floats just above
+   the composer regardless of how tall the composer has grown. */
+.chatScrollArea {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
 .chatMessages {
   flex: 1;
   overflow-y: auto;
@@ -530,6 +539,44 @@ button {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+.chatJumpLatest {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--bg-elev);
+  color: var(--ink-soft);
+  cursor: pointer;
+  box-shadow: var(--shadow, 0 2px 8px rgb(0 0 0 / 0.18));
+  animation: jumpLatestIn 120ms ease-out;
+}
+.chatJumpLatest:hover {
+  color: var(--ink);
+  border-color: var(--accent);
+}
+@keyframes jumpLatestIn {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 6px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .chatJumpLatest {
+    animation: none;
+  }
 }
 .msgUser {
   align-self: flex-end;


### PR DESCRIPTION
## Problem

`ChatPane` scrolled to the bottom unconditionally on every `messages`/`busy` change:

```tsx
useEffect(() => {
  scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight })
}, [messages, busy])
```

So any text the agent added while working dragged the view away from whatever the user had scrolled up to read.

Electron is unaffected — it has no chat pane. The only `viewer-ui` scroll calls (`SidecarPanel`, `CrossLink`) are user-initiated anchor jumps.

## Approach

Stick-to-bottom, the pattern every mature chat UI uses: follow new content **only** while the user is pinned at the bottom, detach the instant they scroll up, and show a jump-to-latest arrow while detached. Never auto-scrolling was the other option considered, but the common case is watching the agent work with no scrolling of your own — that would make it require constant manual scrolling, and leave the arrow visible during every response.

Details that matter:

- **Detach on input events, not position deltas.** `wheel` up, `touchmove`, PageUp/ArrowUp/Home, and scrollbar-gutter `pointerdown`. While a turn streams, the document grows underneath the viewport many times a second, and position-only logic can't tell "the user scrolled up" from "the content got taller".
- **Re-attach only on a real `scroll` event** landing within 64px of the bottom. Growth alone moves no `scrollTop`, so it fires nothing and can't silently re-arm following. The threshold is not an equality check — fractional device pixel ratios leave `scrollTop + clientHeight` a pixel or two short even when fully pinned.
- **Follow instantly; smooth only on the arrow click.** A smooth scroll is still animating when the next chunk lands, so the view lags and rubber-bands.
- **Re-attach on send**, and deliberately **not** on `turn_done` — finishing a response is not a reason to yank someone out of the passage they scrolled up to read.

## Verification

Driven live against `make server-mock` + `make web-dev`:

| Behavior | Result |
|---|---|
| Pinned at bottom → follows new content | `scrollHeight − scrollTop − clientHeight == 0` after every one of ~14 message additions and a full transcript replay |
| Arrow while pinned | hidden |
| Wheel-up on an overflowing transcript | detaches, arrow appears |
| Detached position through an active turn | held at 120 for 25s+ across React re-renders |
| Arrow click | 120 → 882 (`gap: 0`), re-attaches, arrow disappears |

Live testing found one bug, fixed here: a wheel-up on a transcript too short to overflow was detaching and showing an arrow pointing at nothing. The detach guard now requires `scrollHeight > clientHeight + threshold`; it can't test "is anything below me" because the gesture fires while still pinned at the bottom.

**One assertion not directly observed:** a content-growth render occurring *while* detached. The mock agent delivers each reply in a single render and then wedges in `busy` after a few turns, so there was never a clean streaming window. The guard for it is `follow()`'s early return on `!stickingRef.current` — the same flag the last two table rows exercise — but flagging it as inferred rather than observed.

`make test-js` passes (124 tests); `pnpm --filter web typecheck` and `build` pass. `apps/web` has no test runner, so this logic has no unit test.

## Not in this PR

Scrolling the user's new message to the *top* on send (the ChatGPT/Claude.ai refinement, so the response fills empty space below and the reading position stays fixed). It needs a dynamic bottom spacer, redefines "at the bottom" for the threshold and the arrow's visibility, and is purely a streaming-feel change that couldn't be evaluated given the mock's behavior. Worth doing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)