### PR TITLE
Close the research-guardrail-bypass gap: caller-id hook, cross-field validation, hard e2e detector

### DIFF
--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -565,6 +565,26 @@ sized by the Phase-0 latency analysis and are not covered by the parent plan's p
   `record-extraction/SKILL.md`. The instrument if it recurs is a
   `context_policy` PreToolUse rule keyed on `agent_id` — eval-only, so it
   would not cover Cowork or the hosted path.
+- [ ] **Investigate giving each of the four GPS guardrail skills its own
+  write tool** (`proof_conclusion_append` / `exhaustiveness_declare` /
+  `person_evidence_link` / `conflict_resolve`, splitting `research_append`'s
+  `proof_summaries`/`exhaustive_declaration`/`person_evidence`/`conflicts`
+  sections off the same way `extraction_append` split off record-extraction,
+  #695). Raised during the PR #893 orchestration-bypass investigation — see
+  `docs/plan/research-guardrail-bypass-plan.md` §3/§5. Splitting doesn't
+  attribute a call to a skill by itself in a shared session (a split tool is
+  exactly as callable by the main thread as the section-branch version is
+  today), but it (a) turns a caller-tracking `PreToolUse` hook into a flat
+  tool-name lookup instead of parsing `ops[]`/`section` out of args, and (b)
+  is close to a prerequisite for ever giving one of these four skills a hard
+  `agent_id`/`disallowedTools` boundary, since that enforcement is tool-name-
+  granular only — a shared `research_append` can't be partially denied.
+  Cost: real multi-file scaffolding (schema/handler/tests/manifest/
+  `mock_mcp.py`/lint scripts) × 4, plus a permanent increase in Cowork's
+  up-front tool-schema count (Cowork does not defer schemas via `ToolSearch`
+  the way both harnesses do). Worth doing if/when one of the four skills is
+  converted to an agent; not worth it standalone. Decide after the plan's
+  caller-id hook ships and its practical gaps, if any, are known.
 - **MCP tool-name prefix differs between Cowork and the harnesses — agent
   `tools:` lists do not bind in Cowork.** Every plugin agent declares
   `mcp__genealogy__*`, correct for the unit + e2e harnesses. A live Cowork

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -585,6 +585,45 @@ sized by the Phase-0 latency analysis and are not covered by the parent plan's p
   the way both harnesses do). Worth doing if/when one of the four skills is
   converted to an agent; not worth it standalone. Decide after the plan's
   caller-id hook ships and its practical gaps, if any, are known.
+- [ ] **Research-guardrail-bypass fix (docs/plan/research-guardrail-bypass-plan.md)
+  does not cover the hosted/production path.** The caller-id `PreToolUse`
+  hook (§4.1), the `Write`/`Edit` lockdown (§4.3), and the two hard-fail
+  checks (§4.4) are all e2e-harness-only (`eval/harness/e2e/orchestrator.py`).
+  `apps/server/app/agent/real_agent.py` still runs `bypassPermissions` with
+  no equivalent guard, so the exact bypass the plan documents (and the live
+  `bagley-father-1884` run confirmed) remains fully reachable in Cowork and
+  the hosted web workbench. The plan explicitly deferred this pending the
+  eval-side mechanism proving out first; it hasn't been ported yet.
+- [ ] **Whether `Skill`-tool content injection survives compaction is
+  unverified — and there's now real reason to suspect it doesn't.**
+  `docs/plan/research-guardrail-bypass-plan.md` §6 flagged this as an open
+  question (proof-conclusion/research-exhaustiveness/person-evidence/
+  conflict-resolution all do an on-demand `Read` of their own
+  `references/*.md`, unverified for reliability). The `feedback-2026-07-27-perf`
+  branch's compaction audit (commits `3455ce84`/`f05757ef`,
+  `docs/plan/research-performance-2026-07-27.md`) independently measured the
+  general mechanism: an unanchored prose rule's compliance decays from
+  ~100% to 3-45% once its skill body is evicted from context by compaction,
+  while tool-validated/output-coupled rules hold at 100%. A guardrail
+  skill's own reference-doc reads are exactly this shape (prose-anchored,
+  no tool validation) — worth the same before/after-compaction segment
+  analysis their audit used, applied to the four guardrail skills
+  specifically, before assuming the reference reads hold up in long runs.
+- [ ] **`gps-mentor`'s proof-critique gate may be as skippable as the four
+  guardrail skills — undetermined.** `find_missing_mentor_verdicts`
+  (`harness/skill_invocation.py`) detects a missing verdict after the fact
+  but does nothing to prevent the orchestrator from silently skipping the
+  `@plugin:gps-mentor` invocation under the same context-pressure conditions
+  that caused the other four skips. No runlog evidence has been checked
+  either way (`docs/plan/research-guardrail-bypass-plan.md` §6).
+- [ ] **`research-append.ts`'s batch-ordering was only audited for one
+  TOCTOU case.** The §4.2 fix (tier vs. `exhaustive_declaration`, checked
+  against pre-call state) closes the specific same-batch establish-and-
+  consume hole found during adversarial review. Other same-batch orderings
+  that could similarly self-satisfy a precondition within one atomic write
+  (e.g. adding a `person_evidence` link and consuming it for an assertion in
+  the same batch) were not exhaustively checked — flagged, not audited, in
+  the plan's §6.
 - **MCP tool-name prefix differs between Cowork and the harnesses — agent
   `tools:` lists do not bind in Cowork.** Every plugin agent declares
   `mcp__genealogy__*`, correct for the unit + e2e harnesses. A live Cowork

--- a/docs/plan/research-guardrail-bypass-plan.md
+++ b/docs/plan/research-guardrail-bypass-plan.md
@@ -421,3 +421,50 @@ found (§6); content-level validation of `stop_criteria`/`log_entry_ids`
 skill's own nested references, an assumption the *current* architecture
 already depends on, not one this plan introduces (§6); whether `gps-mentor`'s
 own gate is itself skippable (§6).
+
+## 9. First live run — `bagley-father-1884` (2026-07-27)
+
+The `eval/tests/e2e/bagley-father-1884` fixture (§ authored to exercise this
+plan) surfaced a real instance of the exact bug this plan targets, on its
+first run, before any of §4.1's shadow logging had a chance to be tuned:
+
+- At tool call index 86 the orchestrator wrote a single 26-op `research_append`
+  batch directly — creating a brand-new tree person (the father) and linking
+  13 assertions to him — never through `person-evidence`. The tell: a raw
+  `Read` of `person-evidence/SKILL.md` at index 77, immediately before, the
+  same read-and-improvise shape found in the `wilkins-death-kentucky` runlog
+  while writing this plan. `person-evidence` was invoked as a `Skill` 52 tool
+  calls later, but only for a separately-extracted, later record — never for
+  the write at index 86. `same_person` was called **zero times in the entire
+  run**.
+- §4.4's "invoked anywhere" hard-fail did not catch this — `person-evidence`
+  *was* invoked somewhere in the run, just not for this write. Only §4.1's
+  shadow-mode recency-window check caught it (one clean hit, no false
+  positive on the legitimate person-evidence write 3 calls after its proper
+  invocation at index 138).
+- The judge scored the run `pass` (proof_quality 3/3). The blind human
+  annotation independently downgraded it: `f1: partial`, proof_quality 2 —
+  "David Bagley added as a new person... but the person is not pinned to an
+  identity — no birth fact, no death fact — and the agent's own narrative
+  surfaces a co-resident 'David Bagley Jr.' in Topsham, so the tree as
+  written does not distinguish which David Bagley was named." This is
+  independent, content-level corroboration (a genealogist grading the
+  research quality, with no visibility into the orchestration-bypass
+  detection) that skipping identity scoring had a real, non-theoretical
+  consequence here — not just a missed formality.
+
+**Added as a result:** `find_person_evidence_missing_same_person` in
+`harness/skill_invocation.py` — every brand-new tree person that receives a
+`person_evidence` link must have been the subject of at least one
+`same_person` call somewhere in the run. Deliberately whole-run-scope like
+§4.4's other checks, not windowed like §4.1: `same_person` is a required
+tool call, not a proximity heuristic, so "was it called for this person" is
+a fact, not a heuristic — no shadow period needed, wired straight into the
+hard-fail path alongside `find_effects_without_invocation` and
+`find_missing_mentor_verdicts`. It does not generalize to the other three
+guardrail skills — none has an equivalently unambiguous required-tool
+fingerprint the way identity-linking has `same_person` — so those stay on
+§4.1's windowed, shadow-mode path.
+
+This run is the first real calibration data point for §4.1's recency window
+and is worth keeping (graded, not discarded) for that purpose.

--- a/docs/plan/research-guardrail-bypass-plan.md
+++ b/docs/plan/research-guardrail-bypass-plan.md
@@ -1,0 +1,423 @@
+# Research Guardrail Bypass — Plan
+
+**Project:** Cowork Genealogy — `/research` orchestration
+**Status:** DRAFT, for review (engineering) — adversarially reviewed once;
+findings incorporated, see §8.
+**Goal:** Close the structural gap that lets autonomous `/research` silently
+bypass `research-exhaustiveness`, `proof-conclusion`, `person-evidence`, and
+`conflict-resolution` — the four sub-skills that own GPS tier/exhaustiveness/
+identity/conflict judgments — without waiting on a full agent-architecture
+rewrite that a separate investigation (issue #702) shows is not free.
+**Companion work:** `docs/specs/research-append-tool-spec.md` §11 (the
+`extraction_append` lane-gating precedent this plan extends, and §11.4's
+"What this does not fix," which already named this exact gap and predicted
+prose wouldn't hold it); `docs/diagnoses/wilkins-death-kentucky-headless-runs2-3.md`
+(prior instance: `person-evidence` silently skipped, fixed with prose that
+later re-broke); `CLAUDE.md` "Cowork plugin agents" → "No playbook/reference
+files for agents" (issue #702, closed not planned 2026-07-27); `docs/TODOs.md`
+"Router-side (main-thread) lane enforcement," "match_score remains fabricable
+by person-evidence," "The router substitutes for a denied subagent tool"; PR
+#893 (`e2e-John-Richardson`, the john-richardson-parents fixture that surfaced
+this).
+
+---
+
+## 1. Problem
+
+PR #893's `john-richardson-parents` fixture captures a real headless run in
+which `proof-conclusion` selected a tier and wrote a `narrative_markdown`
+claiming the case was "proved" and "reasonably exhaustive" while
+`exhaustive_declaration.declared` was `false` and plan items were still open —
+directly contradicting the project's own recorded state. The mother (Mary
+Mallalieu) was left identified only as "Mary," maiden name unestablished,
+under a conclusion that claimed the opposite.
+
+The PR author traced this to autonomous `/research` bypassing the four GPS
+guardrail skills: interactively (Cowork), `research-exhaustiveness` is
+invoked correctly; headless, it and the other three guardrail skills are
+sometimes not invoked as `Skill` calls at all. A prose fix — a "MANDATORY...
+invoke the skill, never a generic subagent" contract added to
+`research/SKILL.md` — was tried and produced an identical bypass on re-run.
+
+Investigation (this thread) found the bypass takes two distinct shapes in
+committed e2e runlogs (`eval/runlogs/e2e/wilkins-death-kentucky/run-2026-07-17_00-16-59.{json,transcript.md}`):
+
+- **Read-and-improvise:** the orchestrator `Glob`/`Read`s the target skill's
+  own `SKILL.md` off disk, then does the work itself inline via
+  `research_append` — no `Skill` call, no `Agent`/`Task` call at all
+  (transcript lines 968–1058).
+- **Untyped subagent:** an `Agent` call with no `subagent_type` key and a
+  hand-written prompt standing in for the skill (tool_calls[44]).
+
+Corpus-wide, all four guardrail skills are invoked correctly *most* of the
+time (`research-exhaustiveness` 79×, `proof-conclusion` 58×, `person-evidence`
+90×, `conflict-resolution` 4× across the runlog corpus) but the bypass recurs
+in ~23 of ~50 committed e2e runs and clusters late in long runs (47–81% of
+the way through), suggesting a context-pressure correlation, not a rare
+fluke.
+
+## 2. Root cause
+
+Nothing in the current architecture mechanically prevents the orchestrator
+from doing a guardrail skill's job itself. Specifically:
+
+- **`allowed-tools:` frontmatter is not enforced in the e2e/headless path.**
+  `research/SKILL.md` declares `allowed-tools: [validate_research_schema]` —
+  by its own contract the orchestrator should be unable to call
+  `research_append` directly — but `eval/harness/e2e/orchestrator.py:738`
+  grants the entire `mcp__genealogy` wildcard to the whole session for the
+  full run. The only place `allowed-tools` becomes a real SDK allow/deny list
+  is the isolated unit-skill harness (`harness/allowed_tools.py` →
+  `harness/skill_runner.py`), and it has never been pointed at `research`
+  itself (no unit-test scenario exists for the orchestrator).
+- **There is no way to attribute a tool call to "which skill is currently
+  active" in a shared session.** The SDK's only context-scoping primitive is
+  `agent_id`, present on `PreToolUseHookInput` only inside a `Task`-spawned
+  subagent. A `Skill`-tool invocation runs inline in the same session with no
+  `agent_id` — indistinguishable, at the tool-call layer, from the
+  orchestrator doing the work itself. `context_policy.py`'s own docstring
+  says as much: it can guard `image_read` only because that check keys on
+  `agent_id`, and states plainly it cannot generalize to sub-skills invoked
+  via `Skill`.
+- **This is a known, previously-named gap, not a new discovery.**
+  `research-append-tool-spec.md` §11.4 already predicted it: *"The router
+  (main thread) is unrestrained in production... nothing stops the router
+  from writing `person_evidence` itself... The mitigation is prose... the
+  instrument if it recurs is a `context_policy` PreToolUse rule keyed on
+  `agent_id`, which is eval-only."* The `wilkins-death-kentucky-headless-runs2-3`
+  diagnosis shows the identical failure for `person-evidence` alone, fixed
+  with routing-table prose that this investigation confirms still fails in
+  later runs. PR #893's prose fix for the other three skills is the same
+  remedy, applied again, with the same result.
+
+Prose fixes keep failing here for a structural reason: the party being asked
+to self-police ("invoke the skill, never a generic subagent") is the same
+party whose behavior degrades under the exact condition (long-run context
+pressure) that produces the bypass.
+
+## 3. Options considered and set aside
+
+**Full agent conversion of the four skills** (gets a real `agent_id` for hook
+enforcement, isolates context growth) was the initial candidate fix but is
+not adopted here. All four skills have mandatory on-demand `Read` of their
+own `references/*.md` (research-exhaustiveness, proof-conclusion,
+person-evidence, conflict-resolution all instruct "read `references/X.md`
+before/when Y"). Issue #702 measured that pattern as unreliable *and silent*
+when done from an agent: across a `record-extraction` playbook experiment
+with the files provably reachable, the agent read the reference on some
+tests, ignored it on others (falling back to a degenerate default), and
+over-applied it on others — pass rate 6/19 against a 12–14/19 baseline. The
+only fix CLAUDE.md sanctions is full inlining, no on-demand `Read`, no
+build-time assembly ("the prompt is the product"). Inlined, `research-exhaustiveness`
+(413 lines) and `proof-conclusion` (509 lines) are comparable to existing
+agent bodies (`gps-mentor` 635, `record-extractor` 818); `person-evidence`
+(941) and `conflict-resolution` (1006) would each be the largest agent body
+in the plugin. Given that cost is concentrated on the two skills that fire
+most often per run (person-evidence ~90×, conflict-resolution far less but
+carries its own identity-safety doctrine), this plan defers agent conversion
+rather than bundling it with an urgent fix. See §5.
+
+**`caller_id` as a tool-call argument the orchestrator/skills set
+themselves** was proposed and rejected. A self-reported field is filled in by
+the same untrusted party whose behavior we don't trust at the moment it
+matters — there is nothing checking it against what actually happened. This
+codebase has direct precedent for exactly this failure: `person-evidence`'s
+`match_score` was meant to attest that `same_person` was consulted; a
+provenance guard for it was designed and cut in #695 with "zero observed true
+positives... against a real false-positive class" (`docs/TODOs.md`). The
+fix below achieves the same *intent* — a caller-id — by having the harness
+infer and track it itself, never the model.
+
+**Splitting each guardrail skill's writes into its own MCP tool**
+(`proof_conclusion_append`, `exhaustiveness_declare`, `person_evidence_link`,
+`conflict_resolve`, mirroring `extraction_append`'s split from
+`research_append`) was raised as a strong idea but scoped out of this plan.
+It doesn't attribute anything by itself in a shared session — a split tool
+is exactly as callable by the orchestrator as the section-branch version is
+today — so it's a multiplier on the fix below, not a substitute. It is a
+near-prerequisite if the deferred agent conversion in §5 ever happens
+(`disallowedTools` enforcement, which binds even under `bypassPermissions`,
+is tool-name-granular only). Tracked as its own investigation in
+`docs/TODOs.md` rather than committed here.
+
+## 4. Recommended changes
+
+### 4.1 Caller-id enforcement hook (harness-tracked, not model-supplied)
+
+Add a session-scoped tracker to the `PreToolUse` hook (`eval/harness/e2e/orchestrator.py`'s
+existing `pretool_hook`, ~lines 596–684, which today only enforces
+`BLOCKED_TREE_TOOLS`, fixture `blocked_tools`, and the tool-call budget cap).
+**Implementation prerequisite:** the hook currently early-returns for any
+non-`mcp__`-prefixed tool name, so a `Skill` call never reaches the hook body
+today — this needs restructuring, not just an added branch.
+
+- On every successful `Skill` tool call, record `(skill_name, question_id if
+  derivable, call_index)`. Gate "successful" on the tool result, not just the
+  call — an errored/degraded `Skill` invocation must not open the window,
+  otherwise "invoke the skill, have it fail, finish the write inline anyway"
+  evades both this hook and §4.4's detector at once (a `Skill` call really
+  is present in the log in that sequence). This requires hooking
+  `PostToolUse` in addition to `PreToolUse` to observe the result.
+- Key the window by `(skill_name, question_id)` where a question id is
+  derivable from the call args, not by `skill_name` alone — a bare
+  skill-name window means `Skill(proof-conclusion)` for question A can leave
+  the window open long enough for an unguarded inline write on question B in
+  a multi-question project (the normal case, not an edge case). Where a
+  question id genuinely can't be extracted from a given write's args, fall
+  back to the global per-skill window and accept the imprecision (documented
+  in §6, not silently).
+- On every write that touches a protected field — see the expanded list
+  below — check that the matching skill was invoked (successfully, for the
+  same question where keyed) within a generous trailing window of tool calls
+  (size TBD — tuned empirically against the runlog corpus, using §4.4's
+  "was this skill invoked" logic as the measurement tool; see §7). Reject
+  otherwise, naming only the required skill (same narrow error-contract
+  style as `extraction_append`'s lane gate: name what's required, not a
+  routing map).
+- **Protected fields, expanded.** The original list (`proof_summaries.tier`,
+  `person_evidence`, `conflicts`, `exhaustive_declaration.declared: true`)
+  covers `research.json` only and misses each guardrail skill's actual
+  documented output on the *tree* side, which is a live bypass route right
+  now, independent of everything else in this plan:
+  - `materialize_facts` can create a new tree person and attach facts to it
+    without any `person_evidence` entry existing — an identity-bypass route
+    that doesn't go through `person-evidence` at all, so watching only
+    `research.json`'s `person_evidence` section misses it entirely.
+  - `proof-conclusion/SKILL.md`'s own Tree-encoding gate says a conclusion
+    isn't complete until it's reflected in `tree.gedcomx.json` (`primary:
+    true` on the concluded fact, the `ParentChild`/`Couple` relationship) —
+    calling a conclusion whose tree-side write never happened "incomplete."
+  Add `tree_edit`/`tree_correct`/`materialize_facts` calls that set `primary:
+  true`, add a `ParentChild`/`Couple` relationship, or create a new tree
+  person to the watched-writes list, gated the same way as the
+  `research.json` fields above.
+- Port this to the hosted/production path (`apps/server/app/agent/real_agent.py`),
+  not just eval. `docs/TODOs.md`'s "Router-side" note already flags that the
+  analogous `context_policy.py` guard is eval-only and doesn't cover Cowork
+  or hosted; this plan explicitly commits to not repeating that limitation
+  for this gate.
+- **Rollout: ship in shadow mode first.** Log rejections without denying,
+  against both the historical runlog corpus and a batch of live runs, and
+  measure the false-positive rate (a legitimate write the window should have
+  covered but didn't) before flipping to hard-deny. See §6 for why this
+  matters — a mistuned window turns a silent quality bug into a loud
+  availability regression, which is a worse failure mode than the one this
+  plan is fixing.
+
+This closes both observed bypass shapes (untyped-`Agent` substitution and
+read-and-improvise), since neither sets the tracked state. It is a recency
+heuristic, not a cryptographic guarantee — see §6.
+
+### 4.2 Mechanical cross-field validation at the write boundary
+
+Add a validation rule (`packages/engine/mcp-server/src/tools/research-append.ts`
+/ wherever `proof_summaries` writes are validated): a `tier` of `proved` or
+`disproved` is rejected unless the referenced question's
+`exhaustive_declaration.declared == true` in the pre-write state.
+
+**Must check against state as of the start of the call, not the end —
+`research_append`'s batch form is a real hole here, not a theoretical one.**
+`research-append.ts`'s batch loop (~lines 1449–1471) mutates one shared
+in-memory document sequentially across `ops[]` and validates the *final*
+state once, after every op has applied. As written, a single batch call
+could set `exhaustive_declaration.declared: true` (with a `stop_criteria`
+whose *content* is unchecked, and `log_entry_ids` never cross-checked
+against real `log[]` entries) and `tier: "proved"` **in the same call**, and
+the rule above would see a document where the declaration is already `true`
+by the time it checks — self-satisfying its own precondition inside one
+atomic write. The rule must diff against the document state as it existed
+**before this call/batch started**, and reject a batch that both establishes
+the declaration and consumes it for a tier in the same call. This also means
+the fix only catches the literal PR #893 shape (declaration left `false`)
+unless this ordering check is included — without it, a bypassing orchestrator
+simply adds one more op to its already-improvised batch and the gate does
+nothing.
+
+Content-level validation of `stop_criteria` and `log_entry_ids` (confirming
+the declaration is actually backed by real, referenced log entries, not just
+present-and-non-empty) is a related, deeper gap this rule does not close —
+flagged here, not fixed here.
+
+This is caller-agnostic — it holds regardless of whether the caller is the
+main thread, an in-session `Skill`, or a future agent — so it doesn't depend
+on §4.1 at all and should ship independently, first if possible.
+
+Out of scope for this rule: detecting overclaiming *language* in
+`narrative_markdown` text (e.g., "reasonably exhaustive" prose when the tier
+doesn't support it). That remains `gps-mentor`'s proof-critique job — see
+4.4's note on verifying that gate actually fires.
+
+### 4.3 Revoke `Write`/`Edit` on `research.json` and `tree.gedcomx.json`
+
+No skill's `allowed-tools` lists bare `Write`/`Edit`, and `research/SKILL.md:167-170`
+already prose-forbids direct writes to these files ("all writes go through
+the writer tools"). No legitimate use was found. Add both file paths to
+`disallowed_tools` for the e2e harness and, for parity, the hosted path (via
+an explicit deny if the SDK supports path-scoped denial, otherwise a
+`PreToolUse` check on `Write`/`Edit` calls whose `file_path` matches either
+file). Low cost, no known workflow breakage — ship immediately, independent
+of the rest of this plan.
+
+**Scope this correctly: it's hygiene, not a fix for the observed bypass.**
+Both bypass shapes documented in §1 write via `research_append`, never via
+raw `Write`/`Edit` — this closes a theoretical escape hatch that hasn't been
+observed in the corpus, not the mechanism actually causing PR #893's bug.
+Worth doing regardless, but §4.1/§4.2 are the real gates.
+
+Explicitly **not** in scope: revoking `Read` on these files. `research_query`
+covers only 11 of `research.json`'s ~15 top-level sections (missing
+`project`, `researcher_profile`, `known_holdings`, `localities`), caps
+results at 50 items with no pagination, and there is no MCP tool that reads
+`tree.gedcomx.json` at all (`person_read` hits the live FamilySearch API, a
+different data source entirely). Closing that gap is a real build project of
+its own — extend `research_query`, build a new `tree_read` tool — not a
+config change, and is not scoped into this plan.
+
+### 4.4 Extend the e2e hard detector
+
+The isolated unit harness already fails a positive test when a skill's
+effect is present but the skill was never invoked
+(`eval/harness/tests/unit/test_orchestrator.py::test_positive_fails_when_skill_not_in_skills_invoked`).
+The e2e path has no equivalent (`skills_invoked` has zero hits across
+`eval/harness/e2e/{orchestrator,judge,result}.py`). Add one: post-run, for
+each of the four guardrail skills, if the final project state shows an
+effect attributable to it — a `research.json` `proof_summaries` entry,
+`person_evidence` link, `conflicts` resolution, or
+`exhaustive_declaration.declared: true`, **or** (per §4.1's expanded
+protected-fields list) a `tree.gedcomx.json` write it's the documented
+owner of (a new tree person or attached fact with no backing
+`person_evidence` entry; a `primary: true` fact or `ParentChild`/`Couple`
+relationship with no matching `proof-conclusion` tier-≥-probable
+conclusion) — with no matching successful `Skill` call anywhere in the run's
+tool-call log, hard-fail the run regardless of judge/validator verdict. This
+check must inspect **both** project files, not `research.json` alone —
+watching only `research.json` misses the `materialize_facts` identity-bypass
+route §4.1 identifies.
+
+Also check that the `gps-mentor` proof-critique gate actually fired for
+every `ps_id` a resolved question references — not just that
+`research/SKILL.md`'s routing table calls it mandatory. That gate is
+nominally the last line of defense against exactly this bug (its own
+description: "specifically designed to catch... a tier claim the cited
+assertions don't support"), and its invocation is exposed to the same
+"orchestrator skips a routing-table step under context pressure" risk as the
+four skills this plan is about. Not confirmed as having actually happened in
+any runlog — flagged as a risk to check, not a proven instance (see §6).
+
+## 5. Deferred (not in this plan)
+
+- **Agent conversion of `research-exhaustiveness`/`proof-conclusion`** — the
+  two cheap-to-inline candidates (413/509 lines fully self-contained,
+  comparable to existing agent bodies). Revisit if §4.1's hook proves to have
+  practical gaps. Treat `person-evidence`/`conflict-resolution` as a separate
+  decision given their inlined size (941/1006 lines) would set a new
+  high-water mark for the plugin.
+- **Thin-agent-calls-`Skill`** — untested variant where a fresh-context agent's
+  only action is `Skill('<name>')`, keeping substantive content in SKILL.md
+  as the single source of truth. Plausible because the record-extractor
+  playbook failure was a *conditional, secondary* fetch, whereas this would
+  be *unconditional and first* — but unverified, and the SDK mechanism for
+  granting a subagent `Skill` access (`AgentDefinition.skills`) is not
+  currently surfaced anywhere in this repo's agent `.md` frontmatter format.
+  A small controlled experiment (cheaper than #702's) should precede
+  committing to it.
+- **Per-skill write tools** — tracked as its own `docs/TODOs.md` investigation
+  (added by this plan); worth doing if/when one of the four is ever
+  converted to an agent, not worth it standalone.
+- **Full `research_query`/`tree_read` coverage** to allow revoking `Read` on
+  the two project files — real value, real build cost, not scoped here.
+
+## 6. Open questions / risks
+
+- **§4.1's recency window is a heuristic, not a guarantee.** A model that
+  invokes the correct `Skill` and then does something unrelated to it while
+  the window is still open would incorrectly pass. Window size needs
+  empirical tuning against the existing runlog corpus (generous enough to
+  cover a skill's legitimate multi-step work, tight enough to mean
+  something) before shipping.
+- **Untested assumption baked into the current architecture, not just this
+  plan's fix:** whether `Skill`-tool content injection is more reliable than
+  an agent's on-demand `Read` for a skill's *own* nested `references/*.md` is
+  not verified — proof-conclusion, research-exhaustiveness, person-evidence,
+  and conflict-resolution all do this today, in-session, and it has never
+  been stress-tested the way #702 tested the agent case. A regression here
+  would look identical to the original bug and would not be caught by
+  anything in this plan except §4.4's detector (which catches "skill never
+  invoked," not "skill invoked but its own reference silently skipped"). Worth
+  a dedicated experiment mirroring #702's reachable/unreachable methodology
+  against the in-session path.
+- **Whether `gps-mentor`'s own gate is itself skippable** the same way the
+  four guardrail skills are — §4.4 adds detection, not prevention, and no
+  runlog evidence was checked to confirm or rule this out.
+- **§4.1's false-positive risk, not just its false-negative risk.** A window
+  that's too tight can hard-deny a legitimate write — turning today's silent
+  quality bug into a loud availability regression, which is a worse outcome
+  for a shipped feature than the bug this plan fixes. A denial that steers
+  the model toward actually invoking the missing skill is fine in principle
+  (arguably the intended effect), but a mistuned window risks a stuck loop —
+  the model re-invoking a skill repeatedly without the write ever landing,
+  especially interacting with headless runs' existing stall/budget-cap
+  machinery, which was not checked against this risk. §4.1's shadow-mode
+  rollout is the mitigation; do not skip it.
+- **Batch semantics beyond the §4.2 TOCTOU fix.** §4.2's fix addresses one
+  same-call ordering hole (declaring exhaustiveness and consuming it in one
+  batch); it was not exhaustively checked for other same-batch orderings
+  that could similarly self-satisfy a precondition (e.g., a batch that adds
+  a `person_evidence` link and then, in the same call, writes an assertion
+  that link was supposed to gate). Worth a dedicated pass over
+  `research-append.ts`'s full validation-ordering behavior before relying on
+  either gate as complete.
+
+## 7. Sequencing
+
+1. **Build §4.4's "was this skill invoked" detection logic first**, ahead of
+   its own hard-fail wiring — it's the direct measurement tool §4.1 needs to
+   tune its recency window against the runlog corpus, so building it as a
+   standalone check before enforcement gives real data instead of a guess.
+2. §4.3 (revoke `Write`/`Edit`) — no dependencies, ship alongside the above.
+3. §4.2 (cross-field validation, including the batch-ordering fix) —
+   directly fixes PR #893's fixture failure mode, caller-agnostic, ship
+   next.
+4. §4.1 (caller-id hook) — tune against the corpus using step 1's tool, ship
+   in shadow mode, measure false-positive rate, then hard-enforce and port
+   to the hosted path.
+5. Wire step 1's detection logic into a hard e2e fail (completing §4.4) once
+   §4.1 is enforcing — it's the regression backstop for this bug class going
+   forward.
+6. Revisit agent conversion / per-skill tools (§5) informed by how §4.1
+   performs in practice.
+
+## 8. Adversarial review findings
+
+One adversarial pass was run against this plan before circulation. Two
+findings changed the design materially and are incorporated above, not just
+noted here:
+
+- **§4.2's original form was defeatable inside a single atomic
+  `research_append` batch call** (verified against `research-append.ts`'s
+  batch-validation loop) — a bypass could set `exhaustive_declaration.declared:
+  true` and `tier: "proved"` in the same call, satisfying the cross-field
+  check against its own just-written state. Fixed by validating against
+  pre-call state and rejecting same-call establish-and-consume (§4.2).
+- **The original "protected fields" list covered `research.json` only**,
+  missing that `materialize_facts` can create tree persons and attach facts
+  without any `person_evidence` entry, and that `proof-conclusion`'s
+  documented output includes tree-side writes (`primary: true`,
+  `ParentChild`/`Couple` relationships) that neither §4.1 nor §4.4 was
+  watching. Both sections now cover `tree.gedcomx.json` writes explicitly
+  (§4.1, §4.4).
+
+Findings incorporated as design refinements rather than section rewrites:
+per-question keying and success-gating for §4.1's recency window; a
+shadow-mode rollout step and false-positive/availability risk (§6); §4.3
+reframed as hygiene rather than a fix for the observed bypass; sequencing
+reordered so §4.4's detection logic is built before §4.1's window is tuned,
+rather than after.
+
+Not incorporated, flagged as residual risk instead: full validation-ordering
+audit of `research-append.ts`'s batch semantics beyond the one TOCTOU case
+found (§6); content-level validation of `stop_criteria`/`log_entry_ids`
+(§4.2); whether `Skill`-tool content injection is actually reliable for a
+skill's own nested references, an assumption the *current* architecture
+already depends on, not one this plan introduces (§6); whether `gps-mentor`'s
+own gate is itself skippable (§6).

--- a/docs/plan/research-guardrail-bypass-plan.md
+++ b/docs/plan/research-guardrail-bypass-plan.md
@@ -468,3 +468,59 @@ fingerprint the way identity-linking has `same_person` — so those stay on
 
 This run is the first real calibration data point for §4.1's recency window
 and is worth keeping (graded, not discarded) for that purpose.
+
+## 10. Retroactive corpus scan and its two follow-on issues
+
+`eval/harness/e2e/guardrail_shadow_report.py` replays
+`find_unguarded_protected_writes` against every already-committed e2e
+runlog's persisted `tool_calls` — no new API spend, no need to wait for new
+live runs to accumulate a calibration sample (§4.1's window can be tuned
+against history; new runs are a validation set on top of that, not the
+primary source). Run against the full corpus (99 committed results, all
+fixtures):
+
+| window | violations | runs affected | by skill |
+|---|---|---|---|
+| 10 | 723 | 93/99 | conflict-resolution=81, person-evidence=277, proof-conclusion=301, research-exhaustiveness=64 |
+| 20 | 610 | 90/99 | conflict-resolution=79, person-evidence=203, proof-conclusion=268, research-exhaustiveness=60 |
+| 40 | 530 | 87/99 | conflict-resolution=79, person-evidence=138, proof-conclusion=258, research-exhaustiveness=55 |
+| 80 | 462 | 83/99 | conflict-resolution=79, person-evidence=85, proof-conclusion=254, research-exhaustiveness=44 |
+| 150 | 430 | 81/99 | conflict-resolution=79, person-evidence=56, proof-conclusion=251, research-exhaustiveness=44 |
+
+The count barely drops from window=10 to window=150 — most of these are not
+"the window was a little tight." Spot-checked 3 of the ~700+ flagged
+violations before trusting the scale of this:
+
+- **`alvro-taylor-marriage-1931` (2026-07-15) — confirmed genuine, and worse
+  than `bagley-father-1884`.** The entire 95-tool-call run invokes only
+  `question-selection`/`research-plan`/`search-records`, then does
+  everything else inline: 27 `person_evidence` appends, a `tree_edit`
+  relationship, an `exhaustive_declaration` write, and a `proof_summaries`
+  append. Zero invocations of any of the four guardrail skills, ever, in the
+  whole run. Verdict: **pass**.
+- **`anders-monsen-ancestry` (2026-07-09) — real signal, but noisy.** Its
+  Skill list includes `assertion-classification`/`check-warnings` — names
+  that don't exist in the current four-skill architecture. Old enough that
+  direct comparison to today's routing table isn't clean; a real caveat for
+  the corpus (older runs used a different skill decomposition, which will
+  read as false-signal noise until filtered out or excluded).
+
+Only 3 samples in, not enough to pick a window size or to say what fraction
+of the 430-723 corpus-wide count is genuine vs. old-skill-naming noise. Two
+GitHub issues track the two different things this scan surfaced, deliberately
+kept separate because they have different audiences and different urgency:
+
+- [**#911**](https://github.com/PioneerAIAcademy/cowork-genealogy/issues/911) —
+  calibrate the §4.1 window before graduating it from shadow-mode logging to
+  actual denial. An engineering task: finish the spot-checking, tune the
+  window, collect ~10-15 new live runs across diverse question types to
+  validate against current (not historical) skill behavior, then graduate.
+- [**#913**](https://github.com/PioneerAIAcademy/cowork-genealogy/issues/913) —
+  the `alvro-taylor-marriage-1931` finding on its own terms: a confirmed
+  historical **pass** verdict that bypassed every GPS guardrail skill
+  entirely, undetectable by the judge or any existing eval gate. This is a
+  question about whether past e2e verdicts can be trusted, not about tuning
+  anything — its suggested next step is running the two *non-windowed* §4.4
+  checks (`find_effects_without_invocation`, `find_missing_mentor_verdicts`)
+  retroactively across the corpus for a precise count, since those need no
+  window-size judgment call at all.

--- a/eval/harness/e2e/guardrail_shadow_report.py
+++ b/eval/harness/e2e/guardrail_shadow_report.py
@@ -1,0 +1,148 @@
+"""Retroactive calibration tool for the §4.1 shadow-mode recency window.
+
+docs/plan/research-guardrail-bypass-plan.md §4.1/§7, GitHub issue #911 — the
+window (`GUARDRAIL_SHADOW_WINDOW` in `e2e/orchestrator.py`) is a first-cut
+default, not yet tuned. Every committed e2e runlog already persists its full
+`tool_calls` list, so `harness.skill_invocation.find_unguarded_protected_writes`
+can be replayed against the whole historical corpus for free — no new API
+spend — rather than waiting on new live runs to accumulate a sample.
+
+This module adds NO instrumentation to a run (same posture as
+`latency_report.py`); it's pure analysis over already-committed data.
+
+CLI (from eval/harness/):
+  uv run python -m e2e.guardrail_shadow_report
+  uv run python -m e2e.guardrail_shadow_report --windows 10,20,40,80,150
+  uv run python -m e2e.guardrail_shadow_report --windows 40 --detail
+  uv run python -m e2e.guardrail_shadow_report --test bagley-father-1884
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from harness.skill_invocation import find_unguarded_protected_writes
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+E2E_RUNLOGS = REPO_ROOT / "eval" / "runlogs" / "e2e"
+
+DEFAULT_WINDOWS = (10, 20, 40, 80, 150)
+
+
+def _is_result_json(p: Path) -> bool:
+    """A committed structured result, not its tree/research/ann/session siblings."""
+    name = p.name
+    return (
+        name.startswith("run-")
+        and name.endswith(".json")
+        and not name.endswith(".ann.json")
+        and ".final-" not in name
+    )
+
+
+def all_result_jsons() -> list[Path]:
+    """EVERY committed run, not just the latest per fixture — calibration
+    wants maximum sample size, unlike latency_report's "latest only" (which
+    exists to avoid stale per-fixture latency numbers, a different goal)."""
+    if not E2E_RUNLOGS.is_dir():
+        return []
+    out: list[Path] = []
+    for d in sorted(E2E_RUNLOGS.iterdir()):
+        if d.is_dir():
+            out.extend(sorted(p for p in d.iterdir() if _is_result_json(p)))
+    return out
+
+
+def result_jsons_for(test_slug: str) -> list[Path]:
+    d = E2E_RUNLOGS / test_slug
+    if not d.is_dir():
+        return []
+    return sorted(p for p in d.iterdir() if _is_result_json(p))
+
+
+def scan_one(path: Path, *, window: int) -> list[dict[str, Any]]:
+    """Violations `find_unguarded_protected_writes` reports for one committed
+    run at a given window size. Each violation is enriched with the source
+    file so a multi-run aggregate stays traceable back to a transcript."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    tool_calls = data.get("tool_calls") or []
+    violations = find_unguarded_protected_writes(tool_calls, window=window)
+    try:
+        display_path = str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        display_path = str(path)  # outside REPO_ROOT (e.g. ad hoc/test usage) -- show absolute
+    for v in violations:
+        v["file"] = display_path
+        v["fixture"] = path.parent.name
+    return violations
+
+
+def scan_corpus(paths: list[Path], *, windows: list[int]) -> dict[int, list[dict[str, Any]]]:
+    """Violations per window size, across every path given."""
+    by_window: dict[int, list[dict[str, Any]]] = {w: [] for w in windows}
+    for path in paths:
+        try:
+            for w in windows:
+                by_window[w].extend(scan_one(path, window=w))
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"  skip {path}: {e}", file=sys.stderr)
+    return by_window
+
+
+def format_summary(by_window: dict[int, list[dict[str, Any]]], *, n_runs: int) -> str:
+    lines = [f"Scanned {n_runs} committed run(s).", ""]
+    lines.append(f"{'window':>8}  {'violations':>10}  {'runs affected':>14}  by-skill breakdown")
+    for w in sorted(by_window):
+        violations = by_window[w]
+        affected = len({v["file"] for v in violations})
+        by_skill: dict[str, int] = {}
+        for v in violations:
+            by_skill[v["required_skill"]] = by_skill.get(v["required_skill"], 0) + 1
+        skill_str = ", ".join(f"{k}={v}" for k, v in sorted(by_skill.items()))
+        lines.append(f"{w:>8}  {len(violations):>10}  {affected:>14}  {skill_str or '(none)'}")
+    return "\n".join(lines)
+
+
+def format_detail(violations: list[dict[str, Any]]) -> str:
+    lines = []
+    for v in violations:
+        lines.append(
+            f"  {v['fixture']:<35} idx={v['index']:<4} tool={v['tool']:<30} "
+            f"needs={v['required_skill']:<24} q={v.get('question_id')}"
+        )
+    return "\n".join(lines) if lines else "  (none)"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Retroactive §4.1 shadow-window calibration (issue #911).")
+    ap.add_argument("--test", help="scan every committed run for this fixture slug only")
+    ap.add_argument(
+        "--windows",
+        default=",".join(str(w) for w in DEFAULT_WINDOWS),
+        help=f"comma-separated window sizes to compare (default: {','.join(str(w) for w in DEFAULT_WINDOWS)})",
+    )
+    ap.add_argument("--detail", action="store_true", help="also print every violation at the smallest window given")
+    args = ap.parse_args(argv)
+
+    windows = sorted({int(w) for w in args.windows.split(",") if w.strip()})
+    paths = result_jsons_for(args.test) if args.test else all_result_jsons()
+    if not paths:
+        print("No committed runs found.", file=sys.stderr)
+        return 1
+
+    by_window = scan_corpus(paths, windows=windows)
+    print(format_summary(by_window, n_runs=len(paths)))
+
+    if args.detail:
+        smallest = min(windows)
+        print(f"\nViolations at window={smallest}:")
+        print(format_detail(by_window[smallest]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/harness/e2e/orchestrator.py
+++ b/eval/harness/e2e/orchestrator.py
@@ -41,6 +41,11 @@ from harness.auth import env_for_sdk, resolve_auth
 from harness.context_policy import (
     bare_tool_name as _bare_tool_name,  # re-exported: callers + tests import it from here
 )
+from harness.skill_invocation import (
+    find_effects_without_invocation,
+    find_missing_mentor_verdicts,
+    find_unguarded_protected_writes,
+)
 
 from e2e.result import E2eResult, timestamp_slug, write_result_files
 from e2e.stop_checker import (
@@ -118,6 +123,15 @@ BLOCKED_TREE_TOOLS = frozenset(
 )
 
 
+# docs/plan/research-guardrail-bypass-plan.md §4.1/§6 — trailing tool-call
+# window for the shadow-mode guardrail check: a first-cut default, not yet
+# empirically tuned against the runlog corpus. Generous on purpose — a
+# guardrail skill legitimately does several reads/searches/writes before its
+# protected write, so this needs to be wide enough to cover that without
+# being so wide it stops meaning anything.
+GUARDRAIL_SHADOW_WINDOW = 40
+
+
 def is_turn_cap_error(detail: str | None) -> bool:
     """Whether an SDK error result is really a turn-cap hit.
 
@@ -151,6 +165,28 @@ def is_fixture_blocked_tool(tool_name: str, blocked_tools: frozenset) -> bool:
     if not tool_name.startswith("mcp__"):
         return False
     return _bare_tool_name(tool_name) in blocked_tools
+
+
+# The two project files that must never be touched by raw Write/Edit — all
+# writes go through the MCP writer tools (research_append, research_log_append,
+# tree_edit, tree_correct), which validate before persisting. See
+# docs/plan/research-guardrail-bypass-plan.md §4.3.
+PROTECTED_PROJECT_FILES = ("research.json", "tree.gedcomx.json")
+
+
+def direct_project_file_write(tool_name: str, tool_input: dict) -> str | None:
+    """The protected filename a Write/Edit call targets, or None.
+
+    Only Write/Edit are candidates — every other tool (including the MCP
+    writer tools) is a different code path. Matched on the `file_path`
+    argument's basename, so it doesn't matter whether the model passed an
+    absolute or relative path.
+    """
+    if tool_name not in ("Write", "Edit"):
+        return None
+    file_path = str((tool_input or {}).get("file_path") or "")
+    name = file_path.rsplit("/", 1)[-1]
+    return name if name in PROTECTED_PROJECT_FILES else None
 
 
 @dataclass
@@ -600,6 +636,30 @@ async def _run_agent(
         # skill writes nothing. The mcp__-only budget cap is tool_call_count,
         # incremented separately below.
         activity_count["n"] += 1
+
+        # docs/plan/research-guardrail-bypass-plan.md §4.3 — no skill's
+        # allowed-tools lists bare Write/Edit, and research/SKILL.md already
+        # prose-forbids direct writes to these two files ("all writes go
+        # through the writer tools"). This closes that as a real denial
+        # instead of a convention. Hygiene, not the fix for the observed
+        # bypass — both known bypass shapes write via research_append, never
+        # raw Write/Edit (see §4.1/§4.2 for the actual gates).
+        protected_file = direct_project_file_write(tool_name, input_data.get("tool_input", {}))
+        if protected_file:
+            _emit(f"[blocked direct write] {tool_name} -> {protected_file}")
+            return {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": (
+                        f"{tool_name} on {protected_file} is disabled — all writes to "
+                        "research.json/tree.gedcomx.json must go through the writer tools "
+                        "(research_append, research_log_append, tree_edit, tree_correct), "
+                        "which validate before persisting. Direct file writes never validate."
+                    ),
+                },
+            }
+
         if not tool_name.startswith("mcp__"):
             return {}
 
@@ -1023,7 +1083,31 @@ async def _run_agent(
             "max_cost_usd": fixture.caps.max_cost_usd,
         },
     }
-    return tool_calls, transcript, usage, aborted_reason, error, blocked_tree_reads
+    # docs/plan/research-guardrail-bypass-plan.md §4.1 — SHADOW MODE ONLY:
+    # computed once over the completed `tool_calls` list (equivalent to
+    # checking live at each call, since the check only ever looks backward),
+    # so this ships without touching pretool_hook's decision path at all.
+    # Graduating to actual denial later requires moving the check into
+    # pretool_hook, since only a live PreToolUse decision can reject a call
+    # before it happens — this post-hoc form can only ever log.
+    guardrail_shadow_violations = find_unguarded_protected_writes(
+        tool_calls, window=GUARDRAIL_SHADOW_WINDOW
+    )
+    if guardrail_shadow_violations:
+        _emit(
+            f"[guardrail-shadow] {len(guardrail_shadow_violations)} protected write(s) "
+            "with no recent matching Skill invocation (shadow mode — not denied)"
+        )
+
+    return (
+        tool_calls,
+        transcript,
+        usage,
+        aborted_reason,
+        error,
+        blocked_tree_reads,
+        guardrail_shadow_violations,
+    )
 
 
 def _find_session_transcript(workspace: Path) -> Path | None:
@@ -1093,6 +1177,12 @@ async def run_e2e_test(
         workspace = build_workspace(
             fixture, Path(tmp), skills_dir, effort_level=effort_level, agent_model=agent_model
         )
+        # Snapshot BEFORE the agent touches the workspace — build_workspace just
+        # copied fixture.starting_tree_path in. Lets the §4.4 guardrail-effects
+        # check (below) tell a fixture's own seeded persons apart from persons
+        # the agent created/enriched this run (docs/plan/
+        # research-guardrail-bypass-plan.md §4.4).
+        starting_tree = read_tree_json(workspace)
 
         (
             tool_calls,
@@ -1101,6 +1191,7 @@ async def run_e2e_test(
             aborted,
             error,
             blocked_tree_reads,
+            guardrail_shadow_violations,
         ) = await _run_agent(
             fixture=fixture,
             workspace=workspace,
@@ -1147,6 +1238,28 @@ async def run_e2e_test(
                 verdict = "skipped"
             judge_seconds = time.monotonic() - judge_start
 
+        # docs/plan/research-guardrail-bypass-plan.md §4.4 — HARD FAIL, not
+        # shadow: a guardrail skill's effect present in the FINAL project
+        # state with no matching successful invocation anywhere in the run,
+        # or a resolved question's proof_summary missing its mandatory
+        # gps-mentor proof-critique verdict. Overrides the judge's verdict
+        # regardless of what it said — mirrors the unit harness's
+        # `test_positive_fails_when_skill_not_in_skills_invoked`, which has no
+        # e2e equivalent otherwise (`skills_invoked` has zero hits in this
+        # module family before this). Unlike §4.1's shadow-mode recency
+        # check, this only looks at whether the skill ran AT ALL across the
+        # whole run, so it's far less prone to false positives and safe to
+        # hard-fail on immediately rather than roll out in shadow mode first.
+        guardrail_effects_without_invocation = find_effects_without_invocation(
+            tool_calls, final_research, final_tree, starting_tree=starting_tree
+        ) + find_missing_mentor_verdicts(final_research)
+        if guardrail_effects_without_invocation:
+            verdict = "fail"
+            judge_output = {
+                **judge_output,
+                "guardrail_bypass_violations": guardrail_effects_without_invocation,
+            }
+
         # `wall_clock_seconds` is the ACTIVE wall-clock (time.monotonic), so it
         # matches the wall-clock cap and the stall watchdog (also monotonic) and
         # is NOT inflated by laptop sleep. `real_clock_seconds` is the literal
@@ -1191,6 +1304,7 @@ async def run_e2e_test(
             error=error,
             tags=fixture.tags,
             blocked_tree_reads=blocked_tree_reads,
+            guardrail_shadow_violations=guardrail_shadow_violations,
             subagents=subagents,
         )
 

--- a/eval/harness/e2e/orchestrator.py
+++ b/eval/harness/e2e/orchestrator.py
@@ -44,6 +44,7 @@ from harness.context_policy import (
 from harness.skill_invocation import (
     find_effects_without_invocation,
     find_missing_mentor_verdicts,
+    find_person_evidence_missing_same_person,
     find_unguarded_protected_writes,
 )
 
@@ -1250,9 +1251,23 @@ async def run_e2e_test(
         # check, this only looks at whether the skill ran AT ALL across the
         # whole run, so it's far less prone to false positives and safe to
         # hard-fail on immediately rather than roll out in shadow mode first.
-        guardrail_effects_without_invocation = find_effects_without_invocation(
-            tool_calls, final_research, final_tree, starting_tree=starting_tree
-        ) + find_missing_mentor_verdicts(final_research)
+        #
+        # find_person_evidence_missing_same_person is a separate, also-hard,
+        # also-non-windowed check added after the first real run of
+        # bagley-father-1884 showed the gap in "invoked anywhere": that run
+        # linked a brand-new person across 13 person_evidence entries with
+        # zero same_person calls in the whole run, while person-evidence
+        # ITSELF was invoked 52 tool calls later for unrelated work — passing
+        # the "invoked anywhere" bar while still skipping the identity-scoring
+        # doctrine entirely. This checks the specific required tool for the
+        # specific person instead of the skill's mere presence in the run.
+        guardrail_effects_without_invocation = (
+            find_effects_without_invocation(tool_calls, final_research, final_tree, starting_tree=starting_tree)
+            + find_missing_mentor_verdicts(final_research)
+            + find_person_evidence_missing_same_person(
+                tool_calls, final_research, final_tree, starting_tree=starting_tree
+            )
+        )
         if guardrail_effects_without_invocation:
             verdict = "fail"
             judge_output = {

--- a/eval/harness/e2e/result.py
+++ b/eval/harness/e2e/result.py
@@ -89,6 +89,17 @@ class E2eResult:
     # See subagent_capture.py.
     subagents: list[dict[str, Any]] = field(default_factory=list)
 
+    # docs/plan/research-guardrail-bypass-plan.md §4.1 — SHADOW MODE ONLY:
+    # protected writes (a proof_summaries/person_evidence/conflicts/
+    # exhaustive_declaration write, or a tree_edit/tree_correct/
+    # materialize_facts write one of the four GPS guardrail skills owns) with
+    # no matching successful `Skill` invocation in a trailing window. Logged,
+    # never denied, at this stage — the point is to measure the false-positive
+    # rate against real runs before any call is ever rejected. Each entry is
+    # {index, tool, required_skill, question_id} — see
+    # harness/skill_invocation.py::find_unguarded_protected_writes.
+    guardrail_shadow_violations: list[dict[str, Any]] = field(default_factory=list)
+
 
 def timestamp_slug(now: datetime | None = None) -> str:
     """A filesystem-safe ISO-ish timestamp for filenames."""

--- a/eval/harness/harness/skill_invocation.py
+++ b/eval/harness/harness/skill_invocation.py
@@ -349,3 +349,82 @@ def find_missing_mentor_verdicts(research: dict[str, Any] | None) -> list[str]:
         "'proof-critique' evaluations[] verdict on record (the mandatory gps-mentor gate)"
         for ps_id in missing
     ]
+
+
+def find_person_evidence_missing_same_person(
+    tool_calls: list[dict[str, Any]],
+    research: dict[str, Any] | None,
+    tree: dict[str, Any] | None,
+    *,
+    starting_tree: dict[str, Any] | None = None,
+) -> list[str]:
+    """Every BRAND-NEW tree person (not present in `starting_tree`) that
+    receives a `person_evidence` link must have been the subject of at least
+    one `same_person` call somewhere in the run — research/SKILL.md's own
+    doctrine ("scores every cross-record link with `same_person` before it
+    links").
+
+    This is a deliberately different, narrower question than
+    `find_effects_without_invocation`'s "was `person-evidence` invoked
+    anywhere" check: it asks whether the specific REQUIRED TOOL ran for THIS
+    specific person, so it catches the case that check cannot — a new
+    identity linked with zero scoring, even when `person-evidence` *was*
+    properly invoked elsewhere in the same run for unrelated work. Confirmed
+    live: the `bagley-father-1884` run linked a brand-new person (the
+    father) across 13 `person_evidence` entries with zero `same_person`
+    calls anywhere in the run, while `person-evidence` itself was invoked 52
+    tool calls later for a different, later-extracted record — invisible to
+    the "invoked anywhere" check, caught by this one.
+
+    `same_person` takes two RECORD-PERSONA arguments (`primaryId1`/
+    `primaryId2`), not a tree `person_id` — but when one side of a call IS
+    the tree, that side's `primaryId` is documented to equal a `persons[].id`
+    in its `gedcomx`, which for a tree-side call is the tree person id
+    itself (confirmed against a live example — a committed
+    `anders-monsen-ancestry` run calls `same_person` with `primaryId2:
+    "LKFW-9XH"`, a literal FamilySearch tree person id). So this is a flat
+    string match against `primaryId1`/`primaryId2` — no need to join through
+    assertions/records.
+
+    Whole-run, no proximity window — same false-positive profile as
+    `find_effects_without_invocation`'s other checks, deliberately not the
+    windowed heuristic `find_unguarded_protected_writes` uses.
+    """
+    research = research or {}
+    tree = tree or {}
+    persons = tree.get("persons") if isinstance(tree.get("persons"), list) else []
+    starting_persons = (
+        (starting_tree or {}).get("persons") if isinstance((starting_tree or {}).get("persons"), list) else []
+    )
+    starting_ids = {p.get("id") for p in starting_persons if isinstance(p, dict)}
+    # No baseline: best-effort, treat every current person as new (may
+    # over-flag) — same convention find_effects_without_invocation documents.
+    new_person_ids = {p.get("id") for p in persons if isinstance(p, dict) and p.get("id") not in starting_ids}
+
+    person_evidence = research.get("person_evidence") if isinstance(research.get("person_evidence"), list) else []
+    linked_new_person_ids = {
+        pe.get("person_id")
+        for pe in person_evidence
+        if isinstance(pe, dict) and pe.get("person_id") in new_person_ids
+    }
+    if not linked_new_person_ids:
+        return []
+
+    scored_ids: set[str] = set()
+    for entry in tool_calls:
+        if entry.get("is_error") is True:
+            continue
+        if bare_tool_name(entry.get("tool", "")) != "same_person":
+            continue
+        args = entry.get("args") or {}
+        for key in ("primaryId1", "primaryId2"):
+            v = args.get(key)
+            if isinstance(v, str):
+                scored_ids.add(v)
+
+    missing = sorted(pid for pid in linked_new_person_ids if pid not in scored_ids)
+    return [
+        f"tree person '{pid}' is new this run and has a person_evidence link, but 'same_person' "
+        "was never called for it anywhere in the run — the identity was asserted, never scored"
+        for pid in missing
+    ]

--- a/eval/harness/harness/skill_invocation.py
+++ b/eval/harness/harness/skill_invocation.py
@@ -1,0 +1,351 @@
+"""Guardrail-skill invocation detection.
+
+docs/plan/research-guardrail-bypass-plan.md §4.1/§4.4 — autonomous `/research`
+sometimes lets the four GPS guardrail skills (`research-exhaustiveness`,
+`proof-conclusion`, `person-evidence`, `conflict-resolution`) get bypassed:
+their documented effect lands in the project files without the skill ever
+having been successfully invoked. This module is pure matching logic, no I/O,
+over the harness's own `tool_calls` list shape
+(`{"tool": ..., "args": ..., "response_summary": ..., "is_error": ...}`, built
+by `e2e/orchestrator.py`'s message loop) plus the project's persisted
+`research.json`/`tree.gedcomx.json`.
+
+Two consumers, both described in the plan:
+  - `owning_skills` + `recently_succeeded` — the live, shadow-mode caller-id
+    check (§4.1): before a protected write is allowed to proceed, was its
+    owning skill successfully invoked recently?
+  - `find_effects_without_invocation` — the post-run hard detector (§4.4):
+    does the FINAL project state show a guardrail skill's effect with no
+    matching successful invocation anywhere in the whole run?
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from harness.context_policy import bare_tool_name
+
+GUARDRAIL_SKILLS = (
+    "research-exhaustiveness",
+    "proof-conclusion",
+    "person-evidence",
+    "conflict-resolution",
+)
+
+_QUESTION_ID_RE = re.compile(r"\bq_\d+\b")
+
+
+def skill_name_if_skill_call(tool: str, args: dict[str, Any] | None) -> str | None:
+    """The skill name if this tool call is a `Skill` invocation, else None.
+
+    Matches the shape observed in committed runlogs and the SDK's own
+    `Skill` tool: `{"tool": "Skill", "args": {"skill": "<name>", ...}}`.
+    """
+    if tool != "Skill":
+        return None
+    name = (args or {}).get("skill")
+    return name if isinstance(name, str) and name else None
+
+
+def _iter_ops(args: dict[str, Any]) -> list[dict[str, Any]]:
+    """Normalize a tool call's single-op vs batch-op (`ops: [...]`) form."""
+    ops = args.get("ops")
+    if isinstance(ops, list):
+        return [op for op in ops if isinstance(op, dict)]
+    return [args]
+
+
+def _question_id_from_skill_call(args: dict[str, Any] | None) -> str | None:
+    """Best-effort question id from a `Skill` call's free-text `args` string
+    (e.g. `"--autonomous q_001 projectPath=..."`, the shape observed in
+    committed runlogs). Returns None when not derivable — callers must treat
+    that as "unknown," not "no question," and fall back to a skill-only
+    window (see docs/plan/research-guardrail-bypass-plan.md §4.1/§6)."""
+    text = (args or {}).get("args")
+    if not isinstance(text, str):
+        return None
+    m = _QUESTION_ID_RE.search(text)
+    return m.group(0) if m else None
+
+
+def _question_id_from_op(op: dict[str, Any]) -> str | None:
+    """Best-effort question id a protected-write op references."""
+    v = op.get("question_id")
+    if isinstance(v, str):
+        return v
+    entry = op.get("entry")
+    if isinstance(entry, dict) and isinstance(entry.get("question_id"), str):
+        return entry["question_id"]
+    fields = op.get("fields")
+    if isinstance(fields, dict) and isinstance(fields.get("question_id"), str):
+        return fields["question_id"]
+    if op.get("section") == "questions" and isinstance(op.get("entryId"), str):
+        return op["entryId"]
+    return None
+
+
+def owning_skills(tool: str, args: dict[str, Any] | None) -> list[str]:
+    """Which guardrail skill(s), if any, own this write.
+
+    Covers both `research.json` fields and the `tree.gedcomx.json` writes the
+    adversarial review added (§8): `materialize_facts` minting a brand-new
+    tree person with no `person_evidence` entry required is a live
+    identity-bypass route distinct from the `person_evidence` section itself,
+    and `proof-conclusion`'s documented output includes the tree-encoding
+    writes (`primary: true`, a `ParentChild`/`Couple` relationship), not just
+    the `proof_summaries` entry. Returns a list (not a single value) since one
+    batch call can touch more than one protected section — the caller decides
+    how to key each; see docs/plan/research-guardrail-bypass-plan.md §6 on
+    batch semantics not being exhaustively audited beyond the one TOCTOU case
+    found in §4.2.
+    """
+    args = args or {}
+    bare = bare_tool_name(tool)
+    owners: list[str] = []
+
+    if bare == "research_append":
+        for op in _iter_ops(args):
+            section = op.get("section")
+            if section == "proof_summaries":
+                owners.append("proof-conclusion")
+            elif section == "person_evidence":
+                owners.append("person-evidence")
+            elif section == "conflicts":
+                owners.append("conflict-resolution")
+            elif section == "questions":
+                fields = op.get("fields") if isinstance(op.get("fields"), dict) else op.get("entry")
+                ed = (fields or {}).get("exhaustive_declaration") if isinstance(fields, dict) else None
+                if isinstance(ed, dict) and ed.get("declared") is True:
+                    owners.append("research-exhaustiveness")
+    elif bare == "materialize_facts":
+        for op in _iter_ops(args):
+            if not op.get("personId"):
+                owners.append("person-evidence")  # mints a brand-new tree person
+    elif bare in ("tree_edit", "tree_correct"):
+        for op in _iter_ops(args):
+            rel = op.get("relationship")
+            if isinstance(rel, dict) and rel.get("type") in ("ParentChild", "Couple"):
+                owners.append("proof-conclusion")
+            fact = op.get("fact")
+            if isinstance(fact, dict) and fact.get("primary") is True:
+                owners.append("proof-conclusion")
+
+    # De-dup, preserve first-seen order.
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for o in owners:
+        if o not in seen:
+            seen.add(o)
+            deduped.append(o)
+    return deduped
+
+
+def recently_succeeded(
+    skill: str,
+    tool_calls: list[dict[str, Any]],
+    *,
+    before_index: int,
+    window: int,
+    question_id: str | None = None,
+) -> bool:
+    """Was `skill` successfully invoked within `window` calls before
+    `before_index`? When `question_id` is given AND a candidate `Skill` call's
+    own question id is derivable, they must match; when either side's
+    question id can't be derived, falls back to a skill-only match (the
+    "generous, not per-question-airtight" behavior documented in the plan)."""
+    lo = max(0, before_index - window)
+    for i in range(lo, before_index):
+        entry = tool_calls[i]
+        if entry.get("is_error") is True:
+            continue
+        name = skill_name_if_skill_call(entry.get("tool", ""), entry.get("args"))
+        if name != skill:
+            continue
+        if question_id is None:
+            return True
+        candidate_q = _question_id_from_skill_call(entry.get("args"))
+        if candidate_q is None or candidate_q == question_id:
+            return True
+    return False
+
+
+def find_unguarded_protected_writes(
+    tool_calls: list[dict[str, Any]],
+    *,
+    window: int,
+) -> list[dict[str, Any]]:
+    """Shadow-mode scan (§4.1): every protected write with no matching
+    successful skill invocation in its trailing window. Returns violation
+    records (never denies anything itself — that's the caller's call, and the
+    plan mandates shadow mode — log, don't deny — until the false-positive
+    rate is measured)."""
+    violations: list[dict[str, Any]] = []
+    for i, entry in enumerate(tool_calls):
+        if entry.get("is_error") is True:
+            continue
+        tool = entry.get("tool", "")
+        args = entry.get("args") or {}
+        owners = owning_skills(tool, args)
+        if not owners:
+            continue
+        qid = None
+        for op in _iter_ops(args):
+            qid = _question_id_from_op(op)
+            if qid:
+                break
+        for owner in owners:
+            if not recently_succeeded(owner, tool_calls, before_index=i, window=window, question_id=qid):
+                violations.append(
+                    {
+                        "index": i,
+                        "tool": tool,
+                        "required_skill": owner,
+                        "question_id": qid,
+                    }
+                )
+    return violations
+
+
+def find_effects_without_invocation(
+    tool_calls: list[dict[str, Any]],
+    research: dict[str, Any] | None,
+    tree: dict[str, Any] | None,
+    *,
+    starting_tree: dict[str, Any] | None = None,
+) -> list[str]:
+    """Post-run hard detector (§4.4): a guardrail skill's documented effect is
+    present in the FINAL project state, but the skill was never successfully
+    invoked anywhere in the run. Mirrors the unit harness's
+    `test_positive_fails_when_skill_not_in_skills_invoked`, extended to cover
+    both project files and to run over a whole e2e run rather than one
+    isolated skill call.
+
+    `starting_tree`, when given, lets the person-evidence check ignore
+    persons that already had facts/names before this run began (a seeded
+    fixture's starting tree) and flag only NEW persons or persons that GAINED
+    facts this run — without it, every already-linked-by-nothing seed person
+    would read as a violation. Best-effort and may over-flag when omitted.
+    """
+    research = research or {}
+    tree = tree or {}
+    violations: list[str] = []
+
+    invoked: set[str] = set()
+    for entry in tool_calls:
+        if entry.get("is_error") is True:
+            continue
+        name = skill_name_if_skill_call(entry.get("tool", ""), entry.get("args"))
+        if name:
+            invoked.add(name)
+
+    questions = research.get("questions") if isinstance(research.get("questions"), list) else []
+    if any(
+        isinstance(q, dict) and (q.get("exhaustive_declaration") or {}).get("declared") is True
+        for q in questions
+    ) and "research-exhaustiveness" not in invoked:
+        violations.append(
+            "research.json has a question with exhaustive_declaration.declared=true "
+            "but 'research-exhaustiveness' was never successfully invoked in this run"
+        )
+
+    proof_summaries = research.get("proof_summaries") if isinstance(research.get("proof_summaries"), list) else []
+    persons = tree.get("persons") if isinstance(tree.get("persons"), list) else []
+    relationships = tree.get("relationships") if isinstance(tree.get("relationships"), list) else []
+    has_primary_fact = any(
+        isinstance(p, dict) and any(isinstance(f, dict) and f.get("primary") is True for f in (p.get("facts") or []))
+        for p in persons
+        if isinstance(p, dict)
+    )
+    has_conclusion_relationship = any(
+        isinstance(r, dict) and r.get("type") in ("ParentChild", "Couple") for r in relationships
+    )
+    if (
+        (len(proof_summaries) > 0 or has_primary_fact or has_conclusion_relationship)
+        and "proof-conclusion" not in invoked
+    ):
+        violations.append(
+            "research.json/tree.gedcomx.json shows a proof_summaries entry and/or an encoded "
+            "conclusion (a primary fact, or a ParentChild/Couple relationship) but "
+            "'proof-conclusion' was never successfully invoked in this run"
+        )
+
+    person_evidence = research.get("person_evidence") if isinstance(research.get("person_evidence"), list) else []
+    linked_person_ids = {pe.get("person_id") for pe in person_evidence if isinstance(pe, dict)}
+    starting_persons = (starting_tree or {}).get("persons") if isinstance((starting_tree or {}).get("persons"), list) else []
+    starting_ids = {p.get("id") for p in starting_persons if isinstance(p, dict)}
+    starting_fact_counts = {p.get("id"): len(p.get("facts") or []) for p in starting_persons if isinstance(p, dict)}
+
+    def _has_content(p: dict[str, Any]) -> bool:
+        return bool(p.get("facts") or p.get("names"))
+
+    def _is_new_content_this_run(p: dict[str, Any]) -> bool:
+        if starting_tree is None:
+            return True  # no baseline available; best-effort per the docstring
+        pid = p.get("id")
+        if pid not in starting_ids:
+            return True  # brand-new person this run
+        return len(p.get("facts") or []) > starting_fact_counts.get(pid, 0)
+
+    unlinked = [
+        p
+        for p in persons
+        if isinstance(p, dict) and _has_content(p) and _is_new_content_this_run(p) and p.get("id") not in linked_person_ids
+    ]
+    if unlinked and "person-evidence" not in invoked:
+        violations.append(
+            f"tree.gedcomx.json has {len(unlinked)} person(s) with new facts/names this run and no "
+            "person_evidence entry linking them (e.g. materialize_facts minting a person directly) "
+            "but 'person-evidence' was never successfully invoked in this run"
+        )
+
+    conflicts = research.get("conflicts") if isinstance(research.get("conflicts"), list) else []
+    if any(isinstance(c, dict) and c.get("status") == "resolved" for c in conflicts) and (
+        "conflict-resolution" not in invoked
+    ):
+        violations.append(
+            "research.json has a resolved conflict but 'conflict-resolution' was never "
+            "successfully invoked in this run"
+        )
+
+    return violations
+
+
+def find_missing_mentor_verdicts(research: dict[str, Any] | None) -> list[str]:
+    """Every `ps_id` a resolved question references must carry a matching
+    `evaluations[]` entry (`focus: "proof-critique"`, `target_id: <ps_id>`) —
+    research/SKILL.md's own final completion check, and per docs/plan/
+    research-guardrail-bypass-plan.md §4.4/§6, this gate is itself just
+    another routing-table step the orchestrator could silently skip under the
+    same context pressure as the four guardrail skills.
+
+    Deliberately reads `research.json`'s `evaluations[]` directly rather than
+    inferring from `tool_calls` — the durable record of whether the gate ran
+    IS the evaluations entry (`gps-mentor` writes only there, per the schema
+    spec's "append-only ownership"), so there's no invocation-log inference
+    needed here the way there is for the four in-session guardrail skills.
+    """
+    research = research or {}
+    questions = research.get("questions") if isinstance(research.get("questions"), list) else []
+    proof_summaries = research.get("proof_summaries") if isinstance(research.get("proof_summaries"), list) else []
+    evaluations = research.get("evaluations") if isinstance(research.get("evaluations"), list) else []
+
+    resolved_question_ids = {
+        q.get("id") for q in questions if isinstance(q, dict) and q.get("status") == "resolved"
+    }
+    referenced_ps_ids = {
+        ps.get("id")
+        for ps in proof_summaries
+        if isinstance(ps, dict) and ps.get("question_id") in resolved_question_ids
+    }
+    verdicted_ps_ids = {
+        ev.get("target_id")
+        for ev in evaluations
+        if isinstance(ev, dict) and ev.get("focus") == "proof-critique"
+    }
+    missing = sorted(pid for pid in (referenced_ps_ids - verdicted_ps_ids) if pid)
+    return [
+        f"proof_summaries entry '{ps_id}' is referenced by a resolved question but has no "
+        "'proof-critique' evaluations[] verdict on record (the mandatory gps-mentor gate)"
+        for ps_id in missing
+    ]

--- a/eval/harness/tests/unit/test_e2e_stall_resume.py
+++ b/eval/harness/tests/unit/test_e2e_stall_resume.py
@@ -117,7 +117,7 @@ def test_watchdog_aborts_on_no_progress_when_resume_off(tmp_path, monkeypatch):
     fx = _fixture(
         tmp_path, progress_stall_seconds=0.3, inactivity_seconds=2, wall_clock_seconds=30
     )
-    _tc, _t, usage, aborted, _e, _b = _drive(fx, tmp_path, resume_on_stall=False)
+    _tc, _t, usage, aborted, _e, _b, _g = _drive(fx, tmp_path, resume_on_stall=False)
     assert aborted == "no_progress_stall"
     assert usage["resumes"] == 0
     assert usage["session_id"] == "S1"  # captured from the init SystemMessage
@@ -147,7 +147,7 @@ def test_resume_recovers_a_stall_in_safe_state(tmp_path, monkeypatch):
     fx = _fixture(
         tmp_path, progress_stall_seconds=0.3, inactivity_seconds=2, wall_clock_seconds=30
     )
-    _tc, _t, usage, aborted, _e, _b = _drive(fx, tmp_path, resume_on_stall=True)
+    _tc, _t, usage, aborted, _e, _b, _g = _drive(fx, tmp_path, resume_on_stall=True)
     assert aborted is None  # completed via resume, no abort
     assert usage["resumes"] == 1
     assert calls["n"] == 2  # query was re-issued with resume

--- a/eval/harness/tests/unit/test_e2e_tree_block.py
+++ b/eval/harness/tests/unit/test_e2e_tree_block.py
@@ -127,3 +127,42 @@ def test_non_turn_cap_errors_not_reclassified():
     assert not is_turn_cap_error("some other SDK error")
     assert not is_turn_cap_error(None)
     assert not is_turn_cap_error("")
+
+
+# --- direct project-file write block (research-guardrail-bypass-plan.md §4.3) --
+
+def test_direct_write_to_research_json_is_blocked():
+    from e2e.orchestrator import direct_project_file_write
+    assert direct_project_file_write("Write", {"file_path": "/tmp/proj/research.json"}) == "research.json"
+
+
+def test_direct_edit_to_tree_gedcomx_is_blocked():
+    from e2e.orchestrator import direct_project_file_write
+    assert (
+        direct_project_file_write("Edit", {"file_path": "/tmp/proj/tree.gedcomx.json"})
+        == "tree.gedcomx.json"
+    )
+
+
+def test_relative_path_still_matches_on_basename():
+    from e2e.orchestrator import direct_project_file_write
+    assert direct_project_file_write("Write", {"file_path": "research.json"}) == "research.json"
+
+
+def test_write_to_an_unrelated_file_is_not_blocked():
+    from e2e.orchestrator import direct_project_file_write
+    assert direct_project_file_write("Write", {"file_path": "/tmp/proj/notes.md"}) is None
+
+
+def test_non_write_edit_tools_are_never_matched():
+    from e2e.orchestrator import direct_project_file_write
+    assert direct_project_file_write("Read", {"file_path": "/tmp/proj/research.json"}) is None
+    assert direct_project_file_write(
+        "mcp__genealogy__research_append", {"file_path": "/tmp/proj/research.json"}
+    ) is None
+
+
+def test_missing_file_path_does_not_crash():
+    from e2e.orchestrator import direct_project_file_write
+    assert direct_project_file_write("Write", {}) is None
+    assert direct_project_file_write("Write", None) is None

--- a/eval/harness/tests/unit/test_guardrail_shadow_report.py
+++ b/eval/harness/tests/unit/test_guardrail_shadow_report.py
@@ -1,0 +1,169 @@
+"""Unit tests for e2e.guardrail_shadow_report — the retroactive §4.1
+shadow-window calibration tool (docs/plan/research-guardrail-bypass-plan.md,
+GitHub issue #911).
+
+Pure filesystem + aggregation logic over synthetic result JSONs written to
+tmp_path. `find_unguarded_protected_writes` itself is already covered by
+test_skill_invocation.py; these tests are about correctly discovering,
+loading, and aggregating across a corpus of files.
+"""
+
+from __future__ import annotations
+
+import json
+
+from e2e.guardrail_shadow_report import (
+    _is_result_json,
+    all_result_jsons,
+    format_detail,
+    format_summary,
+    result_jsons_for,
+    scan_corpus,
+    scan_one,
+)
+
+
+def _write_run(dir_, name, tool_calls):
+    dir_.mkdir(parents=True, exist_ok=True)
+    (dir_ / name).write_text(json.dumps({"tool_calls": tool_calls}), encoding="utf-8")
+    return dir_ / name
+
+
+def _unguarded_write():
+    return {
+        "tool": "mcp__genealogy__research_append",
+        "args": {"section": "person_evidence", "op": "append", "entry": {"person_id": "I1"}},
+    }
+
+
+# --- _is_result_json ----------------------------------------------------
+
+
+def test_is_result_json_accepts_a_run_file(tmp_path):
+    assert _is_result_json(tmp_path / "run-2026-07-27_20-01-40.json") is True
+
+
+def test_is_result_json_rejects_ann_and_final_and_transcript(tmp_path):
+    assert _is_result_json(tmp_path / "run-2026-07-27_20-01-40.ann.json") is False
+    assert _is_result_json(tmp_path / "run-2026-07-27_20-01-40.final-research.json") is False
+    assert _is_result_json(tmp_path / "run-2026-07-27_20-01-40.final-tree.gedcomx.json") is False
+    assert _is_result_json(tmp_path / "run-2026-07-27_20-01-40.transcript.md") is False
+
+
+def test_is_result_json_rejects_scratch(tmp_path):
+    assert _is_result_json(tmp_path / "scratch_2026-07-27_20-01-40.json") is False
+
+
+# --- discovery: all_result_jsons / result_jsons_for -----------------------
+
+
+def test_all_result_jsons_finds_every_fixture(tmp_path, monkeypatch):
+    import e2e.guardrail_shadow_report as mod
+
+    monkeypatch.setattr(mod, "E2E_RUNLOGS", tmp_path)
+    _write_run(tmp_path / "fixture-a", "run-2026-07-01_00-00-00.json", [])
+    _write_run(tmp_path / "fixture-a", "run-2026-07-02_00-00-00.json", [])
+    _write_run(tmp_path / "fixture-b", "run-2026-07-01_00-00-00.json", [])
+    # siblings that must be excluded
+    (tmp_path / "fixture-a" / "run-2026-07-01_00-00-00.ann.json").write_text("{}")
+
+    found = all_result_jsons()
+    assert len(found) == 3  # not the latest-per-fixture-only; every run
+
+
+def test_result_jsons_for_scopes_to_one_fixture(tmp_path, monkeypatch):
+    import e2e.guardrail_shadow_report as mod
+
+    monkeypatch.setattr(mod, "E2E_RUNLOGS", tmp_path)
+    _write_run(tmp_path / "fixture-a", "run-2026-07-01_00-00-00.json", [])
+    _write_run(tmp_path / "fixture-b", "run-2026-07-01_00-00-00.json", [])
+
+    assert len(result_jsons_for("fixture-a")) == 1
+    assert result_jsons_for("nonexistent-fixture") == []
+
+
+# --- scan_one / scan_corpus ------------------------------------------------
+
+
+def test_scan_one_finds_a_violation_and_tags_it_with_the_source_file(tmp_path, monkeypatch):
+    import e2e.guardrail_shadow_report as mod
+
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    path = _write_run(tmp_path / "eval" / "runlogs" / "e2e" / "fixture-a", "run-x.json", [_unguarded_write()])
+
+    violations = scan_one(path, window=40)
+    assert len(violations) == 1
+    assert violations[0]["required_skill"] == "person-evidence"
+    assert violations[0]["fixture"] == "fixture-a"
+    assert "fixture-a" in violations[0]["file"]
+
+
+def test_scan_one_finds_nothing_on_a_clean_run(tmp_path):
+    path = _write_run(
+        tmp_path,
+        "run-x.json",
+        [
+            {"tool": "Skill", "args": {"skill": "person-evidence"}},
+            _unguarded_write(),
+        ],
+    )
+    assert scan_one(path, window=40) == []
+
+
+def test_scan_corpus_aggregates_across_multiple_windows_and_files(tmp_path):
+    p1 = _write_run(tmp_path / "f1", "run-x.json", [_unguarded_write()])
+    p2 = _write_run(
+        tmp_path / "f2",
+        "run-y.json",
+        [{"tool": "Skill", "args": {"skill": "person-evidence"}}] + [_unguarded_write()] * 2,
+    )
+    by_window = scan_corpus([p1, p2], windows=[1, 40])
+    # window=1: the Skill call in p2 is only 1 call before the FIRST unguarded
+    # write, not the second -> p2 contributes 1 violation; p1 contributes 1.
+    assert len(by_window[1]) == 2
+    # window=40: p2's Skill call covers both of its writes -> only p1's violation remains.
+    assert len(by_window[40]) == 1
+
+
+def test_scan_corpus_skips_unreadable_files_without_crashing(tmp_path, capsys):
+    bad = tmp_path / "f1" / "run-bad.json"
+    bad.parent.mkdir(parents=True)
+    bad.write_text("not json")
+    good = _write_run(tmp_path / "f2", "run-good.json", [_unguarded_write()])
+
+    by_window = scan_corpus([bad, good], windows=[40])
+    assert len(by_window[40]) == 1
+    assert "skip" in capsys.readouterr().err
+
+
+# --- formatting --------------------------------------------------------
+
+
+def test_format_summary_reports_per_window_counts_and_skill_breakdown():
+    by_window = {
+        40: [
+            {"required_skill": "person-evidence", "file": "a"},
+            {"required_skill": "person-evidence", "file": "b"},
+            {"required_skill": "proof-conclusion", "file": "a"},
+        ]
+    }
+    out = format_summary(by_window, n_runs=2)
+    assert "person-evidence=2" in out
+    assert "proof-conclusion=1" in out
+
+
+def test_format_summary_handles_a_window_with_no_violations():
+    out = format_summary({40: []}, n_runs=5)
+    assert "(none)" in out
+
+
+def test_format_detail_lists_every_violation():
+    violations = [
+        {"fixture": "f1", "index": 3, "tool": "mcp__genealogy__research_append", "required_skill": "person-evidence", "question_id": None},
+    ]
+    out = format_detail(violations)
+    assert "f1" in out and "person-evidence" in out
+
+
+def test_format_detail_empty_list():
+    assert "none" in format_detail([])

--- a/eval/harness/tests/unit/test_skill_invocation.py
+++ b/eval/harness/tests/unit/test_skill_invocation.py
@@ -8,6 +8,7 @@ from harness.skill_invocation import (
     GUARDRAIL_SKILLS,
     find_effects_without_invocation,
     find_missing_mentor_verdicts,
+    find_person_evidence_missing_same_person,
     find_unguarded_protected_writes,
     owning_skills,
     recently_succeeded,
@@ -363,3 +364,125 @@ def test_does_not_flag_a_proof_summary_on_an_unresolved_question():
 def test_empty_research_has_no_violations():
     assert find_missing_mentor_verdicts({}) == []
     assert find_missing_mentor_verdicts(None) == []
+
+
+# --- find_person_evidence_missing_same_person --------------------------------
+
+
+def _same_person_call(primary_id1=None, primary_id2=None, is_error=False):
+    args = {"gedcomx1": {}, "gedcomx2": {}}
+    if primary_id1 is not None:
+        args["primaryId1"] = primary_id1
+    if primary_id2 is not None:
+        args["primaryId2"] = primary_id2
+    entry = {"tool": "mcp__genealogy__same_person", "args": args}
+    if is_error:
+        entry["is_error"] = True
+    return entry
+
+
+def test_flags_a_new_person_linked_with_zero_same_person_calls():
+    """The bagley-father-1884 case: person-evidence invoked, but not for
+    this link, and same_person never called for the new person at all."""
+    tree = {"persons": [{"id": "I1", "names": [{"given": "David"}]}]}
+    research = {"person_evidence": [{"id": "pe_001", "person_id": "I1"}]}
+    calls = [_skill_call("person-evidence")]  # invoked, but irrelevant here
+    violations = find_person_evidence_missing_same_person(calls, research, tree, starting_tree={"persons": []})
+    assert len(violations) == 1
+    assert "I1" in violations[0]
+
+
+def test_does_not_flag_when_same_person_was_called_as_primaryId1():
+    tree = {"persons": [{"id": "I1", "names": [{"given": "David"}]}]}
+    research = {"person_evidence": [{"id": "pe_001", "person_id": "I1"}]}
+    calls = [_same_person_call(primary_id1="I1", primary_id2="p_260268760900")]
+    assert find_person_evidence_missing_same_person(calls, research, tree, starting_tree={"persons": []}) == []
+
+
+def test_does_not_flag_when_same_person_was_called_as_primaryId2():
+    tree = {"persons": [{"id": "I1", "names": [{"given": "David"}]}]}
+    research = {"person_evidence": [{"id": "pe_001", "person_id": "I1"}]}
+    calls = [_same_person_call(primary_id1="p_260268760900", primary_id2="I1")]
+    assert find_person_evidence_missing_same_person(calls, research, tree, starting_tree={"persons": []}) == []
+
+
+def test_a_same_person_call_for_a_different_person_does_not_clear_the_flag():
+    """The crude 'was same_person called at all' version would wrongly clear
+    this — this is exactly the precision gap that version was rejected for."""
+    tree = {
+        "persons": [
+            {"id": "I1", "names": [{"given": "David"}]},
+            {"id": "I2", "names": [{"given": "Someone Else"}]},
+        ]
+    }
+    research = {
+        "person_evidence": [
+            {"id": "pe_001", "person_id": "I1"},
+            {"id": "pe_002", "person_id": "I2"},
+        ]
+    }
+    # same_person is called, but only for I2 -- I1 is still unscored.
+    calls = [_same_person_call(primary_id1="p_999", primary_id2="I2")]
+    violations = find_person_evidence_missing_same_person(calls, research, tree, starting_tree={"persons": []})
+    assert len(violations) == 1
+    assert "I1" in violations[0]
+
+
+def test_an_errored_same_person_call_does_not_count_as_scoring():
+    tree = {"persons": [{"id": "I1", "names": [{"given": "David"}]}]}
+    research = {"person_evidence": [{"id": "pe_001", "person_id": "I1"}]}
+    calls = [_same_person_call(primary_id1="I1", primary_id2="p_999", is_error=True)]
+    violations = find_person_evidence_missing_same_person(calls, research, tree, starting_tree={"persons": []})
+    assert len(violations) == 1
+
+
+def test_does_not_flag_a_person_already_in_the_starting_tree():
+    """Only BRAND-NEW persons are in scope -- an already-known person
+    (e.g. the research subject) confirming their own identity again is not
+    what this check is for; find_effects_without_invocation's coarser
+    unlinked-person check covers the general case."""
+    seed = {"id": "MJDL-Q8B", "names": [{"given": "William"}]}
+    tree = {"persons": [seed]}
+    research = {"person_evidence": [{"id": "pe_001", "person_id": "MJDL-Q8B"}]}
+    calls = []  # no same_person call anywhere
+    assert find_person_evidence_missing_same_person(calls, research, tree, starting_tree={"persons": [seed]}) == []
+
+
+def test_does_not_flag_a_new_person_with_no_person_evidence_link_at_all():
+    """No link yet -> nothing for this check to flag (find_effects_without_
+    invocation's unlinked-person check is the one that covers this case)."""
+    tree = {"persons": [{"id": "I1", "names": [{"given": "David"}]}]}
+    research = {"person_evidence": []}
+    assert find_person_evidence_missing_same_person([], research, tree, starting_tree={"persons": []}) == []
+
+
+def test_multiple_new_persons_only_unscored_ones_flagged():
+    tree = {
+        "persons": [
+            {"id": "I1", "names": [{"given": "David"}]},
+            {"id": "I2", "names": [{"given": "Sarah"}]},
+        ]
+    }
+    research = {
+        "person_evidence": [
+            {"id": "pe_001", "person_id": "I1"},
+            {"id": "pe_002", "person_id": "I2"},
+        ]
+    }
+    calls = [_same_person_call(primary_id1="p_1", primary_id2="I1")]  # only I1 scored
+    violations = find_person_evidence_missing_same_person(calls, research, tree, starting_tree={"persons": []})
+    assert len(violations) == 1
+    assert "I2" in violations[0]
+
+
+def test_no_starting_tree_treats_every_current_person_as_new():
+    tree = {"persons": [{"id": "I1", "names": [{"given": "David"}]}]}
+    research = {"person_evidence": [{"id": "pe_001", "person_id": "I1"}]}
+    # Best-effort with no baseline: still flags an unscored link.
+    violations = find_person_evidence_missing_same_person([], research, tree)
+    assert len(violations) == 1
+
+
+def test_empty_tree_and_research_have_no_violations():
+    assert find_person_evidence_missing_same_person([], {}, {}) == []
+    assert find_person_evidence_missing_same_person([], None, None) == []

--- a/eval/harness/tests/unit/test_skill_invocation.py
+++ b/eval/harness/tests/unit/test_skill_invocation.py
@@ -1,0 +1,365 @@
+"""Unit tests for harness/skill_invocation.py.
+
+docs/plan/research-guardrail-bypass-plan.md §4.1/§4.4 — pure matching logic
+over the harness's `tool_calls` list shape, no I/O, no SDK types.
+"""
+
+from harness.skill_invocation import (
+    GUARDRAIL_SKILLS,
+    find_effects_without_invocation,
+    find_missing_mentor_verdicts,
+    find_unguarded_protected_writes,
+    owning_skills,
+    recently_succeeded,
+    skill_name_if_skill_call,
+)
+
+
+def _skill_call(name, args_text=None, is_error=False):
+    entry = {"tool": "Skill", "args": {"skill": name}}
+    if args_text is not None:
+        entry["args"]["args"] = args_text
+    if is_error:
+        entry["is_error"] = True
+    return entry
+
+
+def _mcp_call(bare_name, args, is_error=False):
+    entry = {"tool": f"mcp__genealogy__{bare_name}", "args": args}
+    if is_error:
+        entry["is_error"] = True
+    return entry
+
+
+# --- skill_name_if_skill_call ------------------------------------------------
+
+
+def test_skill_name_extracted_from_skill_tool_call():
+    assert skill_name_if_skill_call("Skill", {"skill": "proof-conclusion"}) == "proof-conclusion"
+
+
+def test_skill_name_none_for_non_skill_tools():
+    assert skill_name_if_skill_call("mcp__genealogy__research_append", {"skill": "proof-conclusion"}) is None
+    assert skill_name_if_skill_call("Agent", {"skill": "proof-conclusion"}) is None
+
+
+def test_skill_name_none_when_skill_arg_missing_or_blank():
+    assert skill_name_if_skill_call("Skill", {}) is None
+    assert skill_name_if_skill_call("Skill", {"skill": ""}) is None
+    assert skill_name_if_skill_call("Skill", None) is None
+
+
+# --- owning_skills: research_append sections ---------------------------------
+
+
+def test_proof_summaries_owned_by_proof_conclusion():
+    args = {"section": "proof_summaries", "op": "append", "entry": {"question_id": "q_001", "tier": "proved"}}
+    assert owning_skills("mcp__genealogy__research_append", args) == ["proof-conclusion"]
+
+
+def test_person_evidence_owned_by_person_evidence():
+    args = {"section": "person_evidence", "op": "append", "entry": {"person_id": "I1"}}
+    assert owning_skills("mcp__genealogy__research_append", args) == ["person-evidence"]
+
+
+def test_conflicts_owned_by_conflict_resolution():
+    args = {"section": "conflicts", "op": "update", "entryId": "c_001", "fields": {"status": "resolved"}}
+    assert owning_skills("mcp__genealogy__research_append", args) == ["conflict-resolution"]
+
+
+def test_exhaustive_declaration_true_owned_by_research_exhaustiveness():
+    args = {
+        "section": "questions",
+        "op": "update",
+        "entryId": "q_001",
+        "fields": {"exhaustive_declaration": {"declared": True}},
+    }
+    assert owning_skills("mcp__genealogy__research_append", args) == ["research-exhaustiveness"]
+
+
+def test_questions_update_without_declaring_true_owns_nothing():
+    args = {"section": "questions", "op": "update", "entryId": "q_001", "fields": {"priority": "low"}}
+    assert owning_skills("mcp__genealogy__research_append", args) == []
+    args2 = {
+        "section": "questions",
+        "op": "update",
+        "entryId": "q_001",
+        "fields": {"exhaustive_declaration": {"declared": False}},
+    }
+    assert owning_skills("mcp__genealogy__research_append", args2) == []
+
+
+def test_unrelated_sections_own_nothing():
+    for section in ("sources", "assertions", "plans", "hypotheses", "timelines", "evaluations"):
+        args = {"section": section, "op": "append", "entry": {}}
+        assert owning_skills("mcp__genealogy__research_append", args) == []
+
+
+def test_batch_form_touching_multiple_sections_returns_all_owners_deduped():
+    args = {
+        "ops": [
+            {"section": "person_evidence", "op": "append", "entry": {"person_id": "I1"}},
+            {"section": "proof_summaries", "op": "append", "entry": {"question_id": "q_001", "tier": "probable"}},
+            {"section": "person_evidence", "op": "append", "entry": {"person_id": "I2"}},
+        ]
+    }
+    assert owning_skills("mcp__genealogy__research_append", args) == ["person-evidence", "proof-conclusion"]
+
+
+# --- owning_skills: materialize_facts / tree_edit / tree_correct ------------
+
+
+def test_materialize_facts_minting_new_person_owned_by_person_evidence():
+    args = {"recordId": "rec_1", "recordRole": "child"}  # no personId => mints new
+    assert owning_skills("mcp__genealogy__materialize_facts", args) == ["person-evidence"]
+
+
+def test_materialize_facts_enriching_existing_person_owns_nothing():
+    args = {"personId": "I1", "recordId": "rec_1", "recordRole": "child"}
+    assert owning_skills("mcp__genealogy__materialize_facts", args) == []
+
+
+def test_tree_edit_add_parent_child_relationship_owned_by_proof_conclusion():
+    args = {"operation": "add_relationship", "relationship": {"type": "ParentChild", "person1": "I1", "person2": "I2"}}
+    assert owning_skills("mcp__genealogy__tree_edit", args) == ["proof-conclusion"]
+
+
+def test_tree_edit_add_couple_relationship_owned_by_proof_conclusion():
+    args = {"operation": "add_relationship", "relationship": {"type": "Couple", "person1": "I1", "person2": "I2"}}
+    assert owning_skills("mcp__genealogy__tree_edit", args) == ["proof-conclusion"]
+
+
+def test_tree_correct_setting_primary_fact_owned_by_proof_conclusion():
+    args = {"operation": "update_fact", "factId": "f1", "fact": {"type": "Death", "primary": True}}
+    assert owning_skills("mcp__genealogy__tree_correct", args) == ["proof-conclusion"]
+
+
+def test_tree_edit_unrelated_op_owns_nothing():
+    args = {"operation": "add_source", "source": {"title": "x"}}
+    assert owning_skills("mcp__genealogy__tree_edit", args) == []
+
+
+def test_non_write_tools_own_nothing():
+    assert owning_skills("mcp__genealogy__record_search", {}) == []
+    assert owning_skills("Read", {"file_path": "research.json"}) == []
+
+
+# --- recently_succeeded ------------------------------------------------------
+
+
+def test_recently_succeeded_true_within_window():
+    calls = [_skill_call("proof-conclusion"), _mcp_call("research_append", {})]
+    assert recently_succeeded("proof-conclusion", calls, before_index=1, window=5) is True
+
+
+def test_recently_succeeded_false_outside_window():
+    calls = [_skill_call("proof-conclusion")] + [_mcp_call("record_search", {})] * 5
+    assert recently_succeeded("proof-conclusion", calls, before_index=6, window=3) is False
+
+
+def test_recently_succeeded_false_when_never_invoked():
+    calls = [_mcp_call("record_search", {})]
+    assert recently_succeeded("proof-conclusion", calls, before_index=1, window=5) is False
+
+
+def test_recently_succeeded_ignores_a_failed_skill_call():
+    """An errored Skill invocation must not open the window — otherwise
+    invoke -> fail -> finish inline evades detection (plan §4.1)."""
+    calls = [_skill_call("proof-conclusion", is_error=True), _mcp_call("research_append", {})]
+    assert recently_succeeded("proof-conclusion", calls, before_index=1, window=5) is False
+
+
+def test_recently_succeeded_keyed_by_question_when_derivable():
+    calls = [_skill_call("proof-conclusion", args_text="--autonomous q_001 projectPath=/x")]
+    assert recently_succeeded("proof-conclusion", calls, before_index=1, window=5, question_id="q_002") is False
+    assert recently_succeeded("proof-conclusion", calls, before_index=1, window=5, question_id="q_001") is True
+
+
+def test_recently_succeeded_falls_back_to_skill_only_when_question_id_not_derivable():
+    calls = [_skill_call("proof-conclusion")]  # no args text -> no derivable question id
+    assert recently_succeeded("proof-conclusion", calls, before_index=1, window=5, question_id="q_001") is True
+
+
+# --- find_unguarded_protected_writes ----------------------------------------
+
+
+def test_flags_a_protected_write_with_no_prior_skill_call():
+    calls = [_mcp_call("research_append", {"section": "proof_summaries", "entry": {"question_id": "q_001", "tier": "probable"}})]
+    violations = find_unguarded_protected_writes(calls, window=10)
+    assert len(violations) == 1
+    assert violations[0]["required_skill"] == "proof-conclusion"
+    assert violations[0]["index"] == 0
+
+
+def test_does_not_flag_a_protected_write_preceded_by_the_right_skill():
+    calls = [
+        _skill_call("proof-conclusion", args_text="--autonomous q_001"),
+        _mcp_call("research_append", {"section": "proof_summaries", "entry": {"question_id": "q_001", "tier": "probable"}}),
+    ]
+    assert find_unguarded_protected_writes(calls, window=10) == []
+
+
+def test_flags_the_read_and_improvise_bypass_shape():
+    """No Skill call at all, no Agent/Task call — just the write."""
+    calls = [
+        _mcp_call("research_append", {"section": "person_evidence", "entry": {"person_id": "I1"}}),
+    ]
+    violations = find_unguarded_protected_writes(calls, window=10)
+    assert violations[0]["required_skill"] == "person-evidence"
+
+
+def test_flags_the_untyped_agent_bypass_shape():
+    """An Agent call with no subagent_type never sets skill_name_if_skill_call
+    to anything, so it never opens a window either."""
+    calls = [
+        {"tool": "Agent", "args": {"description": "write proof summary", "prompt": "..."}},
+        _mcp_call("research_append", {"section": "proof_summaries", "entry": {"question_id": "q_001", "tier": "probable"}}),
+    ]
+    violations = find_unguarded_protected_writes(calls, window=10)
+    assert violations[0]["required_skill"] == "proof-conclusion"
+
+
+# --- find_effects_without_invocation -----------------------------------------
+
+
+def test_no_violations_on_a_clean_run():
+    calls = [
+        _skill_call("research-exhaustiveness"),
+        _skill_call("proof-conclusion"),
+        _skill_call("person-evidence"),
+        _skill_call("conflict-resolution"),
+    ]
+    research = {
+        "questions": [{"id": "q_001", "exhaustive_declaration": {"declared": True}}],
+        "proof_summaries": [{"id": "ps_001", "question_id": "q_001", "tier": "proved"}],
+        "person_evidence": [{"id": "pe_001", "person_id": "I1"}],
+        "conflicts": [{"id": "c_001", "status": "resolved"}],
+    }
+    tree = {"persons": [{"id": "I1", "names": [{"given": "A"}], "facts": []}], "relationships": []}
+    assert find_effects_without_invocation(calls, research, tree, starting_tree=tree) == []
+
+
+def test_flags_exhaustive_declaration_with_no_research_exhaustiveness_invocation():
+    research = {"questions": [{"id": "q_001", "exhaustive_declaration": {"declared": True}}]}
+    violations = find_effects_without_invocation([], research, {})
+    assert any("research-exhaustiveness" in v for v in violations)
+
+
+def test_flags_proof_summaries_entry_with_no_proof_conclusion_invocation():
+    research = {"proof_summaries": [{"id": "ps_001", "question_id": "q_001", "tier": "probable"}]}
+    violations = find_effects_without_invocation([], research, {})
+    assert any("proof-conclusion" in v for v in violations)
+
+
+def test_flags_a_primary_fact_with_no_proof_conclusion_invocation_even_with_no_proof_summary():
+    """proof-conclusion's tree-encoding output, not just the research.json entry."""
+    tree = {"persons": [{"id": "I1", "facts": [{"type": "Death", "primary": True}]}], "relationships": []}
+    violations = find_effects_without_invocation([], {}, tree)
+    assert any("proof-conclusion" in v for v in violations)
+
+
+def test_flags_a_parent_child_relationship_with_no_proof_conclusion_invocation():
+    tree = {"persons": [], "relationships": [{"type": "ParentChild", "person1": "I1", "person2": "I2"}]}
+    violations = find_effects_without_invocation([], {}, tree)
+    assert any("proof-conclusion" in v for v in violations)
+
+
+def test_flags_a_new_unlinked_person_with_no_person_evidence_invocation():
+    """The materialize_facts identity-bypass route the adversarial review found."""
+    tree = {"persons": [{"id": "I9", "names": [{"given": "New"}], "facts": [{"type": "Birth"}]}], "relationships": []}
+    violations = find_effects_without_invocation([], {"person_evidence": []}, tree, starting_tree={"persons": []})
+    assert any("person-evidence" in v for v in violations)
+
+
+def test_does_not_flag_a_seed_person_already_in_the_starting_tree():
+    """A fixture's starting tree naturally has unlinked persons with facts —
+    that's not a bypass, it's the fixture's initial state."""
+    seed_person = {"id": "I1", "names": [{"given": "Seed"}], "facts": [{"type": "Birth"}]}
+    tree = {"persons": [seed_person], "relationships": []}
+    violations = find_effects_without_invocation([], {"person_evidence": []}, tree, starting_tree=tree)
+    assert not any("person-evidence" in v for v in violations)
+
+
+def test_flags_a_seed_person_who_gained_new_facts_this_run():
+    starting = {"persons": [{"id": "I1", "names": [{"given": "Seed"}], "facts": [{"type": "Birth"}]}]}
+    grown = {"persons": [{"id": "I1", "names": [{"given": "Seed"}], "facts": [{"type": "Birth"}, {"type": "Death"}]}], "relationships": []}
+    violations = find_effects_without_invocation([], {"person_evidence": []}, grown, starting_tree=starting)
+    assert any("person-evidence" in v for v in violations)
+
+
+def test_flags_a_resolved_conflict_with_no_conflict_resolution_invocation():
+    research = {"conflicts": [{"id": "c_001", "status": "resolved"}]}
+    violations = find_effects_without_invocation([], research, {})
+    assert any("conflict-resolution" in v for v in violations)
+
+
+def test_unresolved_conflict_does_not_require_invocation():
+    research = {"conflicts": [{"id": "c_001", "status": "unresolved"}]}
+    assert find_effects_without_invocation([], research, {}) == []
+
+
+def test_a_failed_skill_call_does_not_count_as_invoked():
+    calls = [_skill_call("proof-conclusion", is_error=True)]
+    research = {"proof_summaries": [{"id": "ps_001", "question_id": "q_001", "tier": "probable"}]}
+    violations = find_effects_without_invocation(calls, research, {})
+    assert any("proof-conclusion" in v for v in violations)
+
+
+def test_guardrail_skills_tuple_is_exactly_the_four():
+    assert set(GUARDRAIL_SKILLS) == {
+        "research-exhaustiveness",
+        "proof-conclusion",
+        "person-evidence",
+        "conflict-resolution",
+    }
+
+
+# --- find_missing_mentor_verdicts --------------------------------------------
+
+
+def test_flags_a_resolved_questions_proof_summary_with_no_proof_critique_verdict():
+    research = {
+        "questions": [{"id": "q_001", "status": "resolved"}],
+        "proof_summaries": [{"id": "ps_001", "question_id": "q_001", "tier": "proved"}],
+        "evaluations": [],
+    }
+    violations = find_missing_mentor_verdicts(research)
+    assert len(violations) == 1
+    assert "ps_001" in violations[0]
+
+
+def test_does_not_flag_when_a_matching_proof_critique_verdict_exists():
+    research = {
+        "questions": [{"id": "q_001", "status": "resolved"}],
+        "proof_summaries": [{"id": "ps_001", "question_id": "q_001", "tier": "proved"}],
+        "evaluations": [
+            {"id": "ev_001", "focus": "proof-critique", "target_id": "ps_001", "target_type": "proof_summary"}
+        ],
+    }
+    assert find_missing_mentor_verdicts(research) == []
+
+
+def test_does_not_flag_an_unrelated_evaluation_focus():
+    """A pre-exhaustiveness or on-demand verdict does not satisfy the
+    mandatory proof-critique gate."""
+    research = {
+        "questions": [{"id": "q_001", "status": "resolved"}],
+        "proof_summaries": [{"id": "ps_001", "question_id": "q_001", "tier": "proved"}],
+        "evaluations": [{"id": "ev_001", "focus": "on-demand", "target_id": "ps_001"}],
+    }
+    violations = find_missing_mentor_verdicts(research)
+    assert len(violations) == 1
+
+
+def test_does_not_flag_a_proof_summary_on_an_unresolved_question():
+    research = {
+        "questions": [{"id": "q_001", "status": "in_progress"}],
+        "proof_summaries": [{"id": "ps_001", "question_id": "q_001", "tier": "probable"}],
+        "evaluations": [],
+    }
+    assert find_missing_mentor_verdicts(research) == []
+
+
+def test_empty_research_has_no_violations():
+    assert find_missing_mentor_verdicts({}) == []
+    assert find_missing_mentor_verdicts(None) == []

--- a/eval/runlogs/e2e/bagley-father-1884/run-2026-07-27_20-01-40.ann.json
+++ b/eval/runlogs/e2e/bagley-father-1884/run-2026-07-27_20-01-40.ann.json
@@ -1,0 +1,9 @@
+{
+  "per_finding": {
+    "f1": "partial"
+  },
+  "proof_quality_score": 2,
+  "notes": {
+    "f1": "Right father and right source: David Bagley added as a new person with a ParentChild link to William A. Bagley, sourced to the 1884 Topsham town-clerk death entry. But the person is not pinned to an identity — no birth fact (expected 22 Feb 1777, Newton, Rockingham, NH), no death fact — and the agent's own narrative surfaces a co-resident 'David Bagley Jr.' in Topsham, so the tree as written does not distinguish which David Bagley was named. Identity-resolution call."
+  }
+}

--- a/eval/runlogs/e2e/bagley-father-1884/run-2026-07-27_20-01-40.final-research.json
+++ b/eval/runlogs/e2e/bagley-father-1884/run-2026-07-27_20-01-40.final-research.json
@@ -1,0 +1,1471 @@
+{
+  "project": {
+    "id": "rp_bagley_father_1884",
+    "objective": "Who was the father of William A. Bagley, born about 1815 and died 31 May 1884 in Topsham, Orange County, Vermont?",
+    "subject_person_ids": [
+      "MJDL-Q8B"
+    ],
+    "status": "completed",
+    "created": "2026-07-27",
+    "updated": "2026-07-27"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [
+    {
+      "id": "q_001",
+      "question": "Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermont)?",
+      "rationale": "The research objective directly targets the identity of William A. Bagley's father. His mother, Sarah Sally Andrews (born 1777 Gloucester, Essex, Massachusetts; died 19 March 1847 Topsham, Orange, Vermont), is already identified in the tree, but no father is recorded. Vermont death records for 1884, early census records (1820\u20131840, when William would appear in a parental household), and Orange County probate records on FamilySearch offer the most direct paths to naming his paternal line.",
+      "selection_basis": "objective_decomposition",
+      "priority": "high",
+      "status": "resolved",
+      "depends_on": [],
+      "unblocks": [],
+      "resolved": "2026-07-27",
+      "resolution_assertion_ids": [
+        "a_005",
+        "a_015"
+      ],
+      "exhaustive_declaration": {
+        "declared": true,
+        "justification": "Searched Vermont Town Clerk vital records (death entries directly naming David Bagley as father), federal census 1820 and 1840 (David Bagley in Topsham both years), Vermont birth index, Vermont marriage records (indexed), Vermont probate (indexed), and full-text search of Topsham Town Records 1771-1860 (imageGroup 005464260, 110 results examined). Two independent evidence units establish the answer: (1) two indexings of one Vermont Town Clerk death entry directly naming David Bagley as William A. Bagley's father (secondary information, direct evidence); (2) the 1820 and 1840 federal census schedules placing David Bagley in Topsham, Orange County, Vermont \u2014 the same town as William \u2014 across two decades (primary information, indirect evidence). Full-text search of Topsham town records corroborates David Bagley's continuous presence as a selectman 1806-1855 and found the name 'Sophia Andrews Bagley' in an 1813 record, suggesting a child of David Bagley and Sarah Andrews named with the maternal maiden surname \u2014 consistent with the established maternal identification. No alternative candidate father appeared in any searched source. Gaps noted: Bradford District probate estate files (collection 1807377, 75K images, 0% name-indexed) are genuinely inaccessible via current tools; no indexed marriage record for David Bagley and Sarah Andrews found (consistent with pre-1857 Vermont recording gaps); land records and Ancestry local history were not searched. These gaps are unlikely to contradict the established conclusion.",
+        "log_entry_ids": [
+          "log_001",
+          "log_002",
+          "log_003",
+          "log_004",
+          "log_005",
+          "log_006",
+          "log_007",
+          "log_008",
+          "log_009",
+          "log_010",
+          "log_011"
+        ],
+        "stop_criteria": {
+          "goal_alignment": "Yes \u2014 two Vermont Town Clerk death record indexings (QPQP-R8T8 and QPQP-24HR, both from the same 31 May 1884 entry) explicitly name David Bagley as William A. Bagley's father. The 1820 census (XHLG-T8R) and 1840 census (XHRB-V42) place David Bagley in Topsham, Orange County, Vermont at times consistent with being William's father.",
+          "repository_breadth": "FamilySearch census 1820, 1830, 1840; Vermont Births and Christenings 1765-1908; Vermont Town Clerk Vital and Town Records 1732-2005; Vermont Marriages 1791-1974; Vermont Vital Records 1760-1954; Vermont Probate Files 1800-1921; Vermont Wills and Deeds; and full-text search of Topsham Town Records 1771-1860 (imageGroup 005464260) all searched. Name variants Bagley/Bayley/Baley found and searched. Bradford District estate files (browse-only, inaccessible) and Ancestry local history 'Sketches of Topsham' documented as unsearched gaps. No indexed church records for Topsham found.",
+          "original_substitution": "Both Vermont Town Clerk death records are original government entries. The 1820 and 1840 federal censuses are original government schedules. No derivative source carries the parentage conclusion \u2014 the indexed entries were the originals in this case (the collection indexes the original town-clerk volume entries).",
+          "independent_verification": "Two independent evidence units: (1) the Vermont death record (QPQP-R8T8/QPQP-24HR are two indexings of one original, counting as one unit \u2014 informant: unidentified family/community member with secondhand knowledge of the 1815 birth); (2) the 1820 and 1840 federal censuses placing David Bagley in Topsham across 20 years \u2014 independent record creation, different informants, different government process. The Topsham town records full-text search adds circumstantial corroboration (selectman records, naming pattern). The death record provides direct evidence; the censuses provide independent indirect corroboration.",
+          "evidence_class": "The Vermont Town Clerk death entry is an original record. The parentage assertion (a_005, a_015) is direct evidence and secondary information \u2014 the record explicitly states the relationship (direct) but the informant was not present at William's 1815 birth (secondary). The 1820 and 1840 censuses are original records with primary information about David Bagley's name and residence.",
+          "conflict_resolution": "No conflicting evidence exists. No source names a different father for William A. Bagley. No contradictory information about parentage appeared in any of the 11 searches conducted. The 1830 census search (log_002) found David Bagley in Topsham but the specific ARK resolved to a wrong record \u2014 this is a data-quality limitation, not a conflict. The two death-record indexings agree completely.",
+          "overturn_risk": "Low. The only meaningfully unsearched sources with potential to bear on parentage are: (1) Bradford District probate estate files \u2014 genuinely inaccessible (75K images, 0% indexed, no full-text search capability); a David Bagley will or estate inventory could corroborate but is unlikely to contradict the explicit death-record naming; (2) Topsham land records \u2014 not searched; a deed referring to 'my son William' would corroborate; no evidence suggests a different father. No alternative candidate has emerged from any source. The explicit parentage statement in the death record, corroborated by 20+ years of census co-location in the same small Vermont town, makes the conclusion highly resistant to overturn."
+        }
+      },
+      "created": "2026-07-27"
+    }
+  ],
+  "plans": [
+    {
+      "id": "pl_001",
+      "question_id": "q_001",
+      "status": "active",
+      "created": "2026-07-27",
+      "items": [
+        {
+          "id": "pli_001",
+          "sequence": 1,
+          "record_type": "census",
+          "jurisdiction": "Topsham, Orange County, Vermont",
+          "date_range": "1820",
+          "repository": "FamilySearch",
+          "rationale": "William A. Bagley was born about 1815. In the 1820 federal census he would be approximately 5 years old and appear as an unnamed male child under age 10 in his father's household. Pre-1850 censuses name only the head of household \u2014 identifying a Bagley household in Topsham with a male child in the under-10 bracket names William's father directly. His mother Sarah Sally Andrews (born 1777) should also appear in the same household in the correct age bracket for females 40-45. This is the highest-probability path to the father's name.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_002",
+          "sequence": 2,
+          "record_type": "census",
+          "jurisdiction": "Topsham, Orange County, Vermont",
+          "date_range": "1830",
+          "repository": "FamilySearch",
+          "rationale": "In the 1830 census William would be approximately 15 and still likely in his father's household. The 1830 census names only the head of household; a Bagley household in Topsham containing a male aged 15-19 confirms the father's name. Sarah Andrews (born 1777) would appear in the 50-59 bracket. Run this immediately after the 1820 search as corroboration \u2014 if one census is missing the family, the other may find them.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_003",
+          "sequence": 3,
+          "record_type": "vital_record",
+          "jurisdiction": "Topsham, Orange County, Vermont",
+          "date_range": "1810-1820",
+          "repository": "FamilySearch",
+          "rationale": "Search Vermont Births and Christenings 1765-1908 (collection 1675544, index only) for a birth record for William A. Bagley or a William Bagley born about 1815 in Topsham or Orange County. Also search Vermont Town Clerk, Vital and Town Records, 1732-2005 (collection 1987653, indexed + images). Per loc_001, state vital registration only began in 1857; pre-1857 births depend on town clerk recording. A birth entry would directly name William's father. Note per loc_001 quirk: the Topsham pre-1857 town records (imageGroup 005464260) are full-text searchable but NOT name-indexed \u2014 this item covers the indexed statewide compilations; the full-text browse of Topsham's own volume is a separate item.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_004",
+          "sequence": 4,
+          "record_type": "vital_record",
+          "jurisdiction": "Vermont",
+          "date_range": "1790-1820",
+          "repository": "FamilySearch",
+          "rationale": "Dedicated search for the marriage of Sarah Sally Andrews to a Bagley \u2014 the parents' marriage record. Per the record-type guide, a parentage plan requires a separate item for the parents' marriage: it (a) establishes the couple as a unit, (b) supplies the mother's maiden name (confirming it IS Sarah Andrews), and (c) by its date relative to William's ca.-1815 birth corroborates any father name found only in a census or derivative source. Sarah (born 1777) would have married between roughly 1795-1815. Search Vermont Marriages 1791-1974 (collection 1675550, index only) and Vermont Vital Records 1760-1954 (collection 1784223, indexed + images) for marriages in Topsham or Orange County under 'Andrews' or 'Bagley'. Also search Vermont Town Clerk Vital and Town Records 1732-2005 (collection 1987653).",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_005",
+          "sequence": 5,
+          "record_type": "vital_record",
+          "jurisdiction": "Topsham, Orange County, Vermont",
+          "date_range": "1771-1860",
+          "repository": "FamilySearch",
+          "rationale": "Full-text search of the Topsham Town Records 1771-1860 (imageGroup 005464260, 265 images). Per loc_001, this volume is full-text searchable but 0% name-indexed \u2014 it cannot be reached by record_search. Route to the search-full-text skill using 'Bagley' as the search term across this imageGroup. Pre-1857 births, marriages, and deaths recorded by the Topsham town clerk are the most likely place to find William's birth entry (naming his father) or his parents' marriage. This is the only mechanism to search this volume.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_006",
+          "sequence": 6,
+          "record_type": "probate",
+          "jurisdiction": "Orange County, Vermont",
+          "date_range": "1800-1860",
+          "repository": "FamilySearch",
+          "rationale": "Search Vermont Probate Files 1800-1921 (collection 1435692, 10,225 records indexed + 204K images) for a Bagley estate in Orange County. If William's father died after 1800, an estate or will naming William as a son would be direct parentage evidence. Also search Vermont, Wills and Deeds, ca. 1700s-2017 (collection 3158875). Per loc_001, Topsham's probate district is Orange County. This indexed collection is the most accessible entry point before browsing the unindexed district files.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_007",
+          "sequence": 7,
+          "record_type": "probate",
+          "jurisdiction": "Orange County, Vermont \u2014 Bradford District",
+          "date_range": "1780-1860",
+          "repository": "FamilySearch",
+          "rationale": "Browse-only fallback for pli_006. Vermont Orange County, Bradford District Estate Files 1780-1915 (collection 1807377, 75,694 images) are digitized but 0% name-indexed and not full-text searchable \u2014 must be browsed image-by-image. Per loc_001, Topsham is in Orange County; the Bradford District estate files are a primary repository for Orange County probate. If the indexed Vermont Probate Files search (pli_006) yields nothing, browse this collection for Bagley-surname files.",
+          "fallback_for": "pli_006",
+          "status": "skipped"
+        },
+        {
+          "id": "pli_008",
+          "sequence": 8,
+          "record_type": "census",
+          "jurisdiction": "Topsham, Orange County, Vermont",
+          "date_range": "1840",
+          "repository": "FamilySearch",
+          "rationale": "In 1840 William would be approximately 25 \u2014 possibly still in his father's household, or the father may now be an older man living with a married son. If William's father was still living in 1840, he would head his own household. The 1840 census names only the head of household; look for an older Bagley male (50s\u201360s) in Topsham with household members in the right age ranges. Also look for William's own nascent household. Lower priority than 1820/1830 since William was more likely to have left home by 1840.",
+          "fallback_for": null,
+          "status": "completed"
+        },
+        {
+          "id": "pli_009",
+          "sequence": 9,
+          "record_type": "other",
+          "jurisdiction": "Topsham, Orange County, Vermont",
+          "date_range": "1929",
+          "repository": "Ancestry",
+          "rationale": "Per loc_001, 'Sketches of the Town of Topsham, Orange County, Vermont' (1929) by Frank H. Craig is available on Ancestry.com (collection 22236). Local town histories of this era routinely include biographical family sketches naming parents, children, and grandchildren. Search for 'Bagley' to identify any compiled genealogical notes naming William's father. Treat any finding as a derivative source requiring corroboration from original records.",
+          "fallback_for": null,
+          "status": "skipped"
+        },
+        {
+          "id": "pli_010",
+          "sequence": 10,
+          "record_type": "land",
+          "jurisdiction": "Topsham, Orange County, Vermont",
+          "date_range": "1800-1850",
+          "repository": "FamilySearch",
+          "rationale": "FAN/contextual item. Vermont Land Records, Early to 1900 (collection 1409123, 169K images) and Topsham land record volumes (full-text searchable, per loc_001) may contain deeds where a Bagley grantee/grantor is identified with relationship terms ('my son William,' 'heirs,' etc.) or where William appears as a witness alongside a Bagley male who could be his father. Also search for Andrews-family land transactions that reference a Bagley son-in-law \u2014 these could establish the father's first name even when vital records are silent. Route the full-text volumes through search-full-text skill.",
+          "fallback_for": null,
+          "status": "skipped"
+        }
+      ]
+    }
+  ],
+  "log": [
+    {
+      "id": "log_001",
+      "plan_item_id": "pli_001",
+      "performed": "2026-07-27T19:13:02.246Z",
+      "tool": "record_search",
+      "query": {
+        "collection": "United States, Census, 1820",
+        "surname": "Bagley",
+        "residencePlace": "Topsham, Vermont",
+        "residenceYear": 1820,
+        "recordType": "census",
+        "count": 50
+      },
+      "outcome": "positive",
+      "results_examined": 4,
+      "external_site": null,
+      "results_ref": "results/log_001.json",
+      "results_available": 14,
+      "notes": "Found 4 Bagley households in Topsham 1820: Christopher (ark:/61903/1:1:XHLG-TXG), Aaron (ark:/61903/1:1:XHLG-TNL), David (ark:/61903/1:1:XHLG-T8R, attached-to-other), John (ark:/61903/1:1:XHLG-TNY). Index stubs only name the head of household \u2014 household tally marks (which would show a boy under 10 = William ~5) require image examination. All four are candidates; need image read to determine which has a male child under 10 and a female aged 40-45 (Sarah Andrews born 1777)."
+    },
+    {
+      "id": "log_002",
+      "plan_item_id": "pli_002",
+      "performed": "2026-07-27T19:17:28.090Z",
+      "tool": "record_search",
+      "query": {
+        "collection": "United States, Census, 1830",
+        "surname": "Bagley",
+        "residencePlace": "Topsham, Vermont",
+        "residenceYear": 1830,
+        "recordType": "census",
+        "count": 50
+      },
+      "outcome": "positive",
+      "results_examined": 9,
+      "external_site": null,
+      "results_ref": "results/log_002.json",
+      "results_available": 9,
+      "notes": "Found 9 Bagley households in Topsham 1830: Aaron (XHLG-T37), Nathan (XHLG-T3Y), Dhan (XHLG-T9F), John (XHLG-T8W), John A (XHLG-TNG), Reber (XHLG-TN3), David (XHLG-T9Q, attached-to-other), John (XHLG-TN9), Philip (XHLG-TNT). David Bagley again appears \u2014 consistent with the 1820 David Bagley household in Topsham. Census stubs name only heads of household; household tally marks require image examination to confirm a male 15-19 (William ~15) and female 50-59 (Sarah Andrews born 1777). David Bagley's presence in both 1820 and 1830 Topsham census is consistent with him being William's father. Two key death records for William A. Bagley found in Vermont Town Clerk records (pli_003) independently name David Bagley as father \u2014 this corroborates the census pattern."
+    },
+    {
+      "id": "log_003",
+      "plan_item_id": "pli_003",
+      "performed": "2026-07-27T19:17:28.093Z",
+      "tool": "record_search",
+      "query": {
+        "collection": "Vermont Births and Christenings, 1765-1908",
+        "collectionId": "1675544",
+        "surname": "Bagley",
+        "givenName": "William",
+        "birthPlace": "Vermont",
+        "birthYearFrom": 1810,
+        "birthYearTo": 1820,
+        "count": 50
+      },
+      "outcome": "negative",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 1,
+      "notes": "Only result: Sally W. Bagley, female, born Corinth, Vermont \u2014 not the subject William A. Bagley (male, born ~1815 Topsham). No birth record for William A. Bagley in this indexed statewide compilation. Pre-1857 Vermont vital registration was not required by the state; births depended on town-clerk recording. The absence here is expected and does not rule out a record in the Topsham town clerk volume (pli_005, full-text searchable imageGroup 005464260)."
+    },
+    {
+      "id": "log_004",
+      "plan_item_id": "pli_003",
+      "performed": "2026-07-27T19:17:28.093Z",
+      "tool": "record_search",
+      "query": {
+        "collection": "Vermont, Town Clerk, Vital and Town Records, 1732-2005",
+        "collectionId": "1987653",
+        "surname": "Bagley",
+        "givenName": "William",
+        "birthYearFrom": 1810,
+        "birthYearTo": 1820,
+        "count": 50
+      },
+      "outcome": "positive",
+      "results_examined": 51,
+      "external_site": null,
+      "results_ref": "results/log_004.json",
+      "results_available": 51,
+      "notes": "Found 51 results. Top two are direct matches for the research subject: (1) ark:/61903/1:1:QPQP-R8T8 \u2014 William A Bagley, death 31 May 1884, father=David Bagley (ark:/61903/1:1:QPQP-R8TJ), mother=Sarah A Bagley (ark:/61903/1:1:QPQP-7JPV); (2) ark:/61903/1:1:QPQP-24HR \u2014 William A Bagley, death 31 May 1884, Topsham Orange Vermont, father=David Bagley (ark:/61903/1:1:QPQP-24HB), mother=Sarah A Bagley (ark:/61903/1:1:QPQP-24C4). Both records independently name DAVID BAGLEY as William A. Bagley's father and Sarah A. Bagley (n\u00e9e Andrews) as his mother. These are two indexings of the same original entry in the Vermont town clerk vital records. This is strong evidence identifying William's father. Note per the locality guide: Vermont death records before 1919 did not require parental information \u2014 these records likely post-date that requirement or the informant supplied the data voluntarily; in any case, both records agree. Records read via record_read; images viewed at ark:/61903/3:1:3QS7-L99D-H995 and ark:/61903/3:1:3QS7-8999-LD1S."
+    },
+    {
+      "id": "log_005",
+      "plan_item_id": "pli_004",
+      "performed": "2026-07-27T19:32:07.015Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Andrews",
+        "spouseSurname": "Bagley",
+        "residencePlace": "Vermont",
+        "marriageYearFrom": 1795,
+        "marriageYearTo": 1820,
+        "recordType": "marriage",
+        "count": 50
+      },
+      "outcome": "negative",
+      "results_examined": 50,
+      "external_site": null,
+      "results_ref": "results/log_005.json",
+      "results_available": 160,
+      "notes": "No Sarah Andrews + Bagley marriage found in top 50 of 160 results. All results are male Andrews relatives of brides in later marriages, not the target Sarah Andrews marrying a Bagley. Indexed Vermont vital records and town clerk records do not appear to contain an indexed entry for this pre-1857 marriage. Pre-1857 Vermont marriages depended on town-clerk recording; the Topsham town records (pli_005, imageGroup 005464260) are the most likely repository but require full-text search."
+    },
+    {
+      "id": "log_006",
+      "plan_item_id": "pli_004",
+      "performed": "2026-07-27T19:32:07.021Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Bagley",
+        "givenName": "David",
+        "spouseGivenName": "Sarah",
+        "residencePlace": "Vermont",
+        "marriageYearFrom": 1795,
+        "marriageYearTo": 1820,
+        "recordType": "marriage",
+        "count": 50
+      },
+      "outcome": "negative",
+      "results_examined": 10,
+      "external_site": null,
+      "results_ref": "results/log_006.json",
+      "results_available": 10,
+      "notes": "10 results. Top results include 'David Bagley and Voda Page' (multiple indexings of the same record in Vermont collections) and 'Otis B. Rollins and Flora E. Bagley' (different Bagley). No David Bagley + Sarah Andrews marriage found. The 'David Bagley and Voda Page' record may be a second marriage after Sarah's death in 1847; its date needs checking. The pre-1815 marriage of David Bagley to Sarah Andrews is not found in indexed Vermont marriage compilations \u2014 consistent with the pre-1857 recording gap."
+    },
+    {
+      "id": "log_007",
+      "plan_item_id": "pli_006",
+      "performed": "2026-07-27T19:32:07.023Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Bagley",
+        "residencePlace": "Orange County, Vermont",
+        "recordType": "probate",
+        "count": 50
+      },
+      "outcome": "negative",
+      "results_examined": 1,
+      "external_site": null,
+      "results_ref": "results/log_007.json",
+      "results_available": 1,
+      "notes": "1 result: Sidney Albert Bagley, probate in Transvaal, South Africa, 1930 \u2014 born Braintree, Orange, Vermont 1896, but completely unrelated to David Bagley circa 1820-1860. No Orange County Vermont probate for any Bagley of the right era found in this indexed search."
+    },
+    {
+      "id": "log_008",
+      "plan_item_id": "pli_006",
+      "performed": "2026-07-27T19:32:07.024Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Bagley",
+        "givenName": "David",
+        "residencePlace": "Vermont",
+        "recordType": "probate",
+        "anyYearFrom": 1820,
+        "anyYearTo": 1870,
+        "count": 50
+      },
+      "outcome": "negative",
+      "results_examined": 0,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 0,
+      "notes": "Zero results. No indexed probate record for David Bagley in Vermont 1820-1870 found in FamilySearch. The indexed Vermont probate collection (1435692) does not contain a David Bagley record. The unindexed Bradford District estate files (pli_007, collection 1807377) would need to be browsed image-by-image and are beyond the current tool capabilities. Marking pli_006 completed; pli_007 (browse fallback) to be skipped with this finding noted."
+    },
+    {
+      "id": "log_009",
+      "plan_item_id": "pli_008",
+      "performed": "2026-07-27T19:32:07.024Z",
+      "tool": "record_search",
+      "query": {
+        "surname": "Bagley",
+        "givenName": "David",
+        "residencePlace": "Topsham, Vermont",
+        "residenceYearFrom": 1840,
+        "residenceYearTo": 1840,
+        "recordType": "census",
+        "count": 50
+      },
+      "outcome": "positive",
+      "results_examined": 2,
+      "external_site": null,
+      "results_ref": "results/log_009.json",
+      "results_available": 2,
+      "notes": "Found 2 results \u2014 both are 'Household of David Bagley, United States, Census, 1840, Topsham, Orange, Vermont' (two indexings of the same entry: XHRB-V42 and XHRB-V4V). Confidence 4, score 5.44. David Bagley was still in Topsham in 1840 when William would be approximately 25. Match ranking against I1 (David Bagley stub) returned scores of 0.15 due to thinness of stub (no birth/death dates), but both records are clearly David Bagley in Topsham, consistent with the father named in the 1884 death records. XHRB-V42 is attachedToOther (already linked in FamilySearch's tree to LVDV-DBC, corroborating the identity match). Will read XHRB-V42 to check household composition."
+    },
+    {
+      "id": "log_010",
+      "plan_item_id": "pli_005",
+      "performed": "2026-07-27T19:44:16.990Z",
+      "tool": "fulltext_search",
+      "query": {
+        "imageGroupNumber": "005464260",
+        "searchTerms": "Bagley",
+        "offset": 0,
+        "count": 50
+      },
+      "outcome": "partial",
+      "results_examined": 50,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 110,
+      "notes": "Full-text search of Topsham Town Records 1771-1860 (imageGroup 005464260), 50 results at offset 0. Key findings: (1) 1813 town record (ark:/61903/3:1:3QS7-L999-L4VT) contains 'David Bagleys', 'David Bagley', 'Aaron Andrews', 'John Andrews' on same image; (2) A 1813 town record contains 'Sophia Andrews Bagley' \u2014 a Bagley child bearing the Andrews maiden surname as middle name, strong circumstantial evidence that Sarah Andrews married David Bagley; (3) David Bagley appears as Topsham selectman from 1806 through at least 1839, consistent with long-term Topsham residence; (4) 'David Bagley Jr.' appears in 1839 record \u2014 two David Bagleys existed in Topsham simultaneously; (5) 'Wm A Bagley' and 'David Bayley Jr' appear on same 1853 page, possibly as brothers (sons of David Sr.); (6) No direct birth record for William Bagley or marriage record for David Bagley + Sarah Andrews found in this offset. 110 total results available; 60 remaining at offset 50."
+    },
+    {
+      "id": "log_011",
+      "plan_item_id": "pli_005",
+      "performed": "2026-07-27T19:44:16.990Z",
+      "tool": "fulltext_search",
+      "query": {
+        "imageGroupNumber": "005464260",
+        "searchTerms": "Bagley",
+        "offset": 50,
+        "count": 60
+      },
+      "outcome": "partial",
+      "results_examined": 53,
+      "external_site": null,
+      "results_ref": null,
+      "results_available": 110,
+      "notes": "Full-text search of Topsham Town Records 1771-1860 (imageGroup 005464260), results at offset 50 (items 51-110). Key findings: (1) 1848 town record (ark:/61903/3:1:3QS7-L999-L4DW) contains 'Sophia A. Bagley' \u2014 a woman named Sophia with initial A (consistent with Andrews middle name), corroborating the Sophia Andrews Bagley child of David and Sarah; (2) David Bagley explicitly identified as Selectman in 1848 (ark:/61903/3:1:3QSQ-G999-L4RH); (3) 1822 record (ark:/61903/3:1:3QS7-8999-L46Y) contains 'Aaron Bagley' + 'John Andrews', 'Hannah Andrews', 'Sophia Andrews' on same image; (4) David Bagley appears in town records continuously 1806-1855; (5) Aaron Bagley, Moses Bagley, Ephraim Bagley, John Bagley also appear \u2014 multiple Bagley family members in Topsham; (6) No direct birth or marriage record for David Bagley + Sarah Andrews found in remaining results. Full-text search of 110-record result set now complete (all results examined)."
+    }
+  ],
+  "sources": [
+    {
+      "id": "src_001",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QPQP-R8T8 : accessed 27 July 2026), Entry for William A Bagley and David Bagley, 31 May 1884.",
+      "citation_detail": {
+        "who": "William A. Bagley (deceased); David Bagley (father); Sarah A. Bagley (mother)",
+        "what": "Death registration entry, Vermont Town Clerk vital record",
+        "when_created": "31 May 1884",
+        "when_accessed": "27 July 2026",
+        "where": "Vermont, Town Clerk, Vital and Town Records, 1732-2005; FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QPQP-R8T8)",
+        "where_within": "Entry for William A Bagley and David Bagley, 31 May 1884"
+      },
+      "source_classification": "original",
+      "repository": "FamilySearch",
+      "access_date": "2026-07-27",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:QPQP-R8T8",
+      "log_entry_id": "log_004",
+      "gedcomx_source_description_id": "S1"
+    },
+    {
+      "id": "src_002",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QPQP-24HR : accessed 2026-07-27), Entry for William A Bagley and David Bagley, 31 May 1884.",
+      "citation_detail": {
+        "who": "William A. Bagley (deceased), David Bagley (father), Sarah A. Bagley (mother)",
+        "what": "Vermont Town Clerk vital record \u2014 death entry for William A. Bagley, 31 May 1884, with parental names indexed",
+        "when_created": "1884",
+        "when_accessed": "2026-07-27",
+        "where": "FamilySearch, Vermont, Town Clerk, Vital and Town Records, 1732-2005 (collection 1987653)",
+        "where_within": "Entry for William A Bagley and David Bagley, 31 May 1884"
+      },
+      "source_classification": "original",
+      "repository": "FamilySearch",
+      "access_date": "2026-07-27",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:QPQP-24HR",
+      "notes": "Second indexing of the same original document as ark:/61903/1:1:QPQP-R8T8. This indexing captures the death place (Topsham, Orange, Vermont) and indexes both William A. Bagley and David Bagley as related persons. Vermont death records of this era (pre-1919) did not require parental information on the death certificate; parental names here are likely reported by a community or family informant with secondhand knowledge.",
+      "log_entry_id": "log_004",
+      "gedcomx_source_description_id": "S2"
+    },
+    {
+      "id": "src_003",
+      "citation": "\"United States, Census, 1820,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:XHLG-T8R : accessed 2026-07-27), entry for David Bagley, Topsham, Orange, Vermont.",
+      "citation_detail": {
+        "who": "David Bagley, head of household",
+        "what": "1820 United States Federal Census schedule, Topsham, Orange County, Vermont",
+        "when_created": "1820",
+        "when_accessed": "2026-07-27",
+        "where": "FamilySearch (https://www.familysearch.org)",
+        "where_within": "Topsham, Orange, Vermont; ark:/61903/1:1:XHLG-T8R"
+      },
+      "source_classification": "original",
+      "repository": "FamilySearch",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:XHLG-T8R",
+      "access_date": "2026-07-27",
+      "log_entry_id": "log_001",
+      "notes": "Pre-1850 census; only the head of household is named. All other household members appear as tally marks in age/sex columns. The image is a digital scan of the original government schedule.",
+      "gedcomx_source_description_id": "S3"
+    },
+    {
+      "id": "src_004",
+      "citation": "\"United States, Census, 1840,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:XHRB-V42 : accessed 2026-07-27), entry for David Bagley, Topsham, Orange, Vermont, 1840.",
+      "citation_detail": {
+        "who": "David Bagley",
+        "what": "1840 United States Federal Census, household schedule",
+        "when_created": "1840",
+        "when_accessed": "2026-07-27",
+        "where": "FamilySearch (https://www.familysearch.org)",
+        "where_within": "Topsham, Orange County, Vermont; ark:/61903/1:1:XHRB-V42"
+      },
+      "source_classification": "original",
+      "repository": "FamilySearch",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:XHRB-V42",
+      "access_date": "2026-07-27",
+      "log_entry_id": "log_009",
+      "notes": "Pre-1850 U.S. census; only the head of household is named. All other household members appear as tally marks by age/sex category only \u2014 no names or individual details are recorded for non-heads. The digital image on FamilySearch was examined via the index entry; the underlying microfilm image at ark:/61903/3:1:33SQ-GYYY-24 is the original schedule.",
+      "gedcomx_source_description_id": "S4"
+    }
+  ],
+  "assertions": [
+    {
+      "id": "a_001",
+      "record_id": "ark:/61903/1:1:QPQP-R8T8",
+      "record_persona_id": "p_104363515691",
+      "record_role": "deceased",
+      "fact_type": "name",
+      "value": "William A. Bagley",
+      "structured_value": {
+        "given": "William A",
+        "surname": "Bagley"
+      },
+      "information_quality": "primary",
+      "informant": "unknown household member or family informant",
+      "informant_proximity": "unknown",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004",
+      "source_id": "src_001"
+    },
+    {
+      "id": "a_002",
+      "record_id": "ark:/61903/1:1:QPQP-R8T8",
+      "record_persona_id": "p_104363515691",
+      "record_role": "deceased",
+      "fact_type": "sex",
+      "value": "Male",
+      "information_quality": "primary",
+      "informant": "unknown household member or family informant",
+      "informant_proximity": "unknown",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_004",
+      "source_id": "src_001"
+    },
+    {
+      "id": "a_003",
+      "record_id": "ark:/61903/1:1:QPQP-R8T8",
+      "record_persona_id": "p_104363515691",
+      "record_role": "deceased",
+      "fact_type": "death",
+      "value": "died 31 May 1884 in Vermont",
+      "date": "31 May 1884",
+      "date_certainty": "exact",
+      "place": "Vermont, United States",
+      "information_quality": "primary",
+      "informant": "unknown household member or family informant",
+      "informant_proximity": "unknown",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004",
+      "source_id": "src_001",
+      "standard_place": "Vermont, United States"
+    },
+    {
+      "id": "a_004",
+      "record_id": "ark:/61903/1:1:QPQP-R8T8",
+      "record_persona_id": "p_104363515691",
+      "record_role": "deceased",
+      "fact_type": "birth",
+      "value": "born 1815 (year stated in record)",
+      "date": "1815",
+      "date_certainty": "approximate",
+      "information_quality": "secondary",
+      "informant": "unknown household member or family informant",
+      "informant_proximity": "unknown",
+      "evidence_type": "indirect",
+      "informant_bias_notes": "The informant for a death registration was not present at William's birth in 1815; birth year is secondhand/recollected knowledge. Date certainty is approximate as only the year is given.",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004",
+      "source_id": "src_001"
+    },
+    {
+      "id": "a_005",
+      "record_id": "ark:/61903/1:1:QPQP-R8T8",
+      "record_persona_id": "p_104363515691",
+      "record_role": "deceased",
+      "fact_type": "relationship",
+      "value": "child of David Bagley",
+      "structured_value": {
+        "relationship_type": "child",
+        "related_person_role": "father_of_deceased"
+      },
+      "information_quality": "secondary",
+      "informant": "unknown household member or family informant",
+      "informant_proximity": "unknown",
+      "evidence_type": "direct",
+      "informant_bias_notes": "The record explicitly states a ParentChild relationship between William A. Bagley and David Bagley. The informant relayed this parentage information secondhand \u2014 they were not present at William's birth in 1815. However, the record directly states this relationship, making it direct evidence for q_001 (who was William's father).",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004",
+      "source_id": "src_001"
+    },
+    {
+      "id": "a_006",
+      "record_id": "ark:/61903/1:1:QPQP-R8T8",
+      "record_persona_id": "p_104363515691",
+      "record_role": "deceased",
+      "fact_type": "relationship",
+      "value": "child of Sarah A. Bagley",
+      "structured_value": {
+        "relationship_type": "child",
+        "related_person_role": "mother_of_deceased"
+      },
+      "information_quality": "secondary",
+      "informant": "unknown household member or family informant",
+      "informant_proximity": "unknown",
+      "evidence_type": "direct",
+      "informant_bias_notes": "The record explicitly states a ParentChild relationship between William A. Bagley and Sarah A. Bagley. The informant relayed this parentage information secondhand. Sarah A. Bagley in this record appears under the surname Bagley (married name); she may correspond to Sarah Sally Andrews (LVDV-6MK) in the project tree.",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004",
+      "source_id": "src_001"
+    },
+    {
+      "id": "a_007",
+      "record_id": "ark:/61903/1:1:QPQP-R8T8",
+      "record_persona_id": "p_104363515697",
+      "record_role": "father_of_deceased",
+      "fact_type": "name",
+      "value": "David Bagley",
+      "structured_value": {
+        "given": "David",
+        "surname": "Bagley"
+      },
+      "information_quality": "secondary",
+      "informant": "unknown household member or family informant",
+      "informant_proximity": "unknown",
+      "evidence_type": "indirect",
+      "informant_bias_notes": "David Bagley is named as the deceased's father by a third-party informant relaying secondhand biographical information about the parent. The name is stated in the record but the informant-knowledge test yields indirect evidence \u2014 the informant is relaying another person's identity.",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004",
+      "source_id": "src_001"
+    },
+    {
+      "id": "a_008",
+      "record_id": "ark:/61903/1:1:QPQP-R8T8",
+      "record_persona_id": "p_104363515697",
+      "record_role": "father_of_deceased",
+      "fact_type": "sex",
+      "value": "Male",
+      "information_quality": "secondary",
+      "informant": "unknown household member or family informant",
+      "informant_proximity": "unknown",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_004",
+      "source_id": "src_001"
+    },
+    {
+      "id": "a_009",
+      "record_id": "ark:/61903/1:1:QPQP-R8T8",
+      "record_persona_id": "p_104362981008",
+      "record_role": "mother_of_deceased",
+      "fact_type": "name",
+      "value": "Sarah A. Bagley",
+      "structured_value": {
+        "given": "Sarah A",
+        "surname": "Bagley"
+      },
+      "information_quality": "secondary",
+      "informant": "unknown household member or family informant",
+      "informant_proximity": "unknown",
+      "evidence_type": "indirect",
+      "informant_bias_notes": "Sarah A. Bagley is named as the deceased's mother by a third-party informant relaying secondhand biographical information. The name is stated in the record but the informant-knowledge test yields indirect \u2014 relaying another person's identity. The surname 'Bagley' here is her married name; the project tree already has Sarah Sally Andrews (LVDV-6MK) as William's mother under her birth surname Andrews.",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004",
+      "source_id": "src_001"
+    },
+    {
+      "id": "a_010",
+      "record_id": "ark:/61903/1:1:QPQP-R8T8",
+      "record_persona_id": "p_104362981008",
+      "record_role": "mother_of_deceased",
+      "fact_type": "sex",
+      "value": "Female",
+      "information_quality": "secondary",
+      "informant": "unknown household member or family informant",
+      "informant_proximity": "unknown",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_004",
+      "source_id": "src_001"
+    },
+    {
+      "id": "a_011",
+      "record_id": "ark:/61903/1:1:QPQP-24HR",
+      "record_persona_id": "p_104363376565",
+      "record_role": "deceased",
+      "fact_type": "name",
+      "value": "William A. Bagley",
+      "structured_value": {
+        "given": "William A",
+        "surname": "Bagley"
+      },
+      "information_quality": "indeterminate",
+      "informant": "unknown",
+      "informant_proximity": "unknown",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_012",
+      "record_id": "ark:/61903/1:1:QPQP-24HR",
+      "record_persona_id": "p_104363376565",
+      "record_role": "deceased",
+      "fact_type": "sex",
+      "value": "Male",
+      "information_quality": "indeterminate",
+      "informant": "unknown",
+      "informant_proximity": "unknown",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_004",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_013",
+      "record_id": "ark:/61903/1:1:QPQP-24HR",
+      "record_persona_id": "p_104363376565",
+      "record_role": "deceased",
+      "fact_type": "death",
+      "value": "31 May 1884",
+      "date": "31 May 1884",
+      "place": "Topsham, Orange, Vermont, United States",
+      "standard_place": "Topsham, Orange, Vermont, United States",
+      "information_quality": "primary",
+      "informant": "local registrar",
+      "informant_proximity": "official_duty",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_014",
+      "record_id": "ark:/61903/1:1:QPQP-24HR",
+      "record_persona_id": "p_104363376565",
+      "record_role": "deceased",
+      "fact_type": "birth",
+      "value": "about 1815",
+      "date": "1815",
+      "date_certainty": "approximate",
+      "information_quality": "indeterminate",
+      "informant": "unknown",
+      "informant_proximity": "unknown",
+      "evidence_type": "indirect",
+      "informant_bias_notes": "Birth year reported on a death record by an unknown informant; the informant was not present at William's birth. Classification is indirect because the figure requires accepting the informant's secondhand knowledge of the birth year.",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_004",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_015",
+      "record_id": "ark:/61903/1:1:QPQP-24HR",
+      "record_persona_id": "p_104363376565",
+      "record_role": "deceased",
+      "fact_type": "relationship",
+      "value": "child of David Bagley",
+      "structured_value": {
+        "relationship_type": "child",
+        "related_person_role": "father"
+      },
+      "information_quality": "secondary",
+      "informant": "unknown family or community informant",
+      "informant_proximity": "family_not_present",
+      "evidence_type": "direct",
+      "informant_bias_notes": "The record explicitly indexes David Bagley as the father of William A. Bagley via a ParentChild relationship. The informant (unknown \u2014 likely a family member or neighbor who reported the death) was not present at William's birth, making this secondary information. However, the fact is directly stated in the record, so evidence type is direct. This assertion directly answers q_001.",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_016",
+      "record_id": "ark:/61903/1:1:QPQP-24HR",
+      "record_persona_id": "p_104363376565",
+      "record_role": "deceased",
+      "fact_type": "relationship",
+      "value": "child of Sarah A. Bagley",
+      "structured_value": {
+        "relationship_type": "child",
+        "related_person_role": "mother"
+      },
+      "information_quality": "secondary",
+      "informant": "unknown family or community informant",
+      "informant_proximity": "family_not_present",
+      "evidence_type": "direct",
+      "informant_bias_notes": "The record explicitly indexes Sarah A. Bagley as the mother of William A. Bagley via a ParentChild relationship. Secondary information because the informant was not present at William's birth. Note: Sarah Sally Andrews (LVDV-6MK) is already in the tree as William's mother \u2014 this assertion corroborates that link.",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_004",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_017",
+      "record_id": "ark:/61903/1:1:QPQP-24HR",
+      "record_persona_id": "p_104363376568",
+      "record_role": "father_of_deceased",
+      "fact_type": "name",
+      "value": "David Bagley",
+      "structured_value": {
+        "given": "David",
+        "surname": "Bagley"
+      },
+      "information_quality": "secondary",
+      "informant": "unknown family or community informant",
+      "informant_proximity": "family_not_present",
+      "evidence_type": "indirect",
+      "informant_bias_notes": "David Bagley's name is reported by the death record's informant (unknown \u2014 family or community member) who was relaying information about a third party. The informant was not present at David's naming and may have had imperfect knowledge. Classified indirect because the informant is relaying a third party's identifying information.",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_004",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_018",
+      "record_id": "ark:/61903/1:1:QPQP-24HR",
+      "record_persona_id": "p_104363376568",
+      "record_role": "father_of_deceased",
+      "fact_type": "sex",
+      "value": "Male",
+      "information_quality": "secondary",
+      "informant": "unknown family or community informant",
+      "informant_proximity": "family_not_present",
+      "evidence_type": "direct",
+      "informant_bias_notes": "Sex stated in the record (male given name, male role as father). Secondary because reported by a third-party informant about someone not the informant themselves.",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_004",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_019",
+      "record_id": "ark:/61903/1:1:QPQP-24HR",
+      "record_persona_id": "p_104363376577",
+      "record_role": "mother_of_deceased",
+      "fact_type": "name",
+      "value": "Sarah A. Bagley",
+      "structured_value": {
+        "given": "Sarah A",
+        "surname": "Bagley"
+      },
+      "information_quality": "secondary",
+      "informant": "unknown family or community informant",
+      "informant_proximity": "family_not_present",
+      "evidence_type": "indirect",
+      "informant_bias_notes": "Sarah A. Bagley's name is reported by the death record's informant relaying information about a third party. Indirect because a third party's identity is being relayed secondhand. The tree already has Sarah Sally Andrews (LVDV-6MK) as William's mother \u2014 the surname 'Bagley' here is her married name, consistent with the tree.",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_004",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_020",
+      "record_id": "ark:/61903/1:1:QPQP-24HR",
+      "record_persona_id": "p_104363376577",
+      "record_role": "mother_of_deceased",
+      "fact_type": "sex",
+      "value": "Female",
+      "information_quality": "secondary",
+      "informant": "unknown family or community informant",
+      "informant_proximity": "family_not_present",
+      "evidence_type": "direct",
+      "informant_bias_notes": "Sex stated by role (mother) and female given name. Secondary because reported by a third-party informant.",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_004",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_021",
+      "record_id": "ark:/61903/1:1:QPQP-24HR",
+      "record_persona_id": "p_104363376568",
+      "record_role": "father_of_deceased",
+      "fact_type": "relationship",
+      "value": "spouse of Sarah A. Bagley (inferred)",
+      "structured_value": {
+        "relationship_type": "spouse_inferred",
+        "related_person_role": "wife"
+      },
+      "information_quality": "secondary",
+      "informant": "the researcher",
+      "informant_proximity": "researcher",
+      "evidence_type": "indirect",
+      "informant_bias_notes": "The record indexes a Couple relationship between David Bagley and Sarah A. Bagley, but the spousal relationship is an indexer inference from their joint ParentChild links to William \u2014 the death record itself does not state they were married. Classified as researcher-inferred from record structure.",
+      "extracted_for_question_ids": [],
+      "log_entry_id": "log_004",
+      "source_id": "src_002"
+    },
+    {
+      "id": "a_022",
+      "record_id": "ark:/61903/1:1:XHLG-T8R",
+      "record_persona_id": "p_10418027755",
+      "record_role": "head_of_household",
+      "fact_type": "name",
+      "value": "David Bagley",
+      "structured_value": {
+        "given": "David",
+        "surname": "Bagley"
+      },
+      "information_quality": "primary",
+      "informant": "David Bagley (household head, likely self-reported to enumerator)",
+      "informant_proximity": "household_member",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_001",
+      "source_id": "src_003"
+    },
+    {
+      "id": "a_023",
+      "record_id": "ark:/61903/1:1:XHLG-T8R",
+      "record_persona_id": "p_10418027755",
+      "record_role": "head_of_household",
+      "fact_type": "sex",
+      "value": "Male",
+      "information_quality": "primary",
+      "informant": "David Bagley (household head, likely self-reported to enumerator)",
+      "informant_proximity": "household_member",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_001",
+      "source_id": "src_003"
+    },
+    {
+      "id": "a_024",
+      "record_id": "ark:/61903/1:1:XHLG-T8R",
+      "record_persona_id": "p_10418027755",
+      "record_role": "head_of_household",
+      "fact_type": "residence",
+      "value": "Topsham, Orange, Vermont, United States",
+      "structured_value": {
+        "place": "Topsham, Orange, Vermont, United States"
+      },
+      "date": "1820",
+      "date_certainty": "exact",
+      "place": "Topsham, Orange, Vermont, United States",
+      "standard_place": "Topsham, Orange, Vermont, United States",
+      "information_quality": "primary",
+      "informant": "census enumerator",
+      "informant_proximity": "witness",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "informant_bias_notes": "Enumerator personally visited the dwelling and recorded the household at this location. Residence is a direct fact \u2014 the enumerator attests the household was enumerated here.",
+      "log_entry_id": "log_001",
+      "source_id": "src_003"
+    },
+    {
+      "id": "a_025",
+      "record_id": "ark:/61903/1:1:XHLG-T8R",
+      "record_persona_id": "p_10418027755",
+      "record_role": "head_of_household",
+      "fact_type": "census",
+      "value": "David Bagley appears as head of household in the 1820 United States Federal Census, Topsham, Orange, Vermont. Pre-1850 census; other household members appear only as tally marks by age/sex bracket and are not named.",
+      "date": "1820",
+      "date_certainty": "exact",
+      "place": "Topsham, Orange, Vermont, United States",
+      "standard_place": "Topsham, Orange, Vermont, United States",
+      "information_quality": "indeterminate",
+      "informant": "unknown household member (likely David Bagley or another resident)",
+      "informant_proximity": "household_member",
+      "evidence_type": "indirect",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "informant_bias_notes": "This census entry is indirect evidence for q_001 (father of William A. Bagley). It establishes David Bagley was head of a household in Topsham in 1820, the same town and period where William (~age 5) would have lived with his father. The census does not name household members other than the head, so William's presence cannot be confirmed from this record alone. Two Vermont Town Clerk death records (src_001, src_002) independently name David Bagley as William's father.",
+      "log_entry_id": "log_001",
+      "source_id": "src_003"
+    },
+    {
+      "id": "a_026",
+      "record_id": "ark:/61903/1:1:XHRB-V42",
+      "record_role": "head_of_household",
+      "fact_type": "name",
+      "value": "David Bagley",
+      "structured_value": {
+        "given": "David",
+        "surname": "Bagley"
+      },
+      "information_quality": "primary",
+      "informant": "unknown household member (likely David Bagley himself)",
+      "informant_proximity": "household_member",
+      "evidence_type": "direct",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_009",
+      "source_id": "src_004",
+      "record_persona_id": "p_10421422430"
+    },
+    {
+      "id": "a_027",
+      "record_id": "ark:/61903/1:1:XHRB-V42",
+      "record_role": "head_of_household",
+      "fact_type": "residence",
+      "value": "Topsham, Orange, Vermont",
+      "place": "Topsham, Orange, Vermont, United States",
+      "date": "1840",
+      "date_certainty": "exact",
+      "information_quality": "primary",
+      "informant": "census enumerator",
+      "informant_proximity": "witness",
+      "evidence_type": "indirect",
+      "extracted_for_question_ids": [
+        "q_001"
+      ],
+      "log_entry_id": "log_009",
+      "informant_bias_notes": "David Bagley's presence in Topsham, Orange County, Vermont in 1840 is consistent with him being the father of William A. Bagley (born ~1815, Topsham). This corroborates the 1884 Vermont death record naming David Bagley as William's father, but does not directly state any parentage relationship. The 1840 census predates William A. Bagley's approximate birth by ~25 years; at this date William would have been approximately 25 years old and may or may not be enumerated in this household (only tally marks for non-heads).",
+      "source_id": "src_004",
+      "record_persona_id": "p_10421422430",
+      "standard_place": "Topsham, Orange, Vermont, United States"
+    }
+  ],
+  "person_evidence": [
+    {
+      "id": "pe_001",
+      "assertion_id": "a_001",
+      "person_id": "MJDL-Q8B",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "William A. Bagley (deceased) named in Vermont Town Clerk vital record, 31 May 1884. Name, death date, and death place in Topsham all match tree subject MJDL-Q8B exactly. This is the research subject found by searching for this specific individual; FamilySearch record-person match returned confidence 5 (accepted).",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_002",
+      "assertion_id": "a_002",
+      "person_id": "MJDL-Q8B",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Sex=Male consistent with MJDL-Q8B (William A. Bagley). Same record as a_001; same confident identification.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_003",
+      "assertion_id": "a_003",
+      "person_id": "MJDL-Q8B",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Death date 31 May 1884 and place Vermont match MJDL-Q8B's known death date exactly. This is the research subject; same confident identification as a_001.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_004",
+      "assertion_id": "a_004",
+      "person_id": "MJDL-Q8B",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Birth year ~1815 consistent with MJDL-Q8B (born Abt 1815). Same confident identification as a_001.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_005",
+      "assertion_id": "a_005",
+      "person_id": "MJDL-Q8B",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Relationship assertion 'child of David Bagley' on the deceased persona bears on William A. Bagley (MJDL-Q8B) as the child party. William is the research subject; this assertion directly links William to his father David Bagley. Confident match per a_001 identification.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_006",
+      "assertion_id": "a_005",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Relationship assertion 'child of David Bagley' on the deceased persona also bears on David Bagley as the parent party. David Bagley is a new tree stub (I1) created from this and related records. Named explicitly as William's father in two Vermont Town Clerk death record indexings (QPQP-R8T8, QPQP-24HR) of the same 1884 entry, and appears as head of household in Topsham in the 1820 census (XHLG-T8R), consistent with being William's father when William was ~5. Probable \u2014 new stub person, no prior independent corroboration; FamilySearch matches this persona to LVDV-DBC at confidence 5 in the FS tree.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_007",
+      "assertion_id": "a_006",
+      "person_id": "MJDL-Q8B",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Relationship assertion 'child of Sarah A. Bagley' bears on William A. Bagley (MJDL-Q8B) as the child party. William is the research subject. Same confident identification as a_001.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_008",
+      "assertion_id": "a_006",
+      "person_id": "LVDV-6MK",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Relationship assertion 'child of Sarah A. Bagley' also bears on Sarah as the mother party. Tree person LVDV-6MK is Sarah Sally Andrews, already linked to MJDL-Q8B as his mother (R4 relationship). Record names 'Sarah A. Bagley' \u2014 surname Bagley is her married name; 'A' likely the initial of her maiden surname Andrews. FamilySearch record-person match returned confidence 4 (accepted) for this persona \u2192 LVDV-6MK. Name and relationship position agree with the tree. Probable \u2014 middle initial interpretation is reasonable but not independently confirmed.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_009",
+      "assertion_id": "a_007",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "David Bagley (father_of_deceased) in Vermont Town Clerk record QPQP-R8T8 is linked to tree person I1 (David Bagley stub). This persona is the father named in the death registration of William A. Bagley (31 May 1884). Same person as the father_of_deceased persona in QPQP-24HR (two indexings of the same source entry) and the head_of_household in 1820 Topsham census XHLG-T8R. Probable \u2014 new stub from a single original source (two indexings); 1820 census independently corroborates Topsham residence.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_010",
+      "assertion_id": "a_008",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Sex=Male for David Bagley (father_of_deceased, QPQP-R8T8) consistent with tree person I1 (male). Same identification as a_007.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_011",
+      "assertion_id": "a_009",
+      "person_id": "LVDV-6MK",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Sarah A. Bagley (mother_of_deceased, QPQP-R8T8) linked to LVDV-6MK (Sarah Sally Andrews). Name 'Sarah A. Bagley': first name Sarah matches; 'A' likely = Andrews (maiden name initial); surname Bagley is her married name. LVDV-6MK already in tree as William's mother (R4). FamilySearch record-person match confidence 4 (accepted) for persona p_104362981008 \u2192 LVDV-6MK. Probable \u2014 middle initial as maiden surname initial is a reasonable inference, not independently confirmed.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_012",
+      "assertion_id": "a_010",
+      "person_id": "LVDV-6MK",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Sex=Female for Sarah A. Bagley (mother_of_deceased, QPQP-R8T8) consistent with LVDV-6MK (female). Same identification as a_009.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_013",
+      "assertion_id": "a_011",
+      "person_id": "MJDL-Q8B",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "William A. Bagley (deceased) in Vermont Town Clerk record QPQP-24HR. Second indexing of the same 1884 Topsham death entry; death place specified as Topsham, Orange, Vermont. Name, death date, place all match MJDL-Q8B. FamilySearch record-person match confidence 5 (accepted). Confident.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_014",
+      "assertion_id": "a_012",
+      "person_id": "MJDL-Q8B",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Sex=Male consistent with MJDL-Q8B. Same record and identification as a_011.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_015",
+      "assertion_id": "a_013",
+      "person_id": "MJDL-Q8B",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Death date 31 May 1884, Topsham, Orange, Vermont matches MJDL-Q8B exactly. Same confident identification as a_011.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_016",
+      "assertion_id": "a_014",
+      "person_id": "MJDL-Q8B",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Birth year ~1815 consistent with MJDL-Q8B (born Abt 1815). Same identification as a_011.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_017",
+      "assertion_id": "a_015",
+      "person_id": "MJDL-Q8B",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Relationship assertion 'child of David Bagley' in QPQP-24HR bears on William A. Bagley (MJDL-Q8B) as the child party. Same confident identification as a_011.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_018",
+      "assertion_id": "a_015",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Relationship assertion 'child of David Bagley' in QPQP-24HR also bears on David Bagley as the parent. Same David Bagley (I1) identified in QPQP-R8T8 (a_005) and in the 1820 census (a_022). Two indexings of the same original entry both name him as father. Probable \u2014 same reasoning as a_005 \u2192 I1 link.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_019",
+      "assertion_id": "a_016",
+      "person_id": "MJDL-Q8B",
+      "confidence": "confident",
+      "match_score": null,
+      "rationale": "Relationship assertion 'child of Sarah A. Bagley' in QPQP-24HR bears on William A. Bagley (MJDL-Q8B) as child party. Same confident identification as a_011.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_020",
+      "assertion_id": "a_016",
+      "person_id": "LVDV-6MK",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Relationship assertion 'child of Sarah A. Bagley' in QPQP-24HR bears on Sarah as the mother. Same LVDV-6MK (Sarah Sally Andrews) identified in a_006 \u2192 LVDV-6MK link. Second indexing of same source corroborates the identification.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_021",
+      "assertion_id": "a_017",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "David Bagley (father_of_deceased, QPQP-24HR) linked to I1. Second indexing of the same 1884 death entry; names David Bagley as father. Same person as in a_007 (QPQP-R8T8). Probable.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_022",
+      "assertion_id": "a_018",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Sex=Male for David Bagley (father_of_deceased, QPQP-24HR). Consistent with I1. Same identification as a_017.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_023",
+      "assertion_id": "a_019",
+      "person_id": "LVDV-6MK",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Sarah A. Bagley (mother_of_deceased, QPQP-24HR) linked to LVDV-6MK. Second indexing corroborates the a_009 identification. Probable.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_024",
+      "assertion_id": "a_020",
+      "person_id": "LVDV-6MK",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Sex=Female for Sarah A. Bagley (mother_of_deceased, QPQP-24HR). Consistent with LVDV-6MK. Same identification as a_019.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_025",
+      "assertion_id": "a_021",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Inferred spousal relationship 'spouse of Sarah A. Bagley' in QPQP-24HR \u2014 bears on David Bagley (I1) as one party. This is researcher-inferred from the joint ParentChild links; the original death record does not explicitly state a marriage. Probable, noting the inference basis.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_026",
+      "assertion_id": "a_021",
+      "person_id": "LVDV-6MK",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Inferred spousal relationship 'spouse of Sarah A. Bagley' in QPQP-24HR also bears on Sarah (LVDV-6MK) as the other party. Same inferred basis as the I1 link; probable.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_027",
+      "assertion_id": "a_022",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "David Bagley (head_of_household, 1820 census, Topsham) linked to I1 (David Bagley). Same name, consistent with the father named in the 1884 death records \u2014 David Bagley was in Topsham in 1820 when William (~age 5) would have been in his father's household. Independent of the death records (a separate original source). Probable \u2014 name and Topsham residence agree; no conflicting evidence; the 1820 census corroborates the death-record identification.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_028",
+      "assertion_id": "a_023",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Sex=Male for David Bagley (head_of_household, 1820 census). Consistent with I1. Same identification as a_022.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_029",
+      "assertion_id": "a_024",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Residence Topsham, Orange, Vermont, 1820 for David Bagley. Consistent with I1 being the David Bagley who fathered William in Topsham. Same identification as a_022.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_030",
+      "assertion_id": "a_025",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "Census note \u2014 David Bagley as head of household, Topsham, 1820. Indirect evidence for q_001 (supports David's Topsham residence when William would have been ~5). Same identification as a_022.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_031",
+      "assertion_id": "a_026",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "The 1840 census head of household 'David Bagley' in Topsham, Orange, Vermont matches I1 (David Bagley) by name and location. I1 is already corroborated by two 1884 Vermont death records naming 'David Bagley' as William A. Bagley's father, and the 1820 federal census placing David Bagley in Topsham. The same name and same locality in 1840 is consistent with I1's established profile. No same_person score available \u2014 I1 is a local stub without a FamilySearch ARK, making any score uninformative. Qualitative correlation: name exact match, location exact match. Confident not used because no birth/death date corroboration is available to fully anchor the identity.",
+      "created": "2026-07-27"
+    },
+    {
+      "id": "pe_032",
+      "assertion_id": "a_027",
+      "person_id": "I1",
+      "confidence": "probable",
+      "match_score": null,
+      "rationale": "David Bagley's 1840 residence in Topsham, Orange, Vermont (from head_of_household role in ark:/61903/1:1:XHRB-V42) is linked to I1 (David Bagley). This is indirect evidence for q_001: it places David Bagley \u2014 named as William A. Bagley's father in the 1884 death record \u2014 in Topsham in 1840, when William was approximately 25 years old, consistent with long-term Topsham residence spanning at least 1820 to 1840. No same_person score available (degenerate stub match). Probable confidence based on name + place correlation, consistent with all existing I1 evidence.",
+      "created": "2026-07-27"
+    }
+  ],
+  "conflicts": [],
+  "hypotheses": [
+    {
+      "id": "h_001",
+      "claim": "David Bagley Jr. \u2014 a second David Bagley documented in Topsham by 1839 \u2014 is William A. Bagley's father rather than David Bagley Sr.",
+      "status": "ruled_out",
+      "supporting_assertion_ids": [],
+      "contradicting_assertion_ids": [
+        "a_025",
+        "a_027"
+      ],
+      "ruled_out": true,
+      "ruled_out_reason": "The full-text search of Topsham Town Records 1771-1860 (log_010) found 'David Bagley Jr.' in an 1839 record and 'Wm A Bagley' alongside 'David Bayley Jr' on the same 1853 page, suggesting they were contemporaries of similar age rather than father and son. For David Bagley Jr. to be William A. Bagley's father (born approximately 1815), David Jr. would need to have been born no later than approximately 1800 \u2014 but the 'Jr.' designation implies he was born after David Bagley Sr. was already established. David Bagley Sr. appears in Topsham records as a selectman from 1806, well before William's approximately 1815 birth, and is the plausible family patriarch. The 1884 Vermont death record's unqualified reference to 'David Bagley' is most naturally the patriarch; by 1884 David Sr. would have been long deceased, and no record links David Jr. to William in a parental role. The 1853 co-appearance of William and David Jr. on the same Topsham town records page is most consistent with them being brothers, not father and son.",
+      "related_question_ids": [
+        "q_001"
+      ],
+      "notes": "Raised by gps-mentor verdict ev_001 as must-address gap in the proof narrative. Chronological analysis rules out David Jr. as William's father."
+    }
+  ],
+  "timelines": [],
+  "proof_summaries": [
+    {
+      "id": "ps_001",
+      "question_id": "q_001",
+      "tier": "probable",
+      "vehicle": "summary",
+      "supporting_assertion_ids": [
+        "a_005",
+        "a_015",
+        "a_024",
+        "a_025",
+        "a_027"
+      ],
+      "resolved_conflict_ids": [],
+      "exhaustive_search_summary": "Research encompassed Vermont Town Clerk vital records (FamilySearch collection 1987653 \u2014 yielded two indexings of the 1884 Topsham death entry naming David Bagley as William A. Bagley's father), Vermont Births and Christenings 1765\u20131908 (collection 1675544 \u2014 negative for William A. Bagley), Vermont marriage records (collections 1675550 and 1784223 \u2014 no indexed record found for a David Bagley and Sarah Andrews marriage, consistent with pre-1857 Vermont recording gaps), Vermont probate records indexed through FamilySearch (collection 1435692 \u2014 no David Bagley entry), federal census 1820 and 1840 for Topsham, Orange County, Vermont (FamilySearch), and a full-text search of Topsham Town Records 1771\u20131860 (FamilySearch imageGroup 005464260, 110 results examined across two search passes). Unsearched sources include the Bradford District estate files (FamilySearch collection 1807377, 75,694 browse-only, unindexed images), Ancestry local history 'Sketches of the Town of Topsham' by Frank H. Craig (1929, collection 22236), and Topsham land records. No competing candidate for William's father appeared in any searched record.",
+      "narrative_markdown": "# Proof Summary: Father of William A. Bagley (born about 1815, died 31 May 1884, Topsham, Orange County, Vermont)\n\n## Conclusion\n\nThe preponderance of available evidence strongly suggests that **David Bagley** was the father of William A. Bagley (born about 1815, died 31 May 1884, Topsham, Orange County, Vermont). This conclusion rests on a Vermont Town Clerk death entry that directly names David Bagley as William's father, corroborated by two federal census records confirming David Bagley's long-term residence in the same small Vermont town and by circumstantial evidence from the Topsham town records. No contradicting evidence was found in any searched record.\n\n## Primary Evidence: Vermont Town Clerk Death Entry (1884)\n\nThe most direct evidence is the Vermont Town Clerk vital record for William A. Bagley's death on 31 May 1884, accessed through two FamilySearch index entries derived from the same underlying original town-clerk entry and therefore constituting a single evidence unit:\n\n- \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QPQP-R8T8 : accessed 27 July 2026), Entry for William A Bagley and David Bagley, 31 May 1884.\n- \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QPQP-24HR : accessed 2026-07-27), Entry for William A Bagley and David Bagley, 31 May 1884.\n\nBoth indexings agree that David Bagley was William A. Bagley's father and that Sarah A. Bagley (n\u00e9e Andrews) was his mother. Classified as an **original record**, this entry provides **direct evidence** of the parentage relationship. The parentage information itself is, however, **secondary information** \u2014 the 1884 informant could not have been present at William's birth approximately seventy years earlier, and the parental names were likely supplied by a family or community member with secondhand knowledge. Vermont death records of this era (pre-1919) did not require parental information by law, making the voluntary inclusion of parental names noteworthy; it suggests the informant had specific knowledge of William's family.\n\n## Corroborating Evidence: Federal Census Records (1820 and 1840)\n\nTwo federal census records independently establish David Bagley's long-term residence in Topsham, Orange County, Vermont, and constitute a second, independent evidence unit drawn from a different record-creation process and different informants.\n\nThe 1820 federal census (original government schedule, primary information) lists David Bagley as head of household in Topsham, when William would have been approximately five years old: \"United States, Census, 1820,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:XHLG-T8R : accessed 2026-07-27), entry for David Bagley, Topsham, Orange, Vermont. Pre-1850 census schedules name only the head of household; all other members are recorded by age-bracket tally marks only, and the census image was not examined to verify household composition. This record confirms that a David Bagley headed a household in Topsham in 1820 but does not independently confirm that William was among its members.\n\nThe 1840 federal census (original government schedule, primary information) again places David Bagley in Topsham, when William would have been approximately twenty-five: \"United States, Census, 1840,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:XHRB-V42 : accessed 2026-07-27), entry for David Bagley, Topsham, Orange, Vermont, 1840. As with the 1820 census, only the head of household is named.\n\nThese records are **indirect evidence** for the parentage question \u2014 they confirm that a David Bagley was a long-term Topsham resident throughout William's childhood and young adulthood, consistent with the father identified in the 1884 death entry, but they do not state the father-son relationship.\n\n## Circumstantial Support: Topsham Town Records (1771\u20131860)\n\nA full-text search of Topsham Town Records 1771\u20131860 (FamilySearch imageGroup 005464260, 110 results examined) confirmed David Bagley's continuous Topsham presence from 1806 through at least 1855 as a town officer and selectman. The search also identified an 1813 Topsham record containing the name \"Sophia Andrews Bagley\" \u2014 a Bagley child bearing the Andrews maiden surname as a middle name, a common nineteenth-century New England practice for honoring the mother's family. William A. Bagley's mother was separately identified as Sarah Sally Andrews (born 1777, Gloucester, Essex, Massachusetts; died 19 March 1847, Topsham). A Bagley child named with the Andrews surname as a middle name is consistent with the conclusion that a member of the Bagley family had married Sarah Andrews, and circumstantially supports the identification of David Bagley as that family member. No formal birth or marriage record naming David Bagley and Sarah Andrews together was found in this volume.\n\n## The David Bagley Jr./Sr. Question\n\nThe same full-text search of Topsham town records found a \"David Bagley Jr.\" in an 1839 record, establishing that two David Bagleys coexisted in Topsham simultaneously. The 1884 death record names simply \"David Bagley\" with no qualifier. This raises the question of whether David Bagley Jr. could be William's father rather than David Bagley Sr.\n\nThis candidate has been considered and ruled out (hypothesis h_001). For David Bagley Jr. to be William's father (born approximately 1815), David Jr. would need to have been born no later than approximately 1800 \u2014 but the \"Jr.\" designation implies he was born after David Bagley Sr. was already established in Topsham. David Bagley Sr. appears in Topsham records as a selectman from 1806, well before William's approximately 1815 birth, making Sr. the plausible patriarch. Additionally, \"Wm A Bagley\" and \"David Bayley Jr\" appear together on a 1853 Topsham town records page \u2014 consistent with them being contemporaries and possible brothers, not father and son. No record links David Bagley Jr. to William in a parental role. The 1884 death record's unqualified \"David Bagley\" most naturally refers to the family patriarch, by then long deceased.\n\n## Negative Evidence and Research Gaps\n\nSearches of indexed Vermont birth records (collection 1675544), indexed Vermont marriage records (collections 1675550 and 1784223), and indexed Vermont probate records (collection 1435692) returned no relevant entries for David Bagley or a David Bagley and Sarah Andrews marriage. These negative results are consistent with Vermont's pre-1857 absence of mandatory statewide vital registration. The Bradford District estate file collection (FamilySearch collection 1807377, 75,694 images, 0% name-indexed) could not be searched by name and was not browsed \u2014 a David Bagley probate or estate record in that collection remains a possible source of additional corroboration. No alternative candidate for the role of William A. Bagley's father emerged from any of the eleven searches conducted.\n\n## Assessment\n\nThe parentage conclusion rests on two independent evidence units: (1) the 1884 Vermont Town Clerk death entry \u2014 an original record providing direct evidence that is secondary information \u2014 and (2) the 1820 and 1840 federal censuses, original records with primary information confirming David Bagley's decades-long Topsham residence independent of the death record. The potential namesake complication raised by \"David Bagley Jr.\" has been addressed and ruled out (h_001). No conflicting evidence was found. The conclusion cannot be elevated to **proved** because the parentage evidence depends on secondary information from a single original document; a second original record providing primary information about the parentage relationship \u2014 such as a David Bagley probate naming William as a son, a land deed identifying William as David's son, or William's own birth or baptism record \u2014 would be necessary to reach that standard.\n\n## Conclusion\n\nIt is **highly probable** that **David Bagley** was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermont). This conclusion reflects the weight of an 1884 Vermont death entry directly naming David Bagley as father, supported by two federal census records confirming his decades-long Topsham residence, and the circumstantial evidence of the Andrews-family naming pattern in the Topsham town records. Future research into the Bradford District probate estate files (FamilySearch collection 1807377) or Topsham land records could provide additional corroboration and potentially advance the conclusion to proved."
+    }
+  ],
+  "evaluations": [
+    {
+      "id": "ev_001",
+      "focus": "proof-critique",
+      "target_id": "ps_001",
+      "target_type": "proof_summary",
+      "verdict": "address_first",
+      "timestamp": "2026-07-27T20:15:00Z",
+      "superseded_by": null,
+      "file_path": "evaluations/proof-critique-ps_001-2026-07-27T20-15-00.json"
+    }
+  ],
+  "localities": [
+    {
+      "id": "loc_001",
+      "place": "Vermont, United States",
+      "for_place": "Topsham, Orange County, Vermont",
+      "time_period": "1800-1890",
+      "jurisdictions": [
+        {
+          "name": "Topsham, Orange, Republic of Vermont",
+          "date_range": "pre-1791"
+        },
+        {
+          "name": "Topsham, Orange, Vermont, United States",
+          "date_range": "1791\u2013present"
+        }
+      ],
+      "collections": [
+        {
+          "id": "1987653",
+          "title": "Vermont, Town Clerk, Vital and Town Records, 1732-2005",
+          "date_range": "1699-2005"
+        },
+        {
+          "id": "1784223",
+          "title": "Vermont, Vital Records, 1760-1954",
+          "date_range": "1760-1954"
+        },
+        {
+          "id": "2075288",
+          "title": "Vermont, Vital Records, 1760-2008",
+          "date_range": "1760-2003"
+        },
+        {
+          "id": "1675544",
+          "title": "Vermont, Births and Christenings, 1765-1908",
+          "date_range": "1765-1908"
+        },
+        {
+          "id": "1675549",
+          "title": "Vermont, Deaths and Burials, 1871-1965",
+          "date_range": "1871-1965"
+        },
+        {
+          "id": "1675550",
+          "title": "Vermont, Marriages, 1791-1974",
+          "date_range": "1791-1974"
+        },
+        {
+          "id": "1435692",
+          "title": "Vermont, Probate Files, 1800-1921",
+          "date_range": "1800-1921"
+        },
+        {
+          "id": "1807377",
+          "title": "Vermont, Orange County, Bradford District Estate Files, 1780-1915",
+          "date_range": "1780-1915"
+        },
+        {
+          "id": "1453983",
+          "title": "Vermont, Orange County, Randolph District Probate Records, 1790-1935",
+          "date_range": "1790-1935"
+        },
+        {
+          "id": "1409123",
+          "title": "Vermont, Land Records, Early to 1900",
+          "date_range": "1600-1900"
+        },
+        {
+          "id": "1627819",
+          "title": "Vermont, Town Records, 1850-2005",
+          "date_range": "1850-2005"
+        },
+        {
+          "id": "3158875",
+          "title": "Vermont, Wills and Deeds, ca. 1700s-2017",
+          "date_range": "1700-2017"
+        }
+      ],
+      "quirks": [
+        "Statewide vital registration began 1857; before that, births/marriages/deaths are in Topsham town clerk records. The Topsham Town Records 1771-1860 (imageGroup 005464260) are digitized on FamilySearch with full-text search but 0% name-indexed \u2014 use full-text search, not record search.",
+        "Vermont death records before 1919 generally do NOT name the deceased's parents. Parental information on death certificates was required only from 1919 onward (Vermont Research Tips wiki). An 1884 death record for William A. Bagley will likely not name his father.",
+        "Topsham's probate district is Orange County, with court in Chelsea, VT. Two Orange County probate collections are on FamilySearch \u2014 Bradford District Estate Files 1780-1915 (imageGroup prefix 007814131 etc.) and Randolph District Probate Records 1790-1935 \u2014 both are browse-only images (0% indexed). Check both for any Bagley estate.",
+        "Also search Vermont Probate Files 1800-1921 (collection 1435692), which IS name-indexed and covers some Orange County records.",
+        "Topsham vital records 1857-1897 (imageGroup 005487650, 2180 images) and the vital statistic indexes 1857-1896 (imageGroup 005464890, 200 images) are 100% indexed and full-text searchable \u2014 primary target for William's 1884 death record.",
+        "Local history: 'Sketches of the Town of Topsham, Orange County, Vermont' (1929) by Frank H. Craig is available on Ancestry.com (collection 22236) and may contain family genealogies naming Bagley parents and children.",
+        "The largest Vermont vital records collection is 'Vermont, Town Clerk, Vital and Town Records, 1732-2005' (collection 1987653, 2.4M records, 1.4M images) \u2014 the primary indexed source for post-1857 Topsham vital records."
+      ],
+      "guide_markdown": "# Locality Guide: Topsham, Orange County, Vermont (1800\u20131890)\n\n## Jurisdictional Context\n\nTopsham was granted its charter 15 August 1763. It lies in Orange County, Vermont, and has three villages: East Topsham, Waits River, and West Topsham. Vermont became the 14th U.S. state on 4 March 1791; before that date, Topsham was in the Republic of Vermont. No boundary changes split the town's records across jurisdictions during the 1800\u20131890 period.\n\n## Vital Records\n\n**Pre-1857 (no state registration):** Town clerk records are the only source. The Topsham Town Records 1771\u20131860 are digitized on FamilySearch (imageGroup 005464260, 265 images). These are **full-text searchable but 0% name-indexed** \u2014 use the full-text search tool, not record search. Original records are also at the Topsham Town Clerk, 6 Harts Rd., Topsham, VT 05076.\n\n**Post-1857 (state registration):** Statewide registration required by law from 1857. Key indexed collections on FamilySearch:\n- **Vermont, Town Clerk, Vital and Town Records, 1732\u20132005** (coll. 1987653) \u2014 2.4M records, indexed + images. Primary target.\n- **Vermont, Vital Records, 1760\u20131954** (coll. 1784223) \u2014 2.3M records, indexed + images.\n- **Vermont, Vital Records, 1760\u20132008** (coll. 2075288) \u2014 1.97M records, indexed.\n- **Vermont, Deaths and Burials, 1871\u20131965** (coll. 1675549) \u2014 82K records, index only.\n- **Vermont, Births and Christenings, 1765\u20131908** (coll. 1675544) \u2014 210K records, index only.\n\nTopsham-specific volumes (100% indexed, full-text searchable): imageGroup 005487650 (births/marriages/deaths 1857\u20131997, 2,180 images) and imageGroup 005464890 (vital statistic indexes 1857\u20131896, 200 images).\n\n\u26a0\ufe0f **Critical quirk:** Vermont death records **before 1919 do not name the deceased's parents**. An 1884 death record for William A. Bagley will likely carry no parental information.\n\n## Census Records\n\nFederal censuses are the primary path to finding a ca.-1815 birth subject in his father's household:\n- **1820, 1830, 1840 censuses** (Ancestry, FamilySearch): William would appear as a child under his father's name. These are indexed.\n- **1850\u20131880 censuses** list all household members by name; 1880 adds relationship to head.\n- Vermont also has miscellaneous census substitutes 1778\u20131840 at American Ancestors and Ancestry.\n\n## Probate Records\n\nTopsham's probate district is Orange County (court at Chelsea, VT). Two district collections:\n- **Vermont, Orange County, Bradford District Estate Files, 1780\u20131915** (coll. 1807377) \u2014 75,694 images, **browse-only** (0% indexed, no full-text).\n- **Vermont, Orange County, Randolph District Probate Records, 1790\u20131935** (coll. 1453983) \u2014 65,929 images, **browse-only**.\n- **Vermont, Probate Files, 1800\u20131921** (coll. 1435692) \u2014 10,225 records **indexed + images** (204K images). Search here first.\n- **Vermont, Wills and Deeds, ca. 1700s\u20132017** (coll. 3158875) \u2014 some indexed records.\n- Ancestry also has **Vermont, U.S., Wills and Probate Records, 1749\u20131999** ($).\n\nIf William's father died in Orange County before 1921, an estate file may name his heirs (including William).\n\n## Land Records\n\n- **Vermont, Land Records, Early to 1900** (coll. 1409123) \u2014 169,270 images, browse-only, also on Ancestry.\n- Topsham land records volumes on FamilySearch are **full-text searchable** (0% name-indexed): vols. 14\u201315 (1853\u20131859), vols. 16\u201317 (1859\u20131869), vols. 18\u201319 (1866\u20131878), vol. 20 (1878\u20131883), vol. 21 (1882\u20131893), vol. 22 (1888\u20131893).\n- Earlier Topsham land volumes (deeds 1794\u20131849; index to deeds 1794\u20131860) are on microfilm at FamilySearch Library catalog 90593.\n\n## Church Records\n\nHistorically dominant denominations in Vermont: Congregational, Baptist, Methodist, Roman Catholic. FamilySearch has **Vermont Miscellaneous Records (includes Vermont Church Records)** from the Daughters of the American Revolution covering 1700s\u20131800s (catalog 383707). See [Vermont Church Records wiki](https://www.familysearch.org/en/wiki/Vermont_Church_Records).\n\n## Local Histories & Compiled Sources\n\n- **'Sketches of the Town of Topsham, Orange County, Vermont' (1929)** by Frank H. Craig \u2014 available on Ancestry.com (collection 22236). Often contains family genealogies naming parents and siblings.\n- *The Vermont Historical Gazetteer* (Hemenway, 1868\u20131923) \u2014 FamilySearch Digital Library, vols. 1\u20136.\n- *Genealogical and Family History of the State of Vermont* (Carleton, 1903) \u2014 FamilySearch Digital Library.\n- Vermont Historical Society (vermonthistory.org) holds genealogical research sources.\n\n## Cemeteries\n\nWest Topsham Cemetery and Old West Topsham Cemetery are the primary cemeteries for this family (per tree). Inscriptions at Find a Grave. Vermont Old Cemetery Association database: voca58.org.\n\n## Newspapers\n\nNo major newspaper served Topsham directly; Orange County was served by papers in Chelsea/Bradford. GenealogyBank has Vermont newspaper archives 1781\u20132006. Chronicling America has some Vermont titles.\n\n## Access Summary\n\n| Record Type | Access Level | Primary Repository |\n|---|---|---|\n| Vital records 1857+ | Indexed + images | FamilySearch (coll. 1987653, 1784223) |\n| Vital records pre-1857 | Full-text searchable (not name-indexed) | FamilySearch imageGroup 005464260 |\n| Census 1820\u20131880 | Indexed | FamilySearch, Ancestry |\n| Probate (indexed) | Indexed + images | FamilySearch coll. 1435692 |\n| Probate (district files) | Browse-only images | FamilySearch colls. 1807377, 1453983 |\n| Land records (post-1849) | Full-text searchable | FamilySearch |\n| Land records (pre-1849) | Microfilm | FamilySearch Library |\n| Local history | Images ($) | Ancestry.com (coll. 22236) |\n",
+      "pages_read": [
+        {
+          "section": "home",
+          "url": "https://www.familysearch.org/en/wiki/Vermont,_United_States_Genealogy",
+          "found": true
+        },
+        {
+          "section": "getting_started",
+          "url": "https://www.familysearch.org/en/wiki/Vermont_Getting_Started",
+          "found": true
+        },
+        {
+          "section": "online_records",
+          "url": "https://www.familysearch.org/en/wiki/Vermont_Online_Genealogy_Records",
+          "found": true
+        },
+        {
+          "section": "research_tips",
+          "url": "https://www.familysearch.org/en/wiki/Vermont_Research_Tips_and_Strategies",
+          "found": true
+        }
+      ],
+      "source": "locality-guide",
+      "created": "2026-07-27"
+    }
+  ]
+}

--- a/eval/runlogs/e2e/bagley-father-1884/run-2026-07-27_20-01-40.final-tree.gedcomx.json
+++ b/eval/runlogs/e2e/bagley-father-1884/run-2026-07-27_20-01-40.final-tree.gedcomx.json
@@ -1,0 +1,482 @@
+{
+  "persons": [
+    {
+      "id": "MJDL-Q8B",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "William A.",
+          "surname": "Bagley"
+        },
+        {
+          "id": "N7",
+          "type": "BirthName",
+          "given": "William A",
+          "surname": "Bagley",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 3
+            },
+            {
+              "ref": "S2",
+              "quality": 3
+            }
+          ]
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "Abt 1815",
+          "standard_date": "Abt 1815",
+          "place": "West Topsham, Orange, Vermont",
+          "standard_place": "Topsham, Orange, Vermont, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 2
+            },
+            {
+              "ref": "S2",
+              "quality": 2
+            }
+          ],
+          "primary": true
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "31 May 1884",
+          "standard_date": "31 May 1884",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 3
+            },
+            {
+              "ref": "S2",
+              "quality": 3
+            }
+          ],
+          "primary": true
+        },
+        {
+          "id": "28119bdf-00ed-4c5f-a9fc-9b39c096b055",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        }
+      ]
+    },
+    {
+      "id": "L528-9HM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Eva Belle",
+          "surname": "Bagley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "c65fd7c9-7586-4a5c-98b1-27981c8f4ed3",
+          "type": "Birth",
+          "date": "29 July 1847",
+          "standard_date": "29 Jul 1847",
+          "place": "Barre, Barre, Washington, Vermont, United States",
+          "standard_place": "Barre City, Washington, Vermont, United States"
+        },
+        {
+          "id": "56040e10-989e-42e1-9470-cf3a7d385136",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "8a8e2950-70c9-42c0-955a-3ebaac83ae4e",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Vermont, United States",
+          "standard_place": "Vermont, United States"
+        },
+        {
+          "id": "926a74b0-628f-430a-85a8-fc5862acc2b9",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "cc5e47c1-61b1-44ba-ac2c-fd5777bdc0d3",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Barre town, north side (excl. Barre city), Washington, Vermont, United States",
+          "standard_place": "Barre Town, Washington, Vermont, United States"
+        },
+        {
+          "id": "4f2dc707-d54e-4d9b-b186-ec63924623b5",
+          "type": "Death",
+          "date": "7 March 1925",
+          "standard_date": "7 Mar 1925",
+          "place": "Barre, Barre, Washington, Vermont, United States",
+          "standard_place": "Barre City, Washington, Vermont, United States"
+        },
+        {
+          "id": "01b023a0-dc7f-441f-bc65-f846e51e9477",
+          "type": "Burial",
+          "place": "West Topsham Cemetery, West Topsham, Orange, Vermont, United States of America",
+          "standard_place": "West Topsham Cemetery, Topsham, Orange, Vermont, United States"
+        }
+      ]
+    },
+    {
+      "id": "KHY4-7VP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Ann",
+          "surname": "Tillotson"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100-KHY4",
+          "type": "Birth",
+          "date": "1826",
+          "standard_date": "1826",
+          "place": "Topsham, Orange, Vt.",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "5bad4ac9-d8e9-4a9b-a820-af1dc0708089",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "716108d5-252f-4c2b-9eaa-0d98e8a7434a",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Vermont, United States",
+          "standard_place": "Vermont, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922-KHY4",
+          "type": "Death",
+          "date": "30 Apr 1876",
+          "standard_date": "30 Apr 1876",
+          "place": "Vermont, United States",
+          "standard_place": "Vermont, United States"
+        },
+        {
+          "id": "c0d5bbc8-4524-4880-9947-245327865519",
+          "type": "Burial",
+          "date": "1876",
+          "standard_date": "1876",
+          "place": "West Topsham, Orange, Vermont, United States of America",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        }
+      ]
+    },
+    {
+      "id": "LVDV-6MK",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Sarah Sally",
+          "surname": "Andrews"
+        },
+        {
+          "id": "N8",
+          "type": "BirthName",
+          "given": "Sarah A",
+          "surname": "Bagley",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 2
+            },
+            {
+              "ref": "S2",
+              "quality": 2
+            }
+          ]
+        }
+      ],
+      "facts": [
+        {
+          "id": "377e6373-a54b-4d9c-8dbb-21e46d2d96e2",
+          "type": "Birth",
+          "date": "1777",
+          "standard_date": "1777",
+          "place": "Gloucester, Essex, Massachusetts, United States",
+          "standard_place": "Gloucester, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "fb32b179-b61e-42ac-a43f-192eae4a6c1b",
+          "type": "Christening",
+          "date": "7 December 1777",
+          "standard_date": "7 Dec 1777",
+          "place": "Gloucester, Essex, Massachusetts, United States",
+          "standard_place": "Gloucester, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "af27bdb3-0190-4145-8100-880432d43893",
+          "type": "Death",
+          "date": "19 March 1847",
+          "standard_date": "19 Mar 1847",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "fc30de70-823f-4852-91a3-ec94704349dc",
+          "type": "Burial",
+          "date": "March 1947",
+          "standard_date": "Mar 1947",
+          "place": "Old West Topsham Cemetery, Topsham, Orange, Vermont, USA",
+          "standard_place": "West Topsham Cemetery, Topsham, Orange, Vermont, United States"
+        }
+      ]
+    },
+    {
+      "id": "I1",
+      "gender": "Male",
+      "names": [
+        {
+          "id": "N6",
+          "type": "BirthName",
+          "given": "David",
+          "surname": "Bagley",
+          "sources": [
+            {
+              "ref": "S1",
+              "quality": 2
+            },
+            {
+              "ref": "S2",
+              "quality": 2
+            },
+            {
+              "ref": "S3",
+              "quality": 3
+            },
+            {
+              "ref": "S4",
+              "quality": 3
+            }
+          ]
+        }
+      ],
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Residence",
+          "date": "1820",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States",
+          "sources": [
+            {
+              "ref": "S3",
+              "quality": 3
+            }
+          ]
+        },
+        {
+          "id": "F2",
+          "type": "Census",
+          "date": "1820",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States",
+          "sources": [
+            {
+              "ref": "S3",
+              "quality": 2
+            }
+          ]
+        },
+        {
+          "id": "F3",
+          "type": "Residence",
+          "date": "1840",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States",
+          "sources": [
+            {
+              "ref": "S4",
+              "quality": 2
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "MJDL-Q8B",
+      "person2": "KHY4-7VP",
+      "facts": [
+        {
+          "id": "2519e746-0a0a-4421-8726-7d1c729c22b8",
+          "type": "Marriage",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        }
+      ]
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "LVDV-6MK",
+      "child": "MJDL-Q8B",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "MJDL-Q8B",
+      "child": "L528-9HM"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "KHY4-7VP",
+      "child": "L528-9HM"
+    },
+    {
+      "type": "ParentChild",
+      "parent": "I1",
+      "child": "MJDL-Q8B",
+      "id": "R7",
+      "sources": [
+        {
+          "ref": "S1",
+          "quality": 3
+        }
+      ]
+    }
+  ],
+  "sources": [
+    {
+      "id": "31KH-KNQ",
+      "title": "William A Bagley, \"United States, Census, 1850\"",
+      "citation": "\"United States, Census, 1850\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:MC26-77Q : Sun Oct 19 18:25:15 UTC 2025), Entry for William A Bagley and Ann Bagley, 1850.",
+      "url": "https://familysearch.org/ark:/61903/1:1:MC26-77Q"
+    },
+    {
+      "id": "3PJB-YFV",
+      "title": "Wm A Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQP-JBTG : Fri Mar 08 23:31:40 UTC 2024), Entry for Andrew Thurston and Eva Ann Bagley.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQP-JBYH"
+    },
+    {
+      "id": "S8BB-N5D",
+      "title": "William Bugby, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQG-NCL1 : Sun Mar 10 04:53:23 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 November 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQR-3PN5"
+    },
+    {
+      "id": "S8BB-N2L",
+      "title": "William Bugby, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQ5-76SN : Sat Mar 09 09:59:37 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 November 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQ5-6Q6G"
+    },
+    {
+      "id": "S8BB-NNT",
+      "title": "William Bugby, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQK-7V5H : Fri Mar 08 04:46:12 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 November 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQV-NR2M"
+    },
+    {
+      "id": "S8BB-N8N",
+      "title": "William Bugby, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQP-LGDS : Sat Mar 09 10:13:38 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 November 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQ5-KDX4"
+    },
+    {
+      "id": "S8BB-FRM",
+      "title": "William Bugbee, \"Vermont, Vital Records, 1760-1954\"",
+      "citation": "\"Vermont, Vital Records, 1760-1954\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XFVQ-L5R : Thu Mar 07 02:55:48 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 Nov 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XFVQ-L5Y"
+    },
+    {
+      "id": "S8BB-FL6",
+      "title": "Wm A Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q28Q-6HTN : Sat Mar 09 19:35:29 UTC 2024), Entry for Andrew Thurston and Andrew Thurston, 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q28Q-6CM7"
+    },
+    {
+      "id": "SCBT-5CN",
+      "title": "William A Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQL-XX78 : Sat Mar 09 22:59:33 UTC 2024), Entry for Andrew Thurston and Eva Ann Bagley, 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQL-XX7V"
+    },
+    {
+      "id": "9NCT-WB5",
+      "title": "William Bagley, \"United States, Census, 1870\"",
+      "citation": "\"United States, Census, 1870\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:M6RC-8PY : Thu Jan 09 15:19:37 UTC 2025), Entry for William Bagley and Ann Bagley, 1870.",
+      "url": "https://familysearch.org/ark:/61903/1:1:M6RC-8PY"
+    },
+    {
+      "id": "9N3F-5LL",
+      "title": "William Bagley, \"Vermont, Vital Records, 1760-2008\"",
+      "citation": "\"Vermont, Vital Records, 1760-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KN9Y-4CM : Wed Jan 29 23:19:38 UTC 2025), Entry for Evie Viel Thurston and William Bagley, 07 Mar 1925.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KN9Y-4C9"
+    },
+    {
+      "id": "9N38-6C4",
+      "title": "William Bagley, \"Vermont, Vital Records, 1760-1954\"",
+      "citation": "\"Vermont, Vital Records, 1760-1954\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:2V7S-65V : Fri Mar 08 22:22:28 UTC 2024), Entry for Evie Vill Thurston and William Bagley, 07 Mar 1925.",
+      "url": "https://familysearch.org/ark:/61903/1:1:2V7S-65K"
+    },
+    {
+      "id": "MSV2-K72",
+      "title": "Wm A Bagley, \"Vermont, Vital Records, 1760-1954\"",
+      "citation": "\"Vermont, Vital Records, 1760-1954\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XFFP-JM2 : Sun Mar 10 11:10:53 UTC 2024), Entry for Andrew Thurston and Eva Ann Bagley, 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XFFP-JMG"
+    },
+    {
+      "id": "S1",
+      "title": "Entry for William A Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:QPQP-R8T8"
+    },
+    {
+      "id": "S2",
+      "title": "Entry for William A Bagley and David Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:QPQP-24HR"
+    },
+    {
+      "id": "S3",
+      "title": "Household of David Bagley, \"United States, Census, 1820\"",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:XHLG-T8R"
+    },
+    {
+      "id": "S4",
+      "title": "Household of David Bagley, \"United States, Census, 1840\"",
+      "url": "https://www.familysearch.org/ark:/61903/1:1:XHRB-V42"
+    }
+  ]
+}

--- a/eval/runlogs/e2e/bagley-father-1884/run-2026-07-27_20-01-40.json
+++ b/eval/runlogs/e2e/bagley-father-1884/run-2026-07-27_20-01-40.json
@@ -1,0 +1,7805 @@
+{
+  "test_id": "bagley-father-1884",
+  "captured_at": "2026-07-27_20-01-40",
+  "verdict": "pass",
+  "stop_reason": "completed",
+  "judge_output": {
+    "per_finding": [
+      {
+        "finding_id": "f1",
+        "matched": "true",
+        "agent_evidence": "Relationship R7 in final_tree.gedcomx.json establishes a ParentChild relationship with parent I1 (David Bagley) and child MJDL-Q8B (William A. Bagley). Person I1 has a BirthName of 'David Bagley' with sources S1 and S2 referencing Vermont Town Clerk vital records. The death entry for William A. Bagley (MJDL-Q8B) on 31 May 1884 at Topsham, Orange County, Vermont is documented with sources S1 and S2, which are the Vermont Town Clerk records that name David Bagley as his father.",
+        "notes": "The agent successfully recovered the core finding that David Bagley was William A. Bagley's father. The parent-child relationship is explicitly modeled in the GEDCOM structure (R7), and both William A. Bagley and David Bagley are present in the final tree with the death date of 31 May 1884 in Topsham, Orange County, Vermont documented. The sources cited (S1 and S2) correspond to the Vermont Town Clerk vital records that directly name David Bagley as father, matching the expected supporting source type. Birth year approximation (Abt 1815 for William) and the father's name both match the expected finding."
+      }
+    ],
+    "recall_required": 1.0,
+    "recall_total": 1.0,
+    "verdict": "pass",
+    "rationale": "The agent successfully recovered the required finding that David Bagley was the father of William A. Bagley (born about 1815, died 31 May 1884 in Topsham, Orange County, Vermont). The parent-child relationship is explicitly modeled in the final GEDCOM tree as relationship R7, connecting David Bagley (person I1) as parent to William A. Bagley (person MJDL-Q8B). The evidence derives from the Vermont Town Clerk vital records (sources S1 and S2) that directly name David Bagley as William's father at the time of William's death, consistent with the expected supporting sources. All required findings have matched status of 'true'.",
+    "proof_quality": {
+      "score": 3,
+      "exhaustiveness": "yes",
+      "conflicts_addressed": "yes",
+      "corroboration": "independent",
+      "tier_appropriate": "yes",
+      "rationale": "The proof summary demonstrates exhaustive searching across multiple record types: Vermont Town Clerk vital records, Vermont births/christenings, Vermont marriages, Vermont probates, federal census records (1820, 1840), full-text search of Topsham town records 1771-1860, with explicitly acknowledged gaps (Bradford District estate files, local history sketches, land records). The summary identifies and resolves a potential conflict\u2014the David Bagley Jr./Sr. question\u2014through careful reasoning that David Jr. could not have fathered William (born ~1815) given the Jr. designation and evidence they were contemporaries/brothers. Corroboration is independent across two evidence units: (1) the 1884 Vermont Town Clerk death entry providing direct evidence of parentage, and (2) the 1820 and 1840 federal census records independently confirming David Bagley's decades-long Topsham residence. The tier declared as 'probable' is appropriately justified by the strength of evidence: direct statement in an original death record (albeit secondary information) plus independent corroboration from census records. The narrative is clear that 'proved' status would require a second original record with primary parentage information, which distinguishes the reasoning for 'probable' rather than higher. Score of 3 reflects sound proof structure."
+    }
+  },
+  "usage": {
+    "duration_ms": 3440494,
+    "duration_api_ms": 3553840,
+    "num_turns": 130,
+    "is_error": false,
+    "stop_reason": "end_turn",
+    "total_cost_usd": 8.8866397,
+    "usage": {
+      "input_tokens": 2216,
+      "cache_creation_input_tokens": 460155,
+      "cache_read_input_tokens": 8075458,
+      "output_tokens": 128578,
+      "server_tool_use": {
+        "web_search_requests": 0,
+        "web_fetch_requests": 0
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 460155,
+        "ephemeral_5m_input_tokens": 0
+      },
+      "inference_geo": "",
+      "iterations": [
+        {
+          "input_tokens": 1,
+          "output_tokens": 481,
+          "cache_read_input_tokens": 153807,
+          "cache_creation_input_tokens": 455,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 455
+          },
+          "type": "message"
+        }
+      ],
+      "speed": "standard"
+    },
+    "usage_source": "result_message",
+    "continue_nudges": 0,
+    "session_id": "19d8b55f-7223-428e-ac48-8cb06bd475bb",
+    "resumes": 0,
+    "resume_on_stall": true,
+    "timeline": [
+      [
+        2.4,
+        "system:init",
+        []
+      ],
+      [
+        10.2,
+        "assistant",
+        []
+      ],
+      [
+        10.3,
+        "assistant",
+        [
+          "Glob"
+        ]
+      ],
+      [
+        10.3,
+        "tool_result",
+        [
+          "Glob"
+        ]
+      ],
+      [
+        14.0,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        14.4,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        14.7,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        14.8,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        29.9,
+        "assistant",
+        []
+      ],
+      [
+        29.9,
+        "assistant",
+        []
+      ],
+      [
+        29.9,
+        "assistant",
+        [
+          "Skill:question-selection"
+        ]
+      ],
+      [
+        29.9,
+        "tool_result",
+        [
+          "Skill:question-selection"
+        ]
+      ],
+      [
+        29.9,
+        "tool_result",
+        []
+      ],
+      [
+        45.3,
+        "assistant",
+        []
+      ],
+      [
+        46.4,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        46.9,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        47.1,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        47.1,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        62.7,
+        "assistant",
+        []
+      ],
+      [
+        62.7,
+        "assistant",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        62.7,
+        "tool_result",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        75.4,
+        "assistant",
+        []
+      ],
+      [
+        81.9,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        82.0,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        90.8,
+        "assistant",
+        []
+      ],
+      [
+        93.7,
+        "assistant",
+        []
+      ],
+      [
+        94.0,
+        "assistant",
+        [
+          "Skill:locality-guide"
+        ]
+      ],
+      [
+        94.0,
+        "tool_result",
+        [
+          "Skill:locality-guide"
+        ]
+      ],
+      [
+        94.0,
+        "tool_result",
+        []
+      ],
+      [
+        99.2,
+        "assistant",
+        []
+      ],
+      [
+        100.8,
+        "assistant",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        100.8,
+        "tool_result",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        104.6,
+        "assistant",
+        []
+      ],
+      [
+        104.8,
+        "assistant",
+        [
+          "place_search_all"
+        ]
+      ],
+      [
+        106.1,
+        "tool_result",
+        [
+          "place_search_all"
+        ]
+      ],
+      [
+        110.7,
+        "assistant",
+        []
+      ],
+      [
+        111.7,
+        "assistant",
+        [
+          "place_population"
+        ]
+      ],
+      [
+        112.1,
+        "tool_result",
+        [
+          "place_population"
+        ]
+      ],
+      [
+        112.6,
+        "assistant",
+        [
+          "collections_search"
+        ]
+      ],
+      [
+        113.0,
+        "assistant",
+        [
+          "volume_search"
+        ]
+      ],
+      [
+        114.0,
+        "assistant",
+        [
+          "external_links_search"
+        ]
+      ],
+      [
+        114.9,
+        "assistant",
+        [
+          "wiki_search"
+        ]
+      ],
+      [
+        115.4,
+        "assistant",
+        [
+          "wiki_place_page"
+        ]
+      ],
+      [
+        115.8,
+        "assistant",
+        [
+          "wiki_place_page"
+        ]
+      ],
+      [
+        116.3,
+        "assistant",
+        [
+          "wiki_place_page"
+        ]
+      ],
+      [
+        116.7,
+        "assistant",
+        [
+          "wiki_place_page"
+        ]
+      ],
+      [
+        117.0,
+        "tool_result",
+        [
+          "collections_search"
+        ]
+      ],
+      [
+        118.4,
+        "tool_result",
+        [
+          "volume_search"
+        ]
+      ],
+      [
+        118.9,
+        "tool_result",
+        [
+          "external_links_search"
+        ]
+      ],
+      [
+        120.9,
+        "tool_result",
+        [
+          "wiki_search"
+        ]
+      ],
+      [
+        120.9,
+        "tool_result",
+        [
+          "wiki_place_page"
+        ]
+      ],
+      [
+        120.9,
+        "tool_result",
+        [
+          "wiki_place_page"
+        ]
+      ],
+      [
+        121.0,
+        "tool_result",
+        [
+          "wiki_place_page"
+        ]
+      ],
+      [
+        121.0,
+        "tool_result",
+        [
+          "wiki_place_page"
+        ]
+      ],
+      [
+        184.0,
+        "assistant",
+        []
+      ],
+      [
+        184.0,
+        "assistant",
+        []
+      ],
+      [
+        236.1,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        236.1,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        242.3,
+        "assistant",
+        []
+      ],
+      [
+        250.5,
+        "assistant",
+        []
+      ],
+      [
+        250.5,
+        "assistant",
+        [
+          "Skill:research-plan"
+        ]
+      ],
+      [
+        250.5,
+        "tool_result",
+        [
+          "Skill:research-plan"
+        ]
+      ],
+      [
+        250.5,
+        "tool_result",
+        []
+      ],
+      [
+        258.4,
+        "assistant",
+        []
+      ],
+      [
+        260.4,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        261.0,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        261.1,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        261.2,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        350.2,
+        "assistant",
+        []
+      ],
+      [
+        351.5,
+        "assistant",
+        []
+      ],
+      [
+        396.3,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        396.3,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        405.0,
+        "assistant",
+        []
+      ],
+      [
+        412.9,
+        "assistant",
+        []
+      ],
+      [
+        412.9,
+        "assistant",
+        [
+          "Skill:search-records"
+        ]
+      ],
+      [
+        412.9,
+        "tool_result",
+        [
+          "Skill:search-records"
+        ]
+      ],
+      [
+        412.9,
+        "tool_result",
+        []
+      ],
+      [
+        429.0,
+        "assistant",
+        []
+      ],
+      [
+        429.0,
+        "assistant",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        429.0,
+        "tool_result",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        440.9,
+        "assistant",
+        []
+      ],
+      [
+        441.0,
+        "assistant",
+        []
+      ],
+      [
+        444.3,
+        "assistant",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        444.7,
+        "tool_result",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        457.7,
+        "assistant",
+        []
+      ],
+      [
+        458.8,
+        "assistant",
+        []
+      ],
+      [
+        461.5,
+        "assistant",
+        [
+          "rank_search_matches"
+        ]
+      ],
+      [
+        462.2,
+        "tool_result",
+        [
+          "rank_search_matches"
+        ]
+      ],
+      [
+        473.9,
+        "assistant",
+        []
+      ],
+      [
+        474.3,
+        "assistant",
+        []
+      ],
+      [
+        474.8,
+        "assistant",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        474.9,
+        "tool_result",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        482.2,
+        "assistant",
+        []
+      ],
+      [
+        485.9,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        486.7,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        489.8,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        489.8,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        490.0,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        490.0,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        490.2,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        490.3,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        525.3,
+        "assistant",
+        []
+      ],
+      [
+        526.9,
+        "assistant",
+        []
+      ],
+      [
+        535.3,
+        "assistant",
+        [
+          "research_log_append"
+        ]
+      ],
+      [
+        535.3,
+        "tool_result",
+        [
+          "research_log_append"
+        ]
+      ],
+      [
+        540.4,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        540.5,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        562.3,
+        "assistant",
+        []
+      ],
+      [
+        562.5,
+        "assistant",
+        []
+      ],
+      [
+        564.4,
+        "assistant",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        564.9,
+        "tool_result",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        566.4,
+        "assistant",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        566.6,
+        "tool_result",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        588.7,
+        "assistant",
+        []
+      ],
+      [
+        589.2,
+        "assistant",
+        []
+      ],
+      [
+        591.5,
+        "assistant",
+        [
+          "rank_search_matches"
+        ]
+      ],
+      [
+        592.5,
+        "tool_result",
+        [
+          "rank_search_matches"
+        ]
+      ],
+      [
+        592.9,
+        "assistant",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        593.4,
+        "tool_result",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        613.3,
+        "assistant",
+        []
+      ],
+      [
+        613.3,
+        "assistant",
+        []
+      ],
+      [
+        616.3,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        616.8,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        617.7,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        617.7,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        617.7,
+        "system:status",
+        []
+      ],
+      [
+        732.3,
+        "system:status",
+        []
+      ],
+      [
+        732.3,
+        "system:compact_boundary",
+        []
+      ],
+      [
+        732.3,
+        "tool_result",
+        []
+      ],
+      [
+        744.4,
+        "assistant",
+        []
+      ],
+      [
+        744.7,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        744.7,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        750.0,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        750.0,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        763.9,
+        "assistant",
+        []
+      ],
+      [
+        764.1,
+        "assistant",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        764.4,
+        "tool_result",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        776.7,
+        "assistant",
+        []
+      ],
+      [
+        801.1,
+        "assistant",
+        [
+          "research_log_append"
+        ]
+      ],
+      [
+        801.2,
+        "tool_result",
+        [
+          "research_log_append"
+        ]
+      ],
+      [
+        804.6,
+        "assistant",
+        []
+      ],
+      [
+        805.1,
+        "assistant",
+        []
+      ],
+      [
+        808.3,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        808.3,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        846.5,
+        "assistant",
+        []
+      ],
+      [
+        846.5,
+        "assistant",
+        []
+      ],
+      [
+        859.2,
+        "assistant",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        859.7,
+        "system:task_started",
+        []
+      ],
+      [
+        859.7,
+        "tool_result",
+        []
+      ],
+      [
+        863.5,
+        "system:task_progress",
+        []
+      ],
+      [
+        863.5,
+        "assistant",
+        [
+          "project_context"
+        ]
+      ],
+      [
+        864.0,
+        "tool_result",
+        [
+          "project_context"
+        ]
+      ],
+      [
+        864.5,
+        "system:task_progress",
+        []
+      ],
+      [
+        864.5,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        864.5,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        867.1,
+        "assistant",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        867.1,
+        "system:task_started",
+        []
+      ],
+      [
+        867.1,
+        "tool_result",
+        []
+      ],
+      [
+        869.5,
+        "system:task_progress",
+        []
+      ],
+      [
+        869.5,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        869.7,
+        "system:task_progress",
+        []
+      ],
+      [
+        869.7,
+        "assistant",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        870.1,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        870.3,
+        "tool_result",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        872.4,
+        "system:task_progress",
+        []
+      ],
+      [
+        872.4,
+        "assistant",
+        [
+          "project_context"
+        ]
+      ],
+      [
+        872.9,
+        "tool_result",
+        [
+          "project_context"
+        ]
+      ],
+      [
+        873.3,
+        "system:task_progress",
+        []
+      ],
+      [
+        873.3,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        873.3,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        873.8,
+        "system:task_progress",
+        []
+      ],
+      [
+        873.8,
+        "assistant",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        873.9,
+        "system:task_progress",
+        []
+      ],
+      [
+        873.9,
+        "assistant",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        874.0,
+        "tool_result",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        874.1,
+        "tool_result",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        926.8,
+        "system:task_progress",
+        []
+      ],
+      [
+        926.8,
+        "assistant",
+        [
+          "extraction_append"
+        ]
+      ],
+      [
+        926.9,
+        "tool_result",
+        [
+          "extraction_append"
+        ]
+      ],
+      [
+        932.5,
+        "system:task_progress",
+        []
+      ],
+      [
+        932.5,
+        "assistant",
+        [
+          "extraction_append"
+        ]
+      ],
+      [
+        932.6,
+        "tool_result",
+        [
+          "extraction_append"
+        ]
+      ],
+      [
+        937.8,
+        "system:task_progress",
+        []
+      ],
+      [
+        937.8,
+        "assistant",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        938.2,
+        "tool_result",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        938.2,
+        "system:task_progress",
+        []
+      ],
+      [
+        938.2,
+        "assistant",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        938.3,
+        "system:task_progress",
+        []
+      ],
+      [
+        938.3,
+        "assistant",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        938.4,
+        "tool_result",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        938.5,
+        "tool_result",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        949.2,
+        "system:task_notification",
+        []
+      ],
+      [
+        949.2,
+        "tool_result",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        957.1,
+        "system:task_notification",
+        []
+      ],
+      [
+        957.1,
+        "tool_result",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        1011.0,
+        "assistant",
+        []
+      ],
+      [
+        1012.0,
+        "assistant",
+        []
+      ],
+      [
+        1024.9,
+        "assistant",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        1025.4,
+        "system:task_started",
+        []
+      ],
+      [
+        1025.4,
+        "tool_result",
+        []
+      ],
+      [
+        1030.1,
+        "system:task_progress",
+        []
+      ],
+      [
+        1030.2,
+        "assistant",
+        [
+          "project_context"
+        ]
+      ],
+      [
+        1030.6,
+        "tool_result",
+        [
+          "project_context"
+        ]
+      ],
+      [
+        1030.9,
+        "assistant",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        1030.9,
+        "system:task_started",
+        []
+      ],
+      [
+        1030.9,
+        "tool_result",
+        []
+      ],
+      [
+        1031.0,
+        "system:task_progress",
+        []
+      ],
+      [
+        1031.0,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        1031.0,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        1036.0,
+        "system:task_progress",
+        []
+      ],
+      [
+        1036.0,
+        "assistant",
+        [
+          "project_context"
+        ]
+      ],
+      [
+        1036.4,
+        "tool_result",
+        [
+          "project_context"
+        ]
+      ],
+      [
+        1036.9,
+        "system:task_progress",
+        []
+      ],
+      [
+        1036.9,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        1036.9,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        1039.7,
+        "system:task_progress",
+        []
+      ],
+      [
+        1039.7,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        1040.2,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        1047.9,
+        "system:task_progress",
+        []
+      ],
+      [
+        1047.9,
+        "assistant",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        1048.2,
+        "tool_result",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        1059.0,
+        "system:task_progress",
+        []
+      ],
+      [
+        1059.0,
+        "assistant",
+        [
+          "extraction_append"
+        ]
+      ],
+      [
+        1059.3,
+        "tool_result",
+        [
+          "extraction_append"
+        ]
+      ],
+      [
+        1059.3,
+        "system:task_progress",
+        []
+      ],
+      [
+        1059.3,
+        "assistant",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        1059.3,
+        "tool_result",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        1059.4,
+        "system:task_notification",
+        []
+      ],
+      [
+        1059.4,
+        "tool_result",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        1063.9,
+        "system:task_progress",
+        []
+      ],
+      [
+        1063.9,
+        "assistant",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        1064.3,
+        "tool_result",
+        [
+          "record_person_matches"
+        ]
+      ],
+      [
+        1078.3,
+        "system:task_notification",
+        []
+      ],
+      [
+        1078.3,
+        "tool_result",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        1126.9,
+        "assistant",
+        []
+      ],
+      [
+        1128.0,
+        "assistant",
+        [
+          "Glob"
+        ]
+      ],
+      [
+        1128.4,
+        "tool_result",
+        [
+          "Glob"
+        ]
+      ],
+      [
+        1128.8,
+        "assistant",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        1128.8,
+        "tool_result",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        1135.9,
+        "assistant",
+        []
+      ],
+      [
+        1138.1,
+        "assistant",
+        [
+          "Glob"
+        ]
+      ],
+      [
+        1138.1,
+        "tool_result",
+        [
+          "Glob"
+        ]
+      ],
+      [
+        1142.6,
+        "assistant",
+        [
+          "Glob"
+        ]
+      ],
+      [
+        1142.6,
+        "tool_result",
+        [
+          "Glob"
+        ]
+      ],
+      [
+        1147.1,
+        "assistant",
+        []
+      ],
+      [
+        1149.0,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1149.1,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1192.9,
+        "assistant",
+        []
+      ],
+      [
+        1192.9,
+        "assistant",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        1192.9,
+        "tool_result",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        1199.4,
+        "assistant",
+        []
+      ],
+      [
+        1200.0,
+        "assistant",
+        []
+      ],
+      [
+        1203.3,
+        "assistant",
+        [
+          "research_query"
+        ]
+      ],
+      [
+        1203.9,
+        "tool_result",
+        [
+          "research_query"
+        ]
+      ],
+      [
+        1204.3,
+        "assistant",
+        [
+          "research_query"
+        ]
+      ],
+      [
+        1204.7,
+        "tool_result",
+        [
+          "research_query"
+        ]
+      ],
+      [
+        1205.7,
+        "assistant",
+        [
+          "research_query"
+        ]
+      ],
+      [
+        1205.7,
+        "tool_result",
+        [
+          "research_query"
+        ]
+      ],
+      [
+        1250.8,
+        "assistant",
+        []
+      ],
+      [
+        1250.8,
+        "assistant",
+        []
+      ],
+      [
+        1253.2,
+        "assistant",
+        [
+          "research_query"
+        ]
+      ],
+      [
+        1253.6,
+        "tool_result",
+        [
+          "research_query"
+        ]
+      ],
+      [
+        1254.1,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1254.1,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1259.4,
+        "assistant",
+        []
+      ],
+      [
+        1260.3,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1260.3,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1361.6,
+        "assistant",
+        []
+      ],
+      [
+        1362.4,
+        "assistant",
+        []
+      ],
+      [
+        1367.0,
+        "assistant",
+        [
+          "materialize_facts"
+        ]
+      ],
+      [
+        1367.0,
+        "tool_result",
+        [
+          "materialize_facts"
+        ]
+      ],
+      [
+        1415.1,
+        "assistant",
+        []
+      ],
+      [
+        1415.1,
+        "assistant",
+        []
+      ],
+      [
+        1463.4,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        1463.4,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        1493.3,
+        "assistant",
+        []
+      ],
+      [
+        1495.7,
+        "assistant",
+        []
+      ],
+      [
+        1499.0,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        1499.0,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        1503.2,
+        "assistant",
+        []
+      ],
+      [
+        1503.9,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1504.0,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1567.2,
+        "assistant",
+        []
+      ],
+      [
+        1568.5,
+        "assistant",
+        []
+      ],
+      [
+        1572.8,
+        "assistant",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1574.2,
+        "assistant",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1574.7,
+        "tool_result",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1575.2,
+        "tool_result",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1576.1,
+        "assistant",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1576.3,
+        "tool_result",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1597.7,
+        "assistant",
+        []
+      ],
+      [
+        1599.1,
+        "assistant",
+        []
+      ],
+      [
+        1600.9,
+        "assistant",
+        [
+          "rank_search_matches"
+        ]
+      ],
+      [
+        1602.0,
+        "tool_result",
+        [
+          "rank_search_matches"
+        ]
+      ],
+      [
+        1603.8,
+        "assistant",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1604.3,
+        "tool_result",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1605.5,
+        "assistant",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1605.7,
+        "tool_result",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1652.7,
+        "assistant",
+        []
+      ],
+      [
+        1654.1,
+        "assistant",
+        []
+      ],
+      [
+        1656.4,
+        "assistant",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1656.8,
+        "tool_result",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1680.0,
+        "assistant",
+        [
+          "research_log_append"
+        ]
+      ],
+      [
+        1680.1,
+        "tool_result",
+        [
+          "research_log_append"
+        ]
+      ],
+      [
+        1687.0,
+        "assistant",
+        []
+      ],
+      [
+        1687.3,
+        "assistant",
+        []
+      ],
+      [
+        1688.3,
+        "assistant",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        1688.7,
+        "tool_result",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        1689.8,
+        "assistant",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1690.2,
+        "tool_result",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1705.0,
+        "assistant",
+        []
+      ],
+      [
+        1706.1,
+        "assistant",
+        []
+      ],
+      [
+        1709.2,
+        "assistant",
+        [
+          "fulltext_search"
+        ]
+      ],
+      [
+        1710.5,
+        "tool_result",
+        [
+          "fulltext_search"
+        ]
+      ],
+      [
+        1710.5,
+        "assistant",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1710.8,
+        "tool_result",
+        [
+          "record_search"
+        ]
+      ],
+      [
+        1720.9,
+        "assistant",
+        []
+      ],
+      [
+        1720.9,
+        "assistant",
+        []
+      ],
+      [
+        1728.8,
+        "assistant",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        1729.2,
+        "system:task_started",
+        []
+      ],
+      [
+        1729.2,
+        "tool_result",
+        []
+      ],
+      [
+        1729.2,
+        "assistant",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        1729.2,
+        "tool_result",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        1733.0,
+        "system:task_progress",
+        []
+      ],
+      [
+        1733.0,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1733.1,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1739.1,
+        "system:task_progress",
+        []
+      ],
+      [
+        1739.1,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1739.1,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1748.0,
+        "system:task_progress",
+        []
+      ],
+      [
+        1748.0,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1748.1,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1754.7,
+        "system:task_progress",
+        []
+      ],
+      [
+        1754.7,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1754.7,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1762.2,
+        "system:task_progress",
+        []
+      ],
+      [
+        1762.2,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1762.2,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1769.8,
+        "system:task_progress",
+        []
+      ],
+      [
+        1769.8,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1769.8,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1777.5,
+        "system:task_progress",
+        []
+      ],
+      [
+        1777.5,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1777.5,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        1857.1,
+        "system:task_notification",
+        []
+      ],
+      [
+        1857.1,
+        "tool_result",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        1888.0,
+        "assistant",
+        []
+      ],
+      [
+        1889.0,
+        "assistant",
+        []
+      ],
+      [
+        1892.0,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        1892.4,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        1892.4,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        1893.4,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        1894.0,
+        "assistant",
+        [
+          "fulltext_search"
+        ]
+      ],
+      [
+        1894.7,
+        "tool_result",
+        [
+          "fulltext_search"
+        ]
+      ],
+      [
+        1894.7,
+        "system:status",
+        []
+      ],
+      [
+        2053.6,
+        "system:status",
+        []
+      ],
+      [
+        2053.6,
+        "system:compact_boundary",
+        []
+      ],
+      [
+        2053.6,
+        "tool_result",
+        []
+      ],
+      [
+        2064.5,
+        "assistant",
+        []
+      ],
+      [
+        2071.1,
+        "assistant",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        2071.5,
+        "system:task_started",
+        []
+      ],
+      [
+        2071.5,
+        "tool_result",
+        []
+      ],
+      [
+        2072.3,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2072.4,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2077.9,
+        "system:task_progress",
+        []
+      ],
+      [
+        2077.9,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2078.1,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2083.1,
+        "system:task_progress",
+        []
+      ],
+      [
+        2083.1,
+        "assistant",
+        [
+          "Grep"
+        ]
+      ],
+      [
+        2083.1,
+        "tool_result",
+        [
+          "Grep"
+        ]
+      ],
+      [
+        2088.2,
+        "system:task_progress",
+        []
+      ],
+      [
+        2088.2,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2088.3,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2092.5,
+        "system:task_progress",
+        []
+      ],
+      [
+        2092.5,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2092.5,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2098.6,
+        "system:task_progress",
+        []
+      ],
+      [
+        2098.6,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2098.6,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2106.5,
+        "system:task_progress",
+        []
+      ],
+      [
+        2106.5,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2106.6,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2114.2,
+        "system:task_progress",
+        []
+      ],
+      [
+        2114.2,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2114.2,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2126.2,
+        "system:task_progress",
+        []
+      ],
+      [
+        2126.2,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2126.3,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2136.2,
+        "system:task_progress",
+        []
+      ],
+      [
+        2136.2,
+        "assistant",
+        [
+          "Grep"
+        ]
+      ],
+      [
+        2136.2,
+        "tool_result",
+        [
+          "Grep"
+        ]
+      ],
+      [
+        2145.1,
+        "system:task_progress",
+        []
+      ],
+      [
+        2145.1,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2145.1,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2151.9,
+        "system:task_progress",
+        []
+      ],
+      [
+        2151.9,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2151.9,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2165.7,
+        "system:task_progress",
+        []
+      ],
+      [
+        2165.7,
+        "assistant",
+        [
+          "Grep"
+        ]
+      ],
+      [
+        2165.7,
+        "tool_result",
+        [
+          "Grep"
+        ]
+      ],
+      [
+        2175.6,
+        "system:task_progress",
+        []
+      ],
+      [
+        2175.6,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2175.6,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2243.8,
+        "system:task_notification",
+        []
+      ],
+      [
+        2243.8,
+        "tool_result",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        2253.9,
+        "assistant",
+        []
+      ],
+      [
+        2254.8,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2254.8,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2257.4,
+        "assistant",
+        []
+      ],
+      [
+        2259.6,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2259.7,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2340.3,
+        "assistant",
+        []
+      ],
+      [
+        2340.3,
+        "assistant",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        2340.3,
+        "tool_result",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        2382.8,
+        "assistant",
+        []
+      ],
+      [
+        2382.8,
+        "assistant",
+        []
+      ],
+      [
+        2385.4,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        2385.4,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        2390.1,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        2390.2,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        2392.1,
+        "assistant",
+        []
+      ],
+      [
+        2393.4,
+        "assistant",
+        []
+      ],
+      [
+        2410.0,
+        "assistant",
+        [
+          "research_log_append"
+        ]
+      ],
+      [
+        2410.1,
+        "tool_result",
+        [
+          "research_log_append"
+        ]
+      ],
+      [
+        2420.3,
+        "assistant",
+        []
+      ],
+      [
+        2420.3,
+        "assistant",
+        []
+      ],
+      [
+        2433.8,
+        "assistant",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        2433.8,
+        "system:task_started",
+        []
+      ],
+      [
+        2433.8,
+        "tool_result",
+        []
+      ],
+      [
+        2436.8,
+        "system:task_progress",
+        []
+      ],
+      [
+        2436.8,
+        "assistant",
+        [
+          "project_context"
+        ]
+      ],
+      [
+        2436.8,
+        "system:task_progress",
+        []
+      ],
+      [
+        2436.8,
+        "assistant",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        2436.9,
+        "tool_result",
+        [
+          "project_context"
+        ]
+      ],
+      [
+        2437.4,
+        "tool_result",
+        [
+          "record_read"
+        ]
+      ],
+      [
+        2461.0,
+        "system:task_progress",
+        []
+      ],
+      [
+        2461.0,
+        "assistant",
+        [
+          "extraction_append"
+        ]
+      ],
+      [
+        2461.1,
+        "tool_result",
+        [
+          "extraction_append"
+        ]
+      ],
+      [
+        2471.9,
+        "system:task_notification",
+        []
+      ],
+      [
+        2471.9,
+        "tool_result",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        2491.5,
+        "assistant",
+        []
+      ],
+      [
+        2491.5,
+        "assistant",
+        []
+      ],
+      [
+        2491.6,
+        "assistant",
+        [
+          "Skill:person-evidence"
+        ]
+      ],
+      [
+        2491.6,
+        "tool_result",
+        [
+          "Skill:person-evidence"
+        ]
+      ],
+      [
+        2491.6,
+        "tool_result",
+        []
+      ],
+      [
+        2532.9,
+        "assistant",
+        []
+      ],
+      [
+        2534.5,
+        "assistant",
+        []
+      ],
+      [
+        2534.5,
+        "assistant",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        2534.5,
+        "tool_result",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        2537.3,
+        "assistant",
+        []
+      ],
+      [
+        2540.2,
+        "assistant",
+        [
+          "materialize_facts"
+        ]
+      ],
+      [
+        2540.2,
+        "tool_result",
+        [
+          "materialize_facts"
+        ]
+      ],
+      [
+        2549.0,
+        "assistant",
+        []
+      ],
+      [
+        2549.1,
+        "assistant",
+        []
+      ],
+      [
+        2558.3,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        2558.3,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        2578.0,
+        "assistant",
+        []
+      ],
+      [
+        2578.0,
+        "assistant",
+        []
+      ],
+      [
+        2578.0,
+        "assistant",
+        [
+          "Skill:research-exhaustiveness"
+        ]
+      ],
+      [
+        2578.0,
+        "tool_result",
+        [
+          "Skill:research-exhaustiveness"
+        ]
+      ],
+      [
+        2578.0,
+        "tool_result",
+        []
+      ],
+      [
+        2667.0,
+        "assistant",
+        []
+      ],
+      [
+        2667.1,
+        "assistant",
+        []
+      ],
+      [
+        2669.2,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2669.2,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2716.7,
+        "assistant",
+        []
+      ],
+      [
+        2729.2,
+        "assistant",
+        []
+      ],
+      [
+        2757.7,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        2757.7,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        2760.0,
+        "assistant",
+        []
+      ],
+      [
+        2760.5,
+        "assistant",
+        []
+      ],
+      [
+        2760.5,
+        "assistant",
+        [
+          "Skill:proof-conclusion"
+        ]
+      ],
+      [
+        2760.5,
+        "tool_result",
+        [
+          "Skill:proof-conclusion"
+        ]
+      ],
+      [
+        2760.5,
+        "tool_result",
+        []
+      ],
+      [
+        2775.3,
+        "assistant",
+        []
+      ],
+      [
+        2775.3,
+        "assistant",
+        []
+      ],
+      [
+        2778.1,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2778.1,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2778.4,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2778.4,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2780.5,
+        "assistant",
+        []
+      ],
+      [
+        2782.6,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2782.7,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2851.0,
+        "assistant",
+        []
+      ],
+      [
+        2856.3,
+        "assistant",
+        []
+      ],
+      [
+        2856.7,
+        "assistant",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        2857.1,
+        "tool_result",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        2858.6,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2858.6,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        2945.5,
+        "assistant",
+        []
+      ],
+      [
+        2945.5,
+        "assistant",
+        []
+      ],
+      [
+        2979.5,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        2979.6,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3024.8,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3024.8,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3028.7,
+        "assistant",
+        []
+      ],
+      [
+        3029.2,
+        "assistant",
+        []
+      ],
+      [
+        3032.1,
+        "assistant",
+        [
+          "tree_edit"
+        ]
+      ],
+      [
+        3032.1,
+        "tool_result",
+        [
+          "tree_edit"
+        ]
+      ],
+      [
+        3042.8,
+        "assistant",
+        []
+      ],
+      [
+        3042.8,
+        "assistant",
+        []
+      ],
+      [
+        3042.8,
+        "assistant",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        3042.9,
+        "tool_result",
+        [
+          "ToolSearch"
+        ]
+      ],
+      [
+        3046.9,
+        "assistant",
+        []
+      ],
+      [
+        3050.4,
+        "assistant",
+        [
+          "tree_correct"
+        ]
+      ],
+      [
+        3050.5,
+        "tool_result",
+        [
+          "tree_correct"
+        ]
+      ],
+      [
+        3060.6,
+        "assistant",
+        []
+      ],
+      [
+        3061.0,
+        "assistant",
+        []
+      ],
+      [
+        3062.2,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3062.3,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3065.2,
+        "assistant",
+        []
+      ],
+      [
+        3065.2,
+        "assistant",
+        []
+      ],
+      [
+        3074.0,
+        "assistant",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        3074.0,
+        "system:task_started",
+        []
+      ],
+      [
+        3074.0,
+        "tool_result",
+        []
+      ],
+      [
+        3076.2,
+        "system:task_progress",
+        []
+      ],
+      [
+        3076.2,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3076.4,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3080.2,
+        "system:task_progress",
+        []
+      ],
+      [
+        3080.2,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3080.2,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3085.1,
+        "system:task_progress",
+        []
+      ],
+      [
+        3085.1,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3085.2,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3088.9,
+        "system:task_progress",
+        []
+      ],
+      [
+        3088.9,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3089.0,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3093.0,
+        "system:task_progress",
+        []
+      ],
+      [
+        3093.0,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3093.1,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3097.0,
+        "system:task_progress",
+        []
+      ],
+      [
+        3097.0,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3097.0,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3101.3,
+        "system:task_progress",
+        []
+      ],
+      [
+        3101.3,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3101.4,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3166.3,
+        "system:task_progress",
+        []
+      ],
+      [
+        3166.3,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3166.5,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3170.3,
+        "system:task_progress",
+        []
+      ],
+      [
+        3170.3,
+        "assistant",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3170.4,
+        "tool_result",
+        [
+          "Read"
+        ]
+      ],
+      [
+        3240.0,
+        "system:task_progress",
+        []
+      ],
+      [
+        3240.0,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3240.1,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3254.1,
+        "system:task_notification",
+        []
+      ],
+      [
+        3254.1,
+        "tool_result",
+        [
+          "Agent"
+        ]
+      ],
+      [
+        3293.8,
+        "assistant",
+        []
+      ],
+      [
+        3294.9,
+        "assistant",
+        []
+      ],
+      [
+        3306.7,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3306.8,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3318.6,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3318.6,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3324.8,
+        "assistant",
+        []
+      ],
+      [
+        3325.1,
+        "assistant",
+        []
+      ],
+      [
+        3371.8,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3371.8,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3390.4,
+        "assistant",
+        []
+      ],
+      [
+        3392.7,
+        "assistant",
+        []
+      ],
+      [
+        3392.7,
+        "assistant",
+        [
+          "Skill:question-selection"
+        ]
+      ],
+      [
+        3392.8,
+        "tool_result",
+        [
+          "Skill:question-selection"
+        ]
+      ],
+      [
+        3392.8,
+        "tool_result",
+        []
+      ],
+      [
+        3419.7,
+        "assistant",
+        []
+      ],
+      [
+        3421.5,
+        "assistant",
+        []
+      ],
+      [
+        3422.8,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3422.8,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3427.7,
+        "assistant",
+        []
+      ],
+      [
+        3428.8,
+        "assistant",
+        []
+      ],
+      [
+        3429.5,
+        "assistant",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3429.6,
+        "tool_result",
+        [
+          "research_append"
+        ]
+      ],
+      [
+        3442.7,
+        "assistant",
+        []
+      ],
+      [
+        3442.8,
+        "result",
+        []
+      ]
+    ],
+    "max_output_tokens": null,
+    "cli_version": null,
+    "caps": {
+      "wall_clock_seconds": 7200,
+      "inactivity_seconds": 600,
+      "progress_stall_seconds": 600,
+      "tool_calls": 300,
+      "max_turns": 250,
+      "max_cost_usd": 15.0
+    },
+    "wall_clock_seconds": 3453.776555208002,
+    "real_clock_seconds": 3453.846039056778,
+    "slept_seconds": 0.06948384877614444,
+    "judge_seconds": 10.695455458000652,
+    "agent_model": "claude-sonnet-4-6",
+    "subagent_model_override": null,
+    "effort_level": "high"
+  },
+  "tool_calls": [
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/**/*.json"
+      },
+      "response_summary": ".claude/skills/init-project/templates/research.json\nresearch.json\ntree.gedcomx.json\n.claude/settings.json"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json"
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_bagley_father_1884\",\n4\t    \"objective\": \"Who was the father of William A. Bagley, born about 1815 and died 31 May 1884 in Topsham, Orange County, Vermont?\",\n5\t    \"subject_person_ids\": [\n6\t      \"MJDL-Q8B\"\n7\t    ],\n8\t    \"status\": \"active\",\n9\t    \"created\": \"2026-07-27\",\n10\t    \"updated\": \"2026-07-27\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\": \"intermediate\",\n14\t    \"subscriptions\": [],\n15\t    \"narration_guidance\": \"concise\"\n16\t  },\n17..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/tree.gedcomx.json"
+      },
+      "response_summary": "1\t{\n2\t  \"persons\": [\n3\t    {\n4\t      \"id\": \"MJDL-Q8B\",\n5\t      \"gender\": \"Male\",\n6\t      \"living\": false,\n7\t      \"names\": [\n8\t        {\n9\t          \"id\": \"N1\",\n10\t          \"given\": \"William A.\",\n11\t          \"surname\": \"Bagley\"\n12\t        }\n13\t      ],\n14\t      \"facts\": [\n15\t        {\n16\t          \"id\": \"ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100\",\n17\t          \"type\": \"Birth\",\n18\t          \"date\": \"Abt 1815\",\n19\t          \"standard_date\": \"Abt 1815\",\n20\t          \"place\": \"West Topsham, Orange, ..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "question-selection"
+      },
+      "response_summary": "Launching skill: question-selection"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/question-selection/references/question-formulation.md"
+      },
+      "response_summary": "1\t# Research Question Formulation\n2\t\n3\tGuidance for formulating effective genealogical research questions\n4\tthat satisfy the GPS standard for planned, purposeful research.\n5\t\n6\t## Research Objectives vs. Research Questions\n7\t\n8\tThese are distinct concepts that must not be conflated:\n9\t\n10\t- **Research objective**: The overarching goal of the research effort.\n11\t  It describes what you ultimately want to know (e.g., \"Identify the\n12\t  parents of John Smith born circa 1820 in Greene County, Ohi..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/question-selection/references/pedigree-analysis.md"
+      },
+      "response_summary": "1\t# Pedigree Analysis for Gap Detection\n2\t\n3\tGuidance for evaluating pedigree data to identify research gaps,\n4\terrors, and candidates for new research questions.\n5\t\n6\t## Purpose\n7\t\n8\tPedigree analysis is the process of systematically reviewing the\n9\tindividuals in a family tree to detect missing information, logical\n10\terrors, and inconsistencies. It is a critical first step before\n11\tselecting new research questions \u2014 it reveals where the gaps are\n12\tand which gaps are most significant.\n13\t..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_append",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "questions",
+        "op": "append",
+        "entry": {
+          "question": "Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermont)?",
+          "rationale": "The research objective directly targets the identity of William A. Bagley's father. His mother, Sarah Sally Andrews (born 1777 Gloucester, Essex, Massachusetts; died 19 March 1847 Topsham, Orange, Vermont), is already identified in the tree, but no father is recorded. Vermont death records for 1884, early census records (1820\u20131840, when William would appear in a parental household), and Orange County probate records on FamilySearch offer the most direct paths to naming his paternal line.",
+          "selection_basis": "objective_decomposition",
+          "priority": "high",
+          "status": "open",
+          "depends_on": [],
+          "unblocks": [],
+          "resolved": null,
+          "resolution_assertion_ids": [],
+          "exhaustive_declaration": {
+            "declared": false,
+            "justification": null,
+            "log_entry_ids": [],
+            "stop_criteria": null
+          }
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"questions\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"q_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "locality-guide"
+      },
+      "response_summary": "Launching skill: locality-guide"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__place_search,mcp__genealogy__place_search_all,mcp__genealogy__collections_search,mcp__genealogy__volume_search,mcp__genealogy__external_links_search,mcp__genealogy__wiki_place_page,mcp__genealogy__wiki_search,mcp__genealogy__place_population",
+        "max_results": 8
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__place_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__place_search_all\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__collections_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__volume_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__external_links_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__wiki_place_page\"}, {\"type\": \"tool_reference\", \"tool_na..."
+    },
+    {
+      "tool": "mcp__genealogy__place_search_all",
+      "args": {
+        "placeName": "Topsham, Orange County, Vermont"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"results\\\": [\\n    {\\n      \\\"standardPlace\\\": \\\"Topsham, Orange, Vermont, United States\\\",\\n      \\\"type\\\": \\\"Town\\\",\\n      \\\"latitude\\\": 44.1331,\\n      \\\"longitude\\\": -72.2515,\\n      \\\"familysearchUrl\\\": \\\"https://www.familysearch.org/en/research/places/?text=Topsham&focusedId=5405424\\\",\\n      \\\"wikipediaUrl\\\": \\\"https://en.wikipedia.org/wiki/Topsham,_Vermont\\\"\\n    },\\n    {\\n      \\\"standardPlace\\\": \\\"Topsham, Orange, Republic of Vermont\\\",\\n      \\\"ty..."
+    },
+    {
+      "tool": "mcp__genealogy__place_population",
+      "args": {
+        "standardPlace": "Topsham, Orange, Vermont, United States",
+        "startYear": 1800,
+        "endYear": 1890
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"error\\\": \\\"Place not found\\\",\\n  \\\"place_id\\\": \\\"1355104\\\"\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__collections_search",
+      "args": {
+        "standardPlace": "Topsham, Orange, Vermont, United States",
+        "startYear": 1800,
+        "endYear": 1890
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"standardPlace\\\": \\\"Topsham, Orange, Vermont, United States\\\",\\n    \\\"startYear\\\": 1800,\\n    \\\"endYear\\\": 1890\\n  },\\n  \\\"scope\\\": \\\"Vermont\\\",\\n  \\\"totalForPlace\\\": 22,\\n  \\\"results\\\": [\\n    {\\n      \\\"id\\\": \\\"1879935\\\",\\n      \\\"title\\\": \\\"Vermont, Addison County and District Probate Files, 1845-1915\\\",\\n      \\\"dateRange\\\": \\\"1845-1915\\\",\\n      \\\"recordCount\\\": 0,\\n      \\\"personCount\\\": 0,\\n      \\\"imageCount\\\": 54451,\\n      \\\"url\\\": ..."
+    },
+    {
+      "tool": "mcp__genealogy__volume_search",
+      "args": {
+        "standardPlace": "Topsham, Orange, Vermont, United States",
+        "startYear": 1800,
+        "endYear": 1890
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"standardPlace\\\": \\\"Topsham, Orange, Vermont, United States\\\",\\n    \\\"startYear\\\": 1800,\\n    \\\"endYear\\\": 1890\\n  },\\n  \\\"totalResults\\\": 20,\\n  \\\"results\\\": [\\n    {\\n      \\\"imageGroupNumber\\\": \\\"007814131_002_M9ZV-457\\\",\\n      \\\"imageGroupPrefix\\\": \\\"007814131\\\",\\n      \\\"imageCount\\\": 405,\\n      \\\"recordSearchablePercent\\\": 0,\\n      \\\"fulltextSearchable\\\": true,\\n      \\\"languages\\\": [\\n        \\\"en\\\"\\n      ],\\n      \\\"coverages\\\": [..."
+    },
+    {
+      "tool": "mcp__genealogy__external_links_search",
+      "args": {
+        "standardPlace": "Topsham, Orange, Vermont, United States",
+        "startYear": 1800,
+        "endYear": 1890
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"standardPlace\\\": \\\"Topsham, Orange, Vermont, United States\\\",\\n    \\\"startYear\\\": 1800,\\n    \\\"endYear\\\": 1890\\n  },\\n  \\\"totalForPlace\\\": 292,\\n  \\\"returned\\\": 239,\\n  \\\"results\\\": [\\n    {\\n      \\\"url\\\": \\\"https://www.findmypast.com/search/results?datasetname=united%20states%2c%20passenger%20and%20crew%20lists&datasettitle=new%20england%20passenger%20and%20crew%20lists&sid=999\\\",\\n      \\\"linkText\\\": \\\"United States, Passenger and Crew Li..."
+    },
+    {
+      "tool": "mcp__genealogy__wiki_search",
+      "args": {
+        "query": "Topsham Orange County Vermont genealogy records research"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": \\\"Topsham Orange County Vermont genealogy records research\\\",\\n  \\\"total_chunks_searched\\\": 1240565,\\n  \\\"results\\\": [\\n    {\\n      \\\"rank\\\": 1,\\n      \\\"relevance_score\\\": 0.902344,\\n      \\\"chunk_text\\\": \\\"### Other Town Records  \\\\nIn Vermont, most records are kept at the town level and generally began being kept at the founding of the town. These records may include the following:  \\\\n|  |\\\\n| --- |\\\\n| * Births * Marriages * Deaths * Burials * ..."
+    },
+    {
+      "tool": "mcp__genealogy__wiki_place_page",
+      "args": {
+        "standardPlace": "Vermont, United States",
+        "section": "home"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"url\\\": \\\"https://www.familysearch.org/en/wiki/Vermont,_United_States_Genealogy\\\",\\n  \\\"content\\\": \\\"# Vermont, United States Genealogy\\\\n\\\\n\\\\n\\\\n[United States](https://www.familysearch.org/en/wiki/United_States_Genealogy \\\\\\\"United States Genealogy\\\\\\\")\\\\n\\\\n[New England](https://www.familysearch.org/en/wiki/New_England \\\\\\\"New England\\\\\\\")\\\\n\\\\nVermont\\\\n\\\\n|  |\\\\n| --- |\\\\n| **Vermont Wiki Topics** |\\\\n| [Vermont flag.png](https://www.familysearch.org/en/..."
+    },
+    {
+      "tool": "mcp__genealogy__wiki_place_page",
+      "args": {
+        "standardPlace": "Vermont, United States",
+        "section": "getting_started"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"url\\\": \\\"https://www.familysearch.org/en/wiki/Vermont_Getting_Started\\\",\\n  \\\"content\\\": \\\"# Vermont Getting Started\\\\n\\\\n\\\\n\\\\n|  |\\\\n| --- |\\\\n| [**Vermont Wiki Topics**](https://www.familysearch.org/en/wiki/Vermont,_United_States_Genealogy \\\\\\\"Vermont, United States Genealogy\\\\\\\") |\\\\n| [Vermont flag.png](https://www.familysearch.org/en/wiki/index.php?title=File:Vermont_flag.png&filetimestamp=20080821015625& \\\\\\\"Vermont flag.png\\\\\\\") |\\\\n| **Beginning Rese..."
+    },
+    {
+      "tool": "mcp__genealogy__wiki_place_page",
+      "args": {
+        "standardPlace": "Vermont, United States",
+        "section": "online_records"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"url\\\": \\\"https://www.familysearch.org/en/wiki/Vermont_Online_Genealogy_Records\\\",\\n  \\\"content\\\": \\\"# Vermont Online Genealogy Records\\\\n\\\\n\\\\n\\\\n[United States](https://www.familysearch.org/en/wiki/United_States_Genealogy \\\\\\\"United States Genealogy\\\\\\\")\\\\n\\\\n[Vermont](https://www.familysearch.org/en/wiki/Vermont,_United_States_Genealogy \\\\\\\"Vermont, United States Genealogy\\\\\\\")\\\\n\\\\nOnline Genealogy Records\\\\n\\\\n|  |  |  |  |  |  |\\\\n| --- | --- | --- | ---..."
+    },
+    {
+      "tool": "mcp__genealogy__wiki_place_page",
+      "args": {
+        "standardPlace": "Vermont, United States",
+        "section": "research_tips"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"url\\\": \\\"https://www.familysearch.org/en/wiki/Vermont_Research_Tips_and_Strategies\\\",\\n  \\\"content\\\": \\\"# Vermont Research Tips and Strategies\\\\n\\\\n\\\\n\\\\n|  |\\\\n| --- |\\\\n| [**Vermont Wiki Topics**](https://www.familysearch.org/en/wiki/Vermont,_United_States_Genealogy \\\\\\\"Vermont, United States Genealogy\\\\\\\") |\\\\n| [Vermont flag.png](https://www.familysearch.org/en/wiki/index.php?title=File:Vermont_flag.png&filetimestamp=20080821015625& \\\\\\\"Vermont flag.png\\\\..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "localities",
+        "op": "append",
+        "entry": {
+          "place": "Vermont, United States",
+          "for_place": "Topsham, Orange County, Vermont",
+          "time_period": "1800-1890",
+          "jurisdictions": [
+            {
+              "name": "Topsham, Orange, Republic of Vermont",
+              "date_range": "pre-1791"
+            },
+            {
+              "name": "Topsham, Orange, Vermont, United States",
+              "date_range": "1791\u2013present"
+            }
+          ],
+          "collections": [
+            {
+              "id": "1987653",
+              "title": "Vermont, Town Clerk, Vital and Town Records, 1732-2005",
+              "date_range": "1699-2005"
+            },
+            {
+              "id": "1784223",
+              "title": "Vermont, Vital Records, 1760-1954",
+              "date_range": "1760-1954"
+            },
+            {
+              "id": "2075288",
+              "title": "Vermont, Vital Records, 1760-2008",
+              "date_range": "1760-2003"
+            },
+            {
+              "id": "1675544",
+              "title": "Vermont, Births and Christenings, 1765-1908",
+              "date_range": "1765-1908"
+            },
+            {
+              "id": "1675549",
+              "title": "Vermont, Deaths and Burials, 1871-1965",
+              "date_range": "1871-1965"
+            },
+            {
+              "id": "1675550",
+              "title": "Vermont, Marriages, 1791-1974",
+              "date_range": "1791-1974"
+            },
+            {
+              "id": "1435692",
+              "title": "Vermont, Probate Files, 1800-1921",
+              "date_range": "1800-1921"
+            },
+            {
+              "id": "1807377",
+              "title": "Vermont, Orange County, Bradford District Estate Files, 1780-1915",
+              "date_range": "1780-1915"
+            },
+            {
+              "id": "1453983",
+              "title": "Vermont, Orange County, Randolph District Probate Records, 1790-1935",
+              "date_range": "1790-1935"
+            },
+            {
+              "id": "1409123",
+              "title": "Vermont, Land Records, Early to 1900",
+              "date_range": "1600-1900"
+            },
+            {
+              "id": "1627819",
+              "title": "Vermont, Town Records, 1850-2005",
+              "date_range": "1850-2005"
+            },
+            {
+              "id": "3158875",
+              "title": "Vermont, Wills and Deeds, ca. 1700s-2017",
+              "date_range": "1700-2017"
+            }
+          ],
+          "quirks": [
+            "Statewide vital registration began 1857; before that, births/marriages/deaths are in Topsham town clerk records. The Topsham Town Records 1771-1860 (imageGroup 005464260) are digitized on FamilySearch with full-text search but 0% name-indexed \u2014 use full-text search, not record search.",
+            "Vermont death records before 1919 generally do NOT name the deceased's parents. Parental information on death certificates was required only from 1919 onward (Vermont Research Tips wiki). An 1884 death record for William A. Bagley will likely not name his father.",
+            "Topsham's probate district is Orange County, with court in Chelsea, VT. Two Orange County probate collections are on FamilySearch \u2014 Bradford District Estate Files 1780-1915 (imageGroup prefix 007814131 etc.) and Randolph District Probate Records 1790-1935 \u2014 both are browse-only images (0% indexed). Check both for any Bagley estate.",
+            "Also search Vermont Probate Files 1800-1921 (collection 1435692), which IS name-indexed and covers some Orange County records.",
+            "Topsham vital records 1857-1897 (imageGroup 005487650, 2180 images) and the vital statistic indexes 1857-1896 (imageGroup 005464890, 200 images) are 100% indexed and full-text searchable \u2014 primary target for William's 1884 death record.",
+            "Local history: 'Sketches of the Town of Topsham, Orange County, Vermont' (1929) by Frank H. Craig is available on Ancestry.com (collection 22236) and may contain family genealogies naming Bagley parents and children.",
+            "The largest Vermont vital records collection is 'Vermont, Town Clerk, Vital and Town Records, 1732-2005' (collection 1987653, 2.4M records, 1.4M images) \u2014 the primary indexed source for post-1857 Topsham vital records."
+          ],
+          "guide_markdown": "# Locality Guide: Topsham, Orange County, Vermont (1800\u20131890)\n\n## Jurisdictional Context\n\nTopsham was granted its charter 15 August 1763. It lies in Orange County, Vermont, and has three villages: East Topsham, Waits River, and West Topsham. Vermont became the 14th U.S. state on 4 March 1791; before that date, Topsham was in the Republic of Vermont. No boundary changes split the town's records across jurisdictions during the 1800\u20131890 period.\n\n## Vital Records\n\n**Pre-1857 (no state registration):** Town clerk records are the only source. The Topsham Town Records 1771\u20131860 are digitized on FamilySearch (imageGroup 005464260, 265 images). These are **full-text searchable but 0% name-indexed** \u2014 use the full-text search tool, not record search. Original records are also at the Topsham Town Clerk, 6 Harts Rd., Topsham, VT 05076.\n\n**Post-1857 (state registration):** Statewide registration required by law from 1857. Key indexed collections on FamilySearch:\n- **Vermont, Town Clerk, Vital and Town Records, 1732\u20132005** (coll. 1987653) \u2014 2.4M records, indexed + images. Primary target.\n- **Vermont, Vital Records, 1760\u20131954** (coll. 1784223) \u2014 2.3M records, indexed + images.\n- **Vermont, Vital Records, 1760\u20132008** (coll. 2075288) \u2014 1.97M records, indexed.\n- **Vermont, Deaths and Burials, 1871\u20131965** (coll. 1675549) \u2014 82K records, index only.\n- **Vermont, Births and Christenings, 1765\u20131908** (coll. 1675544) \u2014 210K records, index only.\n\nTopsham-specific volumes (100% indexed, full-text searchable): imageGroup 005487650 (births/marriages/deaths 1857\u20131997, 2,180 images) and imageGroup 005464890 (vital statistic indexes 1857\u20131896, 200 images).\n\n\u26a0\ufe0f **Critical quirk:** Vermont death records **before 1919 do not name the deceased's parents**. An 1884 death record for William A. Bagley will likely carry no parental information.\n\n## Census Records\n\nFederal censuses are the primary path to finding a ca.-1815 birth subject in his father's household:\n- **1820, 1830, 1840 censuses** (Ancestry, FamilySearch): William would appear as a child under his father's name. These are indexed.\n- **1850\u20131880 censuses** list all household members by name; 1880 adds relationship to head.\n- Vermont also has miscellaneous census substitutes 1778\u20131840 at American Ancestors and Ancestry.\n\n## Probate Records\n\nTopsham's probate district is Orange County (court at Chelsea, VT). Two district collections:\n- **Vermont, Orange County, Bradford District Estate Files, 1780\u20131915** (coll. 1807377) \u2014 75,694 images, **browse-only** (0% indexed, no full-text).\n- **Vermont, Orange County, Randolph District Probate Records, 1790\u20131935** (coll. 1453983) \u2014 65,929 images, **browse-only**.\n- **Vermont, Probate Files, 1800\u20131921** (coll. 1435692) \u2014 10,225 records **indexed + images** (204K images). Search here first.\n- **Vermont, Wills and Deeds, ca. 1700s\u20132017** (coll. 3158875) \u2014 some indexed records.\n- Ancestry also has **Vermont, U.S., Wills and Probate Records, 1749\u20131999** ($).\n\nIf William's father died in Orange County before 1921, an estate file may name his heirs (including William).\n\n## Land Records\n\n- **Vermont, Land Records, Early to 1900** (coll. 1409123) \u2014 169,270 images, browse-only, also on Ancestry.\n- Topsham land records volumes on FamilySearch are **full-text searchable** (0% name-indexed): vols. 14\u201315 (1853\u20131859), vols. 16\u201317 (1859\u20131869), vols. 18\u201319 (1866\u20131878), vol. 20 (1878\u20131883), vol. 21 (1882\u20131893), vol. 22 (1888\u20131893).\n- Earlier Topsham land volumes (deeds 1794\u20131849; index to deeds 1794\u20131860) are on microfilm at FamilySearch Library catalog 90593.\n\n## Church Records\n\nHistorically dominant denominations in Vermont: Congregational, Baptist, Methodist, Roman Catholic. FamilySearch has **Vermont Miscellaneous Records (includes Vermont Church Records)** from the Daughters of the American Revolution covering 1700s\u20131800s (catalog 383707). See [Vermont Church Records wiki](https://www.familysearch.org/en/wiki/Vermont_Church_Records).\n\n## Local Histories & Compiled Sources\n\n- **'Sketches of the Town of Topsham, Orange County, Vermont' (1929)** by Frank H. Craig \u2014 available on Ancestry.com (collection 22236). Often contains family genealogies naming parents and siblings.\n- *The Vermont Historical Gazetteer* (Hemenway, 1868\u20131923) \u2014 FamilySearch Digital Library, vols. 1\u20136.\n- *Genealogical and Family History of the State of Vermont* (Carleton, 1903) \u2014 FamilySearch Digital Library.\n- Vermont Historical Society (vermonthistory.org) holds genealogical research sources.\n\n## Cemeteries\n\nWest Topsham Cemetery and Old West Topsham Cemetery are the primary cemeteries for this family (per tree). Inscriptions at Find a Grave. Vermont Old Cemetery Association database: voca58.org.\n\n## Newspapers\n\nNo major newspaper served Topsham directly; Orange County was served by papers in Chelsea/Bradford. GenealogyBank has Vermont newspaper archives 1781\u20132006. Chronicling America has some Vermont titles.\n\n## Access Summary\n\n| Record Type | Access Level | Primary Repository |\n|---|---|---|\n| Vital records 1857+ | Indexed + images | FamilySearch (coll. 1987653, 1784223) |\n| Vital records pre-1857 | Full-text searchable (not name-indexed) | FamilySearch imageGroup 005464260 |\n| Census 1820\u20131880 | Indexed | FamilySearch, Ancestry |\n| Probate (indexed) | Indexed + images | FamilySearch coll. 1435692 |\n| Probate (district files) | Browse-only images | FamilySearch colls. 1807377, 1453983 |\n| Land records (post-1849) | Full-text searchable | FamilySearch |\n| Land records (pre-1849) | Microfilm | FamilySearch Library |\n| Local history | Images ($) | Ancestry.com (coll. 22236) |\n",
+          "pages_read": [
+            {
+              "section": "home",
+              "url": "https://www.familysearch.org/en/wiki/Vermont,_United_States_Genealogy",
+              "found": true
+            },
+            {
+              "section": "getting_started",
+              "url": "https://www.familysearch.org/en/wiki/Vermont_Getting_Started",
+              "found": true
+            },
+            {
+              "section": "online_records",
+              "url": "https://www.familysearch.org/en/wiki/Vermont_Online_Genealogy_Records",
+              "found": true
+            },
+            {
+              "section": "research_tips",
+              "url": "https://www.familysearch.org/en/wiki/Vermont_Research_Tips_and_Strategies",
+              "found": true
+            }
+          ],
+          "source": "locality-guide"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"localities\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"loc_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "research-plan"
+      },
+      "response_summary": "Launching skill: research-plan"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/research-plan/references/planning-standards.md"
+      },
+      "response_summary": "1\t# BCG Standards for Research Planning (Standards 9-18)\n2\t\n3\tThese ten standards from the Board for Certification of Genealogists\n4\tgovern how genealogists plan and scope their research. Every research\n5\tplan created by this skill should satisfy all applicable standards.\n6\t\n7\t---\n8\t\n9\t## Standard 9: Planned Research\n10\t\n11\tResearch begins with and follows a dynamic plan for gathering\n12\tinformation. The plan's purpose is to meet stated objectives, usually\n13\tframed as research questions. Hap..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/research-plan/references/record-type-guide.md"
+      },
+      "response_summary": "1\t# Record Type Selection Guide\n2\t\n3\tUse this reference when identifying which record sets to include in a\n4\tresearch plan. Match the research goal to record types, then check the\n5\tcontextual factors that affect availability.\n6\t\n7\t---\n8\t\n9\t## Record types by research goal\n10\t\n11\t| Goal | Primary record types | Secondary/fallback |\n12\t|------|---------------------|-------------------|\n13\t| Identify parents | Census (household), marriage (parents' marriage record), vital records (death/birth c..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "ops": [
+          {
+            "section": "plans",
+            "op": "append",
+            "entry": {
+              "question_id": "q_001",
+              "status": "active",
+              "created": "2026-07-27"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 1,
+              "record_type": "census",
+              "jurisdiction": "Topsham, Orange County, Vermont",
+              "date_range": "1820",
+              "repository": "FamilySearch",
+              "rationale": "William A. Bagley was born about 1815. In the 1820 federal census he would be approximately 5 years old and appear as an unnamed male child under age 10 in his father's household. Pre-1850 censuses name only the head of household \u2014 identifying a Bagley household in Topsham with a male child in the under-10 bracket names William's father directly. His mother Sarah Sally Andrews (born 1777) should also appear in the same household in the correct age bracket for females 40-45. This is the highest-probability path to the father's name.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 2,
+              "record_type": "census",
+              "jurisdiction": "Topsham, Orange County, Vermont",
+              "date_range": "1830",
+              "repository": "FamilySearch",
+              "rationale": "In the 1830 census William would be approximately 15 and still likely in his father's household. The 1830 census names only the head of household; a Bagley household in Topsham containing a male aged 15-19 confirms the father's name. Sarah Andrews (born 1777) would appear in the 50-59 bracket. Run this immediately after the 1820 search as corroboration \u2014 if one census is missing the family, the other may find them.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 3,
+              "record_type": "vital_record",
+              "jurisdiction": "Topsham, Orange County, Vermont",
+              "date_range": "1810-1820",
+              "repository": "FamilySearch",
+              "rationale": "Search Vermont Births and Christenings 1765-1908 (collection 1675544, index only) for a birth record for William A. Bagley or a William Bagley born about 1815 in Topsham or Orange County. Also search Vermont Town Clerk, Vital and Town Records, 1732-2005 (collection 1987653, indexed + images). Per loc_001, state vital registration only began in 1857; pre-1857 births depend on town clerk recording. A birth entry would directly name William's father. Note per loc_001 quirk: the Topsham pre-1857 town records (imageGroup 005464260) are full-text searchable but NOT name-indexed \u2014 this item covers the indexed statewide compilations; the full-text browse of Topsham's own volume is a separate item.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 4,
+              "record_type": "vital_record",
+              "jurisdiction": "Vermont",
+              "date_range": "1790-1820",
+              "repository": "FamilySearch",
+              "rationale": "Dedicated search for the marriage of Sarah Sally Andrews to a Bagley \u2014 the parents' marriage record. Per the record-type guide, a parentage plan requires a separate item for the parents' marriage: it (a) establishes the couple as a unit, (b) supplies the mother's maiden name (confirming it IS Sarah Andrews), and (c) by its date relative to William's ca.-1815 birth corroborates any father name found only in a census or derivative source. Sarah (born 1777) would have married between roughly 1795-1815. Search Vermont Marriages 1791-1974 (collection 1675550, index only) and Vermont Vital Records 1760-1954 (collection 1784223, indexed + images) for marriages in Topsham or Orange County under 'Andrews' or 'Bagley'. Also search Vermont Town Clerk Vital and Town Records 1732-2005 (collection 1987653).",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 5,
+              "record_type": "vital_record",
+              "jurisdiction": "Topsham, Orange County, Vermont",
+              "date_range": "1771-1860",
+              "repository": "FamilySearch",
+              "rationale": "Full-text search of the Topsham Town Records 1771-1860 (imageGroup 005464260, 265 images). Per loc_001, this volume is full-text searchable but 0% name-indexed \u2014 it cannot be reached by record_search. Route to the search-full-text skill using 'Bagley' as the search term across this imageGroup. Pre-1857 births, marriages, and deaths recorded by the Topsham town clerk are the most likely place to find William's birth entry (naming his father) or his parents' marriage. This is the only mechanism to search this volume.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 6,
+              "record_type": "probate",
+              "jurisdiction": "Orange County, Vermont",
+              "date_range": "1800-1860",
+              "repository": "FamilySearch",
+              "rationale": "Search Vermont Probate Files 1800-1921 (collection 1435692, 10,225 records indexed + 204K images) for a Bagley estate in Orange County. If William's father died after 1800, an estate or will naming William as a son would be direct parentage evidence. Also search Vermont, Wills and Deeds, ca. 1700s-2017 (collection 3158875). Per loc_001, Topsham's probate district is Orange County. This indexed collection is the most accessible entry point before browsing the unindexed district files.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 7,
+              "record_type": "probate",
+              "jurisdiction": "Orange County, Vermont \u2014 Bradford District",
+              "date_range": "1780-1860",
+              "repository": "FamilySearch",
+              "rationale": "Browse-only fallback for pli_006. Vermont Orange County, Bradford District Estate Files 1780-1915 (collection 1807377, 75,694 images) are digitized but 0% name-indexed and not full-text searchable \u2014 must be browsed image-by-image. Per loc_001, Topsham is in Orange County; the Bradford District estate files are a primary repository for Orange County probate. If the indexed Vermont Probate Files search (pli_006) yields nothing, browse this collection for Bagley-surname files.",
+              "fallback_for": "pli_006",
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 8,
+              "record_type": "census",
+              "jurisdiction": "Topsham, Orange County, Vermont",
+              "date_range": "1840",
+              "repository": "FamilySearch",
+              "rationale": "In 1840 William would be approximately 25 \u2014 possibly still in his father's household, or the father may now be an older man living with a married son. If William's father was still living in 1840, he would head his own household. The 1840 census names only the head of household; look for an older Bagley male (50s\u201360s) in Topsham with household members in the right age ranges. Also look for William's own nascent household. Lower priority than 1820/1830 since William was more likely to have left home by 1840.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 9,
+              "record_type": "other",
+              "jurisdiction": "Topsham, Orange County, Vermont",
+              "date_range": "1929",
+              "repository": "Ancestry",
+              "rationale": "Per loc_001, 'Sketches of the Town of Topsham, Orange County, Vermont' (1929) by Frank H. Craig is available on Ancestry.com (collection 22236). Local town histories of this era routinely include biographical family sketches naming parents, children, and grandchildren. Search for 'Bagley' to identify any compiled genealogical notes naming William's father. Treat any finding as a derivative source requiring corroboration from original records.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "append",
+            "planId": "pl_001",
+            "entry": {
+              "sequence": 10,
+              "record_type": "land",
+              "jurisdiction": "Topsham, Orange County, Vermont",
+              "date_range": "1800-1850",
+              "repository": "FamilySearch",
+              "rationale": "FAN/contextual item. Vermont Land Records, Early to 1900 (collection 1409123, 169K images) and Topsham land record volumes (full-text searchable, per loc_001) may contain deeds where a Bagley grantee/grantor is identified with relationship terms ('my son William,' 'heirs,' etc.) or where William appears as a witness alongside a Bagley male who could be his father. Also search for Andrews-family land transactions that reference a Bagley son-in-law \u2014 these could establish the father's first name even when vital records are silent. Route the full-text volumes through search-full-text skill.",
+              "fallback_for": null,
+              "status": "planned"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plans\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pl_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pli_003\\\"\\n    },..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "search-records"
+      },
+      "response_summary": "Launching skill: search-records"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__record_search,mcp__genealogy__rank_search_matches,mcp__genealogy__research_log_append",
+        "max_results": 3
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__rank_search_matches\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_log_append\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Bagley",
+        "residencePlace": "Topsham, Vermont",
+        "residenceYearFrom": 1820,
+        "residenceYearTo": 1820,
+        "recordType": "census",
+        "count": 50,
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Bagley\\\",\\n    \\\"residencePlace\\\": \\\"Topsham, Vermont\\\",\\n    \\\"residenceYearFrom\\\": 1820,\\n    \\\"residenceYearTo\\\": 1820,\\n    \\\"recordType\\\": \\\"census\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\\\"\\n  },\\n  \\\"totalMatches\\\": 14,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 14,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\":..."
+    },
+    {
+      "tool": "mcp__genealogy__rank_search_matches",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "stagedResultsRef": "results/.staging/a6300853-f613-4d86-abe8-9d8578310f28.json",
+        "subjectId": "MJDL-Q8B",
+        "checkAttachments": true
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"subjectId\\\": \\\"MJDL-Q8B\\\",\\n  \\\"scoredCount\\\": 14,\\n  \\\"returnedCount\\\": 10,\\n  \\\"scoringErrors\\\": 0,\\n  \\\"scoreLogError\\\": null,\\n  \\\"matches\\\": [\\n    {\\n      \\\"matchRank\\\": 1,\\n      \\\"searchRank\\\": 8,\\n      \\\"recordId\\\": \\\"ark:/61903/1:1:XHLG-R2K\\\",\\n      \\\"matchScore\\\": 0.025175294,\\n      \\\"primaryId\\\": \\\"p_10418027119\\\",\\n      \\\"personName\\\": \\\"William Bagley\\\",\\n      \\\"collectionTitle\\\": \\\"United States, Census, 1820\\\",\\n      \\\"recordArk\\\": \\\"ar..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__record_read",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_read\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:XHLG-TXG",
+        "resultsRef": "results/.staging/a6300853-f613-4d86-abe8-9d8578310f28.json",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_10418027842\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:XHLG-TXG\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"surname\\\": \\\"Bagley\\\",\\n          \\\"given\\\": \\\"Christopher\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"type\\\": \\\"Census\\\",\\n          \\\"primary\\\": true,\\n          \\\"date\\\": \\\"1820\\\",\\n          \\\"standard_date\\\": \\\"1820\\\",\\n          \\\"place\\\": \\\"Topsham, Oran..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:XHLG-TNL",
+        "resultsRef": "results/.staging/a6300853-f613-4d86-abe8-9d8578310f28.json",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_10418027901\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:XHLG-TNL\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"surname\\\": \\\"Bagley\\\",\\n          \\\"given\\\": \\\"Aaron\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"type\\\": \\\"Census\\\",\\n          \\\"primary\\\": true,\\n          \\\"date\\\": \\\"1820\\\",\\n          \\\"standard_date\\\": \\\"1820\\\",\\n          \\\"place\\\": \\\"Topsham, Orange, Ve..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:XHLG-T8R",
+        "resultsRef": "results/.staging/a6300853-f613-4d86-abe8-9d8578310f28.json",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_10418027755\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:XHLG-T8R\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"surname\\\": \\\"Bagley\\\",\\n          \\\"given\\\": \\\"David\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"type\\\": \\\"Census\\\",\\n          \\\"primary\\\": true,\\n          \\\"date\\\": \\\"1820\\\",\\n          \\\"standard_date\\\": \\\"1820\\\",\\n          \\\"place\\\": \\\"Topsham, Orange, Ve..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:XHLG-TNY",
+        "resultsRef": "results/.staging/a6300853-f613-4d86-abe8-9d8578310f28.json",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_10418027907\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:XHLG-TNY\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"surname\\\": \\\"Bagley\\\",\\n          \\\"given\\\": \\\"John\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"type\\\": \\\"Census\\\",\\n          \\\"primary\\\": true,\\n          \\\"date\\\": \\\"1820\\\",\\n          \\\"standard_date\\\": \\\"1820\\\",\\n          \\\"place\\\": \\\"Topsham, Orange, Ver..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "tool": "record_search",
+        "planItemId": "pli_001",
+        "query": {
+          "collection": "United States, Census, 1820",
+          "surname": "Bagley",
+          "residencePlace": "Topsham, Vermont",
+          "residenceYear": 1820,
+          "recordType": "census",
+          "count": 50
+        },
+        "outcome": "positive",
+        "resultsExamined": 4,
+        "resultsAvailable": 14,
+        "stagedResultsRef": "results/.staging/a6300853-f613-4d86-abe8-9d8578310f28.json",
+        "notes": "Found 4 Bagley households in Topsham 1820: Christopher (ark:/61903/1:1:XHLG-TXG), Aaron (ark:/61903/1:1:XHLG-TNL), David (ark:/61903/1:1:XHLG-T8R, attached-to-other), John (ark:/61903/1:1:XHLG-TNY). Index stubs only name the head of household \u2014 household tally marks (which would show a boy under 10 = William ~5) require image examination. All four are candidates; need image read to determine which has a male child under 10 and a female aged 40-45 (Sarah Andrews born 1777)."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"logId\\\": \\\"log_001\\\",\\n  \\\"performed\\\": \\\"2026-07-27T19:13:02.246Z\\\",\\n  \\\"resultsRef\\\": \\\"results/log_001.json\\\",\\n  \\\"returnedCount\\\": 14,\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"results/log_001.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "plan_items",
+        "op": "update",
+        "planId": "pl_001",
+        "entryId": "pli_001",
+        "fields": {
+          "status": "in_progress"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"plan_items\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"pli_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Bagley",
+        "residencePlace": "Topsham, Vermont",
+        "residenceYearFrom": 1830,
+        "residenceYearTo": 1830,
+        "recordType": "census",
+        "count": 50,
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Bagley\\\",\\n    \\\"residencePlace\\\": \\\"Topsham, Vermont\\\",\\n    \\\"residenceYearFrom\\\": 1830,\\n    \\\"residenceYearTo\\\": 1830,\\n    \\\"recordType\\\": \\\"census\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\\\"\\n  },\\n  \\\"totalMatches\\\": 18,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 18,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\":..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Bagley",
+        "givenName": "William",
+        "birthYearFrom": 1810,
+        "birthYearTo": 1820,
+        "birthPlace": "Vermont",
+        "collectionId": "1675544",
+        "count": 50,
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Bagley\\\",\\n    \\\"givenName\\\": \\\"William\\\",\\n    \\\"birthYearFrom\\\": 1810,\\n    \\\"birthYearTo\\\": 1820,\\n    \\\"birthPlace\\\": \\\"Vermont\\\",\\n    \\\"collectionId\\\": \\\"1675544\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\\\"\\n  },\\n  \\\"totalMatches\\\": 1,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 1,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n ..."
+    },
+    {
+      "tool": "mcp__genealogy__rank_search_matches",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "stagedResultsRef": "results/.staging/f7a96264-d0a6-4d5e-9af3-9d8c9760604d.json",
+        "subjectId": "MJDL-Q8B",
+        "checkAttachments": true
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"subjectId\\\": \\\"MJDL-Q8B\\\",\\n  \\\"scoredCount\\\": 18,\\n  \\\"returnedCount\\\": 10,\\n  \\\"scoringErrors\\\": 0,\\n  \\\"scoreLogError\\\": null,\\n  \\\"matches\\\": [\\n    {\\n      \\\"matchRank\\\": 1,\\n      \\\"searchRank\\\": 18,\\n      \\\"recordId\\\": \\\"ark:/61903/1:1:XH5X-PCD\\\",\\n      \\\"matchScore\\\": 0.020554332,\\n      \\\"primaryId\\\": \\\"p_10420238982\\\",\\n      \\\"personName\\\": \\\"William Bogley\\\",\\n      \\\"collectionTitle\\\": \\\"United States, Census, 1830\\\",\\n      \\\"recordArk\\\": \\\"a..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "surname": "Bagley",
+        "givenName": "William",
+        "birthYearFrom": 1810,
+        "birthYearTo": 1820,
+        "collectionId": "1987653",
+        "count": 50,
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"surname\\\": \\\"Bagley\\\",\\n    \\\"givenName\\\": \\\"William\\\",\\n    \\\"birthYearFrom\\\": 1810,\\n    \\\"birthYearTo\\\": 1820,\\n    \\\"collectionId\\\": \\\"1987653\\\",\\n    \\\"count\\\": 50,\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\\\"\\n  },\\n  \\\"totalMatches\\\": 51,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 50,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"r..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:QPQP-R8T8",
+        "resultsRef": "results/.staging/25ae5adb-1f83-463c-91b7-c232f8007f27.json",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_104363515691\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:QPQP-R8T8\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"William A\\\",\\n          \\\"surname\\\": \\\"Bagley\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"type\\\": \\\"Birth\\\",\\n          \\\"date\\\": \\\"1815\\\",\\n          \\\"standard_date\\\": \\\"1815\\\"\\n        },\\n        {\\n          \\\"type..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:QPQP-24HR",
+        "resultsRef": "results/.staging/25ae5adb-1f83-463c-91b7-c232f8007f27.json",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_104363376565\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:QPQP-24HR\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"surname\\\": \\\"Bagley\\\",\\n          \\\"given\\\": \\\"William A\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"type\\\": \\\"Birth\\\",\\n          \\\"date\\\": \\\"1815\\\",\\n          \\\"standard_date\\\": \\\"1815\\\"\\n        },\\n        {\\n          \\\"type..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json",
+        "limit": 80
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_bagley_father_1884\",\n4\t    \"objective\": \"Who was the father of William A. Bagley, born about 1815 and died 31 May 1884 in Topsham, Orange County, Vermont?\",\n5\t    \"subject_person_ids\": [\n6\t      \"MJDL-Q8B\"\n7\t    ],\n8\t    \"status\": \"active\",\n9\t    \"created\": \"2026-07-27\",\n10\t    \"updated\": \"2026-07-27\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\": \"intermediate\",\n14\t    \"subscriptions\": [],\n15\t    \"narration_guidance\": \"concise\"\n16\t  },\n17..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json",
+        "offset": 80,
+        "limit": 120
+      },
+      "response_summary": "80\t          \"sequence\": 4,\n81\t          \"record_type\": \"vital_record\",\n82\t          \"jurisdiction\": \"Vermont\",\n83\t          \"date_range\": \"1790-1820\",\n84\t          \"repository\": \"FamilySearch\",\n85\t          \"rationale\": \"Dedicated search for the marriage of Sarah Sally Andrews to a Bagley \u2014 the parents' marriage record. Per the record-type guide, a parentage plan requires a separate item for the parents' marriage: it (a) establishes the couple as a unit, (b) supplies the mother's maiden name..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_log_append,mcp__genealogy__research_append",
+        "max_results": 2
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_log_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "ops": [
+          {
+            "planItemId": "pli_002",
+            "tool": "record_search",
+            "query": {
+              "collection": "United States, Census, 1830",
+              "surname": "Bagley",
+              "residencePlace": "Topsham, Vermont",
+              "residenceYear": 1830,
+              "recordType": "census",
+              "count": 50
+            },
+            "outcome": "positive",
+            "resultsExamined": 9,
+            "resultsAvailable": 9,
+            "stagedResultsRef": "results/.staging/f7a96264-d0a6-4d5e-9af3-9d8c9760604d.json",
+            "notes": "Found 9 Bagley households in Topsham 1830: Aaron (XHLG-T37), Nathan (XHLG-T3Y), Dhan (XHLG-T9F), John (XHLG-T8W), John A (XHLG-TNG), Reber (XHLG-TN3), David (XHLG-T9Q, attached-to-other), John (XHLG-TN9), Philip (XHLG-TNT). David Bagley again appears \u2014 consistent with the 1820 David Bagley household in Topsham. Census stubs name only heads of household; household tally marks require image examination to confirm a male 15-19 (William ~15) and female 50-59 (Sarah Andrews born 1777). David Bagley's presence in both 1820 and 1830 Topsham census is consistent with him being William's father. Two key death records for William A. Bagley found in Vermont Town Clerk records (pli_003) independently name David Bagley as father \u2014 this corroborates the census pattern."
+          },
+          {
+            "planItemId": "pli_003",
+            "tool": "record_search",
+            "query": {
+              "collection": "Vermont Births and Christenings, 1765-1908",
+              "collectionId": "1675544",
+              "surname": "Bagley",
+              "givenName": "William",
+              "birthPlace": "Vermont",
+              "birthYearFrom": 1810,
+              "birthYearTo": 1820,
+              "count": 50
+            },
+            "outcome": "negative",
+            "resultsExamined": 1,
+            "resultsAvailable": 1,
+            "stagedResultsRef": null,
+            "notes": "Only result: Sally W. Bagley, female, born Corinth, Vermont \u2014 not the subject William A. Bagley (male, born ~1815 Topsham). No birth record for William A. Bagley in this indexed statewide compilation. Pre-1857 Vermont vital registration was not required by the state; births depended on town-clerk recording. The absence here is expected and does not rule out a record in the Topsham town clerk volume (pli_005, full-text searchable imageGroup 005464260)."
+          },
+          {
+            "planItemId": "pli_003",
+            "tool": "record_search",
+            "query": {
+              "collection": "Vermont, Town Clerk, Vital and Town Records, 1732-2005",
+              "collectionId": "1987653",
+              "surname": "Bagley",
+              "givenName": "William",
+              "birthYearFrom": 1810,
+              "birthYearTo": 1820,
+              "count": 50
+            },
+            "outcome": "positive",
+            "resultsExamined": 51,
+            "resultsAvailable": 51,
+            "stagedResultsRef": "results/.staging/25ae5adb-1f83-463c-91b7-c232f8007f27.json",
+            "notes": "Found 51 results. Top two are direct matches for the research subject: (1) ark:/61903/1:1:QPQP-R8T8 \u2014 William A Bagley, death 31 May 1884, father=David Bagley (ark:/61903/1:1:QPQP-R8TJ), mother=Sarah A Bagley (ark:/61903/1:1:QPQP-7JPV); (2) ark:/61903/1:1:QPQP-24HR \u2014 William A Bagley, death 31 May 1884, Topsham Orange Vermont, father=David Bagley (ark:/61903/1:1:QPQP-24HB), mother=Sarah A Bagley (ark:/61903/1:1:QPQP-24C4). Both records independently name DAVID BAGLEY as William A. Bagley's father and Sarah A. Bagley (n\u00e9e Andrews) as his mother. These are two indexings of the same original entry in the Vermont town clerk vital records. This is strong evidence identifying William's father. Note per the locality guide: Vermont death records before 1919 did not require parental information \u2014 these records likely post-date that requirement or the informant supplied the data voluntarily; in any case, both records agree. Records read via record_read; images viewed at ark:/61903/3:1:3QS7-L99D-H995 and ark:/61903/3:1:3QS7-8999-LD1S."
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"logId\\\": \\\"log_002\\\",\\n      \\\"performed\\\": \\\"2026-07-27T19:17:28.090Z\\\",\\n      \\\"resultsRef\\\": \\\"results/log_002.json\\\",\\n      \\\"returnedCount\\\": 18\\n    },\\n    {\\n      \\\"logId\\\": \\\"log_003\\\",\\n      \\\"performed\\\": \\\"2026-07-27T19:17:28.093Z\\\",\\n      \\\"resultsRef\\\": null,\\n      \\\"returnedCount\\\": null\\n    },\\n    {\\n      \\\"logId\\\": \\\"log_004\\\",\\n      \\\"performed\\\": \\\"2026-07-27T19:17:28.093Z\\\",\\n      \\\"..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "ops": [
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_002",
+            "fields": {
+              "status": "in_progress"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_003",
+            "fields": {
+              "status": "in_progress"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_003\\\"\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Extract death record QPQP-R8T8",
+        "subagent_type": "record-extractor",
+        "prompt": "Extract ALL assertions from this genealogical record into the research project.\n\n**Project path:** `/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2`\n**Record ID:** `ark:/61903/1:1:QPQP-R8T8`\n**Log entry:** `log_004`\n**Results ref:** `results/log_004.json` (the staged sidecar for log_004)\n\n**Research context:** The research objective is to identify the father of William A. Bagley (born about 1815, died 31 May 1884 in Topsham, Orange County, Vermont). The research subject in tree.gedcomx.json is person `MJDL-Q8B` (William A. Bagley). His mother Sarah Sally Andrews (LVDV-6MK) is already in the tree; no father is recorded.\n\n**What this record is:** A Vermont Town Clerk vital record \u2014 an entry for the death of William A. Bagley on 31 May 1884. The record has two related persons indexed: father = David Bagley (ark:/61903/1:1:QPQP-R8TJ) and mother = Sarah A. Bagley (ark:/61903/1:1:QPQP-7JPV). The citation appears as \"Entry for William A Bagley and David Bagley, 31 May 1884.\"\n\nRead the record via `record_read` to get the full content, then extract ALL facts and relationships as GPS-classified assertions. Pay attention to:\n- William A. Bagley's death date, place, and any other personal facts\n- The ParentChild relationships listed (father = David Bagley, mother = Sarah A. Bagley)\n- Information quality: the informant for a death record reporting parental names is secondary information (the informant likely did not personally observe the birth)\n- Source classification: this is an original government vital record\n- Evidence type: ParentChild assertions naming David Bagley as father are DIRECT evidence for the research question (directly answers \"who was William's father\")\n\nCreate the source entry, all assertions with GPS three-layer classification, and link them properly. Also check record_person_matches to see if any record persons should be linked to existing tree persons."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"All 11 ops persisted successfully. Here is the extraction summary:\\n\\n**Source:** src_001 / S1 \\u2014 created (Vermont, Town Clerk, Vital and Town Records, 1732-2005; original government vital record, death registration 31 May 1884)\\n\\n**Assertions written: 11 total**\\n- deceased (William A. Bagley, p_104363515691): name (a_001), sex (a_002), death date+place (a_003), birth year ~1815 (a_004), relationship child-of-David (a_005), relationship child-of-Sarah (a_006)\\..."
+    },
+    {
+      "tool": "mcp__genealogy__project_context",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"projectStatus\\\": \\\"active\\\",\\n  \\\"openQuestions\\\": [\\n    {\\n      \\\"id\\\": \\\"q_001\\\",\\n      \\\"question\\\": \\\"Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermon\\u2026\\\"\\n    }\\n  ],\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"MJDL-Q8B\\\",\\n      \\\"name\\\": \\\"William A. Bagley\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"sourceRefs\\\": []\\n    },\\n    {\\n      \\\"id\\..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:QPQP-R8T8",
+        "resultsRef": "results/log_004.json",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_104363515691\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:QPQP-R8T8\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"William A\\\",\\n          \\\"surname\\\": \\\"Bagley\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"type\\\": \\\"Birth\\\",\\n          \\\"date\\\": \\\"1815\\\",\\n          \\\"standard_date\\\": \\\"1815\\\"\\n        },\\n        {\\n          \\\"type..."
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Extract death record QPQP-24HR",
+        "subagent_type": "record-extractor",
+        "prompt": "Extract ALL assertions from this genealogical record into the research project.\n\n**Project path:** `/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2`\n**Record ID:** `ark:/61903/1:1:QPQP-24HR`\n**Log entry:** `log_004`\n**Results ref:** `results/log_004.json` (the staged sidecar for log_004)\n\n**Research context:** The research objective is to identify the father of William A. Bagley (born about 1815, died 31 May 1884 in Topsham, Orange County, Vermont). The research subject in tree.gedcomx.json is person `MJDL-Q8B` (William A. Bagley). His mother Sarah Sally Andrews (LVDV-6MK) is already in the tree; no father is recorded.\n\n**What this record is:** A Vermont Town Clerk vital record \u2014 a second indexing of the death entry for William A. Bagley on 31 May 1884 in Topsham, Orange, Vermont. The record has two related persons indexed: father = David Bagley (ark:/61903/1:1:QPQP-24HB) and mother = Sarah A. Bagley (ark:/61903/1:1:QPQP-24C4). The death place is specified as Topsham, Orange, Vermont. The citation appears as \"Entry for William A Bagley and David Bagley, 31 May 1884.\"\n\nRead the record via `record_read` to get the full content, then extract ALL facts and relationships as GPS-classified assertions. Pay attention to:\n- William A. Bagley's death date, place, and any other personal facts\n- The ParentChild relationships listed (father = David Bagley, mother = Sarah A. Bagley)\n- Information quality: the informant for a death record reporting parental names is secondary information (the informant likely did not personally observe the birth)\n- Source classification: this is an original government vital record\n- Evidence type: ParentChild assertions naming David Bagley as father are DIRECT evidence for the research question (directly answers \"who was William's father\")\n\nThis is a second indexing of the same original document as QPQP-R8T8. Note any differences in what data was captured (e.g. the death place \"Topsham, Orange, Vermont\" is specified here). The source tool will handle deduplication \u2014 supply the sourceDescription and let it auto-detect reuse.\n\nCreate the source entry, all assertions with GPS three-layer classification, and link them properly. Also check record_person_matches to see if any record persons should be linked to existing tree persons."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"Extraction complete. Here is the compact summary:\\n\\n**Source:** src_002 / S2 \\u2014 created (new source, no prior reuse)\\n**Assertions written:** 12 total\\n- `deceased` (William A. Bagley, p_104363376565): name (a_011), sex (a_012), death date+place (a_013), birth year ~1815 (a_014), child-of-David relationship (a_015), child-of-Sarah relationship (a_016)\\n- `father_of_deceased` (David Bagley, p_104363376568): name (a_017), sex (a_018), spouse-of-Sarah inferred (a_..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:QPQP-R8TJ"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_104363515691\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:QPQP-R8T8\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"5643e741-2290-4ceb-b127-1284aaf6b354\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"William A\\\",\\n          \\\"surname\\\": \\\"Bagley\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"b30fda72-ff34-47e5-9356-c04b6ec882d7\\\",\\n          \\\"type\\\":..."
+    },
+    {
+      "tool": "mcp__genealogy__record_person_matches",
+      "args": {
+        "id": "QPQP-R8T8"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"queryArk\\\": \\\"ark:/61903/1:1:QPQP-R8T8\\\",\\n  \\\"resultCount\\\": 1,\\n  \\\"returned\\\": 1,\\n  \\\"title\\\": \\\"Matches for ark:/61903/1:1:QPQP-R8T8\\\",\\n  \\\"updated\\\": \\\"2024-03-08T08:57:46.188Z\\\",\\n  \\\"matches\\\": [\\n    {\\n      \\\"ark\\\": \\\"ark:/61903/4:1:MJDL-Q8B\\\",\\n      \\\"pid\\\": \\\"MJDL-Q8B\\\",\\n      \\\"arkType\\\": \\\"4:1:\\\",\\n      \\\"confidence\\\": 5,\\n      \\\"score\\\": 0.99831176,\\n      \\\"title\\\": \\\"\\\",\\n      \\\"status\\\": \\\"accepted\\\",\\n      \\\"collection\\\": \\\"https://..."
+    },
+    {
+      "tool": "mcp__genealogy__project_context",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"projectStatus\\\": \\\"active\\\",\\n  \\\"openQuestions\\\": [\\n    {\\n      \\\"id\\\": \\\"q_001\\\",\\n      \\\"question\\\": \\\"Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermon\\u2026\\\"\\n    }\\n  ],\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"MJDL-Q8B\\\",\\n      \\\"name\\\": \\\"William A. Bagley\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"sourceRefs\\\": []\\n    },\\n    {\\n      \\\"id\\..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:QPQP-24HR",
+        "resultsRef": "results/log_004.json",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_104363376565\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:QPQP-24HR\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"surname\\\": \\\"Bagley\\\",\\n          \\\"given\\\": \\\"William A\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"type\\\": \\\"Birth\\\",\\n          \\\"date\\\": \\\"1815\\\",\\n          \\\"standard_date\\\": \\\"1815\\\"\\n        },\\n        {\\n          \\\"type..."
+    },
+    {
+      "tool": "mcp__genealogy__record_person_matches",
+      "args": {
+        "id": "QPQP-R8TJ"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"queryArk\\\": \\\"ark:/61903/1:1:QPQP-R8TJ\\\",\\n  \\\"resultCount\\\": 1,\\n  \\\"returned\\\": 1,\\n  \\\"title\\\": \\\"Matches for ark:/61903/1:1:QPQP-R8TJ\\\",\\n  \\\"updated\\\": \\\"2024-03-08T08:57:46.188Z\\\",\\n  \\\"matches\\\": [\\n    {\\n      \\\"ark\\\": \\\"ark:/61903/4:1:LVDV-DBC\\\",\\n      \\\"pid\\\": \\\"LVDV-DBC\\\",\\n      \\\"arkType\\\": \\\"4:1:\\\",\\n      \\\"confidence\\\": 5,\\n      \\\"score\\\": 0.9979437,\\n      \\\"title\\\": \\\"\\\",\\n      \\\"status\\\": \\\"accepted\\\",\\n      \\\"collection\\\": \\\"https://f..."
+    },
+    {
+      "tool": "mcp__genealogy__record_person_matches",
+      "args": {
+        "id": "QPQP-7JPV"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"queryArk\\\": \\\"ark:/61903/1:1:QPQP-7JPV\\\",\\n  \\\"resultCount\\\": 3,\\n  \\\"returned\\\": 3,\\n  \\\"title\\\": \\\"Matches for ark:/61903/1:1:QPQP-7JPV\\\",\\n  \\\"updated\\\": \\\"2024-03-08T08:57:46.188Z\\\",\\n  \\\"matches\\\": [\\n    {\\n      \\\"ark\\\": \\\"ark:/61903/4:1:LVDV-6MK\\\",\\n      \\\"pid\\\": \\\"LVDV-6MK\\\",\\n      \\\"arkType\\\": \\\"4:1:\\\",\\n      \\\"confidence\\\": 4,\\n      \\\"score\\\": 0.89352185,\\n      \\\"title\\\": \\\"\\\",\\n      \\\"status\\\": \\\"accepted\\\",\\n      \\\"collection\\\": \\\"https://..."
+    },
+    {
+      "tool": "mcp__genealogy__extraction_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "sourceDescription": {
+          "title": "Entry for William A Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+          "url": "https://www.familysearch.org/ark:/61903/1:1:QPQP-R8T8"
+        },
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QPQP-R8T8 : accessed 27 July 2026), Entry for William A Bagley and David Bagley, 31 May 1884.",
+              "citation_detail": {
+                "who": "William A. Bagley (deceased); David Bagley (father); Sarah A. Bagley (mother)",
+                "what": "Death registration entry, Vermont Town Clerk vital record",
+                "when_created": "31 May 1884",
+                "when_accessed": "27 July 2026",
+                "where": "Vermont, Town Clerk, Vital and Town Records, 1732-2005; FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QPQP-R8T8)",
+                "where_within": "Entry for William A Bagley and David Bagley, 31 May 1884"
+              },
+              "source_classification": "original",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-27",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:QPQP-R8T8",
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-R8T8",
+              "record_persona_id": "p_104363515691",
+              "record_role": "deceased",
+              "fact_type": "name",
+              "value": "William A. Bagley",
+              "structured_value": {
+                "given": "William A",
+                "surname": "Bagley"
+              },
+              "information_quality": "primary",
+              "informant": "unknown household member or family informant",
+              "informant_proximity": "unknown",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-R8T8",
+              "record_persona_id": "p_104363515691",
+              "record_role": "deceased",
+              "fact_type": "sex",
+              "value": "Male",
+              "information_quality": "primary",
+              "informant": "unknown household member or family informant",
+              "informant_proximity": "unknown",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-R8T8",
+              "record_persona_id": "p_104363515691",
+              "record_role": "deceased",
+              "fact_type": "death",
+              "value": "died 31 May 1884 in Vermont",
+              "date": "31 May 1884",
+              "date_certainty": "exact",
+              "place": "Vermont, United States",
+              "information_quality": "primary",
+              "informant": "unknown household member or family informant",
+              "informant_proximity": "unknown",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-R8T8",
+              "record_persona_id": "p_104363515691",
+              "record_role": "deceased",
+              "fact_type": "birth",
+              "value": "born 1815 (year stated in record)",
+              "date": "1815",
+              "date_certainty": "approximate",
+              "information_quality": "secondary",
+              "informant": "unknown household member or family informant",
+              "informant_proximity": "unknown",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "The informant for a death registration was not present at William's birth in 1815; birth year is secondhand/recollected knowledge. Date certainty is approximate as only the year is given.",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-R8T8",
+              "record_persona_id": "p_104363515691",
+              "record_role": "deceased",
+              "fact_type": "relationship",
+              "value": "child of David Bagley",
+              "structured_value": {
+                "relationship_type": "child",
+                "related_person_role": "father_of_deceased"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown household member or family informant",
+              "informant_proximity": "unknown",
+              "evidence_type": "direct",
+              "informant_bias_notes": "The record explicitly states a ParentChild relationship between William A. Bagley and David Bagley. The informant relayed this parentage information secondhand \u2014 they were not present at William's birth in 1815. However, the record directly states this relationship, making it direct evidence for q_001 (who was William's father).",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-R8T8",
+              "record_persona_id": "p_104363515691",
+              "record_role": "deceased",
+              "fact_type": "relationship",
+              "value": "child of Sarah A. Bagley",
+              "structured_value": {
+                "relationship_type": "child",
+                "related_person_role": "mother_of_deceased"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown household member or family informant",
+              "informant_proximity": "unknown",
+              "evidence_type": "direct",
+              "informant_bias_notes": "The record explicitly states a ParentChild relationship between William A. Bagley and Sarah A. Bagley. The informant relayed this parentage information secondhand. Sarah A. Bagley in this record appears under the surname Bagley (married name); she may correspond to Sarah Sally Andrews (LVDV-6MK) in the project tree.",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-R8T8",
+              "record_persona_id": "p_104363515697",
+              "record_role": "father_of_deceased",
+              "fact_type": "name",
+              "value": "David Bagley",
+              "structured_value": {
+                "given": "David",
+                "surname": "Bagley"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown household member or family informant",
+              "informant_proximity": "unknown",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "David Bagley is named as the deceased's father by a third-party informant relaying secondhand biographical information about the parent. The name is stated in the record but the informant-knowledge test yields indirect evidence \u2014 the informant is relaying another person's identity.",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-R8T8",
+              "record_persona_id": "p_104363515697",
+              "record_role": "father_of_deceased",
+              "fact_type": "sex",
+              "value": "Male",
+              "information_quality": "secondary",
+              "informant": "unknown household member or family informant",
+              "informant_proximity": "unknown",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-R8T8",
+              "record_persona_id": "p_104362981008",
+              "record_role": "mother_of_deceased",
+              "fact_type": "name",
+              "value": "Sarah A. Bagley",
+              "structured_value": {
+                "given": "Sarah A",
+                "surname": "Bagley"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown household member or family informant",
+              "informant_proximity": "unknown",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "Sarah A. Bagley is named as the deceased's mother by a third-party informant relaying secondhand biographical information. The name is stated in the record but the informant-knowledge test yields indirect \u2014 relaying another person's identity. The surname 'Bagley' here is her married name; the project tree already has Sarah Sally Andrews (LVDV-6MK) as William's mother under her birth surname Andrews.",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-R8T8",
+              "record_persona_id": "p_104362981008",
+              "record_role": "mother_of_deceased",
+              "fact_type": "sex",
+              "value": "Female",
+              "information_quality": "secondary",
+              "informant": "unknown household member or family informant",
+              "informant_proximity": "unknown",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_004"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_003\\\"\\n    },\\n ..."
+    },
+    {
+      "tool": "mcp__genealogy__extraction_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "sourceDescription": {
+          "title": "Entry for William A Bagley and David Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+          "url": "https://www.familysearch.org/ark:/61903/1:1:QPQP-24HR"
+        },
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QPQP-24HR : accessed 2026-07-27), Entry for William A Bagley and David Bagley, 31 May 1884.",
+              "citation_detail": {
+                "who": "William A. Bagley (deceased), David Bagley (father), Sarah A. Bagley (mother)",
+                "what": "Vermont Town Clerk vital record \u2014 death entry for William A. Bagley, 31 May 1884, with parental names indexed",
+                "when_created": "1884",
+                "when_accessed": "2026-07-27",
+                "where": "FamilySearch, Vermont, Town Clerk, Vital and Town Records, 1732-2005 (collection 1987653)",
+                "where_within": "Entry for William A Bagley and David Bagley, 31 May 1884"
+              },
+              "source_classification": "original",
+              "repository": "FamilySearch",
+              "access_date": "2026-07-27",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:QPQP-24HR",
+              "notes": "Second indexing of the same original document as ark:/61903/1:1:QPQP-R8T8. This indexing captures the death place (Topsham, Orange, Vermont) and indexes both William A. Bagley and David Bagley as related persons. Vermont death records of this era (pre-1919) did not require parental information on the death certificate; parental names here are likely reported by a community or family informant with secondhand knowledge.",
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-24HR",
+              "record_persona_id": "p_104363376565",
+              "record_role": "deceased",
+              "fact_type": "name",
+              "value": "William A. Bagley",
+              "structured_value": {
+                "given": "William A",
+                "surname": "Bagley"
+              },
+              "information_quality": "indeterminate",
+              "informant": "unknown",
+              "informant_proximity": "unknown",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-24HR",
+              "record_persona_id": "p_104363376565",
+              "record_role": "deceased",
+              "fact_type": "sex",
+              "value": "Male",
+              "information_quality": "indeterminate",
+              "informant": "unknown",
+              "informant_proximity": "unknown",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-24HR",
+              "record_persona_id": "p_104363376565",
+              "record_role": "deceased",
+              "fact_type": "death",
+              "value": "31 May 1884",
+              "date": "31 May 1884",
+              "place": "Topsham, Orange, Vermont, United States",
+              "standard_place": "Topsham, Orange, Vermont, United States",
+              "information_quality": "primary",
+              "informant": "local registrar",
+              "informant_proximity": "official_duty",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-24HR",
+              "record_persona_id": "p_104363376565",
+              "record_role": "deceased",
+              "fact_type": "birth",
+              "value": "about 1815",
+              "date": "1815",
+              "date_certainty": "approximate",
+              "information_quality": "indeterminate",
+              "informant": "unknown",
+              "informant_proximity": "unknown",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "Birth year reported on a death record by an unknown informant; the informant was not present at William's birth. Classification is indirect because the figure requires accepting the informant's secondhand knowledge of the birth year.",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-24HR",
+              "record_persona_id": "p_104363376565",
+              "record_role": "deceased",
+              "fact_type": "relationship",
+              "value": "child of David Bagley",
+              "structured_value": {
+                "relationship_type": "child",
+                "related_person_role": "father"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown family or community informant",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "direct",
+              "informant_bias_notes": "The record explicitly indexes David Bagley as the father of William A. Bagley via a ParentChild relationship. The informant (unknown \u2014 likely a family member or neighbor who reported the death) was not present at William's birth, making this secondary information. However, the fact is directly stated in the record, so evidence type is direct. This assertion directly answers q_001.",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-24HR",
+              "record_persona_id": "p_104363376565",
+              "record_role": "deceased",
+              "fact_type": "relationship",
+              "value": "child of Sarah A. Bagley",
+              "structured_value": {
+                "relationship_type": "child",
+                "related_person_role": "mother"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown family or community informant",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "direct",
+              "informant_bias_notes": "The record explicitly indexes Sarah A. Bagley as the mother of William A. Bagley via a ParentChild relationship. Secondary information because the informant was not present at William's birth. Note: Sarah Sally Andrews (LVDV-6MK) is already in the tree as William's mother \u2014 this assertion corroborates that link.",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-24HR",
+              "record_persona_id": "p_104363376568",
+              "record_role": "father_of_deceased",
+              "fact_type": "name",
+              "value": "David Bagley",
+              "structured_value": {
+                "given": "David",
+                "surname": "Bagley"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown family or community informant",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "David Bagley's name is reported by the death record's informant (unknown \u2014 family or community member) who was relaying information about a third party. The informant was not present at David's naming and may have had imperfect knowledge. Classified indirect because the informant is relaying a third party's identifying information.",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-24HR",
+              "record_persona_id": "p_104363376568",
+              "record_role": "father_of_deceased",
+              "fact_type": "sex",
+              "value": "Male",
+              "information_quality": "secondary",
+              "informant": "unknown family or community informant",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "direct",
+              "informant_bias_notes": "Sex stated in the record (male given name, male role as father). Secondary because reported by a third-party informant about someone not the informant themselves.",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-24HR",
+              "record_persona_id": "p_104363376577",
+              "record_role": "mother_of_deceased",
+              "fact_type": "name",
+              "value": "Sarah A. Bagley",
+              "structured_value": {
+                "given": "Sarah A",
+                "surname": "Bagley"
+              },
+              "information_quality": "secondary",
+              "informant": "unknown family or community informant",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "Sarah A. Bagley's name is reported by the death record's informant relaying information about a third party. Indirect because a third party's identity is being relayed secondhand. The tree already has Sarah Sally Andrews (LVDV-6MK) as William's mother \u2014 the surname 'Bagley' here is her married name, consistent with the tree.",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-24HR",
+              "record_persona_id": "p_104363376577",
+              "record_role": "mother_of_deceased",
+              "fact_type": "sex",
+              "value": "Female",
+              "information_quality": "secondary",
+              "informant": "unknown family or community informant",
+              "informant_proximity": "family_not_present",
+              "evidence_type": "direct",
+              "informant_bias_notes": "Sex stated by role (mother) and female given name. Secondary because reported by a third-party informant.",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_004"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:QPQP-24HR",
+              "record_persona_id": "p_104363376568",
+              "record_role": "father_of_deceased",
+              "fact_type": "relationship",
+              "value": "spouse of Sarah A. Bagley (inferred)",
+              "structured_value": {
+                "relationship_type": "spouse_inferred",
+                "related_person_role": "wife"
+              },
+              "information_quality": "secondary",
+              "informant": "the researcher",
+              "informant_proximity": "researcher",
+              "evidence_type": "indirect",
+              "informant_bias_notes": "The record indexes a Couple relationship between David Bagley and Sarah A. Bagley, but the spousal relationship is an indexer inference from their joint ParentChild links to William \u2014 the death record itself does not state they were married. Classified as researcher-inferred from record structure.",
+              "extracted_for_question_ids": [],
+              "log_entry_id": "log_004"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_011\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_012\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_013\\\"\\n    },\\n ..."
+    },
+    {
+      "tool": "mcp__genealogy__record_person_matches",
+      "args": {
+        "id": "QPQP-24HR"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"queryArk\\\": \\\"ark:/61903/1:1:QPQP-24HR\\\",\\n  \\\"resultCount\\\": 1,\\n  \\\"returned\\\": 1,\\n  \\\"title\\\": \\\"Matches for ark:/61903/1:1:QPQP-24HR\\\",\\n  \\\"updated\\\": \\\"2024-03-09T16:01:36.876Z\\\",\\n  \\\"matches\\\": [\\n    {\\n      \\\"ark\\\": \\\"ark:/61903/4:1:MJDL-Q8B\\\",\\n      \\\"pid\\\": \\\"MJDL-Q8B\\\",\\n      \\\"arkType\\\": \\\"4:1:\\\",\\n      \\\"confidence\\\": 5,\\n      \\\"score\\\": 0.99926287,\\n      \\\"title\\\": \\\"\\\",\\n      \\\"status\\\": \\\"accepted\\\",\\n      \\\"collection\\\": \\\"https://..."
+    },
+    {
+      "tool": "mcp__genealogy__record_person_matches",
+      "args": {
+        "id": "QPQP-24HB"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"queryArk\\\": \\\"ark:/61903/1:1:QPQP-24HB\\\",\\n  \\\"resultCount\\\": 1,\\n  \\\"returned\\\": 1,\\n  \\\"title\\\": \\\"Matches for ark:/61903/1:1:QPQP-24HB\\\",\\n  \\\"updated\\\": \\\"2024-03-09T16:01:36.876Z\\\",\\n  \\\"matches\\\": [\\n    {\\n      \\\"ark\\\": \\\"ark:/61903/4:1:LVDV-DBC\\\",\\n      \\\"pid\\\": \\\"LVDV-DBC\\\",\\n      \\\"arkType\\\": \\\"4:1:\\\",\\n      \\\"confidence\\\": 5,\\n      \\\"score\\\": 0.9996911,\\n      \\\"title\\\": \\\"\\\",\\n      \\\"status\\\": \\\"accepted\\\",\\n      \\\"collection\\\": \\\"https://f..."
+    },
+    {
+      "tool": "mcp__genealogy__record_person_matches",
+      "args": {
+        "id": "QPQP-24C4"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"queryArk\\\": \\\"ark:/61903/1:1:QPQP-24C4\\\",\\n  \\\"resultCount\\\": 3,\\n  \\\"returned\\\": 3,\\n  \\\"title\\\": \\\"Matches for ark:/61903/1:1:QPQP-24C4\\\",\\n  \\\"updated\\\": \\\"2024-03-09T16:01:36.876Z\\\",\\n  \\\"matches\\\": [\\n    {\\n      \\\"ark\\\": \\\"ark:/61903/4:1:LVDV-6MK\\\",\\n      \\\"pid\\\": \\\"LVDV-6MK\\\",\\n      \\\"arkType\\\": \\\"4:1:\\\",\\n      \\\"confidence\\\": 4,\\n      \\\"score\\\": 0.9150831,\\n      \\\"title\\\": \\\"\\\",\\n      \\\"status\\\": \\\"accepted\\\",\\n      \\\"collection\\\": \\\"https://f..."
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Extract 1820 census David Bagley",
+        "subagent_type": "record-extractor",
+        "prompt": "Extract ALL assertions from this genealogical record into the research project.\n\n**Project path:** `/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2`\n**Record ID:** `ark:/61903/1:1:XHLG-T8R`\n**Log entry:** `log_001`\n**Results ref:** `results/log_001.json`\n\n**Research context:** The research objective is to identify the father of William A. Bagley (born about 1815, died 31 May 1884 in Topsham, Orange County, Vermont). Tree subject is MJDL-Q8B (William A. Bagley). Two Vermont Town Clerk death records (src_001, src_002) have already been extracted and both name David Bagley as William's father. This 1820 census record is for David Bagley, head of household, Topsham, Vermont \u2014 corroborating evidence that David Bagley lived in Topsham in 1820, when William (~5 years old) would have been in his father's household.\n\n**What this record is:** 1820 United States Federal Census entry for David Bagley, head of household, Topsham, Orange, Vermont. Pre-1850 censuses name only the head of household \u2014 other members appear as tally marks by age/sex bracket. The index stub may only show the head's name and location.\n\nRead the record via `record_read` to get the full content. Extract:\n- David Bagley's name, role (head of household), residence (Topsham, Orange, Vermont, 1820)\n- Any household composition data visible in the record (tally marks showing number/age of males and females)\n- Evidence type: this is INDIRECT evidence for q_001 \u2014 it shows David Bagley was in Topsham in 1820 when William would have been ~5, consistent with him being William's father, but the census does not name other household members\n- Source classification: original government record\n- Information quality: primary (David Bagley himself was likely the informant for his own household enumeration)\n\nAlso run record_person_matches to see if the record's persona matches any tree person."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"All done. Here is the summary:\\n\\n**Source:** src_003 / S3 \\u2014 created (new). 1820 U.S. Federal Census, David Bagley, Topsham, Orange, Vermont.\\n\\n**Assertions written (4 total, all for head_of_household persona p_10418027755):**\\n- a_022: name \\u2014 \\\"David Bagley\\\" (direct, primary, q_001)\\n- a_023: sex \\u2014 \\\"Male\\\" (direct, primary, q_001)\\n- a_024: residence \\u2014 Topsham, Orange, Vermont, 1820 (direct, primary, witness/enumerator, q_001)\\n- a_025: censu..."
+    },
+    {
+      "tool": "mcp__genealogy__project_context",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"projectStatus\\\": \\\"active\\\",\\n  \\\"openQuestions\\\": [\\n    {\\n      \\\"id\\\": \\\"q_001\\\",\\n      \\\"question\\\": \\\"Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermon\\u2026\\\"\\n    }\\n  ],\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"MJDL-Q8B\\\",\\n      \\\"name\\\": \\\"William A. Bagley\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"sourceRefs\\\": []\\n    },\\n    {\\n      \\\"id\\..."
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Extract 1830 census David Bagley",
+        "subagent_type": "record-extractor",
+        "prompt": "Extract ALL assertions from this genealogical record into the research project.\n\n**Project path:** `/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2`\n**Record ID:** `ark:/61903/1:1:XHLG-T9Q`\n**Log entry:** `log_002`\n**Results ref:** `results/log_002.json`\n\n**Research context:** The research objective is to identify the father of William A. Bagley (born about 1815, died 31 May 1884 in Topsham, Orange County, Vermont). Tree subject is MJDL-Q8B (William A. Bagley). Two Vermont Town Clerk death records (src_001, src_002) have already been extracted and both name David Bagley as William's father. This 1830 census record is for David Bagley, head of household, Topsham, Vermont \u2014 corroborating evidence that David Bagley lived in Topsham in 1830, when William (~15 years old) would still likely have been in his father's household.\n\n**What this record is:** 1830 United States Federal Census entry for David Bagley, head of household, Topsham, Orange, Vermont. Pre-1850 censuses name only the head of household \u2014 other members appear as tally marks by age/sex bracket. The index stub may only show the head's name and location.\n\nRead the record via `record_read` to get the full content. Extract:\n- David Bagley's name, role (head of household), residence (Topsham, Orange, Vermont, 1830)\n- Any household composition data visible in the record (tally marks showing number/age of males and females, including whether there is a male in the 15-19 bracket that could be William)\n- Evidence type: this is INDIRECT evidence for q_001 \u2014 it shows David Bagley was in Topsham in 1830 when William would have been ~15, consistent with him being William's father, but the census does not name other members\n- Source classification: original government record\n- Information quality: primary (David Bagley himself was likely the informant for his own household enumeration)\n\nAlso run record_person_matches to see if the record's persona matches any tree person."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"**STOP \\u2014 Record identity mismatch. No assertions persisted.**\\n\\nThe ARK `ark:/61903/1:1:XHLG-T9Q` does not resolve to a David Bagley 1830 census record. The live read returned:\\n\\n- **Person:** John Brown\\n- **Record type:** 1820 U.S. Census (not 1830)\\n- **Place:** Corinth, Orange, Vermont (not Topsham)\\n\\nThis is a completely different record \\u2014 wrong head, wrong year, wrong town. Persisting it as David Bagley's 1830 Topsham census entry would be a fabri..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:XHLG-T8R",
+        "resultsRef": "results/log_001.json",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_10418027755\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:XHLG-T8R\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"surname\\\": \\\"Bagley\\\",\\n          \\\"given\\\": \\\"David\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"type\\\": \\\"Census\\\",\\n          \\\"primary\\\": true,\\n          \\\"date\\\": \\\"1820\\\",\\n          \\\"standard_date\\\": \\\"1820\\\",\\n          \\\"place\\\": \\\"Topsham, Orange, Ve..."
+    },
+    {
+      "tool": "mcp__genealogy__project_context",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"projectStatus\\\": \\\"active\\\",\\n  \\\"openQuestions\\\": [\\n    {\\n      \\\"id\\\": \\\"q_001\\\",\\n      \\\"question\\\": \\\"Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermon\\u2026\\\"\\n    }\\n  ],\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"MJDL-Q8B\\\",\\n      \\\"name\\\": \\\"William A. Bagley\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"sourceRefs\\\": []\\n    },\\n    {\\n      \\\"id\\..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:XHLG-T9Q",
+        "resultsRef": "results/log_002.json",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "{\"error\":\"record 'ark:/61903/1:1:XHLG-T9Q' was not found in staged results 'results/log_002.json'. Do a live read (omit `resultsRef`) instead, or verify the ref/id.\"}"
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:XHLG-T9Q"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_10418027434\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:XHLG-T9Q\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"a0736ad6-5be5-4cb1-8786-a3722e46bddf\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"surname\\\": \\\"Brown\\\",\\n          \\\"given\\\": \\\"John\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"fe847fa3-84bd-4b15-851d-2f7d686147b1\\\",\\n          \\\"type\\\": \\\"Census\\\",\\n          \\\"primary\\\": ..."
+    },
+    {
+      "tool": "mcp__genealogy__record_person_matches",
+      "args": {
+        "id": "ark:/61903/1:1:XHLG-T9Q"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"queryArk\\\": \\\"ark:/61903/1:1:XHLG-T9Q\\\",\\n  \\\"resultCount\\\": 0,\\n  \\\"returned\\\": 0,\\n  \\\"title\\\": \\\"Matches for ark:/61903/1:1:XHLG-T9Q\\\",\\n  \\\"updated\\\": \\\"2024-03-09T21:31:32.737Z\\\",\\n  \\\"matches\\\": []\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__extraction_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "sourceDescription": {
+          "title": "Household of David Bagley, \"United States, Census, 1820\"",
+          "url": "https://www.familysearch.org/ark:/61903/1:1:XHLG-T8R"
+        },
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "citation": "\"United States, Census, 1820,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:XHLG-T8R : accessed 2026-07-27), entry for David Bagley, Topsham, Orange, Vermont.",
+              "citation_detail": {
+                "who": "David Bagley, head of household",
+                "what": "1820 United States Federal Census schedule, Topsham, Orange County, Vermont",
+                "when_created": "1820",
+                "when_accessed": "2026-07-27",
+                "where": "FamilySearch (https://www.familysearch.org)",
+                "where_within": "Topsham, Orange, Vermont; ark:/61903/1:1:XHLG-T8R"
+              },
+              "source_classification": "original",
+              "repository": "FamilySearch",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:XHLG-T8R",
+              "access_date": "2026-07-27",
+              "log_entry_id": "log_001",
+              "notes": "Pre-1850 census; only the head of household is named. All other household members appear as tally marks in age/sex columns. The image is a digital scan of the original government schedule."
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:XHLG-T8R",
+              "record_persona_id": "p_10418027755",
+              "record_role": "head_of_household",
+              "fact_type": "name",
+              "value": "David Bagley",
+              "structured_value": {
+                "given": "David",
+                "surname": "Bagley"
+              },
+              "information_quality": "primary",
+              "informant": "David Bagley (household head, likely self-reported to enumerator)",
+              "informant_proximity": "household_member",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_001"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:XHLG-T8R",
+              "record_persona_id": "p_10418027755",
+              "record_role": "head_of_household",
+              "fact_type": "sex",
+              "value": "Male",
+              "information_quality": "primary",
+              "informant": "David Bagley (household head, likely self-reported to enumerator)",
+              "informant_proximity": "household_member",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_001"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:XHLG-T8R",
+              "record_persona_id": "p_10418027755",
+              "record_role": "head_of_household",
+              "fact_type": "residence",
+              "value": "Topsham, Orange, Vermont, United States",
+              "structured_value": {
+                "place": "Topsham, Orange, Vermont, United States"
+              },
+              "date": "1820",
+              "date_certainty": "exact",
+              "place": "Topsham, Orange, Vermont, United States",
+              "standard_place": "Topsham, Orange, Vermont, United States",
+              "information_quality": "primary",
+              "informant": "census enumerator",
+              "informant_proximity": "witness",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "informant_bias_notes": "Enumerator personally visited the dwelling and recorded the household at this location. Residence is a direct fact \u2014 the enumerator attests the household was enumerated here.",
+              "log_entry_id": "log_001"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:XHLG-T8R",
+              "record_persona_id": "p_10418027755",
+              "record_role": "head_of_household",
+              "fact_type": "census",
+              "value": "David Bagley appears as head of household in the 1820 United States Federal Census, Topsham, Orange, Vermont. Pre-1850 census; other household members appear only as tally marks by age/sex bracket and are not named.",
+              "date": "1820",
+              "date_certainty": "exact",
+              "place": "Topsham, Orange, Vermont, United States",
+              "standard_place": "Topsham, Orange, Vermont, United States",
+              "information_quality": "indeterminate",
+              "informant": "unknown household member (likely David Bagley or another resident)",
+              "informant_proximity": "household_member",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "informant_bias_notes": "This census entry is indirect evidence for q_001 (father of William A. Bagley). It establishes David Bagley was head of a household in Topsham in 1820, the same town and period where William (~age 5) would have lived with his father. The census does not name household members other than the head, so William's presence cannot be confirmed from this record alone. Two Vermont Town Clerk death records (src_001, src_002) independently name David Bagley as William's father.",
+              "log_entry_id": "log_001"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_022\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_023\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_024\\\"\\n    },\\n ..."
+    },
+    {
+      "tool": "mcp__genealogy__record_person_matches",
+      "args": {
+        "id": "p_10418027755"
+      },
+      "response_summary": "{\"error\":\"Unrecognized id \\\"p_10418027755\\\". Expected a personId (e.g. \\\"KNDX-MKG\\\") or a full FamilySearch ARK.\"}"
+    },
+    {
+      "tool": "mcp__genealogy__record_person_matches",
+      "args": {
+        "id": "ark:/61903/1:1:XHLG-T8R"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"queryArk\\\": \\\"ark:/61903/1:1:XHLG-T8R\\\",\\n  \\\"resultCount\\\": 1,\\n  \\\"returned\\\": 1,\\n  \\\"title\\\": \\\"Matches for ark:/61903/1:1:XHLG-T8R\\\",\\n  \\\"updated\\\": \\\"2024-03-08T17:17:36.234Z\\\",\\n  \\\"matches\\\": [\\n    {\\n      \\\"ark\\\": \\\"ark:/61903/4:1:LVDV-DBC\\\",\\n      \\\"pid\\\": \\\"LVDV-DBC\\\",\\n      \\\"arkType\\\": \\\"4:1:\\\",\\n      \\\"confidence\\\": 4,\\n      \\\"score\\\": 0.8798159,\\n      \\\"title\\\": \\\"\\\",\\n      \\\"status\\\": \\\"accepted\\\",\\n      \\\"collection\\\": \\\"https://fam..."
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": "**/*person-evidence*",
+        "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "No files found"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__record_search,mcp__genealogy__rank_search_matches",
+        "max_results": 2
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_search\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__rank_search_matches\"}]"
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": ".claude/skills/*/skill.md",
+        "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "No files found"
+    },
+    {
+      "tool": "Glob",
+      "args": {
+        "pattern": ".claude/skills/**/*.md",
+        "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": ".claude/skills/check-warnings/SKILL.md\n.claude/skills/check-warnings/references/assumption-categories.md\n.claude/skills/check-warnings/references/warning-checks.md\n.claude/skills/check-warnings/references/warnings-as-identity-signals.md\n.claude/skills/citation/SKILL.md\n.claude/skills/citation/references/gps-citation-standards.md\n.claude/skills/citation/references/validation-protocol.md\n.claude/skills/conflict-resolution/SKILL.md\n.claude/skills/conflict-resolution/references/historical-contrad..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/person-evidence/SKILL.md"
+      },
+      "response_summary": "1\t---\n2\tname: person-evidence\n3\tmodel: claude-sonnet-4-6\n4\tdescription: >-\n5\t  Links assertions to GedcomX persons \u2014 identity resolution. Evaluates whether\n6\t  a record's person matches a tree person, creates person_evidence entries with\n7\t  confidence and rationale, and creates stub persons when none match. Also\n8\t  reviews/audits existing person_evidence links, and builds out a record's\n9\t  household skeleton in the tree from extracted assertions. GPS Step 3 \u2014\n10\t  Analysis and Correlation...."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__materialize_facts,mcp__genealogy__tree_edit,mcp__genealogy__same_person,mcp__genealogy__research_query",
+        "max_results": 4
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__materialize_facts\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__tree_edit\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__same_person\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_query\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_query",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "assertions",
+        "recordId": "ark:/61903/1:1:QPQP-R8T8"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"assertions\\\",\\n  \\\"count\\\": 10,\\n  \\\"items\\\": [\\n    {\\n      \\\"id\\\": \\\"a_001\\\",\\n      \\\"record_id\\\": \\\"ark:/61903/1:1:QPQP-R8T8\\\",\\n      \\\"record_persona_id\\\": \\\"p_104363515691\\\",\\n      \\\"record_role\\\": \\\"deceased\\\",\\n      \\\"fact_type\\\": \\\"name\\\",\\n      \\\"value\\\": \\\"William A. Bagley\\\",\\n      \\\"structured_value\\\": {\\n        \\\"given\\\": \\\"William A\\\",\\n        \\\"surname\\\": \\\"Bagley\\\"\\n      },\\n      \\\"information_quality\\\"..."
+    },
+    {
+      "tool": "mcp__genealogy__research_query",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "assertions",
+        "recordId": "ark:/61903/1:1:QPQP-24HR"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"assertions\\\",\\n  \\\"count\\\": 11,\\n  \\\"items\\\": [\\n    {\\n      \\\"id\\\": \\\"a_011\\\",\\n      \\\"record_id\\\": \\\"ark:/61903/1:1:QPQP-24HR\\\",\\n      \\\"record_persona_id\\\": \\\"p_104363376565\\\",\\n      \\\"record_role\\\": \\\"deceased\\\",\\n      \\\"fact_type\\\": \\\"name\\\",\\n      \\\"value\\\": \\\"William A. Bagley\\\",\\n      \\\"structured_value\\\": {\\n        \\\"given\\\": \\\"William A\\\",\\n        \\\"surname\\\": \\\"Bagley\\\"\\n      },\\n      \\\"information_quality\\\"..."
+    },
+    {
+      "tool": "mcp__genealogy__research_query",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "assertions",
+        "recordId": "ark:/61903/1:1:XHLG-T8R"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"assertions\\\",\\n  \\\"count\\\": 4,\\n  \\\"items\\\": [\\n    {\\n      \\\"id\\\": \\\"a_022\\\",\\n      \\\"record_id\\\": \\\"ark:/61903/1:1:XHLG-T8R\\\",\\n      \\\"record_persona_id\\\": \\\"p_10418027755\\\",\\n      \\\"record_role\\\": \\\"head_of_household\\\",\\n      \\\"fact_type\\\": \\\"name\\\",\\n      \\\"value\\\": \\\"David Bagley\\\",\\n      \\\"structured_value\\\": {\\n        \\\"given\\\": \\\"David\\\",\\n        \\\"surname\\\": \\\"Bagley\\\"\\n      },\\n      \\\"information_quality\\\": \\..."
+    },
+    {
+      "tool": "mcp__genealogy__research_query",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "person_evidence"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"person_evidence\\\",\\n  \\\"count\\\": 0,\\n  \\\"items\\\": [],\\n  \\\"truncated\\\": false\\n}\"}]"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/tree.gedcomx.json",
+        "limit": 30
+      },
+      "response_summary": "1\t{\n2\t  \"persons\": [\n3\t    {\n4\t      \"id\": \"MJDL-Q8B\",\n5\t      \"gender\": \"Male\",\n6\t      \"living\": false,\n7\t      \"names\": [\n8\t        {\n9\t          \"id\": \"N1\",\n10\t          \"given\": \"William A.\",\n11\t          \"surname\": \"Bagley\"\n12\t        }\n13\t      ],\n14\t      \"facts\": [\n15\t        {\n16\t          \"id\": \"ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100\",\n17\t          \"type\": \"Birth\",\n18\t          \"date\": \"Abt 1815\",\n19\t          \"standard_date\": \"Abt 1815\",\n20\t          \"place\": \"West Topsham, Orange, ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/tree.gedcomx.json",
+        "limit": 50,
+        "offset": 30
+      },
+      "response_summary": "30\t        },\n31\t        {\n32\t          \"id\": \"28119bdf-00ed-4c5f-a9fc-9b39c096b055\",\n33\t          \"type\": \"Residence\",\n34\t          \"date\": \"1850\",\n35\t          \"standard_date\": \"1850\",\n36\t          \"place\": \"Topsham, Orange, Vermont, United States\",\n37\t          \"standard_place\": \"Topsham, Orange, Vermont, United States\"\n38\t        }\n39\t      ]\n40\t    },\n41\t    {\n42\t      \"id\": \"L528-9HM\",\n43\t      \"gender\": \"Female\",\n44\t      \"living\": false,\n45\t      \"names\": [\n46\t        {\n47\t          \"..."
+    },
+    {
+      "tool": "mcp__genealogy__materialize_facts",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "ops": [
+          {
+            "personId": "I1",
+            "recordId": "ark:/61903/1:1:QPQP-R8T8",
+            "recordRole": "father_of_deceased"
+          },
+          {
+            "personId": "I1",
+            "recordId": "ark:/61903/1:1:QPQP-24HR",
+            "recordRole": "father_of_deceased"
+          },
+          {
+            "personId": "I1",
+            "recordId": "ark:/61903/1:1:XHLG-T8R",
+            "recordRole": "head_of_household"
+          },
+          {
+            "personId": "MJDL-Q8B",
+            "recordId": "ark:/61903/1:1:QPQP-R8T8",
+            "recordRole": "deceased"
+          },
+          {
+            "personId": "MJDL-Q8B",
+            "recordId": "ark:/61903/1:1:QPQP-24HR",
+            "recordRole": "deceased"
+          },
+          {
+            "personId": "LVDV-6MK",
+            "recordId": "ark:/61903/1:1:QPQP-R8T8",
+            "recordRole": "mother_of_deceased"
+          },
+          {
+            "personId": "LVDV-6MK",
+            "recordId": "ark:/61903/1:1:QPQP-24HR",
+            "recordRole": "mother_of_deceased"
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"personId\\\": \\\"I1\\\",\\n      \\\"created\\\": true,\\n      \\\"factsAdded\\\": 0,\\n      \\\"factsEnriched\\\": 0,\\n      \\\"namesAdded\\\": 1,\\n      \\\"refsAttached\\\": 1,\\n      \\\"conflicts_surfaced\\\": []\\n    },\\n    {\\n      \\\"personId\\\": \\\"I1\\\",\\n      \\\"created\\\": false,\\n      \\\"factsAdded\\\": 0,\\n      \\\"factsEnriched\\\": 0,\\n      \\\"namesAdded\\\": 0,\\n      \\\"refsAttached\\\": 1,\\n      \\\"conflicts_surfaced\\\": []\\n    },\\n    {..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "ops": [
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_001",
+              "person_id": "MJDL-Q8B",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "William A. Bagley (deceased) named in Vermont Town Clerk vital record, 31 May 1884. Name, death date, and death place in Topsham all match tree subject MJDL-Q8B exactly. This is the research subject found by searching for this specific individual; FamilySearch record-person match returned confidence 5 (accepted)."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_002",
+              "person_id": "MJDL-Q8B",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Sex=Male consistent with MJDL-Q8B (William A. Bagley). Same record as a_001; same confident identification."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_003",
+              "person_id": "MJDL-Q8B",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Death date 31 May 1884 and place Vermont match MJDL-Q8B's known death date exactly. This is the research subject; same confident identification as a_001."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_004",
+              "person_id": "MJDL-Q8B",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Birth year ~1815 consistent with MJDL-Q8B (born Abt 1815). Same confident identification as a_001."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_005",
+              "person_id": "MJDL-Q8B",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Relationship assertion 'child of David Bagley' on the deceased persona bears on William A. Bagley (MJDL-Q8B) as the child party. William is the research subject; this assertion directly links William to his father David Bagley. Confident match per a_001 identification."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_005",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Relationship assertion 'child of David Bagley' on the deceased persona also bears on David Bagley as the parent party. David Bagley is a new tree stub (I1) created from this and related records. Named explicitly as William's father in two Vermont Town Clerk death record indexings (QPQP-R8T8, QPQP-24HR) of the same 1884 entry, and appears as head of household in Topsham in the 1820 census (XHLG-T8R), consistent with being William's father when William was ~5. Probable \u2014 new stub person, no prior independent corroboration; FamilySearch matches this persona to LVDV-DBC at confidence 5 in the FS tree."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_006",
+              "person_id": "MJDL-Q8B",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Relationship assertion 'child of Sarah A. Bagley' bears on William A. Bagley (MJDL-Q8B) as the child party. William is the research subject. Same confident identification as a_001."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_006",
+              "person_id": "LVDV-6MK",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Relationship assertion 'child of Sarah A. Bagley' also bears on Sarah as the mother party. Tree person LVDV-6MK is Sarah Sally Andrews, already linked to MJDL-Q8B as his mother (R4 relationship). Record names 'Sarah A. Bagley' \u2014 surname Bagley is her married name; 'A' likely the initial of her maiden surname Andrews. FamilySearch record-person match returned confidence 4 (accepted) for this persona \u2192 LVDV-6MK. Name and relationship position agree with the tree. Probable \u2014 middle initial interpretation is reasonable but not independently confirmed."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_007",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "David Bagley (father_of_deceased) in Vermont Town Clerk record QPQP-R8T8 is linked to tree person I1 (David Bagley stub). This persona is the father named in the death registration of William A. Bagley (31 May 1884). Same person as the father_of_deceased persona in QPQP-24HR (two indexings of the same source entry) and the head_of_household in 1820 Topsham census XHLG-T8R. Probable \u2014 new stub from a single original source (two indexings); 1820 census independently corroborates Topsham residence."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_008",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Sex=Male for David Bagley (father_of_deceased, QPQP-R8T8) consistent with tree person I1 (male). Same identification as a_007."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_009",
+              "person_id": "LVDV-6MK",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Sarah A. Bagley (mother_of_deceased, QPQP-R8T8) linked to LVDV-6MK (Sarah Sally Andrews). Name 'Sarah A. Bagley': first name Sarah matches; 'A' likely = Andrews (maiden name initial); surname Bagley is her married name. LVDV-6MK already in tree as William's mother (R4). FamilySearch record-person match confidence 4 (accepted) for persona p_104362981008 \u2192 LVDV-6MK. Probable \u2014 middle initial as maiden surname initial is a reasonable inference, not independently confirmed."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_010",
+              "person_id": "LVDV-6MK",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Sex=Female for Sarah A. Bagley (mother_of_deceased, QPQP-R8T8) consistent with LVDV-6MK (female). Same identification as a_009."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_011",
+              "person_id": "MJDL-Q8B",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "William A. Bagley (deceased) in Vermont Town Clerk record QPQP-24HR. Second indexing of the same 1884 Topsham death entry; death place specified as Topsham, Orange, Vermont. Name, death date, place all match MJDL-Q8B. FamilySearch record-person match confidence 5 (accepted). Confident."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_012",
+              "person_id": "MJDL-Q8B",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Sex=Male consistent with MJDL-Q8B. Same record and identification as a_011."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_013",
+              "person_id": "MJDL-Q8B",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Death date 31 May 1884, Topsham, Orange, Vermont matches MJDL-Q8B exactly. Same confident identification as a_011."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_014",
+              "person_id": "MJDL-Q8B",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Birth year ~1815 consistent with MJDL-Q8B (born Abt 1815). Same identification as a_011."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_015",
+              "person_id": "MJDL-Q8B",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Relationship assertion 'child of David Bagley' in QPQP-24HR bears on William A. Bagley (MJDL-Q8B) as the child party. Same confident identification as a_011."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_015",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Relationship assertion 'child of David Bagley' in QPQP-24HR also bears on David Bagley as the parent. Same David Bagley (I1) identified in QPQP-R8T8 (a_005) and in the 1820 census (a_022). Two indexings of the same original entry both name him as father. Probable \u2014 same reasoning as a_005 \u2192 I1 link."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_016",
+              "person_id": "MJDL-Q8B",
+              "confidence": "confident",
+              "match_score": null,
+              "rationale": "Relationship assertion 'child of Sarah A. Bagley' in QPQP-24HR bears on William A. Bagley (MJDL-Q8B) as child party. Same confident identification as a_011."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_016",
+              "person_id": "LVDV-6MK",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Relationship assertion 'child of Sarah A. Bagley' in QPQP-24HR bears on Sarah as the mother. Same LVDV-6MK (Sarah Sally Andrews) identified in a_006 \u2192 LVDV-6MK link. Second indexing of same source corroborates the identification."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_017",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "David Bagley (father_of_deceased, QPQP-24HR) linked to I1. Second indexing of the same 1884 death entry; names David Bagley as father. Same person as in a_007 (QPQP-R8T8). Probable."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_018",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Sex=Male for David Bagley (father_of_deceased, QPQP-24HR). Consistent with I1. Same identification as a_017."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_019",
+              "person_id": "LVDV-6MK",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Sarah A. Bagley (mother_of_deceased, QPQP-24HR) linked to LVDV-6MK. Second indexing corroborates the a_009 identification. Probable."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_020",
+              "person_id": "LVDV-6MK",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Sex=Female for Sarah A. Bagley (mother_of_deceased, QPQP-24HR). Consistent with LVDV-6MK. Same identification as a_019."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_021",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Inferred spousal relationship 'spouse of Sarah A. Bagley' in QPQP-24HR \u2014 bears on David Bagley (I1) as one party. This is researcher-inferred from the joint ParentChild links; the original death record does not explicitly state a marriage. Probable, noting the inference basis."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_021",
+              "person_id": "LVDV-6MK",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Inferred spousal relationship 'spouse of Sarah A. Bagley' in QPQP-24HR also bears on Sarah (LVDV-6MK) as the other party. Same inferred basis as the I1 link; probable."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_022",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "David Bagley (head_of_household, 1820 census, Topsham) linked to I1 (David Bagley). Same name, consistent with the father named in the 1884 death records \u2014 David Bagley was in Topsham in 1820 when William (~age 5) would have been in his father's household. Independent of the death records (a separate original source). Probable \u2014 name and Topsham residence agree; no conflicting evidence; the 1820 census corroborates the death-record identification."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_023",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Sex=Male for David Bagley (head_of_household, 1820 census). Consistent with I1. Same identification as a_022."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_024",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Residence Topsham, Orange, Vermont, 1820 for David Bagley. Consistent with I1 being the David Bagley who fathered William in Topsham. Same identification as a_022."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_025",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "Census note \u2014 David Bagley as head of household, Topsham, 1820. Indirect evidence for q_001 (supports David's Topsham residence when William would have been ~5). Same identification as a_022."
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_003\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "ops": [
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_001",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_002",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_003",
+            "fields": {
+              "status": "completed"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_001\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_002\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_003\\\"\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n  ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/research-exhaustiveness/SKILL.md"
+      },
+      "response_summary": "1\t---\n2\tname: research-exhaustiveness\n3\tmodel: claude-sonnet-4-6\n4\tdescription: Evaluates whether research on a question is reasonably\n5\t  exhaustive \u2014 applies the five threshold questions and the 7-point\n6\t  stop criteria, then either writes the exhaustive_declaration on the\n7\t  question or explains what's missing. GPS Step 1 \u2014 Reasonably\n8\t  Exhaustive Research. Use when the user says \"is this research\n9\t  exhaustive?\", \"are we done?\", \"have we searched enough?\", \"can we\n10\t  declare exhaus..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "surname": "Andrews",
+        "spouseSurname": "Bagley",
+        "residencePlace": "Vermont",
+        "marriageYearFrom": 1795,
+        "marriageYearTo": 1820,
+        "recordType": "marriage",
+        "count": 50
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\\\",\\n    \\\"surname\\\": \\\"Andrews\\\",\\n    \\\"spouseSurname\\\": \\\"Bagley\\\",\\n    \\\"residencePlace\\\": \\\"Vermont\\\",\\n    \\\"marriageYearFrom\\\": 1795,\\n    \\\"marriageYearTo\\\": 1820,\\n    \\\"recordType\\\": \\\"marriage\\\",\\n    \\\"count\\\": 50\\n  },\\n  \\\"totalMatches\\\": 160,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 50,\\n  \\\"offset\\\": 0,\\n  \\\"hasM..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "surname": "Bagley",
+        "residencePlace": "Orange County, Vermont",
+        "recordType": "probate",
+        "count": 50
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\\\",\\n    \\\"surname\\\": \\\"Bagley\\\",\\n    \\\"residencePlace\\\": \\\"Orange County, Vermont\\\",\\n    \\\"recordType\\\": \\\"probate\\\",\\n    \\\"count\\\": 50\\n  },\\n  \\\"totalMatches\\\": 1,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 1,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [\\n    {\\n      \\\"recordId\\\": \\\"ark:/61903/1:1:QPR5-62QD\\\",\\..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "surname": "Bagley",
+        "givenName": "David",
+        "residencePlace": "Topsham, Vermont",
+        "residenceYearFrom": 1840,
+        "residenceYearTo": 1840,
+        "recordType": "census",
+        "count": 50
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\\\",\\n    \\\"surname\\\": \\\"Bagley\\\",\\n    \\\"givenName\\\": \\\"David\\\",\\n    \\\"residencePlace\\\": \\\"Topsham, Vermont\\\",\\n    \\\"residenceYearFrom\\\": 1840,\\n    \\\"residenceYearTo\\\": 1840,\\n    \\\"recordType\\\": \\\"census\\\",\\n    \\\"count\\\": 50\\n  },\\n  \\\"totalMatches\\\": 2,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 2,\\n  \\\"offset\\\": 0,\\n  \\\"hasM..."
+    },
+    {
+      "tool": "mcp__genealogy__rank_search_matches",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "stagedResultsRef": "results/.staging/c3c42b9d-0bdc-4ad8-b2f3-ebd28c048d5b.json",
+        "subjectId": "I1",
+        "checkAttachments": true
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"subjectId\\\": \\\"I1\\\",\\n  \\\"scoredCount\\\": 2,\\n  \\\"returnedCount\\\": 2,\\n  \\\"scoringErrors\\\": 0,\\n  \\\"scoreLogError\\\": null,\\n  \\\"matches\\\": [\\n    {\\n      \\\"matchRank\\\": 1,\\n      \\\"searchRank\\\": 1,\\n      \\\"recordId\\\": \\\"ark:/61903/1:1:XHRB-V42\\\",\\n      \\\"matchScore\\\": 0.15053548,\\n      \\\"primaryId\\\": \\\"p_10421422430\\\",\\n      \\\"personName\\\": \\\"David Bagley\\\",\\n      \\\"collectionTitle\\\": \\\"United States, Census, 1840\\\",\\n      \\\"recordArk\\\": \\\"ark:/61903/1:..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "surname": "Bagley",
+        "givenName": "David",
+        "spouseGivenName": "Sarah",
+        "residencePlace": "Vermont",
+        "marriageYearFrom": 1795,
+        "marriageYearTo": 1820,
+        "recordType": "marriage",
+        "count": 50
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\\\",\\n    \\\"surname\\\": \\\"Bagley\\\",\\n    \\\"givenName\\\": \\\"David\\\",\\n    \\\"spouseGivenName\\\": \\\"Sarah\\\",\\n    \\\"residencePlace\\\": \\\"Vermont\\\",\\n    \\\"marriageYearFrom\\\": 1795,\\n    \\\"marriageYearTo\\\": 1820,\\n    \\\"recordType\\\": \\\"marriage\\\",\\n    \\\"count\\\": 50\\n  },\\n  \\\"totalMatches\\\": 10,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 1..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "surname": "Bagley",
+        "givenName": "David",
+        "residencePlace": "Vermont",
+        "recordType": "probate",
+        "anyYearFrom": 1820,
+        "anyYearTo": 1870,
+        "count": 50
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\\\",\\n    \\\"surname\\\": \\\"Bagley\\\",\\n    \\\"givenName\\\": \\\"David\\\",\\n    \\\"residencePlace\\\": \\\"Vermont\\\",\\n    \\\"recordType\\\": \\\"probate\\\",\\n    \\\"anyYearFrom\\\": 1820,\\n    \\\"anyYearTo\\\": 1870,\\n    \\\"count\\\": 50\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"r..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "collectionId": "4337554",
+        "surname": "Bagley",
+        "residencePlace": "Topsham, Vermont",
+        "count": 50
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\\\",\\n    \\\"collectionId\\\": \\\"4337554\\\",\\n    \\\"surname\\\": \\\"Bagley\\\",\\n    \\\"residencePlace\\\": \\\"Topsham, Vermont\\\",\\n    \\\"count\\\": 50\\n  },\\n  \\\"totalMatches\\\": 0,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 0,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\": [],\\n  \\\"staged\\\": null\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "ops": [
+          {
+            "planItemId": "pli_004",
+            "tool": "record_search",
+            "query": {
+              "surname": "Andrews",
+              "spouseSurname": "Bagley",
+              "residencePlace": "Vermont",
+              "marriageYearFrom": 1795,
+              "marriageYearTo": 1820,
+              "recordType": "marriage",
+              "count": 50
+            },
+            "outcome": "negative",
+            "resultsExamined": 50,
+            "resultsAvailable": 160,
+            "stagedResultsRef": "results/.staging/71f54920-3322-456c-97e5-301c1b65dc40.json",
+            "notes": "No Sarah Andrews + Bagley marriage found in top 50 of 160 results. All results are male Andrews relatives of brides in later marriages, not the target Sarah Andrews marrying a Bagley. Indexed Vermont vital records and town clerk records do not appear to contain an indexed entry for this pre-1857 marriage. Pre-1857 Vermont marriages depended on town-clerk recording; the Topsham town records (pli_005, imageGroup 005464260) are the most likely repository but require full-text search."
+          },
+          {
+            "planItemId": "pli_004",
+            "tool": "record_search",
+            "query": {
+              "surname": "Bagley",
+              "givenName": "David",
+              "spouseGivenName": "Sarah",
+              "residencePlace": "Vermont",
+              "marriageYearFrom": 1795,
+              "marriageYearTo": 1820,
+              "recordType": "marriage",
+              "count": 50
+            },
+            "outcome": "negative",
+            "resultsExamined": 10,
+            "resultsAvailable": 10,
+            "stagedResultsRef": "results/.staging/00547ce2-bef8-4702-ad92-0864c8571c40.json",
+            "notes": "10 results. Top results include 'David Bagley and Voda Page' (multiple indexings of the same record in Vermont collections) and 'Otis B. Rollins and Flora E. Bagley' (different Bagley). No David Bagley + Sarah Andrews marriage found. The 'David Bagley and Voda Page' record may be a second marriage after Sarah's death in 1847; its date needs checking. The pre-1815 marriage of David Bagley to Sarah Andrews is not found in indexed Vermont marriage compilations \u2014 consistent with the pre-1857 recording gap."
+          },
+          {
+            "planItemId": "pli_006",
+            "tool": "record_search",
+            "query": {
+              "surname": "Bagley",
+              "residencePlace": "Orange County, Vermont",
+              "recordType": "probate",
+              "count": 50
+            },
+            "outcome": "negative",
+            "resultsExamined": 1,
+            "resultsAvailable": 1,
+            "stagedResultsRef": "results/.staging/f05a3434-05e0-402e-a990-ef750d94c355.json",
+            "notes": "1 result: Sidney Albert Bagley, probate in Transvaal, South Africa, 1930 \u2014 born Braintree, Orange, Vermont 1896, but completely unrelated to David Bagley circa 1820-1860. No Orange County Vermont probate for any Bagley of the right era found in this indexed search."
+          },
+          {
+            "planItemId": "pli_006",
+            "tool": "record_search",
+            "query": {
+              "surname": "Bagley",
+              "givenName": "David",
+              "residencePlace": "Vermont",
+              "recordType": "probate",
+              "anyYearFrom": 1820,
+              "anyYearTo": 1870,
+              "count": 50
+            },
+            "outcome": "negative",
+            "resultsExamined": 0,
+            "resultsAvailable": 0,
+            "stagedResultsRef": null,
+            "notes": "Zero results. No indexed probate record for David Bagley in Vermont 1820-1870 found in FamilySearch. The indexed Vermont probate collection (1435692) does not contain a David Bagley record. The unindexed Bradford District estate files (pli_007, collection 1807377) would need to be browsed image-by-image and are beyond the current tool capabilities. Marking pli_006 completed; pli_007 (browse fallback) to be skipped with this finding noted."
+          },
+          {
+            "planItemId": "pli_008",
+            "tool": "record_search",
+            "query": {
+              "surname": "Bagley",
+              "givenName": "David",
+              "residencePlace": "Topsham, Vermont",
+              "residenceYearFrom": 1840,
+              "residenceYearTo": 1840,
+              "recordType": "census",
+              "count": 50
+            },
+            "outcome": "positive",
+            "resultsExamined": 2,
+            "resultsAvailable": 2,
+            "stagedResultsRef": "results/.staging/c3c42b9d-0bdc-4ad8-b2f3-ebd28c048d5b.json",
+            "notes": "Found 2 results \u2014 both are 'Household of David Bagley, United States, Census, 1840, Topsham, Orange, Vermont' (two indexings of the same entry: XHRB-V42 and XHRB-V4V). Confidence 4, score 5.44. David Bagley was still in Topsham in 1840 when William would be approximately 25. Match ranking against I1 (David Bagley stub) returned scores of 0.15 due to thinness of stub (no birth/death dates), but both records are clearly David Bagley in Topsham, consistent with the father named in the 1884 death records. XHRB-V42 is attachedToOther (already linked in FamilySearch's tree to LVDV-DBC, corroborating the identity match). Will read XHRB-V42 to check household composition."
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"logId\\\": \\\"log_005\\\",\\n      \\\"performed\\\": \\\"2026-07-27T19:32:07.015Z\\\",\\n      \\\"resultsRef\\\": \\\"results/log_005.json\\\",\\n      \\\"returnedCount\\\": 50\\n    },\\n    {\\n      \\\"logId\\\": \\\"log_006\\\",\\n      \\\"performed\\\": \\\"2026-07-27T19:32:07.021Z\\\",\\n      \\\"resultsRef\\\": \\\"results/log_006.json\\\",\\n      \\\"returnedCount\\\": 10\\n    },\\n    {\\n      \\\"logId\\\": \\\"log_007\\\",\\n      \\\"performed\\\": \\\"2026-07-27T19:32:07..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__fulltext_search",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__fulltext_search\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "surname": "Bagley",
+        "residencePlace": "Topsham, Vermont",
+        "recordType": "census",
+        "residenceYearFrom": 1840,
+        "residenceYearTo": 1840,
+        "count": 50
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\\\",\\n    \\\"surname\\\": \\\"Bagley\\\",\\n    \\\"residencePlace\\\": \\\"Topsham, Vermont\\\",\\n    \\\"recordType\\\": \\\"census\\\",\\n    \\\"residenceYearFrom\\\": 1840,\\n    \\\"residenceYearTo\\\": 1840,\\n    \\\"count\\\": 50\\n  },\\n  \\\"totalMatches\\\": 18,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 18,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": false,\\n  \\\"results\\\":..."
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "keywords": "+Bagley",
+        "imageGroupNumber": "005464260",
+        "count": 50
+      },
+      "response_summary": "Error: result (109,336 characters across 4,344 lines) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt.\nFormat: Plain text\n- For targeted searches (find a line, locate a string): use grep on the file directly.\n- For analysis or summarization that requires reading the ful..."
+    },
+    {
+      "tool": "mcp__genealogy__record_search",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "recordId": "ark:/61903/1:1:XHRB-V42",
+        "surname": "Bagley",
+        "count": 1
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"query\\\": {\\n    \\\"projectPath\\\": \\\"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\\\",\\n    \\\"recordId\\\": \\\"ark:/61903/1:1:XHRB-V42\\\",\\n    \\\"surname\\\": \\\"Bagley\\\",\\n    \\\"count\\\": 1\\n  },\\n  \\\"totalMatches\\\": 1172591,\\n  \\\"paginationCappedAt\\\": 4999,\\n  \\\"returned\\\": 1,\\n  \\\"offset\\\": 0,\\n  \\\"hasMore\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"recordId\\\": \\\"ark:/61903/1:1:XS7S-YYH\\\",\\n      \\\"events\\\": [\\n        {\\n   ..."
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Analyze Topsham full-text search results",
+        "prompt": "Read the file at `/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt` in chunks of ~677 lines using offset/limit until you have read all 4,344 lines.\n\nThis is the result of a FamilySearch full-text search for \"+Bagley\" in imageGroup 005464260 (Topsham Town Records, Vermont, 1771-1860). The file contains JSON results about pages in this volume that mention \"Bagley.\"\n\nAfter reading all 4,344 lines, report:\n1. How many total results/hits were returned?\n2. List every result that mentions a Bagley person in the context of a birth, baptism, marriage, death, or parentage event \u2014 especially any entry that names a \"David Bagley\" OR mentions \"William\" as a child, OR mentions \"Sarah\" or \"Andrews\" alongside \"Bagley\"\n3. For each relevant result, quote the `transcriptText` or `text` field verbatim and note the `imageGroupNumber`, `imageNumber`, `filmNumber`, or any other identifiers present\n4. Summarize what record types are represented (births, marriages, deaths, land records, etc.)\n5. Note any hits that could be William A. Bagley's birth record naming his father, or David Bagley's marriage to Sarah Andrews\n\nBe thorough \u2014 quote every relevant line verbatim."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"I have now read all 4,344 lines. Here is my full report:\\n\\n---\\n\\n## 1. Total Results / Hits\\n\\n- **totalResults: 110** (the query matched 110 pages in the volume)\\n- **returned: 50** (only the first 50 are included in this file; the query had `hasMore: true`)\\n- No `transcriptText` or `text` fields are present in any result \\u2014 these are index/metadata records only, listing extracted `names`, `places`, and `dates` per page image. There is no verbatim transcript..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__record_read",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__record_read\"}]"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt",
+        "limit": 677,
+        "offset": 0
+      },
+      "response_summary": "0\t{\n1\t  \"query\": {\n2\t    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\",\n3\t    \"keywords\": \"+Bagley\",\n4\t    \"imageGroupNumber\": \"005464260\",\n5\t    \"count\": 50\n6\t  },\n7\t  \"totalResults\": 110,\n8\t  \"returned\": 50,\n9\t  \"offset\": 0,\n10\t  \"hasMore\": true,\n11\t  \"results\": [\n12\t    {\n13\t      \"id\": \"ark:/61903/3:1:3QS7-8999-L4XM\",\n14\t      \"sourceUrl\": \"https://www.familysearch.org/ark:/61903/3:1:3QS7-8999-L4XM\",\n15\t      \"collectionId\": \"M9J..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt",
+        "limit": 677,
+        "offset": 677
+      },
+      "response_summary": "677\t        \"Calleton\",\n678\t        \"County Grand\",\n679\t        \"Town Juners\"\n680\t      ],\n681\t      \"dates\": [\n682\t        \"1839\"\n683\t      ],\n684\t      \"highlightTerms\": [\n685\t        \"Bagley\"\n686\t      ]\n687\t    },\n688\t    {\n689\t      \"id\": \"ark:/61903/3:1:3QSQ-G999-LH9L\",\n690\t      \"sourceUrl\": \"https://www.familysearch.org/ark:/61903/3:1:3QSQ-G999-LH9L\",\n691\t      \"collectionId\": \"M9J1-72F\",\n692\t      \"collectionTitle\": \"United States, Vermont, Legal, from 1583 to 2005\",\n693\t      \"title..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt",
+        "limit": 677,
+        "offset": 1354
+      },
+      "response_summary": "1354\t        \"Daniel McCalloway\",\n1355\t        \"Carliss\"\n1356\t      ],\n1357\t      \"places\": [\n1358\t        \"County Grand Chase\"\n1359\t      ],\n1360\t      \"highlightTerms\": [\n1361\t        \"Bagley\"\n1362\t      ]\n1363\t    },\n1364\t    {\n1365\t      \"id\": \"ark:/61903/3:1:3QSQ-G999-L4KT\",\n1366\t      \"sourceUrl\": \"https://www.familysearch.org/ark:/61903/3:1:3QSQ-G999-L4KT\",\n1367\t      \"collectionId\": \"M9J1-72F\",\n1368\t      \"collectionTitle\": \"United States, Vermont, Legal, from 1583 to 2005\",\n1369\t    ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt",
+        "limit": 677,
+        "offset": 2031
+      },
+      "response_summary": "2031\t      \"highlightTerms\": [\n2032\t        \"Bagley\"\n2033\t      ]\n2034\t    },\n2035\t    {\n2036\t      \"id\": \"ark:/61903/3:1:3QSQ-G999-L47Z\",\n2037\t      \"sourceUrl\": \"https://www.familysearch.org/ark:/61903/3:1:3QSQ-G999-L47Z\",\n2038\t      \"collectionId\": \"M9J1-72F\",\n2039\t      \"collectionTitle\": \"United States, Vermont, Legal, from 1583 to 2005\",\n2040\t      \"title\": \"Topsham, Orange, Vermont, United States Town 1819\",\n2041\t      \"recordDate\": \"1819\",\n2042\t      \"recordType\": \"Town\",\n2043\t      \"..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt",
+        "limit": 677,
+        "offset": 2708
+      },
+      "response_summary": "2708\t        \"Chaser\",\n2709\t        \"Levi Jaber\",\n2710\t        \"James F George\",\n2711\t        \"Thomas J Currier\",\n2712\t        \"Wm Rogers\",\n2713\t        \"Moses A. Dustin\",\n2714\t        \"Hal Graw\",\n2715\t        \"Thomas Eastman\",\n2716\t        \"Charles Graw\",\n2717\t        \"Hanson Rogers\",\n2718\t        \"Chase\",\n2719\t        \"Calvin Taber\",\n2720\t        \"David Baghhase \",\n2721\t        \"Samuel Batchelder\",\n2722\t        \"Amos Garland\",\n2723\t        \"Daniel R Sargent\",\n2724\t        \"Chase McKeeth\",\n2..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt",
+        "limit": 677,
+        "offset": 3385
+      },
+      "response_summary": "3385\t        \"Ma Wallace\",\n3386\t        \"Rebecca Gale\",\n3387\t        \"James\",\n3388\t        \"M Samuel Gibson\",\n3389\t        \"Betsey Cartman\",\n3390\t        \"Geo Campbell\",\n3391\t        \"George K Bagley\",\n3392\t        \"Susan M Worthley\",\n3393\t        \"John Andrews\",\n3394\t        \"Elizabeth Sanborn\",\n3395\t        \"Ophir Shipman\",\n3396\t        \"M William Gentleman Jr\",\n3397\t        \"Rachel Sylle\",\n3398\t        \"Ophin Shipman\",\n3399\t        \"Cyrus R Lawgay\",\n3400\t        \"Susan Gardan\",\n3401\t      ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt",
+        "limit": 677,
+        "offset": 4062
+      },
+      "response_summary": "4062\t      ]\n4063\t    },\n4064\t    {\n4065\t      \"id\": \"ark:/61903/3:1:3QS7-8999-LWKQ\",\n4066\t      \"sourceUrl\": \"https://www.familysearch.org/ark:/61903/3:1:3QS7-8999-LWKQ\",\n4067\t      \"collectionId\": \"M9J1-72F\",\n4068\t      \"collectionTitle\": \"United States, Vermont, Legal, from 1583 to 2005\",\n4069\t      \"title\": \"Topsham, Orange, Vermont, United States Town 1853\",\n4070\t      \"recordDate\": \"1853\",\n4071\t      \"recordType\": \"Town\",\n4072\t      \"recordPlace\": \"Topsham, Orange, Vermont, United State..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:XHRB-V42",
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "resultsRef": "results/log_009.json"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_10421422430\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:XHRB-V42\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"surname\\\": \\\"Bagley\\\",\\n          \\\"given\\\": \\\"David\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"type\\\": \\\"Census\\\",\\n          \\\"primary\\\": true,\\n          \\\"date\\\": \\\"1840\\\",\\n          \\\"standard_date\\\": \\\"1840\\\",\\n          \\\"place\\\": \\\"Topsham, Orange, Ve..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:XHRB-KZL"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_10421423421\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:XHRB-KZL\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"69456c29-c10a-4e2f-818e-f6957df8a509\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"given\\\": \\\"Wm A\\\",\\n          \\\"surname\\\": \\\"Bagley\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"2c9d51fc-a151-429d-957a-73512835d293\\\",\\n          \\\"type\\\": \\\"Census\\\",\\n          \\\"primary\\\":..."
+    },
+    {
+      "tool": "mcp__genealogy__fulltext_search",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "keywords": "+Bagley",
+        "imageGroupNumber": "005464260",
+        "count": 60,
+        "offset": 50
+      },
+      "response_summary": "Error: result (109,735 characters across 4,353 lines) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt.\nFormat: Plain text\n- For targeted searches (find a line, locate a string): use grep on the file directly.\n- For analysis or summarization that requires reading the ful..."
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Analyze second fulltext search file for Topsham vital records",
+        "prompt": "Read the file at `/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt` and extract ALL entries that mention any of the following names: Bagley, Baley, Bayley, Andrews, David, William, Sarah, Sophia. \n\nThis is a full-text search result from Topsham, Vermont town records (imageGroup 005464260), covering results at offset=50 (items 51-110). I need to know:\n\n1. Any marriages involving a Bagley + Andrews pairing (David Bagley marrying Sarah Andrews, or any Andrews-Bagley marriage)\n2. Any births/baptisms/vital records for a David Bagley\n3. Any record naming William Bagley's parents\n4. Any record of Sarah Andrews or a Sarah Bagley (n\u00e9e Andrews)\n5. The full text of every hit that mentions \"Bagley\" or \"Baley\" or \"Bayley\" \u2014 give me the complete snippet text and the imageGroupId/imageId for each\n\nReport back ALL matching entries with their full text snippets and imageIds. Do not summarize or omit any hits. Report nothing found if you find nothing.",
+        "run_in_background": false
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"Now I have all the information I need. Let me compile the complete findings.\\n\\nHere is the complete report of every hit mentioning Bagley, Baley, Bayley, and the co-occurring Andrews/Sarah/Sophia names from this result set (offset 50, items 51\\u2013110, imageGroup 005464260):\\n\\n---\\n\\nCOMPLETE BAGLEY / BALEY / BAYLEY HITS (items 51\\u2013110)\\n\\nEach entry is from collection M9J1-72F, \\\"United States, Vermont, Legal, from 1583 to 2005,\\\" Topsham, Orange, Vermont. T..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json",
+        "limit": 100
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_bagley_father_1884\",\n4\t    \"objective\": \"Who was the father of William A. Bagley, born about 1815 and died 31 May 1884 in Topsham, Orange County, Vermont?\",\n5\t    \"subject_person_ids\": [\n6\t      \"MJDL-Q8B\"\n7\t    ],\n8\t    \"status\": \"active\",\n9\t    \"created\": \"2026-07-27\",\n10\t    \"updated\": \"2026-07-27\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\": \"intermediate\",\n14\t    \"subscriptions\": [],\n15\t    \"narration_guidance\": \"concise\"\n16\t  },\n17..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt"
+      },
+      "response_summary": "File content (38485 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "Bagley|Baley|Bayley",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt",
+        "output_mode": "content",
+        "context": 8,
+        "head_limit": 0,
+        "-i": true
+      },
+      "response_summary": "<persisted-output>\nOutput too large (65.5KB). Full output saved to: /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/toolu_019MEfXkswdGSVJTnASevZoT.txt\n\nPreview (first 2KB):\n1-{\n2-  \"query\": {\n3:    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\",\n4:    \"keywords\": \"+Bagley\",\n5-    \"imageGroupNumber\": \"005464260\",\n6-..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/toolu_019MEfXkswdGSVJTnASevZoT.txt"
+      },
+      "response_summary": "File content (27021 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/toolu_019MEfXkswdGSVJTnASevZoT.txt",
+        "limit": 400
+      },
+      "response_summary": "1\t1-{\n2\t2-  \"query\": {\n3\t3:    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\",\n4\t4:    \"keywords\": \"+Bagley\",\n5\t5-    \"imageGroupNumber\": \"005464260\",\n6\t6-    \"count\": 60,\n7\t7-    \"offset\": 50\n8\t8-  },\n9\t9-  \"totalResults\": 110,\n10\t10-  \"returned\": 60,\n11\t11-  \"offset\": 50,\n12\t12-  \"hasMore\": false,\n13\t--\n14\t59-        \"Chase Wm Wood\",\n15\t60-        \"Samuel Labor\",\n16\t61-        \"Daniel Jones\",\n17\t62-        \"Ebenezer White\",\n18\t63-  ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/toolu_019MEfXkswdGSVJTnASevZoT.txt",
+        "offset": 400,
+        "limit": 400
+      },
+      "response_summary": "400\t764-        \"John Lord\",\n401\t765-        \"Richard H Huntley\",\n402\t766-        \"Chase Lemuel Tabor Town\",\n403\t767-        \"Chase Harris McLaughlin\",\n404\t768-        \"Samuel Butterfield\"\n405\t769-      ],\n406\t770-      \"places\": [\n407\t--\n408\t773-        \"Lemuel\",\n409\t774-        \"Topsham\"\n410\t775-      ],\n411\t776-      \"dates\": [\n412\t777-        \"1805\",\n413\t778-        \"1806\"\n414\t779-      ],\n415\t780-      \"highlightTerms\": [\n416\t781:        \"Bagley\"\n417\t782-      ]\n418\t783-    },\n419\t784-  ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/toolu_019MEfXkswdGSVJTnASevZoT.txt",
+        "offset": 800,
+        "limit": 400
+      },
+      "response_summary": "800\t1407-        \"Duncan M. Ruth\",\n801\t1408-        \"Carliss\",\n802\t1409-        \"Moses Dustin\",\n803\t1410:        \"David Bagley\",\n804\t1411-        \"John R Dusten\",\n805\t1412-        \"Lea Tabor\",\n806\t1413-        \"Charles Grass\",\n807\t1414-        \"James Chamberlain\",\n808\t1415-        \"Wilber Butterfield\",\n809\t1416-        \"Samuel Easton\",\n810\t1417-        \"Thomas Eastman\",\n811\t1418-        \"Jonathan Baldwin\",\n812\t--\n813\t1445-        \"Defray Town\",\n814\t1446-        \"Exton\",\n815\t1447-        \"Roug..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/toolu_019MEfXkswdGSVJTnASevZoT.txt",
+        "offset": 1200,
+        "limit": 400
+      },
+      "response_summary": "1200\t2162-      \"sourceUrl\": \"https://www.familysearch.org/ark:/61903/3:1:3QS7-L999-LWY6\",\n1201\t2163-      \"collectionId\": \"M9J1-72F\",\n1202\t2164-      \"collectionTitle\": \"United States, Vermont, Legal, from 1583 to 2005\",\n1203\t2165-      \"title\": \"Topsham, Orange, Vermont, United States Town 1826\",\n1204\t--\n1205\t2178-        \"Popham\",\n1206\t2179-        \"Mary\",\n1207\t2180-        \"Jonathan Tenness\",\n1208\t2181-        \"Samuel Bachelder\",\n1209\t2182-        \"Daniel James\",\n1210\t2183-        \"Copham..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/toolu_019MEfXkswdGSVJTnASevZoT.txt",
+        "offset": 1600,
+        "limit": 400
+      },
+      "response_summary": "1600\t2905-        \"Erastus Fairbanks\",\n1601\t2906-        \"Lawrence Brainard\",\n1602\t2907-        \"Jefferson P Kidder\",\n1603\t2908-        \"William Kitridge\",\n1604\t2909-        \"William M Pingry\",\n1605\t2910-        \"Samuel Hutchins\",\n1606\t2911-        \"Frasier\",\n1607\t--\n1608\t2953-        \"State of Vermont\"\n1609\t2954-      ],\n1610\t2955-      \"dates\": [\n1611\t2956-        \"1853\",\n1612\t2957-        \"1833\",\n1613\t2958-        \"1679\"\n1614\t2959-      ],\n1615\t2960-      \"highlightTerms\": [\n1616\t2961:    ..."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "Andrews|Sarah|Sophia",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt",
+        "output_mode": "content",
+        "context": 5,
+        "head_limit": 0,
+        "-i": true
+      },
+      "response_summary": "108-        \"John Bagleys\",\n109-        \"Henry Bagley\",\n110-        \"Sargan Bagly\",\n111-        \"Michael Thompson\",\n112-        \"Mary Bishop Thompson\",\n113:        \"Sarah Johnston\",\n114-        \"Thompson Corn\",\n115-        \"Jesse\",\n116-        \"Harris\",\n117-        \"Eldridge Findley\",\n118-        \"Barn Patram\",\n--\n136-        \"M. Ruth Wilson\",\n137-        \"Thomas Crown\",\n138-        \"Elizabeth Crown\",\n139-        \"Hannah Crown\",\n140-        \"Jesse Crown\",\n141:        \"Sarah N Crown\",\n142-    ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt",
+        "limit": 200
+      },
+      "response_summary": "1\t{\n2\t  \"query\": {\n3\t    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\",\n4\t    \"keywords\": \"+Bagley\",\n5\t    \"imageGroupNumber\": \"005464260\",\n6\t    \"count\": 60,\n7\t    \"offset\": 50\n8\t  },\n9\t  \"totalResults\": 110,\n10\t  \"returned\": 60,\n11\t  \"offset\": 50,\n12\t  \"hasMore\": false,\n13\t  \"results\": [\n14\t    {\n15\t      \"id\": \"ark:/61903/3:1:3QSQ-G999-L44F\",\n16\t      \"sourceUrl\": \"https://www.familysearch.org/ark:/61903/3:1:3QSQ-G999-L44F\",\n17\t  ..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt",
+        "offset": 200,
+        "limit": 300
+      },
+      "response_summary": "200\t      \"names\": [\n201\t        \"Samuel Tabor\",\n202\t        \"Samuel Butterfield\",\n203\t        \"Moses Wallace\",\n204\t        \"Daniel Jones\",\n205\t        \"John George\",\n206\t        \"James George\",\n207\t        \"Samuel Dickerman\",\n208\t        \"John Brown\",\n209\t        \"Huntley\",\n210\t        \"Isaac Tabor\",\n211\t        \"David Bagley\",\n212\t        \"Edmund George\",\n213\t        \"Jonathan Sanburn\",\n214\t        \"Blanchard\",\n215\t        \"Daniel Jonesin \",\n216\t        \"John Ford\",\n217\t        \"Elen White\"..."
+    },
+    {
+      "tool": "Grep",
+      "args": {
+        "pattern": "Sophia A. Bagley|David Bagley Selectman|G W Bagley|George R. Bagley|William H Bagley|John M Bagley|Wm A Bagley|Charles Bagley|Dee David Bagley|Ephraim Bagley|Enoch Bagley|Moses Bagley|John Bagley|Aaron Bagley|Elijah Bagley|Peter Bagley|Aaron Bagley",
+        "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt",
+        "output_mode": "content",
+        "context": 3,
+        "head_limit": 0
+      },
+      "response_summary": "105-        \"May R\",\n106-        \"Joseph Smith\",\n107-        \"Burton Smith\",\n108:        \"John Bagleys\",\n109-        \"Henry Bagley\",\n110-        \"Sargan Bagly\",\n111-        \"Michael Thompson\",\n--\n257-        \"Sheep Marks\",\n258-        \"Cartman\",\n259-        \"John Crown\",\n260:        \"Aaron Bagley\",\n261-        \"Corless\",\n262-        \"Ebenezer Fenton\",\n263-        \"Wm Davidson\"\n--\n357-        \"William\",\n358-        \"Chillis\",\n359-        \"Mary\",\n360:        \"Aaron Bagley\",\n361-        \"Sheep M..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt",
+        "offset": 1220,
+        "limit": 200
+      },
+      "response_summary": "1220\t        \"Levi Jaban\",\n1221\t        \"Freeman\",\n1222\t        \"John Dustin\",\n1223\t        \"Chase Jonathan Kenness\",\n1224\t        \"Josiah Butler\",\n1225\t        \"Henry Clin\",\n1226\t        \"Samuel Crafts\",\n1227\t        \"Josiah Dana\",\n1228\t        \"Benjamin Swan\",\n1229\t        \"Merrell\",\n1230\t        \"John Roberts\",\n1231\t        \"George Worthington\",\n1232\t        \"Leman\",\n1233\t        \"Benjamin Deming\"\n1234\t      ],\n1235\t      \"places\": [\n1236\t        \"Topsham\",\n1237\t        \"Depray Town\",\n1238..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json",
+        "offset": 100,
+        "limit": 200
+      },
+      "response_summary": "100\t        {\n101\t          \"id\": \"pli_006\",\n102\t          \"sequence\": 6,\n103\t          \"record_type\": \"probate\",\n104\t          \"jurisdiction\": \"Orange County, Vermont\",\n105\t          \"date_range\": \"1800-1860\",\n106\t          \"repository\": \"FamilySearch\",\n107\t          \"rationale\": \"Search Vermont Probate Files 1800-1921 (collection 1435692, 10,225 records indexed + 204K images) for a Bagley estate in Orange County. If William's father died after 1800, an estate or will naming William as a son..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json",
+        "offset": 300,
+        "limit": 200
+      },
+      "response_summary": "300\t      \"results_available\": 1,\n301\t      \"notes\": \"1 result: Sidney Albert Bagley, probate in Transvaal, South Africa, 1930 \u2014 born Braintree, Orange, Vermont 1896, but completely unrelated to David Bagley circa 1820-1860. No Orange County Vermont probate for any Bagley of the right era found in this indexed search.\"\n302\t    },\n303\t    {\n304\t      \"id\": \"log_008\",\n305\t      \"plan_item_id\": \"pli_006\",\n306\t      \"performed\": \"2026-07-27T19:32:07.024Z\",\n307\t      \"tool\": \"record_search\",\n308\t ..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__research_append,mcp__genealogy__research_log_append",
+        "max_results": 2
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_append\"}, {\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__research_log_append\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "ops": [
+          {
+            "section": "plan_items",
+            "op": "update",
+            "entryId": "pli_004",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "entryId": "pli_005",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "entryId": "pli_006",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "entryId": "pli_007",
+            "fields": {
+              "status": "skipped"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "entryId": "pli_008",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "entryId": "pli_009",
+            "fields": {
+              "status": "skipped"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "entryId": "pli_010",
+            "fields": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"ops[0]: section 'plan_items' requires a 'planId'\\\",\\n    \\\"worked example for 'plan_items':\\\\nresearch_append({\\\\n  projectPath: \\\\\\\"<absolute-path-to-project-directory>\\\\\\\",\\\\n  section: \\\\\\\"plan_items\\\\\\\",\\\\n  op: \\\\\\\"update\\\\\\\",\\\\n  planId: \\\\\\\"pl_001\\\\\\\",\\\\n  entryId: \\\\\\\"<existing-id>\\\\\\\",\\\\n  fields: { /* only the fields you are changing */ }\\\\n})\\\"\\n  ],\\n  \\\"opsReceived\\\": 7\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "ops": [
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_004",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_005",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_006",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_007",
+            "fields": {
+              "status": "skipped"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_008",
+            "fields": {
+              "status": "completed"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_009",
+            "fields": {
+              "status": "skipped"
+            }
+          },
+          {
+            "section": "plan_items",
+            "op": "update",
+            "planId": "pl_001",
+            "entryId": "pli_010",
+            "fields": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_004\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_005\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_006\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"plan_items\\\",\\n      \\\"op\\\": \\\"update\\\",\\n      \\\"entryId\\\": \\\"pli_007\\\"\\n..."
+    },
+    {
+      "tool": "mcp__genealogy__research_log_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "ops": [
+          {
+            "tool": "fulltext_search",
+            "planItemId": "pli_005",
+            "query": {
+              "imageGroupNumber": "005464260",
+              "searchTerms": "Bagley",
+              "offset": 0,
+              "count": 50
+            },
+            "outcome": "partial",
+            "resultsExamined": 50,
+            "resultsAvailable": 110,
+            "stagedResultsRef": null,
+            "notes": "Full-text search of Topsham Town Records 1771-1860 (imageGroup 005464260), 50 results at offset 0. Key findings: (1) 1813 town record (ark:/61903/3:1:3QS7-L999-L4VT) contains 'David Bagleys', 'David Bagley', 'Aaron Andrews', 'John Andrews' on same image; (2) A 1813 town record contains 'Sophia Andrews Bagley' \u2014 a Bagley child bearing the Andrews maiden surname as middle name, strong circumstantial evidence that Sarah Andrews married David Bagley; (3) David Bagley appears as Topsham selectman from 1806 through at least 1839, consistent with long-term Topsham residence; (4) 'David Bagley Jr.' appears in 1839 record \u2014 two David Bagleys existed in Topsham simultaneously; (5) 'Wm A Bagley' and 'David Bayley Jr' appear on same 1853 page, possibly as brothers (sons of David Sr.); (6) No direct birth record for William Bagley or marriage record for David Bagley + Sarah Andrews found in this offset. 110 total results available; 60 remaining at offset 50."
+          },
+          {
+            "tool": "fulltext_search",
+            "planItemId": "pli_005",
+            "query": {
+              "imageGroupNumber": "005464260",
+              "searchTerms": "Bagley",
+              "offset": 50,
+              "count": 60
+            },
+            "outcome": "partial",
+            "resultsExamined": 53,
+            "resultsAvailable": 110,
+            "stagedResultsRef": null,
+            "notes": "Full-text search of Topsham Town Records 1771-1860 (imageGroup 005464260), results at offset 50 (items 51-110). Key findings: (1) 1848 town record (ark:/61903/3:1:3QS7-L999-L4DW) contains 'Sophia A. Bagley' \u2014 a woman named Sophia with initial A (consistent with Andrews middle name), corroborating the Sophia Andrews Bagley child of David and Sarah; (2) David Bagley explicitly identified as Selectman in 1848 (ark:/61903/3:1:3QSQ-G999-L4RH); (3) 1822 record (ark:/61903/3:1:3QS7-8999-L46Y) contains 'Aaron Bagley' + 'John Andrews', 'Hannah Andrews', 'Sophia Andrews' on same image; (4) David Bagley appears in town records continuously 1806-1855; (5) Aaron Bagley, Moses Bagley, Ephraim Bagley, John Bagley also appear \u2014 multiple Bagley family members in Topsham; (6) No direct birth or marriage record for David Bagley + Sarah Andrews found in remaining results. Full-text search of 110-record result set now complete (all results examined)."
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"logId\\\": \\\"log_010\\\",\\n      \\\"performed\\\": \\\"2026-07-27T19:44:16.990Z\\\",\\n      \\\"resultsRef\\\": null,\\n      \\\"returnedCount\\\": null\\n    },\\n    {\\n      \\\"logId\\\": \\\"log_011\\\",\\n      \\\"performed\\\": \\\"2026-07-27T19:44:16.990Z\\\",\\n      \\\"resultsRef\\\": null,\\n      \\\"returnedCount\\\": null\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\"..."
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "Extract 1840 David Bagley census record",
+        "subagent_type": "record-extractor",
+        "prompt": "Extract all assertions from this 1840 census record into research.json and tree.gedcomx.json.\n\n**Project path:** `/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2`\n\n**Record ID:** `ark:/61903/1:1:XHRB-V42`\n\n**Log entry ID:** `log_009`\n\n**Question this is extracted for:** `q_001` \u2014 \"Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermont)?\"\n\n**Context about the record:**\nThis is the 1840 United States Federal Census, Topsham, Orange County, Vermont. The head of household is David Bagley. It was found via a record_search for David Bagley in Topsham 1840. The search also returned XHRB-V4V which is a second indexing of the same entry. Use XHRB-V42.\n\nThis record is important as corroborating/indirect evidence that David Bagley \u2014 named as William A. Bagley's father in the 1884 Vermont death records \u2014 was still residing in Topsham, Orange County, Vermont in 1840, when William A. Bagley was approximately 25 years old.\n\n**Key persons in the project tree:**\n- MJDL-Q8B = William A. Bagley (research subject, born ~1815, died 31 May 1884 Topsham, Orange, Vermont)\n- I1 = David Bagley (candidate father; name and 1820 Topsham residence already in tree from src_003)\n- LVDV-6MK = Sarah Sally Andrews (already identified as William's mother)\n\n**GPS Classification guidance:**\n- The 1840 census is an original record\n- Information about the head of household's name and residence is primary information (the census taker recorded it directly from the household)\n- For q_001 (who was William's father): David Bagley appearing in Topsham in 1840 is INDIRECT evidence \u2014 it places him in the right location consistently with being William's father, but does not directly state the parentage relationship\n- Pre-1850 censuses only name the head of household; all other household members appear as tally marks \u2014 record ONLY what the record actually states (head's name, location, year)\n\nPlease call `record_read` on `ark:/61903/1:1:XHRB-V42` to get the full record content, then extract all assertions. Write the source entry and assertions to research.json, and update tree person I1 with any new facts."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"Extraction complete.\\n\\n**Source:** src_004 / S4 \\u2014 created (new source)\\n\\n**Assertions written:** 2 assertions for `head_of_household` (David Bagley)\\n- a_026: `name` \\u2014 \\\"David Bagley\\\" (primary, direct, q_001)\\n- a_027: `residence` \\u2014 Topsham, Orange, Vermont, 1840 (primary/witness, indirect, q_001)\\n\\n**Key findings:**\\n- Record is an original 1840 federal census schedule. Pre-1850, so only the head of household is named; all other occupants are tal..."
+    },
+    {
+      "tool": "mcp__genealogy__project_context",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"projectStatus\\\": \\\"active\\\",\\n  \\\"openQuestions\\\": [\\n    {\\n      \\\"id\\\": \\\"q_001\\\",\\n      \\\"question\\\": \\\"Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermon\\u2026\\\"\\n    }\\n  ],\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"MJDL-Q8B\\\",\\n      \\\"name\\\": \\\"William A. Bagley\\\",\\n      \\\"gender\\\": \\\"Male\\\",\\n      \\\"sourceRefs\\\": [\\n        \\\"S1\\\",\\n        \\\"..."
+    },
+    {
+      "tool": "mcp__genealogy__record_read",
+      "args": {
+        "recordId": "ark:/61903/1:1:XHRB-V42"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"persons\\\": [\\n    {\\n      \\\"id\\\": \\\"p_10421422430\\\",\\n      \\\"ark\\\": \\\"ark:/61903/1:1:XHRB-V42\\\",\\n      \\\"names\\\": [\\n        {\\n          \\\"id\\\": \\\"3923965b-4837-4e00-9c4c-45a9b3d26c1e\\\",\\n          \\\"type\\\": \\\"BirthName\\\",\\n          \\\"surname\\\": \\\"Bagley\\\",\\n          \\\"given\\\": \\\"David\\\"\\n        }\\n      ],\\n      \\\"facts\\\": [\\n        {\\n          \\\"id\\\": \\\"b9bde81c-3ec4-4979-91cd-444eb74dbe64\\\",\\n          \\\"type\\\": \\\"Census\\\",\\n          \\\"primary\\\"..."
+    },
+    {
+      "tool": "mcp__genealogy__extraction_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "sourceDescription": {
+          "title": "Household of David Bagley, \"United States, Census, 1840\"",
+          "url": "https://www.familysearch.org/ark:/61903/1:1:XHRB-V42"
+        },
+        "ops": [
+          {
+            "section": "sources",
+            "op": "append",
+            "entry": {
+              "citation": "\"United States, Census, 1840,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:XHRB-V42 : accessed 2026-07-27), entry for David Bagley, Topsham, Orange, Vermont, 1840.",
+              "citation_detail": {
+                "who": "David Bagley",
+                "what": "1840 United States Federal Census, household schedule",
+                "when_created": "1840",
+                "when_accessed": "2026-07-27",
+                "where": "FamilySearch (https://www.familysearch.org)",
+                "where_within": "Topsham, Orange County, Vermont; ark:/61903/1:1:XHRB-V42"
+              },
+              "source_classification": "original",
+              "repository": "FamilySearch",
+              "url": "https://www.familysearch.org/ark:/61903/1:1:XHRB-V42",
+              "access_date": "2026-07-27",
+              "log_entry_id": "log_009",
+              "notes": "Pre-1850 U.S. census; only the head of household is named. All other household members appear as tally marks by age/sex category only \u2014 no names or individual details are recorded for non-heads. The digital image on FamilySearch was examined via the index entry; the underlying microfilm image at ark:/61903/3:1:33SQ-GYYY-24 is the original schedule."
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:XHRB-V42",
+              "record_role": "head_of_household",
+              "fact_type": "name",
+              "value": "David Bagley",
+              "structured_value": {
+                "given": "David",
+                "surname": "Bagley"
+              },
+              "information_quality": "primary",
+              "informant": "unknown household member (likely David Bagley himself)",
+              "informant_proximity": "household_member",
+              "evidence_type": "direct",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_009"
+            }
+          },
+          {
+            "section": "assertions",
+            "op": "append",
+            "entry": {
+              "record_id": "ark:/61903/1:1:XHRB-V42",
+              "record_role": "head_of_household",
+              "fact_type": "residence",
+              "value": "Topsham, Orange, Vermont",
+              "place": "Topsham, Orange, Vermont, United States",
+              "date": "1840",
+              "date_certainty": "exact",
+              "information_quality": "primary",
+              "informant": "census enumerator",
+              "informant_proximity": "witness",
+              "evidence_type": "indirect",
+              "extracted_for_question_ids": [
+                "q_001"
+              ],
+              "log_entry_id": "log_009",
+              "informant_bias_notes": "David Bagley's presence in Topsham, Orange County, Vermont in 1840 is consistent with him being the father of William A. Bagley (born ~1815, Topsham). This corroborates the 1884 Vermont death record naming David Bagley as William's father, but does not directly state any parentage relationship. The 1840 census predates William A. Bagley's approximate birth by ~25 years; at this date William would have been approximately 25 years old and may or may not be enumerated in this household (only tally marks for non-heads)."
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"sources\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"src_004\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_026\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"assertions\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"a_027\\\"\\n    }\\n  ],\\n  \\\"sourceDescriptionId\\\": \\\"S4\\\",\\n  \\\"sourceReuse\\\": {\\n    \\\"action\\\": \\\"created\\\",\\n    \\\"srcId\\\": \\..."
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "person-evidence"
+      },
+      "response_summary": "Launching skill: person-evidence"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__materialize_facts",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__materialize_facts\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__materialize_facts",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "personId": "I1",
+        "recordId": "ark:/61903/1:1:XHRB-V42",
+        "recordRole": "head_of_household"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"personId\\\": \\\"I1\\\",\\n  \\\"created\\\": false,\\n  \\\"factsAdded\\\": 1,\\n  \\\"factsEnriched\\\": 0,\\n  \\\"namesAdded\\\": 0,\\n  \\\"refsAttached\\\": 2,\\n  \\\"conflicts_surfaced\\\": [],\\n  \\\"filesWritten\\\": [\\n    \\\"tree.gedcomx.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "ops": [
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_026",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "The 1840 census head of household 'David Bagley' in Topsham, Orange, Vermont matches I1 (David Bagley) by name and location. I1 is already corroborated by two 1884 Vermont death records naming 'David Bagley' as William A. Bagley's father, and the 1820 federal census placing David Bagley in Topsham. The same name and same locality in 1840 is consistent with I1's established profile. No same_person score available \u2014 I1 is a local stub without a FamilySearch ARK, making any score uninformative. Qualitative correlation: name exact match, location exact match. Confident not used because no birth/death date corroboration is available to fully anchor the identity."
+            }
+          },
+          {
+            "section": "person_evidence",
+            "op": "append",
+            "entry": {
+              "assertion_id": "a_027",
+              "person_id": "I1",
+              "confidence": "probable",
+              "match_score": null,
+              "rationale": "David Bagley's 1840 residence in Topsham, Orange, Vermont (from head_of_household role in ark:/61903/1:1:XHRB-V42) is linked to I1 (David Bagley). This is indirect evidence for q_001: it places David Bagley \u2014 named as William A. Bagley's father in the 1884 death record \u2014 in Topsham in 1840, when William was approximately 25 years old, consistent with long-term Topsham residence spanning at least 1820 to 1840. No same_person score available (degenerate stub match). Probable confidence based on name + place correlation, consistent with all existing I1 evidence."
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_031\\\"\\n    },\\n    {\\n      \\\"section\\\": \\\"person_evidence\\\",\\n      \\\"op\\\": \\\"append\\\",\\n      \\\"entryId\\\": \\\"pe_032\\\"\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "research-exhaustiveness"
+      },
+      "response_summary": "Launching skill: research-exhaustiveness"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/research-exhaustiveness/references/research-exhaustiveness.md"
+      },
+      "response_summary": "1\t# Exhaustiveness Evaluation\n2\t\n3\tGuidance for determining when research on a question qualifies as\n4\t\"reasonably exhaustive\" under GPS Component 1.\n5\t\n6\t## What \"Reasonably Exhaustive\" Means\n7\t\n8\tReasonably exhaustive research is systematic investigation that\n9\tsearches all available and relevant sources \u2014 not just the ones\n10\tthat are easiest to access or most popular. The standard requires\n11\tlooking broadly across record types, repositories, and time periods\n12\tto ensure no significant s..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "questions",
+        "op": "update",
+        "entryId": "q_001",
+        "fields": {
+          "status": "exhaustive_declared",
+          "exhaustive_declaration": {
+            "declared": true,
+            "justification": "Searched Vermont Town Clerk vital records (death entries directly naming David Bagley as father), federal census 1820 and 1840 (David Bagley in Topsham both years), Vermont birth index, Vermont marriage records (indexed), Vermont probate (indexed), and full-text search of Topsham Town Records 1771-1860 (imageGroup 005464260, 110 results examined). Two independent evidence units establish the answer: (1) two indexings of one Vermont Town Clerk death entry directly naming David Bagley as William A. Bagley's father (secondary information, direct evidence); (2) the 1820 and 1840 federal census schedules placing David Bagley in Topsham, Orange County, Vermont \u2014 the same town as William \u2014 across two decades (primary information, indirect evidence). Full-text search of Topsham town records corroborates David Bagley's continuous presence as a selectman 1806-1855 and found the name 'Sophia Andrews Bagley' in an 1813 record, suggesting a child of David Bagley and Sarah Andrews named with the maternal maiden surname \u2014 consistent with the established maternal identification. No alternative candidate father appeared in any searched source. Gaps noted: Bradford District probate estate files (collection 1807377, 75K images, 0% name-indexed) are genuinely inaccessible via current tools; no indexed marriage record for David Bagley and Sarah Andrews found (consistent with pre-1857 Vermont recording gaps); land records and Ancestry local history were not searched. These gaps are unlikely to contradict the established conclusion.",
+            "log_entry_ids": [
+              "log_001",
+              "log_002",
+              "log_003",
+              "log_004",
+              "log_005",
+              "log_006",
+              "log_007",
+              "log_008",
+              "log_009",
+              "log_010",
+              "log_011"
+            ],
+            "stop_criteria": {
+              "goal_alignment": "Yes \u2014 two Vermont Town Clerk death record indexings (QPQP-R8T8 and QPQP-24HR, both from the same 31 May 1884 entry) explicitly name David Bagley as William A. Bagley's father. The 1820 census (XHLG-T8R) and 1840 census (XHRB-V42) place David Bagley in Topsham, Orange County, Vermont at times consistent with being William's father.",
+              "repository_breadth": "FamilySearch census 1820, 1830, 1840; Vermont Births and Christenings 1765-1908; Vermont Town Clerk Vital and Town Records 1732-2005; Vermont Marriages 1791-1974; Vermont Vital Records 1760-1954; Vermont Probate Files 1800-1921; Vermont Wills and Deeds; and full-text search of Topsham Town Records 1771-1860 (imageGroup 005464260) all searched. Name variants Bagley/Bayley/Baley found and searched. Bradford District estate files (browse-only, inaccessible) and Ancestry local history 'Sketches of Topsham' documented as unsearched gaps. No indexed church records for Topsham found.",
+              "original_substitution": "Both Vermont Town Clerk death records are original government entries. The 1820 and 1840 federal censuses are original government schedules. No derivative source carries the parentage conclusion \u2014 the indexed entries were the originals in this case (the collection indexes the original town-clerk volume entries).",
+              "independent_verification": "Two independent evidence units: (1) the Vermont death record (QPQP-R8T8/QPQP-24HR are two indexings of one original, counting as one unit \u2014 informant: unidentified family/community member with secondhand knowledge of the 1815 birth); (2) the 1820 and 1840 federal censuses placing David Bagley in Topsham across 20 years \u2014 independent record creation, different informants, different government process. The Topsham town records full-text search adds circumstantial corroboration (selectman records, naming pattern). The death record provides direct evidence; the censuses provide independent indirect corroboration.",
+              "evidence_class": "The Vermont Town Clerk death entry is an original record. The parentage assertion (a_005, a_015) is direct evidence and secondary information \u2014 the record explicitly states the relationship (direct) but the informant was not present at William's 1815 birth (secondary). The 1820 and 1840 censuses are original records with primary information about David Bagley's name and residence.",
+              "conflict_resolution": "No conflicting evidence exists. No source names a different father for William A. Bagley. No contradictory information about parentage appeared in any of the 11 searches conducted. The 1830 census search (log_002) found David Bagley in Topsham but the specific ARK resolved to a wrong record \u2014 this is a data-quality limitation, not a conflict. The two death-record indexings agree completely.",
+              "overturn_risk": "Low. The only meaningfully unsearched sources with potential to bear on parentage are: (1) Bradford District probate estate files \u2014 genuinely inaccessible (75K images, 0% indexed, no full-text search capability); a David Bagley will or estate inventory could corroborate but is unlikely to contradict the explicit death-record naming; (2) Topsham land records \u2014 not searched; a deed referring to 'my son William' would corroborate; no evidence suggests a different father. No alternative candidate has emerged from any source. The explicit parentage statement in the death record, corroborated by 20+ years of census co-location in the same small Vermont town, makes the conclusion highly resistant to overturn."
+            }
+          }
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"questions\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"q_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "proof-conclusion"
+      },
+      "response_summary": "Launching skill: proof-conclusion"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/proof-conclusion/references/gps-proof-writing.md"
+      },
+      "response_summary": "1\t# GPS Proof Writing Reference\n2\t\n3\tThis reference provides detailed guidance for writing genealogical\n4\tproof conclusions that conform to the Genealogical Proof Standard.\n5\t\n6\t## The Five GPS Components (All Required for Proof)\n7\t\n8\tA conclusion qualifies as \"proved\" ONLY when all five are satisfied:\n9\t\n10\t1. **Reasonably exhaustive research** \u2014 Every record type and\n11\t   repository that could plausibly contain relevant information has\n12\t   been searched. Not every record ever created, bu..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json",
+        "offset": 346,
+        "limit": 80
+      },
+      "response_summary": "346\t      \"plan_item_id\": \"pli_008\",\n347\t      \"performed\": \"2026-07-27T19:32:07.024Z\",\n348\t      \"tool\": \"record_search\",\n349\t      \"query\": {\n350\t        \"surname\": \"Bagley\",\n351\t        \"givenName\": \"David\",\n352\t        \"residencePlace\": \"Topsham, Vermont\",\n353\t        \"residenceYearFrom\": 1840,\n354\t        \"residenceYearTo\": 1840,\n355\t        \"recordType\": \"census\",\n356\t        \"count\": 50\n357\t      },\n358\t      \"outcome\": \"positive\",\n359\t      \"results_examined\": 2,\n360\t      \"external_s..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json",
+        "offset": 430,
+        "limit": 50
+      },
+      "response_summary": "430\t        \"where_within\": \"Entry for William A Bagley and David Bagley, 31 May 1884\"\n431\t      },\n432\t      \"source_classification\": \"original\",\n433\t      \"repository\": \"FamilySearch\",\n434\t      \"access_date\": \"2026-07-27\",\n435\t      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:QPQP-24HR\",\n436\t      \"notes\": \"Second indexing of the same original document as ark:/61903/1:1:QPQP-R8T8. This indexing captures the death place (Topsham, Orange, Vermont) and indexes both William A. Bagley a..."
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__tree_edit",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__tree_edit\"}]"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/tree.gedcomx.json",
+        "limit": 60
+      },
+      "response_summary": "1\t{\n2\t  \"persons\": [\n3\t    {\n4\t      \"id\": \"MJDL-Q8B\",\n5\t      \"gender\": \"Male\",\n6\t      \"living\": false,\n7\t      \"names\": [\n8\t        {\n9\t          \"id\": \"N1\",\n10\t          \"given\": \"William A.\",\n11\t          \"surname\": \"Bagley\"\n12\t        },\n13\t        {\n14\t          \"id\": \"N7\",\n15\t          \"type\": \"BirthName\",\n16\t          \"given\": \"William A\",\n17\t          \"surname\": \"Bagley\",\n18\t          \"sources\": [\n19\t            {\n20\t              \"ref\": \"S1\",\n21\t              \"quality\": 3\n22\t      ..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {},
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"research.json not found in projectPath\\\"\\n  ]\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "proof_summaries",
+        "op": "append",
+        "entry": {
+          "question_id": "q_001",
+          "tier": "probable",
+          "vehicle": "summary",
+          "supporting_assertion_ids": [
+            "a_005",
+            "a_015",
+            "a_024",
+            "a_025",
+            "a_027"
+          ],
+          "resolved_conflict_ids": [],
+          "exhaustive_search_summary": "Research encompassed Vermont Town Clerk vital records (FamilySearch collection 1987653 \u2014 yielded two indexings of the 1884 Topsham death entry naming David Bagley as William A. Bagley's father), Vermont Births and Christenings 1765\u20131908 (collection 1675544 \u2014 negative for William A. Bagley), Vermont marriage records (collections 1675550 and 1784223 \u2014 no indexed record found for a David Bagley and Sarah Andrews marriage, consistent with pre-1857 Vermont recording gaps), Vermont probate records indexed through FamilySearch (collection 1435692 \u2014 no David Bagley entry), federal census 1820 and 1840 for Topsham, Orange County, Vermont (FamilySearch), and a full-text search of Topsham Town Records 1771\u20131860 (FamilySearch imageGroup 005464260, 110 results examined across two search passes). Unsearched sources include the Bradford District estate files (FamilySearch collection 1807377, 75,694 browse-only, unindexed images), Ancestry local history 'Sketches of the Town of Topsham' by Frank H. Craig (1929, collection 22236), and Topsham land records. No competing candidate for William's father appeared in any searched record.",
+          "narrative_markdown": "# Proof Summary: Father of William A. Bagley (born about 1815, died 31 May 1884, Topsham, Orange County, Vermont)\n\n## Conclusion\n\nThe preponderance of available evidence strongly suggests that **David Bagley** was the father of William A. Bagley (born about 1815, died 31 May 1884, Topsham, Orange County, Vermont). This conclusion rests on a Vermont Town Clerk death entry that directly names David Bagley as William's father, corroborated by two federal census records placing David Bagley in Topsham across two decades and by circumstantial evidence from the Topsham town records. No contradicting evidence was found in any searched record.\n\n## Primary Evidence: Vermont Town Clerk Death Entry (1884)\n\nThe most direct evidence is the Vermont Town Clerk vital record for William A. Bagley's death on 31 May 1884, accessed through two FamilySearch index entries derived from the same underlying original town-clerk entry and therefore constituting a single evidence unit:\n\n- \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QPQP-R8T8 : accessed 27 July 2026), Entry for William A Bagley and David Bagley, 31 May 1884.\n- \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QPQP-24HR : accessed 2026-07-27), Entry for William A Bagley and David Bagley, 31 May 1884.\n\nBoth indexings agree that David Bagley was William A. Bagley's father and that Sarah A. Bagley (n\u00e9e Andrews) was his mother. Classified as an **original record**, this entry provides **direct evidence** of the parentage relationship. The parentage information itself is, however, **secondary information** \u2014 the 1884 informant could not have been present at William's birth approximately seventy years earlier, and the parental names were likely supplied by a family or community member with secondhand knowledge. Vermont death records of this era (pre-1919) did not require parental information by law, making the voluntary inclusion of parental names noteworthy; it suggests the informant had specific knowledge of William's family.\n\n## Corroborating Evidence: Federal Census Records (1820 and 1840)\n\nTwo federal census records independently establish David Bagley's long-term residence in Topsham, Orange County, Vermont, and constitute a second, independent evidence unit drawn from a different record-creation process and different informants.\n\nThe 1820 federal census (original government schedule, primary information) lists David Bagley as head of household in Topsham. The household's age-bracket tally marks show one male under age ten \u2014 consistent with William A. Bagley, born approximately 1815 \u2014 and a female in the 40\u201344 age bracket consistent with William's mother Sarah Andrews, born approximately 1777: \"United States, Census, 1820,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:XHLG-T8R : accessed 2026-07-27), entry for David Bagley, Topsham, Orange, Vermont.\n\nThe 1840 federal census (original government schedule, primary information) again places David Bagley in Topsham, when William would have been approximately twenty-five: \"United States, Census, 1840,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:XHRB-V42 : accessed 2026-07-27), entry for David Bagley, Topsham, Orange, Vermont, 1840.\n\nPre-1850 census schedules name only the head of household; all other members are recorded by age-bracket tally marks only. These records are **indirect evidence** for the parentage question \u2014 they place David Bagley in the right community at the right times but do not state the father-son relationship \u2014 yet they provide independent corroboration that a David Bagley was a long-term Topsham resident throughout William's childhood and young adulthood.\n\n## Circumstantial Support: Topsham Town Records (1771\u20131860)\n\nA full-text search of Topsham Town Records 1771\u20131860 (FamilySearch imageGroup 005464260, 110 results examined) confirmed David Bagley's continuous Topsham presence from 1806 through at least 1855 as a town officer and selectman. The search also identified an 1813 Topsham record containing the name \"Sophia Andrews Bagley\" \u2014 a Bagley child bearing the Andrews maiden surname as a middle name, a common nineteenth-century New England practice for honoring the mother's family. William A. Bagley's mother was separately identified as Sarah Sally Andrews (born 1777, Gloucester, Essex, Massachusetts; died 19 March 1847, Topsham). A Bagley child named with the Andrews surname as a middle name is consistent with \u2014 and circumstantially supports \u2014 the conclusion that a member of the Bagley family, most plausibly David Bagley, had married Sarah Andrews. No formal birth or marriage record naming David Bagley and Sarah Andrews together was found in this volume.\n\n## Negative Evidence and Research Gaps\n\nSearches of indexed Vermont birth records (collection 1675544), indexed Vermont marriage records (collections 1675550 and 1784223), and indexed Vermont probate records (collection 1435692) returned no relevant entries for David Bagley or a David Bagley and Sarah Andrews marriage. These negative results are consistent with Vermont's pre-1857 absence of mandatory statewide vital registration; marriages and births in this period depended on voluntary town-clerk recording and frequently went unregistered. The Bradford District estate file collection (FamilySearch collection 1807377, 75,694 images, 0% name-indexed) could not be searched by name and was not browsed due to the volume's size and lack of indexing \u2014 a David Bagley probate or estate record in that collection remains a possible source of additional corroboration. No alternative candidate for the role of William A. Bagley's father emerged from any of the eleven searches conducted.\n\n## Assessment\n\nThe parentage conclusion rests on two independent evidence units: (1) the 1884 Vermont Town Clerk death entry \u2014 an original record providing direct evidence that is, however, secondary information \u2014 and (2) the 1820 and 1840 federal census records, original records with primary information providing independent indirect corroboration. The convergence of these sources on the same individual, the absence of any contradicting evidence, and the circumstantial support from the naming pattern in the Topsham town records all point in the same direction. The conclusion cannot be elevated to **proved** because the parentage evidence depends on secondary information from a single original document; a second original record providing primary information about the parentage \u2014 such as a David Bagley probate naming William as a son, a land deed identifying William as David's son, or William's own birth or baptism record \u2014 would be necessary to reach that standard.\n\n## Conclusion\n\nIt is **highly probable** that **David Bagley** was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermont). This conclusion reflects the weight of a 1884 Vermont death entry directly naming David Bagley as father, supported by two federal census records confirming his decades-long Topsham residence and the circumstantial evidence of the Andrews-family naming pattern in the Topsham town records. Future research into the Bradford District probate estate files (FamilySearch collection 1807377) or Topsham land records could provide additional corroboration and potentially advance the conclusion to proved."
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"proof_summaries\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"ps_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__tree_edit",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "operation": "add_relationship",
+        "relationship": {
+          "type": "ParentChild",
+          "parent": "I1",
+          "child": "MJDL-Q8B"
+        },
+        "sourceAssertionId": "a_005"
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"operation\\\": \\\"add_relationship\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"tree.gedcomx.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  },\\n  \\\"assignedIds\\\": {\\n    \\\"relationship\\\": \\\"R7\\\"\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "ToolSearch",
+      "args": {
+        "query": "select:mcp__genealogy__tree_correct",
+        "max_results": 1
+      },
+      "response_summary": "[{\"type\": \"tool_reference\", \"tool_name\": \"mcp__genealogy__tree_correct\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__tree_correct",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "ops": [
+          {
+            "operation": "update_fact",
+            "personId": "MJDL-Q8B",
+            "factId": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+            "fact": {
+              "primary": true
+            }
+          },
+          {
+            "operation": "update_fact",
+            "personId": "MJDL-Q8B",
+            "factId": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+            "fact": {
+              "primary": true
+            }
+          }
+        ]
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"results\\\": [\\n    {\\n      \\\"operation\\\": \\\"update_fact\\\"\\n    },\\n    {\\n      \\\"operation\\\": \\\"update_fact\\\"\\n    }\\n  ],\\n  \\\"filesWritten\\\": [\\n    \\\"tree.gedcomx.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "project",
+        "op": "update",
+        "fields": {}
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"project\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"project\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Agent",
+      "args": {
+        "description": "GPS mentor proof-critique of ps_001",
+        "subagent_type": "gps-mentor",
+        "prompt": "Please conduct a mandatory `proof-critique` evaluation of proof summary **ps_001** for question q_001 in the research project at:\n\n**Project path:** `/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2`\n\n**Context:** This is the required post-proof-conclusion mentor gate. The proof summary ps_001 was just written (tier: probable, vehicle: summary). It concludes that David Bagley (tree person I1) was highly probably the father of William A. Bagley (tree person MJDL-Q8B, born ~1815, died 31 May 1884, Topsham, Orange County, Vermont). A ParentChild relationship R7 (I1 \u2192 MJDL-Q8B) has been written to tree.gedcomx.json.\n\nPlease read the proof summary from research.json and evaluate it against GPS standards. Record your structured verdict in the evaluations section via research_append. Focus specifically on:\n1. Whether the `probable` tier is appropriately calibrated given that the parentage evidence rests on secondary information from a single original document (two indexings of one original = one evidence unit)\n2. Whether the narrative honestly handles the limitations of the evidence\n3. Whether the research scope justification is adequate\n4. Whether any must-address issues exist that would affect the tier or the tree encoding\n\nWrite your verdict to evaluations[] with focus: \"proof-critique\" and target_id: \"ps_001\"."
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"The verdict is written and validated. Here's the review:\\n\\n# Mentor review: proof-critique on ps_001\\n\\n## What you've done well\\nYou handled the two-indexings-of-one-document problem exactly right: a_005 and a_015 are both drawn from the same original 1884 town-clerk entry, and you counted them as *one* evidence unit rather than pretending two indexings equal two witnesses. That's the discipline behind Standard 46, and it's exactly why you correctly capped the tie..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json"
+      },
+      "response_summary": "File content (28268 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json",
+        "offset": 1,
+        "limit": 100
+      },
+      "response_summary": "1\t{\n2\t  \"project\": {\n3\t    \"id\": \"rp_bagley_father_1884\",\n4\t    \"objective\": \"Who was the father of William A. Bagley, born about 1815 and died 31 May 1884 in Topsham, Orange County, Vermont?\",\n5\t    \"subject_person_ids\": [\n6\t      \"MJDL-Q8B\"\n7\t    ],\n8\t    \"status\": \"active\",\n9\t    \"created\": \"2026-07-27\",\n10\t    \"updated\": \"2026-07-27\"\n11\t  },\n12\t  \"researcher_profile\": {\n13\t    \"experience_level\": \"intermediate\",\n14\t    \"subscriptions\": [],\n15\t    \"narration_guidance\": \"concise\"\n16\t  },\n17..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json",
+        "offset": 100,
+        "limit": 250
+      },
+      "response_summary": "100\t          \"sequence\": 4,\n101\t          \"record_type\": \"vital_record\",\n102\t          \"jurisdiction\": \"Vermont\",\n103\t          \"date_range\": \"1790-1820\",\n104\t          \"repository\": \"FamilySearch\",\n105\t          \"rationale\": \"Dedicated search for the marriage of Sarah Sally Andrews to a Bagley \u2014 the parents' marriage record. Per the record-type guide, a parentage plan requires a separate item for the parents' marriage: it (a) establishes the couple as a unit, (b) supplies the mother's maide..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json",
+        "offset": 350,
+        "limit": 250
+      },
+      "response_summary": "350\t        \"surname\": \"Bagley\",\n351\t        \"givenName\": \"David\",\n352\t        \"residencePlace\": \"Topsham, Vermont\",\n353\t        \"residenceYearFrom\": 1840,\n354\t        \"residenceYearTo\": 1840,\n355\t        \"recordType\": \"census\",\n356\t        \"count\": 50\n357\t      },\n358\t      \"outcome\": \"positive\",\n359\t      \"results_examined\": 2,\n360\t      \"external_site\": null,\n361\t      \"results_ref\": \"results/log_009.json\",\n362\t      \"results_available\": 2,\n363\t      \"notes\": \"Found 2 results \u2014 both are 'H..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json",
+        "offset": 600,
+        "limit": 250
+      },
+      "response_summary": "600\t    },\n601\t    {\n602\t      \"id\": \"a_007\",\n603\t      \"record_id\": \"ark:/61903/1:1:QPQP-R8T8\",\n604\t      \"record_persona_id\": \"p_104363515697\",\n605\t      \"record_role\": \"father_of_deceased\",\n606\t      \"fact_type\": \"name\",\n607\t      \"value\": \"David Bagley\",\n608\t      \"structured_value\": {\n609\t        \"given\": \"David\",\n610\t        \"surname\": \"Bagley\"\n611\t      },\n612\t      \"information_quality\": \"secondary\",\n613\t      \"informant\": \"unknown household member or family informant\",\n614\t      \"inf..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json",
+        "offset": 850,
+        "limit": 250
+      },
+      "response_summary": "850\t      \"id\": \"a_020\",\n851\t      \"record_id\": \"ark:/61903/1:1:QPQP-24HR\",\n852\t      \"record_persona_id\": \"p_104363376577\",\n853\t      \"record_role\": \"mother_of_deceased\",\n854\t      \"fact_type\": \"sex\",\n855\t      \"value\": \"Female\",\n856\t      \"information_quality\": \"secondary\",\n857\t      \"informant\": \"unknown family or community informant\",\n858\t      \"informant_proximity\": \"family_not_present\",\n859\t      \"evidence_type\": \"direct\",\n860\t      \"informant_bias_notes\": \"Sex stated by role (mother) a..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json",
+        "offset": 1100,
+        "limit": 250
+      },
+      "response_summary": "1100\t      \"confidence\": \"probable\",\n1101\t      \"match_score\": null,\n1102\t      \"rationale\": \"Sex=Male for David Bagley (father_of_deceased, QPQP-R8T8) consistent with tree person I1 (male). Same identification as a_007.\",\n1103\t      \"created\": \"2026-07-27\"\n1104\t    },\n1105\t    {\n1106\t      \"id\": \"pe_011\",\n1107\t      \"assertion_id\": \"a_009\",\n1108\t      \"person_id\": \"LVDV-6MK\",\n1109\t      \"confidence\": \"probable\",\n1110\t      \"match_score\": null,\n1111\t      \"rationale\": \"Sarah A. Bagley (mother..."
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/tree.gedcomx.json",
+        "limit": 1
+      },
+      "response_summary": "1\t{"
+    },
+    {
+      "tool": "Read",
+      "args": {
+        "file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/tree.gedcomx.json"
+      },
+      "response_summary": "1\t{\n2\t  \"persons\": [\n3\t    {\n4\t      \"id\": \"MJDL-Q8B\",\n5\t      \"gender\": \"Male\",\n6\t      \"living\": false,\n7\t      \"names\": [\n8\t        {\n9\t          \"id\": \"N1\",\n10\t          \"given\": \"William A.\",\n11\t          \"surname\": \"Bagley\"\n12\t        },\n13\t        {\n14\t          \"id\": \"N7\",\n15\t          \"type\": \"BirthName\",\n16\t          \"given\": \"William A\",\n17\t          \"surname\": \"Bagley\",\n18\t          \"sources\": [\n19\t            {\n20\t              \"ref\": \"S1\",\n21\t              \"quality\": 3\n22\t      ..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "evaluations",
+        "op": "append",
+        "verdict": {
+          "focus": "proof-critique",
+          "target_id": "ps_001",
+          "target_type": "proof_summary",
+          "verdict": "address_first",
+          "strengths": [
+            "ps_001 correctly treats the two FamilySearch indexings of the 1884 death entry (src_001/S1, src_002/S2, assertions a_005/a_015) as a single evidence unit and explicitly disqualifies the conclusion from 'Proved' on that basis \u2014 a disciplined, honest application of Standard 46/43 that many researchers get wrong.",
+            "The exhaustive_search_summary and 'Negative Evidence and Research Gaps' section name specific unsearched collections (Bradford District estate files, collection 1807377; Ancestry 'Sketches of Topsham') rather than glossing over them \u2014 good Standard 13 practice."
+          ],
+          "must_address": [
+            {
+              "standard": "Standard 43 \u2014 evidence integrity / follow the evidence",
+              "issue": "The narrative's 1820 census paragraph states the household tally marks 'show one male under age ten... and a female in the 40-44 age bracket' as if confirmed, but no assertion or log entry ever records that image examination. a_025's own informant_bias_notes says the opposite: 'the census does not name household members other than the head, so William's presence cannot be confirmed from this record alone.' log_001 flagged that image review was still needed and no later log entry reports the result.",
+              "what_would_change_my_mind": "Either strike the specific tally-mark claim from the narrative (falling back to 'David Bagley resided in the same small town across two decades' as the actual corroboration) or pull the 1820/1840 census images, log the confirmed household composition as a new assertion, and only then restate the claim.",
+              "suggested_skill": "proof-conclusion",
+              "specific_action": "Revise the 'Corroborating Evidence' paragraph in ps_001's narrative_markdown to remove the unconfirmed tally-mark detail, or obtain and log the image evidence first."
+            },
+            {
+              "standard": "Standard 43 / structural backing for identity reasoning",
+              "issue": "log_010 found 'David Bagley Jr.' as a distinct person in an 1839 Topsham record and explicitly noted 'two David Bagleys existed in Topsham simultaneously.' This namesake complication bears directly on whether the 'David Bagley' named as father in 1884 and enumerated in 1820/1840 is a single consistent identity, yet it is never mentioned in the proof narrative and conflicts[]/hypotheses[] remain empty.",
+              "what_would_change_my_mind": "A hypotheses or conflicts entry reasoning through why David Bagley Sr. (selectman since 1806) rather than David Bagley Jr. is the correct identification \u2014 e.g., Jr. was too young in 1815 to have fathered William, since he first appears as a distinct adult only in 1839.",
+              "suggested_skill": "hypothesis-tracking",
+              "specific_action": "Add a hypotheses entry documenting the Sr./Jr. elimination and cite it by id from ps_001's narrative."
+            }
+          ],
+          "consider_addressing": [
+            {
+              "standard": "Standard 14 (repository diversity) / overturn-risk discussion",
+              "issue": "All evidence in ps_001 comes from FamilySearch; the one Ancestry item (pli_009, town history) was skipped rather than executed, so repository diversity is effectively zero.",
+              "specific_action": "Either execute the Ancestry 'Sketches of Topsham' search before finalizing, or note the single-repository limitation explicitly in the proof's overturn-risk discussion."
+            }
+          ],
+          "non_blocking_notes": [
+            "src_003 (1820 census, XHLG-T8R) was flagged 'attached-to-other' in log_001 without stating to whom \u2014 worth a one-line clarification in citation_detail or notes for future readers."
+          ],
+          "narrative_for_user": "# Mentor review: proof-critique on ps_001\n\n## What you've done well\nYou handled the two-indexings-of-one-document problem exactly right: a_005 and a_015 are both drawn from the same original 1884 town-clerk entry, and you counted them as *one* evidence unit rather than pretending two indexings equal two witnesses. That's the discipline behind Standard 46, and it's exactly why you correctly capped the tier at Probable instead of reaching for Proved. Your negative-evidence section is also honest \u2014 you name the Bradford District estate files and the Ancestry town history as unsearched, rather than letting them quietly disappear.\n\n## What to address before moving on\nTwo things need attention, and one is more serious than the other.\n\nFirst, and most important: your narrative's census paragraph claims the 1820 household's tally marks 'show one male under age ten... and a female in the 40-44 age bracket' as if this were confirmed. It wasn't. Your own assertion a_025 says the opposite \u2014 'the census does not name household members other than the head, so William's presence cannot be confirmed from this record alone' \u2014 and no log entry ever records that you actually opened the census image to check the tally marks. This is the kind of detail a BCG peer reviewer would catch immediately, and it's a Standard 43 problem: the narrative is bending the evidence toward the conclusion you wanted rather than reporting what you actually found. The good news is the fix doesn't threaten your tier \u2014 'David Bagley resided in the same small Vermont town across two decades' is still real corroboration even without the tally-mark specifics. Just say that instead.\n\nSecond: your own full-text search (log_010) turned up something you never followed through on \u2014 'two David Bagleys existed in Topsham simultaneously,' with a 'David Bagley Jr.' appearing by 1839. That's exactly the kind of namesake complication that could mean the person enumerated in 1820/1840 or named in the death record isn't a single consistent individual. You never opened a hypotheses or conflicts entry to reason through why David Sr. (not Jr.) is the right identification, and the proof narrative doesn't mention the issue at all. It's very likely resolvable \u2014 Jr. was probably too young in 1815 to be William's father \u2014 but that reasoning needs to exist somewhere structural, not just in your head.\n\n## Worth considering\nEverything here comes from FamilySearch; the one Ancestry item on your plan was skipped rather than run. That's fine for a Probable-tier conclusion, but it's worth a one-line acknowledgment in your overturn-risk discussion rather than leaving repository diversity unaddressed.\n\n## What would change my mind\nFor the census overstatement: either strike the specific tally-mark claim from the narrative, or actually pull the images, log what the tally marks show, and only then write the claim. For the Sr./Jr. question: a short hypotheses entry eliminating David Bagley Jr. as a candidate, cited by id in the proof, closes the loop. Neither issue should move your tier off Probable once fixed \u2014 the core death-record evidence and the town-of-residence corroboration are sound. But the narrative needs to say only what you actually verified."
+        },
+        "entry": {
+          "focus": "proof-critique",
+          "target_id": "ps_001",
+          "target_type": "proof_summary",
+          "verdict": "address_first",
+          "timestamp": "2026-07-27T20:15:00Z",
+          "superseded_by": null
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"evaluations\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"ev_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\",\\n    \\\"evaluations/proof-critique-ps_001-2026-07-27T20-15-00.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "hypotheses",
+        "op": "append",
+        "entry": {
+          "question_id": "q_001",
+          "hypothesis": "David Bagley Jr. \u2014 a second David Bagley documented in Topsham by 1839 \u2014 is William A. Bagley's father rather than David Bagley Sr.",
+          "status": "rejected",
+          "evidence_for": [],
+          "evidence_against": [
+            "a_025",
+            "a_027"
+          ],
+          "rationale": "The full-text search of Topsham Town Records 1771-1860 (log_010) found a 'David Bagley Jr.' in an 1839 record, establishing that two David Bagleys coexisted in Topsham simultaneously. The same search found 'Wm A Bagley' and 'David Bayley Jr' on the same 1853 page \u2014 suggesting they were contemporaries of similar age rather than father and son. For David Bagley Jr. to be William A. Bagley's father (born approximately 1815), David Jr. would need to have been born no later than approximately 1800, making him at least 15 years old at William's birth. However, the 'Jr.' designation implies David Jr. was named after a pre-existing David Bagley Sr. and was therefore born after Sr. was already established. David Bagley Sr. appears in Topsham town records as a selectman from 1806 onward (log_010/log_011) \u2014 well before William's approximately 1815 birth \u2014 making Sr. the plausible patriarch of the family. The 1884 Vermont death record names simply 'David Bagley' with no Jr./Sr. qualifier; by 1884, David Sr. would long have been deceased, and the absence of 'Jr.' is consistent with the informant identifying the family patriarch rather than a junior member. The co-occurrence of 'Wm A Bagley' and 'David Bayley Jr' in the 1853 Topsham town records page (log_010) is most consistent with them being brothers (sons of David Sr.) rather than father and son. No evidence was found in any searched record naming David Bagley Jr. as William's father or suggesting any parental relationship between David Jr. and William.",
+          "conclusion": "David Bagley Jr. is not a plausible candidate for William A. Bagley's father. The chronological constraints, the co-enumeration of William and David Jr. as apparent contemporaries in 1853, and the absence of any record linking David Jr. to William in a parental role all point to David Bagley Sr. as the correct identification. The 1884 death record's unqualified reference to 'David Bagley' is most naturally read as referring to the family patriarch, consistent with David Bagley Sr.'s documented Topsham presence from 1806 onward."
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": false,\\n  \\\"errors\\\": [\\n    \\\"research.json/hypotheses[0]: missing required field 'claim'\\\",\\n    \\\"research.json/hypotheses[0]: missing required field 'supporting_assertion_ids'\\\",\\n    \\\"research.json/hypotheses[0]: missing required field 'contradicting_assertion_ids'\\\",\\n    \\\"research.json/hypotheses[0]: missing required field 'ruled_out'\\\",\\n    \\\"research.json/hypotheses[0]: missing required field 'related_question_ids'\\\",\\n    \\\"research.json/hy..."
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "hypotheses",
+        "op": "append",
+        "entry": {
+          "claim": "David Bagley Jr. \u2014 a second David Bagley documented in Topsham by 1839 \u2014 is William A. Bagley's father rather than David Bagley Sr.",
+          "status": "ruled_out",
+          "supporting_assertion_ids": [],
+          "contradicting_assertion_ids": [
+            "a_025",
+            "a_027"
+          ],
+          "ruled_out": true,
+          "ruled_out_reason": "The full-text search of Topsham Town Records 1771-1860 (log_010) found 'David Bagley Jr.' in an 1839 record and 'Wm A Bagley' alongside 'David Bayley Jr' on the same 1853 page, suggesting they were contemporaries of similar age rather than father and son. For David Bagley Jr. to be William A. Bagley's father (born approximately 1815), David Jr. would need to have been born no later than approximately 1800 \u2014 but the 'Jr.' designation implies he was born after David Bagley Sr. was already established. David Bagley Sr. appears in Topsham records as a selectman from 1806, well before William's approximately 1815 birth, and is the plausible family patriarch. The 1884 Vermont death record's unqualified reference to 'David Bagley' is most naturally the patriarch; by 1884 David Sr. would have been long deceased, and no record links David Jr. to William in a parental role. The 1853 co-appearance of William and David Jr. on the same Topsham town records page is most consistent with them being brothers, not father and son.",
+          "related_question_ids": [
+            "q_001"
+          ],
+          "notes": "Raised by gps-mentor verdict ev_001 as must-address gap in the proof narrative. Chronological analysis rules out David Jr. as William's father."
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"hypotheses\\\",\\n  \\\"op\\\": \\\"append\\\",\\n  \\\"entryId\\\": \\\"h_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "proof_summaries",
+        "op": "update",
+        "entryId": "ps_001",
+        "fields": {
+          "narrative_markdown": "# Proof Summary: Father of William A. Bagley (born about 1815, died 31 May 1884, Topsham, Orange County, Vermont)\n\n## Conclusion\n\nThe preponderance of available evidence strongly suggests that **David Bagley** was the father of William A. Bagley (born about 1815, died 31 May 1884, Topsham, Orange County, Vermont). This conclusion rests on a Vermont Town Clerk death entry that directly names David Bagley as William's father, corroborated by two federal census records confirming David Bagley's long-term residence in the same small Vermont town and by circumstantial evidence from the Topsham town records. No contradicting evidence was found in any searched record.\n\n## Primary Evidence: Vermont Town Clerk Death Entry (1884)\n\nThe most direct evidence is the Vermont Town Clerk vital record for William A. Bagley's death on 31 May 1884, accessed through two FamilySearch index entries derived from the same underlying original town-clerk entry and therefore constituting a single evidence unit:\n\n- \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QPQP-R8T8 : accessed 27 July 2026), Entry for William A Bagley and David Bagley, 31 May 1884.\n- \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QPQP-24HR : accessed 2026-07-27), Entry for William A Bagley and David Bagley, 31 May 1884.\n\nBoth indexings agree that David Bagley was William A. Bagley's father and that Sarah A. Bagley (n\u00e9e Andrews) was his mother. Classified as an **original record**, this entry provides **direct evidence** of the parentage relationship. The parentage information itself is, however, **secondary information** \u2014 the 1884 informant could not have been present at William's birth approximately seventy years earlier, and the parental names were likely supplied by a family or community member with secondhand knowledge. Vermont death records of this era (pre-1919) did not require parental information by law, making the voluntary inclusion of parental names noteworthy; it suggests the informant had specific knowledge of William's family.\n\n## Corroborating Evidence: Federal Census Records (1820 and 1840)\n\nTwo federal census records independently establish David Bagley's long-term residence in Topsham, Orange County, Vermont, and constitute a second, independent evidence unit drawn from a different record-creation process and different informants.\n\nThe 1820 federal census (original government schedule, primary information) lists David Bagley as head of household in Topsham, when William would have been approximately five years old: \"United States, Census, 1820,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:XHLG-T8R : accessed 2026-07-27), entry for David Bagley, Topsham, Orange, Vermont. Pre-1850 census schedules name only the head of household; all other members are recorded by age-bracket tally marks only, and the census image was not examined to verify household composition. This record confirms that a David Bagley headed a household in Topsham in 1820 but does not independently confirm that William was among its members.\n\nThe 1840 federal census (original government schedule, primary information) again places David Bagley in Topsham, when William would have been approximately twenty-five: \"United States, Census, 1840,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:XHRB-V42 : accessed 2026-07-27), entry for David Bagley, Topsham, Orange, Vermont, 1840. As with the 1820 census, only the head of household is named.\n\nThese records are **indirect evidence** for the parentage question \u2014 they confirm that a David Bagley was a long-term Topsham resident throughout William's childhood and young adulthood, consistent with the father identified in the 1884 death entry, but they do not state the father-son relationship.\n\n## Circumstantial Support: Topsham Town Records (1771\u20131860)\n\nA full-text search of Topsham Town Records 1771\u20131860 (FamilySearch imageGroup 005464260, 110 results examined) confirmed David Bagley's continuous Topsham presence from 1806 through at least 1855 as a town officer and selectman. The search also identified an 1813 Topsham record containing the name \"Sophia Andrews Bagley\" \u2014 a Bagley child bearing the Andrews maiden surname as a middle name, a common nineteenth-century New England practice for honoring the mother's family. William A. Bagley's mother was separately identified as Sarah Sally Andrews (born 1777, Gloucester, Essex, Massachusetts; died 19 March 1847, Topsham). A Bagley child named with the Andrews surname as a middle name is consistent with the conclusion that a member of the Bagley family had married Sarah Andrews, and circumstantially supports the identification of David Bagley as that family member. No formal birth or marriage record naming David Bagley and Sarah Andrews together was found in this volume.\n\n## The David Bagley Jr./Sr. Question\n\nThe same full-text search of Topsham town records found a \"David Bagley Jr.\" in an 1839 record, establishing that two David Bagleys coexisted in Topsham simultaneously. The 1884 death record names simply \"David Bagley\" with no qualifier. This raises the question of whether David Bagley Jr. could be William's father rather than David Bagley Sr.\n\nThis candidate has been considered and ruled out (hypothesis h_001). For David Bagley Jr. to be William's father (born approximately 1815), David Jr. would need to have been born no later than approximately 1800 \u2014 but the \"Jr.\" designation implies he was born after David Bagley Sr. was already established in Topsham. David Bagley Sr. appears in Topsham records as a selectman from 1806, well before William's approximately 1815 birth, making Sr. the plausible patriarch. Additionally, \"Wm A Bagley\" and \"David Bayley Jr\" appear together on a 1853 Topsham town records page \u2014 consistent with them being contemporaries and possible brothers, not father and son. No record links David Bagley Jr. to William in a parental role. The 1884 death record's unqualified \"David Bagley\" most naturally refers to the family patriarch, by then long deceased.\n\n## Negative Evidence and Research Gaps\n\nSearches of indexed Vermont birth records (collection 1675544), indexed Vermont marriage records (collections 1675550 and 1784223), and indexed Vermont probate records (collection 1435692) returned no relevant entries for David Bagley or a David Bagley and Sarah Andrews marriage. These negative results are consistent with Vermont's pre-1857 absence of mandatory statewide vital registration. The Bradford District estate file collection (FamilySearch collection 1807377, 75,694 images, 0% name-indexed) could not be searched by name and was not browsed \u2014 a David Bagley probate or estate record in that collection remains a possible source of additional corroboration. No alternative candidate for the role of William A. Bagley's father emerged from any of the eleven searches conducted.\n\n## Assessment\n\nThe parentage conclusion rests on two independent evidence units: (1) the 1884 Vermont Town Clerk death entry \u2014 an original record providing direct evidence that is secondary information \u2014 and (2) the 1820 and 1840 federal censuses, original records with primary information confirming David Bagley's decades-long Topsham residence independent of the death record. The potential namesake complication raised by \"David Bagley Jr.\" has been addressed and ruled out (h_001). No conflicting evidence was found. The conclusion cannot be elevated to **proved** because the parentage evidence depends on secondary information from a single original document; a second original record providing primary information about the parentage relationship \u2014 such as a David Bagley probate naming William as a son, a land deed identifying William as David's son, or William's own birth or baptism record \u2014 would be necessary to reach that standard.\n\n## Conclusion\n\nIt is **highly probable** that **David Bagley** was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermont). This conclusion reflects the weight of an 1884 Vermont death entry directly naming David Bagley as father, supported by two federal census records confirming his decades-long Topsham residence, and the circumstantial evidence of the Andrews-family naming pattern in the Topsham town records. Future research into the Bradford District probate estate files (FamilySearch collection 1807377) or Topsham land records could provide additional corroboration and potentially advance the conclusion to proved."
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"proof_summaries\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"ps_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "Skill",
+      "args": {
+        "skill": "question-selection"
+      },
+      "response_summary": "Launching skill: question-selection"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "questions",
+        "op": "update",
+        "entryId": "q_001",
+        "fields": {
+          "status": "resolved",
+          "resolved": "2026-07-27",
+          "resolution_assertion_ids": [
+            "a_005",
+            "a_015"
+          ]
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"questions\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"q_001\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    },
+    {
+      "tool": "mcp__genealogy__research_append",
+      "args": {
+        "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+        "section": "project",
+        "op": "update",
+        "fields": {
+          "status": "completed"
+        }
+      },
+      "response_summary": "[{\"type\": \"text\", \"text\": \"{\\n  \\\"ok\\\": true,\\n  \\\"section\\\": \\\"project\\\",\\n  \\\"op\\\": \\\"update\\\",\\n  \\\"entryId\\\": \\\"project\\\",\\n  \\\"filesWritten\\\": [\\n    \\\"research.json\\\"\\n  ],\\n  \\\"validation\\\": {\\n    \\\"valid\\\": true,\\n    \\\"warnings\\\": []\\n  }\\n}\"}]"
+    }
+  ],
+  "error": null,
+  "tags": {
+    "question_type": "parents",
+    "era": "1810s-1880s",
+    "geography": "US-VT"
+  },
+  "blocked_tree_reads": [],
+  "subagents": [
+    {
+      "agent_type": "record-extractor",
+      "description": "Extract death record QPQP-R8T8",
+      "num_assistant_turns": 12,
+      "max_output_tokens": 3664,
+      "hit_output_cap": false,
+      "runaway_thinking": false,
+      "turns": [
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "tool_use:project_context"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 285,
+          "blocks": [
+            "tool_use:record_read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "tool_use:record_read"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 172,
+          "blocks": [
+            "tool_use:record_person_matches"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "tool_use:record_person_matches"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 145,
+          "blocks": [
+            "tool_use:record_person_matches"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 7,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 3664,
+          "blocks": [
+            "tool_use:extraction_append"
+          ]
+        },
+        {
+          "stop_reason": "end_turn",
+          "output_tokens": 848,
+          "blocks": [
+            "text"
+          ]
+        }
+      ],
+      "transcript": "agent-a3f923f73a23d64b3.jsonl"
+    },
+    {
+      "agent_type": "record-extractor",
+      "description": "Extract death record QPQP-24HR",
+      "num_assistant_turns": 10,
+      "max_output_tokens": 4047,
+      "hit_output_cap": false,
+      "runaway_thinking": false,
+      "turns": [
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "tool_use:project_context"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 283,
+          "blocks": [
+            "tool_use:record_read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 4047,
+          "blocks": [
+            "tool_use:extraction_append"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 2,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 2,
+          "blocks": [
+            "tool_use:record_person_matches"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 2,
+          "blocks": [
+            "tool_use:record_person_matches"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 191,
+          "blocks": [
+            "tool_use:record_person_matches"
+          ]
+        },
+        {
+          "stop_reason": "end_turn",
+          "output_tokens": 706,
+          "blocks": [
+            "text"
+          ]
+        }
+      ],
+      "transcript": "agent-aaba132f0c37d07d9.jsonl"
+    },
+    {
+      "agent_type": "record-extractor",
+      "description": "Extract 1830 census David Bagley",
+      "num_assistant_turns": 8,
+      "max_output_tokens": 398,
+      "hit_output_cap": false,
+      "runaway_thinking": false,
+      "turns": [
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "tool_use:project_context"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 283,
+          "blocks": [
+            "tool_use:record_read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 94,
+          "blocks": [
+            "tool_use:record_read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 258,
+          "blocks": [
+            "tool_use:record_person_matches"
+          ]
+        },
+        {
+          "stop_reason": "end_turn",
+          "output_tokens": 398,
+          "blocks": [
+            "text"
+          ]
+        }
+      ],
+      "transcript": "agent-a4901619c4f94834b.jsonl"
+    },
+    {
+      "agent_type": "record-extractor",
+      "description": "Extract 1820 census David Bagley",
+      "num_assistant_turns": 9,
+      "max_output_tokens": 1843,
+      "hit_output_cap": false,
+      "runaway_thinking": false,
+      "turns": [
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "tool_use:project_context"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 283,
+          "blocks": [
+            "tool_use:record_read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "tool_use:extraction_append"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 1843,
+          "blocks": [
+            "tool_use:record_person_matches"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 94,
+          "blocks": [
+            "tool_use:record_person_matches"
+          ]
+        },
+        {
+          "stop_reason": "end_turn",
+          "output_tokens": 533,
+          "blocks": [
+            "text"
+          ]
+        }
+      ],
+      "transcript": "agent-a98029147dc5db27c.jsonl"
+    },
+    {
+      "agent_type": "general-purpose",
+      "description": "Analyze Topsham full-text search results",
+      "num_assistant_turns": 9,
+      "max_output_tokens": 4884,
+      "hit_output_cap": false,
+      "runaway_thinking": false,
+      "turns": [
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 220,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 195,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 36,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 196,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 196,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 196,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 196,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": "end_turn",
+          "output_tokens": 4884,
+          "blocks": [
+            "text"
+          ]
+        }
+      ],
+      "transcript": "agent-ac360fbe437dd0d69.jsonl"
+    },
+    {
+      "agent_type": "general-purpose",
+      "description": "Analyze second fulltext search file for Topsham vital records",
+      "num_assistant_turns": 22,
+      "max_output_tokens": 4259,
+      "hit_output_cap": false,
+      "runaway_thinking": false,
+      "turns": [
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 169,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 277,
+          "blocks": [
+            "tool_use:Grep"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 200,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 183,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 200,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 36,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 201,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 201,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 4,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 298,
+          "blocks": [
+            "tool_use:Grep"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 260,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 2,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 227,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 2,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 397,
+          "blocks": [
+            "tool_use:Grep"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 289,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": "end_turn",
+          "output_tokens": 4259,
+          "blocks": [
+            "text"
+          ]
+        }
+      ],
+      "transcript": "agent-a75d0b769ad8f0ebe.jsonl"
+    },
+    {
+      "agent_type": "record-extractor",
+      "description": "Extract 1840 David Bagley census record",
+      "num_assistant_turns": 6,
+      "max_output_tokens": 1337,
+      "hit_output_cap": false,
+      "runaway_thinking": false,
+      "turns": [
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 186,
+          "blocks": [
+            "tool_use:project_context"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 186,
+          "blocks": [
+            "tool_use:record_read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 1,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 1337,
+          "blocks": [
+            "tool_use:extraction_append"
+          ]
+        },
+        {
+          "stop_reason": "end_turn",
+          "output_tokens": 490,
+          "blocks": [
+            "text"
+          ]
+        }
+      ],
+      "transcript": "agent-a7ca11edd19079f9e.jsonl"
+    },
+    {
+      "agent_type": "gps-mentor",
+      "description": "GPS mentor proof-critique of ps_001",
+      "num_assistant_turns": 21,
+      "max_output_tokens": 6137,
+      "hit_output_cap": false,
+      "runaway_thinking": false,
+      "turns": [
+        {
+          "stop_reason": null,
+          "output_tokens": 5,
+          "blocks": [
+            "thinking"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 145,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 2,
+          "blocks": [
+            "thinking"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 195,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 7,
+          "blocks": [
+            "thinking"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 288,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 5,
+          "blocks": [
+            "thinking"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 196,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 9,
+          "blocks": [
+            "thinking"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 203,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 2,
+          "blocks": [
+            "text"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 197,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 3,
+          "blocks": [
+            "thinking"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 206,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 5,
+          "blocks": [
+            "thinking"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 5,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 5,
+          "blocks": [
+            "thinking"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 210,
+          "blocks": [
+            "tool_use:Read"
+          ]
+        },
+        {
+          "stop_reason": null,
+          "output_tokens": 5,
+          "blocks": [
+            "thinking"
+          ]
+        },
+        {
+          "stop_reason": "tool_use",
+          "output_tokens": 6137,
+          "blocks": [
+            "tool_use:research_append"
+          ]
+        },
+        {
+          "stop_reason": "end_turn",
+          "output_tokens": 1244,
+          "blocks": [
+            "text"
+          ]
+        }
+      ],
+      "transcript": "agent-a71382fbb5eaac400.jsonl"
+    }
+  ],
+  "guardrail_shadow_violations": [
+    {
+      "index": 86,
+      "tool": "mcp__genealogy__research_append",
+      "required_skill": "person-evidence",
+      "question_id": null
+    }
+  ]
+}

--- a/eval/runlogs/e2e/bagley-father-1884/run-2026-07-27_20-01-40.transcript.md
+++ b/eval/runlogs/e2e/bagley-father-1884/run-2026-07-27_20-01-40.transcript.md
@@ -1,0 +1,1525 @@
+# E2e run: bagley-father-1884
+
+## User message
+
+```
+/research --autonomous Who was the father of William A. Bagley, born about 1815 and died 31 May 1884 in Topsham, Orange County, Vermont?
+```
+
+## Trace
+
+**tool_use** `Glob` — args: {"pattern": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/**/*.json"}
+
+**tool_result:** .claude/skills/init-project/templates/research.json
+research.json
+tree.gedcomx.json
+.claude/settings.json
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json"}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_bagley_father_1884",
+4	    "objective": "Who was the father of William A. Bagley, born about 1815 and died 31 May 1884 in Topsham, Orange County, Vermont?",
+5	    "subject_person_ids": [
+6	      "MJDL-Q8B"
+7	    ],
+8	    "status": "active",
+9	    "created": "2026-07-27",
+10	    "updated": "2026-07-27"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level": "intermediate",
+14	    "subscriptions": [],
+15	    "narration_guidance": "concise"
+16	  },
+17...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/tree.gedcomx.json"}
+
+**tool_result:** 1	{
+2	  "persons": [
+3	    {
+4	      "id": "MJDL-Q8B",
+5	      "gender": "Male",
+6	      "living": false,
+7	      "names": [
+8	        {
+9	          "id": "N1",
+10	          "given": "William A.",
+11	          "surname": "Bagley"
+12	        }
+13	      ],
+14	      "facts": [
+15	        {
+16	          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+17	          "type": "Birth",
+18	          "date": "Abt 1815",
+19	          "standard_date": "Abt 1815",
+20	          "place": "West Topsham, Orange, ...
+
+**assistant:** The project is initialized with the objective but no questions yet. I'll route to `question-selection` first.
+
+**tool_use** `Skill` — args: {"skill": "question-selection"}
+
+**tool_result:** Launching skill: question-selection
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/question-selection/references/question-formulation.md"}
+
+**tool_result:** 1	# Research Question Formulation
+2	
+3	Guidance for formulating effective genealogical research questions
+4	that satisfy the GPS standard for planned, purposeful research.
+5	
+6	## Research Objectives vs. Research Questions
+7	
+8	These are distinct concepts that must not be conflated:
+9	
+10	- **Research objective**: The overarching goal of the research effort.
+11	  It describes what you ultimately want to know (e.g., "Identify the
+12	  parents of John Smith born circa 1820 in Greene County, Ohi...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/question-selection/references/pedigree-analysis.md"}
+
+**tool_result:** 1	# Pedigree Analysis for Gap Detection
+2	
+3	Guidance for evaluating pedigree data to identify research gaps,
+4	errors, and candidates for new research questions.
+5	
+6	## Purpose
+7	
+8	Pedigree analysis is the process of systematically reviewing the
+9	individuals in a family tree to detect missing information, logical
+10	errors, and inconsistencies. It is a critical first step before
+11	selecting new research questions — it reveals where the gaps are
+12	and which gaps are most significant.
+13	...
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_append", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "questions", "op": "append", "entry": {"question": "Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermont)?", "rationale": "The research objective directly targets the identity of William A. Bagley's father. His mother, Sarah Sally Andrews (born 1777 Gloucester, Essex, Massachusetts; died 1...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"questions\",\n  \"op\": \"append\",\n  \"entryId\": \"q_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Question q_001 written: **"Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermont)?"**
+
+- **Basis:** `objective_decomposition` — the objective IS this single-fact parentage question; his mother (Sarah Sally Andrews) is already in the tree, his father is not.  
+- **Rationale:** Vermont death records (1884), early census records (1820–1840, when William would appear in a parental household), and Orange County probate records provide the most direct paths.  
+- **Depends on / unblocks:** neither (first question).
+
+**Next step:** No localities entry exists yet for Topsham, Orange County, Vermont — routing to `locality-guide` to survey the jurisdiction before planning.
+
+**tool_use** `Skill` — args: {"skill": "locality-guide"}
+
+**tool_result:** Launching skill: locality-guide
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__place_search,mcp__genealogy__place_search_all,mcp__genealogy__collections_search,mcp__genealogy__volume_search,mcp__genealogy__external_links_search,mcp__genealogy__wiki_place_page,mcp__genealogy__wiki_search,mcp__genealogy__place_population", "max_results": 8}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__place_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__place_search_all"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__collections_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__volume_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__external_links_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__wiki_place_page"}, {"type": "tool_reference", "tool_na...
+
+**tool_use** `mcp__genealogy__place_search_all` — args: {"placeName": "Topsham, Orange County, Vermont"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"results\": [\n    {\n      \"standardPlace\": \"Topsham, Orange, Vermont, United States\",\n      \"type\": \"Town\",\n      \"latitude\": 44.1331,\n      \"longitude\": -72.2515,\n      \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Topsham&focusedId=5405424\",\n      \"wikipediaUrl\": \"https://en.wikipedia.org/wiki/Topsham,_Vermont\"\n    },\n    {\n      \"standardPlace\": \"Topsham, Orange, Republic of Vermont\",\n      \"ty...
+
+**tool_use** `mcp__genealogy__place_population` — args: {"standardPlace": "Topsham, Orange, Vermont, United States", "startYear": 1800, "endYear": 1890}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"error\": \"Place not found\",\n  \"place_id\": \"1355104\"\n}"}]
+
+**tool_use** `mcp__genealogy__collections_search` — args: {"standardPlace": "Topsham, Orange, Vermont, United States", "startYear": 1800, "endYear": 1890}
+
+**tool_use** `mcp__genealogy__volume_search` — args: {"standardPlace": "Topsham, Orange, Vermont, United States", "startYear": 1800, "endYear": 1890}
+
+**tool_use** `mcp__genealogy__external_links_search` — args: {"standardPlace": "Topsham, Orange, Vermont, United States", "startYear": 1800, "endYear": 1890}
+
+**tool_use** `mcp__genealogy__wiki_search` — args: {"query": "Topsham Orange County Vermont genealogy records research"}
+
+**tool_use** `mcp__genealogy__wiki_place_page` — args: {"standardPlace": "Vermont, United States", "section": "home"}
+
+**tool_use** `mcp__genealogy__wiki_place_page` — args: {"standardPlace": "Vermont, United States", "section": "getting_started"}
+
+**tool_use** `mcp__genealogy__wiki_place_page` — args: {"standardPlace": "Vermont, United States", "section": "online_records"}
+
+**tool_use** `mcp__genealogy__wiki_place_page` — args: {"standardPlace": "Vermont, United States", "section": "research_tips"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"standardPlace\": \"Topsham, Orange, Vermont, United States\",\n    \"startYear\": 1800,\n    \"endYear\": 1890\n  },\n  \"scope\": \"Vermont\",\n  \"totalForPlace\": 22,\n  \"results\": [\n    {\n      \"id\": \"1879935\",\n      \"title\": \"Vermont, Addison County and District Probate Files, 1845-1915\",\n      \"dateRange\": \"1845-1915\",\n      \"recordCount\": 0,\n      \"personCount\": 0,\n      \"imageCount\": 54451,\n      \"url\": ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"standardPlace\": \"Topsham, Orange, Vermont, United States\",\n    \"startYear\": 1800,\n    \"endYear\": 1890\n  },\n  \"totalResults\": 20,\n  \"results\": [\n    {\n      \"imageGroupNumber\": \"007814131_002_M9ZV-457\",\n      \"imageGroupPrefix\": \"007814131\",\n      \"imageCount\": 405,\n      \"recordSearchablePercent\": 0,\n      \"fulltextSearchable\": true,\n      \"languages\": [\n        \"en\"\n      ],\n      \"coverages\": [...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"standardPlace\": \"Topsham, Orange, Vermont, United States\",\n    \"startYear\": 1800,\n    \"endYear\": 1890\n  },\n  \"totalForPlace\": 292,\n  \"returned\": 239,\n  \"results\": [\n    {\n      \"url\": \"https://www.findmypast.com/search/results?datasetname=united%20states%2c%20passenger%20and%20crew%20lists&datasettitle=new%20england%20passenger%20and%20crew%20lists&sid=999\",\n      \"linkText\": \"United States, Passenger and Crew Li...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": \"Topsham Orange County Vermont genealogy records research\",\n  \"total_chunks_searched\": 1240565,\n  \"results\": [\n    {\n      \"rank\": 1,\n      \"relevance_score\": 0.902344,\n      \"chunk_text\": \"### Other Town Records  \\nIn Vermont, most records are kept at the town level and generally began being kept at the founding of the town. These records may include the following:  \\n|  |\\n| --- |\\n| * Births * Marriages * Deaths * Burials * ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"url\": \"https://www.familysearch.org/en/wiki/Vermont,_United_States_Genealogy\",\n  \"content\": \"# Vermont, United States Genealogy\\n\\n\\n\\n[United States](https://www.familysearch.org/en/wiki/United_States_Genealogy \\\"United States Genealogy\\\")\\n\\n[New England](https://www.familysearch.org/en/wiki/New_England \\\"New England\\\")\\n\\nVermont\\n\\n|  |\\n| --- |\\n| **Vermont Wiki Topics** |\\n| [Vermont flag.png](https://www.familysearch.org/en/...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"url\": \"https://www.familysearch.org/en/wiki/Vermont_Getting_Started\",\n  \"content\": \"# Vermont Getting Started\\n\\n\\n\\n|  |\\n| --- |\\n| [**Vermont Wiki Topics**](https://www.familysearch.org/en/wiki/Vermont,_United_States_Genealogy \\\"Vermont, United States Genealogy\\\") |\\n| [Vermont flag.png](https://www.familysearch.org/en/wiki/index.php?title=File:Vermont_flag.png&filetimestamp=20080821015625& \\\"Vermont flag.png\\\") |\\n| **Beginning Rese...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"url\": \"https://www.familysearch.org/en/wiki/Vermont_Online_Genealogy_Records\",\n  \"content\": \"# Vermont Online Genealogy Records\\n\\n\\n\\n[United States](https://www.familysearch.org/en/wiki/United_States_Genealogy \\\"United States Genealogy\\\")\\n\\n[Vermont](https://www.familysearch.org/en/wiki/Vermont,_United_States_Genealogy \\\"Vermont, United States Genealogy\\\")\\n\\nOnline Genealogy Records\\n\\n|  |  |  |  |  |  |\\n| --- | --- | --- | ---...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"url\": \"https://www.familysearch.org/en/wiki/Vermont_Research_Tips_and_Strategies\",\n  \"content\": \"# Vermont Research Tips and Strategies\\n\\n\\n\\n|  |\\n| --- |\\n| [**Vermont Wiki Topics**](https://www.familysearch.org/en/wiki/Vermont,_United_States_Genealogy \\\"Vermont, United States Genealogy\\\") |\\n| [Vermont flag.png](https://www.familysearch.org/en/wiki/index.php?title=File:Vermont_flag.png&filetimestamp=20080821015625& \\\"Vermont flag.png\\...
+
+**assistant:** Now I have everything I need. Let me compile and persist the locality guide.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "localities", "op": "append", "entry": {"place": "Vermont, United States", "for_place": "Topsham, Orange County, Vermont", "time_period": "1800-1890", "jurisdictions": [{"name": "Topsham, Orange, Republic of Vermont", "date_range": "pre-1791"}, {"name": "Topsham, Orange, Vermont, United States", "date_range": "1791\u2013present"}], "collections": [{"id": "1987653", "title": "...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"localities\",\n  \"op\": \"append\",\n  \"entryId\": \"loc_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Locality guide persisted as **loc_001** for Topsham, Orange County, Vermont, 1800–1890. Key findings for q_001:
+
+- **Vital registration started 1857** — pre-1857 birth records are in town clerk records (full-text searchable on FamilySearch, imageGroup 005464260)
+- **1884 death record will not name William's parents** — Vermont only required parental info on death certs from 1919
+- **Best path to the father:** 1820/1830/1840 censuses (William as a child in father's household) + early Topsham town records + Orange County probate files
+- **Probate:** Orange County Bradford District estate files (browse-only) + Vermont Probate Files 1800–1921 (indexed)
+- **Local history:** *Sketches of Topsham* (1929) by Frank Craig on Ancestry may have Bagley genealogy
+
+Routing to **research-plan** for q_001.
+
+**tool_use** `Skill` — args: {"skill": "research-plan"}
+
+**tool_result:** Launching skill: research-plan
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/research-plan/references/planning-standards.md"}
+
+**tool_result:** 1	# BCG Standards for Research Planning (Standards 9-18)
+2	
+3	These ten standards from the Board for Certification of Genealogists
+4	govern how genealogists plan and scope their research. Every research
+5	plan created by this skill should satisfy all applicable standards.
+6	
+7	---
+8	
+9	## Standard 9: Planned Research
+10	
+11	Research begins with and follows a dynamic plan for gathering
+12	information. The plan's purpose is to meet stated objectives, usually
+13	framed as research questions. Hap...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/research-plan/references/record-type-guide.md"}
+
+**tool_result:** 1	# Record Type Selection Guide
+2	
+3	Use this reference when identifying which record sets to include in a
+4	research plan. Match the research goal to record types, then check the
+5	contextual factors that affect availability.
+6	
+7	---
+8	
+9	## Record types by research goal
+10	
+11	| Goal | Primary record types | Secondary/fallback |
+12	|------|---------------------|-------------------|
+13	| Identify parents | Census (household), marriage (parents' marriage record), vital records (death/birth c...
+
+**assistant:** Good. I have the locality guide (loc_001) in context, the record-type guide loaded, and the question state. No existing plans, so the next plan is `pl_001` and items begin at `pli_001`. I'll write the whole plan in one batch.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "ops": [{"section": "plans", "op": "append", "entry": {"question_id": "q_001", "status": "active", "created": "2026-07-27"}}, {"section": "plan_items", "op": "append", "planId": "pl_001", "entry": {"sequence": 1, "record_type": "census", "jurisdiction": "Topsham, Orange County, Vermont", "date_range": "1820", "repository": "FamilySearch", "rationale": "William A. Bagley was born about 1...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plans\",\n      \"op\": \"append\",\n      \"entryId\": \"pl_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_002\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"append\",\n      \"entryId\": \"pli_003\"\n    },...
+
+**assistant:** Plan pl_001 written — 10 items for q_001. Returning to the research orchestrator for execution.
+
+**pl_001 summary for q_001:**
+1. **pli_001** — 1820 census, Topsham, VT (William ~5 in father's household)
+2. **pli_002** — 1830 census, Topsham, VT (William ~15, still likely in father's)
+3. **pli_003** — VT Births & Christenings 1765-1908 + Town Clerk records (birth record for William naming father)
+4. **pli_004** — Parents' marriage: Sarah Andrews to Bagley (VT Marriages 1791-1974, Vital Records)
+5. **pli_005** — Topsham Town Records 1771-1860 full-text search (imageGroup 005464260) via search-full-text
+6. **pli_006** — VT Probate Files 1800-1921, indexed (Bagley estate naming William)
+7. **pli_007** — Bradford District Estate Files 1780-1915, browse-only (fallback for pli_006)
+8. **pli_008** — 1840 census, Topsham, VT (William ~25, father possibly older household head)
+9. **pli_009** — *Sketches of Topsham* (1929), Ancestry coll. 22236
+10. **pli_010** — VT Land Records 1800-1850, FAN/contextual (deed relationships, Andrews-Bagley connections)
+
+**tool_use** `Skill` — args: {"skill": "search-records"}
+
+**tool_result:** Launching skill: search-records
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__record_search,mcp__genealogy__rank_search_matches,mcp__genealogy__research_log_append", "max_results": 3}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__record_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__rank_search_matches"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_log_append"}]
+
+**assistant:** Executing pli_001 (1820 census) first — searching for Bagley households in Topsham, Vermont to find William's father.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Bagley", "residencePlace": "Topsham, Vermont", "residenceYearFrom": 1820, "residenceYearTo": 1820, "recordType": "census", "count": 50, "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Bagley\",\n    \"residencePlace\": \"Topsham, Vermont\",\n    \"residenceYearFrom\": 1820,\n    \"residenceYearTo\": 1820,\n    \"recordType\": \"census\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\"\n  },\n  \"totalMatches\": 14,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 14,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\":...
+
+**assistant:** Four Topsham Bagley households in 1820: Christopher, Aaron, David, John. Now I'll rank against the subject and then read the top Topsham records.
+
+**tool_use** `mcp__genealogy__rank_search_matches` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "stagedResultsRef": "results/.staging/a6300853-f613-4d86-abe8-9d8578310f28.json", "subjectId": "MJDL-Q8B", "checkAttachments": true}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"subjectId\": \"MJDL-Q8B\",\n  \"scoredCount\": 14,\n  \"returnedCount\": 10,\n  \"scoringErrors\": 0,\n  \"scoreLogError\": null,\n  \"matches\": [\n    {\n      \"matchRank\": 1,\n      \"searchRank\": 8,\n      \"recordId\": \"ark:/61903/1:1:XHLG-R2K\",\n      \"matchScore\": 0.025175294,\n      \"primaryId\": \"p_10418027119\",\n      \"personName\": \"William Bagley\",\n      \"collectionTitle\": \"United States, Census, 1820\",\n      \"recordArk\": \"ar...
+
+**assistant:** Match scores are low (census enumerated household heads, not William as a child — expected). I need to read the actual records for all four Topsham Bagley households to find which one had a boy aged under 10 (William ~5 in 1820) and a woman aged 40–45 (Sarah Andrews born 1777 → age ~43).
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__record_read", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__record_read"}]
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:XHLG-TXG", "resultsRef": "results/.staging/a6300853-f613-4d86-abe8-9d8578310f28.json", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_10418027842\",\n      \"ark\": \"ark:/61903/1:1:XHLG-TXG\",\n      \"names\": [\n        {\n          \"type\": \"BirthName\",\n          \"surname\": \"Bagley\",\n          \"given\": \"Christopher\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"type\": \"Census\",\n          \"primary\": true,\n          \"date\": \"1820\",\n          \"standard_date\": \"1820\",\n          \"place\": \"Topsham, Oran...
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:XHLG-TNL", "resultsRef": "results/.staging/a6300853-f613-4d86-abe8-9d8578310f28.json", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_10418027901\",\n      \"ark\": \"ark:/61903/1:1:XHLG-TNL\",\n      \"names\": [\n        {\n          \"type\": \"BirthName\",\n          \"surname\": \"Bagley\",\n          \"given\": \"Aaron\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"type\": \"Census\",\n          \"primary\": true,\n          \"date\": \"1820\",\n          \"standard_date\": \"1820\",\n          \"place\": \"Topsham, Orange, Ve...
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:XHLG-T8R", "resultsRef": "results/.staging/a6300853-f613-4d86-abe8-9d8578310f28.json", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_10418027755\",\n      \"ark\": \"ark:/61903/1:1:XHLG-T8R\",\n      \"names\": [\n        {\n          \"type\": \"BirthName\",\n          \"surname\": \"Bagley\",\n          \"given\": \"David\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"type\": \"Census\",\n          \"primary\": true,\n          \"date\": \"1820\",\n          \"standard_date\": \"1820\",\n          \"place\": \"Topsham, Orange, Ve...
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:XHLG-TNY", "resultsRef": "results/.staging/a6300853-f613-4d86-abe8-9d8578310f28.json", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_10418027907\",\n      \"ark\": \"ark:/61903/1:1:XHLG-TNY\",\n      \"names\": [\n        {\n          \"type\": \"BirthName\",\n          \"surname\": \"Bagley\",\n          \"given\": \"John\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"type\": \"Census\",\n          \"primary\": true,\n          \"date\": \"1820\",\n          \"standard_date\": \"1820\",\n          \"place\": \"Topsham, Orange, Ver...
+
+**assistant:** The index stubs only return the head's name; the 1820 census household tally marks (ages/sex of members) are in the images. I'll log this search as positive (4 Topsham Bagley households found), update pli_001 to `in_progress`, then immediately run the 1830 census search and a birth-record search in parallel before examining images.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "tool": "record_search", "planItemId": "pli_001", "query": {"collection": "United States, Census, 1820", "surname": "Bagley", "residencePlace": "Topsham, Vermont", "residenceYear": 1820, "recordType": "census", "count": 50}, "outcome": "positive", "resultsExamined": 4, "resultsAvailable": 14, "stagedResultsRef": "results/.staging/a6300853-f613-4d86-abe8-9d8578310f28.json", "notes": "Fou...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"logId\": \"log_001\",\n  \"performed\": \"2026-07-27T19:13:02.246Z\",\n  \"resultsRef\": \"results/log_001.json\",\n  \"returnedCount\": 14,\n  \"filesWritten\": [\n    \"research.json\",\n    \"results/log_001.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_001", "fields": {"status": "in_progress"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"plan_items\",\n  \"op\": \"update\",\n  \"entryId\": \"pli_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now running pli_002 (1830 census) and pli_003 (Vermont Births & Christenings) in parallel.
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Bagley", "residencePlace": "Topsham, Vermont", "residenceYearFrom": 1830, "residenceYearTo": 1830, "recordType": "census", "count": 50, "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Bagley\",\n    \"residencePlace\": \"Topsham, Vermont\",\n    \"residenceYearFrom\": 1830,\n    \"residenceYearTo\": 1830,\n    \"recordType\": \"census\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\"\n  },\n  \"totalMatches\": 18,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 18,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\":...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Bagley", "givenName": "William", "birthYearFrom": 1810, "birthYearTo": 1820, "birthPlace": "Vermont", "collectionId": "1675544", "count": 50, "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Bagley\",\n    \"givenName\": \"William\",\n    \"birthYearFrom\": 1810,\n    \"birthYearTo\": 1820,\n    \"birthPlace\": \"Vermont\",\n    \"collectionId\": \"1675544\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\"\n  },\n  \"totalMatches\": 1,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 1,\n  \"offset\": 0,\n  \"hasMore\": false,\n ...
+
+**assistant:** Good data. Let me rank the 1830 results and simultaneously search the Town Clerk records for William's birth.
+
+**tool_use** `mcp__genealogy__rank_search_matches` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "stagedResultsRef": "results/.staging/f7a96264-d0a6-4d5e-9af3-9d8c9760604d.json", "subjectId": "MJDL-Q8B", "checkAttachments": true}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"subjectId\": \"MJDL-Q8B\",\n  \"scoredCount\": 18,\n  \"returnedCount\": 10,\n  \"scoringErrors\": 0,\n  \"scoreLogError\": null,\n  \"matches\": [\n    {\n      \"matchRank\": 1,\n      \"searchRank\": 18,\n      \"recordId\": \"ark:/61903/1:1:XH5X-PCD\",\n      \"matchScore\": 0.020554332,\n      \"primaryId\": \"p_10420238982\",\n      \"personName\": \"William Bogley\",\n      \"collectionTitle\": \"United States, Census, 1830\",\n      \"recordArk\": \"a...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"surname": "Bagley", "givenName": "William", "birthYearFrom": 1810, "birthYearTo": 1820, "collectionId": "1987653", "count": 50, "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"surname\": \"Bagley\",\n    \"givenName\": \"William\",\n    \"birthYearFrom\": 1810,\n    \"birthYearTo\": 1820,\n    \"collectionId\": \"1987653\",\n    \"count\": 50,\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\"\n  },\n  \"totalMatches\": 51,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 50,\n  \"offset\": 0,\n  \"hasMore\": true,\n  \"results\": [\n    {\n      \"r...
+
+**assistant:** **Critical find!** The Vermont Town Clerk search surfaced two records for "William A Bagley" with birth 1815 and death 31 May 1884 — our subject exactly. I'll read both immediately in parallel while logging the searches.
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:QPQP-R8T8", "resultsRef": "results/.staging/25ae5adb-1f83-463c-91b7-c232f8007f27.json", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_104363515691\",\n      \"ark\": \"ark:/61903/1:1:QPQP-R8T8\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"type\": \"BirthName\",\n          \"given\": \"William A\",\n          \"surname\": \"Bagley\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"type\": \"Birth\",\n          \"date\": \"1815\",\n          \"standard_date\": \"1815\"\n        },\n        {\n          \"type...
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:QPQP-24HR", "resultsRef": "results/.staging/25ae5adb-1f83-463c-91b7-c232f8007f27.json", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_104363376565\",\n      \"ark\": \"ark:/61903/1:1:QPQP-24HR\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"type\": \"BirthName\",\n          \"surname\": \"Bagley\",\n          \"given\": \"William A\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"type\": \"Birth\",\n          \"date\": \"1815\",\n          \"standard_date\": \"1815\"\n        },\n        {\n          \"type...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json", "limit": 80}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_bagley_father_1884",
+4	    "objective": "Who was the father of William A. Bagley, born about 1815 and died 31 May 1884 in Topsham, Orange County, Vermont?",
+5	    "subject_person_ids": [
+6	      "MJDL-Q8B"
+7	    ],
+8	    "status": "active",
+9	    "created": "2026-07-27",
+10	    "updated": "2026-07-27"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level": "intermediate",
+14	    "subscriptions": [],
+15	    "narration_guidance": "concise"
+16	  },
+17...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json", "offset": 80, "limit": 120}
+
+**tool_result:** 80	          "sequence": 4,
+81	          "record_type": "vital_record",
+82	          "jurisdiction": "Vermont",
+83	          "date_range": "1790-1820",
+84	          "repository": "FamilySearch",
+85	          "rationale": "Dedicated search for the marriage of Sarah Sally Andrews to a Bagley — the parents' marriage record. Per the record-type guide, a parentage plan requires a separate item for the parents' marriage: it (a) establishes the couple as a unit, (b) supplies the mother's maiden name...
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_log_append,mcp__genealogy__research_append", "max_results": 2}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_log_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "ops": [{"planItemId": "pli_002", "tool": "record_search", "query": {"collection": "United States, Census, 1830", "surname": "Bagley", "residencePlace": "Topsham, Vermont", "residenceYear": 1830, "recordType": "census", "count": 50}, "outcome": "positive", "resultsExamined": 9, "resultsAvailable": 9, "stagedResultsRef": "results/.staging/f7a96264-d0a6-4d5e-9af3-9d8c9760604d.json", "note...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"logId\": \"log_002\",\n      \"performed\": \"2026-07-27T19:17:28.090Z\",\n      \"resultsRef\": \"results/log_002.json\",\n      \"returnedCount\": 18\n    },\n    {\n      \"logId\": \"log_003\",\n      \"performed\": \"2026-07-27T19:17:28.093Z\",\n      \"resultsRef\": null,\n      \"returnedCount\": null\n    },\n    {\n      \"logId\": \"log_004\",\n      \"performed\": \"2026-07-27T19:17:28.093Z\",\n      \"...
+
+**assistant:** Now update pli_002 and pli_003 to `in_progress`:
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "ops": [{"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_002", "fields": {"status": "in_progress"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_003", "fields": {"status": "in_progress"}}]}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_002\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_003\"\n    }\n  ],\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Logs written (log_002–log_004). Now hand off both Vermont Town Clerk death records to extraction — spawning two record-extractor agents in parallel:
+
+**tool_use** `Agent` — args: {"description": "Extract death record QPQP-R8T8", "subagent_type": "record-extractor", "prompt": "Extract ALL assertions from this genealogical record into the research project.\n\n**Project path:** `/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2`\n**Record ID:** `ark:/61903/1:1:QPQP-R8T8`\n**Log entry:** `log_004`\n**Results ref:** `results/log_004.json` (the staged sidecar for log_004)\n\n**Research context:** The research objective is to identify t...
+
+**tool_use** `mcp__genealogy__project_context` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"projectStatus\": \"active\",\n  \"openQuestions\": [\n    {\n      \"id\": \"q_001\",\n      \"question\": \"Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermon\u2026\"\n    }\n  ],\n  \"persons\": [\n    {\n      \"id\": \"MJDL-Q8B\",\n      \"name\": \"William A. Bagley\",\n      \"gender\": \"Male\",\n      \"sourceRefs\": []\n    },\n    {\n      \"id\...
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:QPQP-R8T8", "resultsRef": "results/log_004.json", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_104363515691\",\n      \"ark\": \"ark:/61903/1:1:QPQP-R8T8\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"type\": \"BirthName\",\n          \"given\": \"William A\",\n          \"surname\": \"Bagley\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"type\": \"Birth\",\n          \"date\": \"1815\",\n          \"standard_date\": \"1815\"\n        },\n        {\n          \"type...
+
+**tool_use** `Agent` — args: {"description": "Extract death record QPQP-24HR", "subagent_type": "record-extractor", "prompt": "Extract ALL assertions from this genealogical record into the research project.\n\n**Project path:** `/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2`\n**Record ID:** `ark:/61903/1:1:QPQP-24HR`\n**Log entry:** `log_004`\n**Results ref:** `results/log_004.json` (the staged sidecar for log_004)\n\n**Research context:** The research objective is to identify t...
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:QPQP-R8TJ"}
+
+**tool_use** `mcp__genealogy__record_person_matches` — args: {"id": "QPQP-R8T8"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_104363515691\",\n      \"ark\": \"ark:/61903/1:1:QPQP-R8T8\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"id\": \"5643e741-2290-4ceb-b127-1284aaf6b354\",\n          \"type\": \"BirthName\",\n          \"given\": \"William A\",\n          \"surname\": \"Bagley\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"b30fda72-ff34-47e5-9356-c04b6ec882d7\",\n          \"type\":...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"queryArk\": \"ark:/61903/1:1:QPQP-R8T8\",\n  \"resultCount\": 1,\n  \"returned\": 1,\n  \"title\": \"Matches for ark:/61903/1:1:QPQP-R8T8\",\n  \"updated\": \"2024-03-08T08:57:46.188Z\",\n  \"matches\": [\n    {\n      \"ark\": \"ark:/61903/4:1:MJDL-Q8B\",\n      \"pid\": \"MJDL-Q8B\",\n      \"arkType\": \"4:1:\",\n      \"confidence\": 5,\n      \"score\": 0.99831176,\n      \"title\": \"\",\n      \"status\": \"accepted\",\n      \"collection\": \"https://...
+
+**tool_use** `mcp__genealogy__project_context` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"projectStatus\": \"active\",\n  \"openQuestions\": [\n    {\n      \"id\": \"q_001\",\n      \"question\": \"Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermon\u2026\"\n    }\n  ],\n  \"persons\": [\n    {\n      \"id\": \"MJDL-Q8B\",\n      \"name\": \"William A. Bagley\",\n      \"gender\": \"Male\",\n      \"sourceRefs\": []\n    },\n    {\n      \"id\...
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:QPQP-24HR", "resultsRef": "results/log_004.json", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_104363376565\",\n      \"ark\": \"ark:/61903/1:1:QPQP-24HR\",\n      \"gender\": \"Male\",\n      \"names\": [\n        {\n          \"type\": \"BirthName\",\n          \"surname\": \"Bagley\",\n          \"given\": \"William A\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"type\": \"Birth\",\n          \"date\": \"1815\",\n          \"standard_date\": \"1815\"\n        },\n        {\n          \"type...
+
+**tool_use** `mcp__genealogy__record_person_matches` — args: {"id": "QPQP-R8TJ"}
+
+**tool_use** `mcp__genealogy__record_person_matches` — args: {"id": "QPQP-7JPV"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"queryArk\": \"ark:/61903/1:1:QPQP-R8TJ\",\n  \"resultCount\": 1,\n  \"returned\": 1,\n  \"title\": \"Matches for ark:/61903/1:1:QPQP-R8TJ\",\n  \"updated\": \"2024-03-08T08:57:46.188Z\",\n  \"matches\": [\n    {\n      \"ark\": \"ark:/61903/4:1:LVDV-DBC\",\n      \"pid\": \"LVDV-DBC\",\n      \"arkType\": \"4:1:\",\n      \"confidence\": 5,\n      \"score\": 0.9979437,\n      \"title\": \"\",\n      \"status\": \"accepted\",\n      \"collection\": \"https://f...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"queryArk\": \"ark:/61903/1:1:QPQP-7JPV\",\n  \"resultCount\": 3,\n  \"returned\": 3,\n  \"title\": \"Matches for ark:/61903/1:1:QPQP-7JPV\",\n  \"updated\": \"2024-03-08T08:57:46.188Z\",\n  \"matches\": [\n    {\n      \"ark\": \"ark:/61903/4:1:LVDV-6MK\",\n      \"pid\": \"LVDV-6MK\",\n      \"arkType\": \"4:1:\",\n      \"confidence\": 4,\n      \"score\": 0.89352185,\n      \"title\": \"\",\n      \"status\": \"accepted\",\n      \"collection\": \"https://...
+
+**tool_use** `mcp__genealogy__extraction_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "sourceDescription": {"title": "Entry for William A Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"", "url": "https://www.familysearch.org/ark:/61903/1:1:QPQP-R8T8"}, "ops": [{"section": "sources", "op": "append", "entry": {"citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", FamilySearch (https://www.familysearch.org/ark:/61903/1:1:QPQP-R8T8 : acc...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_001\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_001\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_002\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_003\"\n    },\n ...
+
+**tool_use** `mcp__genealogy__extraction_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "sourceDescription": {"title": "Entry for William A Bagley and David Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"", "url": "https://www.familysearch.org/ark:/61903/1:1:QPQP-24HR"}, "ops": [{"section": "sources", "op": "append", "entry": {"citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", FamilySearch (https://www.familysearch.org/ark:/61903/1:...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_002\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_011\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_012\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_013\"\n    },\n ...
+
+**tool_use** `mcp__genealogy__record_person_matches` — args: {"id": "QPQP-24HR"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"queryArk\": \"ark:/61903/1:1:QPQP-24HR\",\n  \"resultCount\": 1,\n  \"returned\": 1,\n  \"title\": \"Matches for ark:/61903/1:1:QPQP-24HR\",\n  \"updated\": \"2024-03-09T16:01:36.876Z\",\n  \"matches\": [\n    {\n      \"ark\": \"ark:/61903/4:1:MJDL-Q8B\",\n      \"pid\": \"MJDL-Q8B\",\n      \"arkType\": \"4:1:\",\n      \"confidence\": 5,\n      \"score\": 0.99926287,\n      \"title\": \"\",\n      \"status\": \"accepted\",\n      \"collection\": \"https://...
+
+**tool_use** `mcp__genealogy__record_person_matches` — args: {"id": "QPQP-24HB"}
+
+**tool_use** `mcp__genealogy__record_person_matches` — args: {"id": "QPQP-24C4"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"queryArk\": \"ark:/61903/1:1:QPQP-24HB\",\n  \"resultCount\": 1,\n  \"returned\": 1,\n  \"title\": \"Matches for ark:/61903/1:1:QPQP-24HB\",\n  \"updated\": \"2024-03-09T16:01:36.876Z\",\n  \"matches\": [\n    {\n      \"ark\": \"ark:/61903/4:1:LVDV-DBC\",\n      \"pid\": \"LVDV-DBC\",\n      \"arkType\": \"4:1:\",\n      \"confidence\": 5,\n      \"score\": 0.9996911,\n      \"title\": \"\",\n      \"status\": \"accepted\",\n      \"collection\": \"https://f...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"queryArk\": \"ark:/61903/1:1:QPQP-24C4\",\n  \"resultCount\": 3,\n  \"returned\": 3,\n  \"title\": \"Matches for ark:/61903/1:1:QPQP-24C4\",\n  \"updated\": \"2024-03-09T16:01:36.876Z\",\n  \"matches\": [\n    {\n      \"ark\": \"ark:/61903/4:1:LVDV-6MK\",\n      \"pid\": \"LVDV-6MK\",\n      \"arkType\": \"4:1:\",\n      \"confidence\": 4,\n      \"score\": 0.9150831,\n      \"title\": \"\",\n      \"status\": \"accepted\",\n      \"collection\": \"https://f...
+
+**tool_result:** [{"type": "text", "text": "All 11 ops persisted successfully. Here is the extraction summary:\n\n**Source:** src_001 / S1 \u2014 created (Vermont, Town Clerk, Vital and Town Records, 1732-2005; original government vital record, death registration 31 May 1884)\n\n**Assertions written: 11 total**\n- deceased (William A. Bagley, p_104363515691): name (a_001), sex (a_002), death date+place (a_003), birth year ~1815 (a_004), relationship child-of-David (a_005), relationship child-of-Sarah (a_006)\...
+
+**tool_result:** [{"type": "text", "text": "Extraction complete. Here is the compact summary:\n\n**Source:** src_002 / S2 \u2014 created (new source, no prior reuse)\n**Assertions written:** 12 total\n- `deceased` (William A. Bagley, p_104363376565): name (a_011), sex (a_012), death date+place (a_013), birth year ~1815 (a_014), child-of-David relationship (a_015), child-of-Sarah relationship (a_016)\n- `father_of_deceased` (David Bagley, p_104363376568): name (a_017), sex (a_018), spouse-of-Sarah inferred (a_...
+
+**assistant:** Both death records extracted. Two independent indexings of the same 1884 Topsham entry both name **David Bagley** as William's father (a_005 / a_015 — direct evidence). David Bagley record-person match → LVDV-DBC (confidence 5 both times).
+
+Log_001 and log_002 are positive with no assertions yet. Extracting the David Bagley census households as corroborating evidence:
+
+**tool_use** `Agent` — args: {"description": "Extract 1820 census David Bagley", "subagent_type": "record-extractor", "prompt": "Extract ALL assertions from this genealogical record into the research project.\n\n**Project path:** `/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2`\n**Record ID:** `ark:/61903/1:1:XHLG-T8R`\n**Log entry:** `log_001`\n**Results ref:** `results/log_001.json`\n\n**Research context:** The research objective is to identify the father of William A. Bagley (...
+
+**tool_use** `mcp__genealogy__project_context` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"projectStatus\": \"active\",\n  \"openQuestions\": [\n    {\n      \"id\": \"q_001\",\n      \"question\": \"Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermon\u2026\"\n    }\n  ],\n  \"persons\": [\n    {\n      \"id\": \"MJDL-Q8B\",\n      \"name\": \"William A. Bagley\",\n      \"gender\": \"Male\",\n      \"sourceRefs\": []\n    },\n    {\n      \"id\...
+
+**tool_use** `Agent` — args: {"description": "Extract 1830 census David Bagley", "subagent_type": "record-extractor", "prompt": "Extract ALL assertions from this genealogical record into the research project.\n\n**Project path:** `/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2`\n**Record ID:** `ark:/61903/1:1:XHLG-T9Q`\n**Log entry:** `log_002`\n**Results ref:** `results/log_002.json`\n\n**Research context:** The research objective is to identify the father of William A. Bagley (...
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:XHLG-T8R", "resultsRef": "results/log_001.json", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_10418027755\",\n      \"ark\": \"ark:/61903/1:1:XHLG-T8R\",\n      \"names\": [\n        {\n          \"type\": \"BirthName\",\n          \"surname\": \"Bagley\",\n          \"given\": \"David\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"type\": \"Census\",\n          \"primary\": true,\n          \"date\": \"1820\",\n          \"standard_date\": \"1820\",\n          \"place\": \"Topsham, Orange, Ve...
+
+**tool_use** `mcp__genealogy__project_context` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"projectStatus\": \"active\",\n  \"openQuestions\": [\n    {\n      \"id\": \"q_001\",\n      \"question\": \"Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermon\u2026\"\n    }\n  ],\n  \"persons\": [\n    {\n      \"id\": \"MJDL-Q8B\",\n      \"name\": \"William A. Bagley\",\n      \"gender\": \"Male\",\n      \"sourceRefs\": []\n    },\n    {\n      \"id\...
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:XHLG-T9Q", "resultsRef": "results/log_002.json", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** {"error":"record 'ark:/61903/1:1:XHLG-T9Q' was not found in staged results 'results/log_002.json'. Do a live read (omit `resultsRef`) instead, or verify the ref/id."}
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:XHLG-T9Q"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_10418027434\",\n      \"ark\": \"ark:/61903/1:1:XHLG-T9Q\",\n      \"names\": [\n        {\n          \"id\": \"a0736ad6-5be5-4cb1-8786-a3722e46bddf\",\n          \"type\": \"BirthName\",\n          \"surname\": \"Brown\",\n          \"given\": \"John\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"fe847fa3-84bd-4b15-851d-2f7d686147b1\",\n          \"type\": \"Census\",\n          \"primary\": ...
+
+**tool_use** `mcp__genealogy__record_person_matches` — args: {"id": "ark:/61903/1:1:XHLG-T9Q"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"queryArk\": \"ark:/61903/1:1:XHLG-T9Q\",\n  \"resultCount\": 0,\n  \"returned\": 0,\n  \"title\": \"Matches for ark:/61903/1:1:XHLG-T9Q\",\n  \"updated\": \"2024-03-09T21:31:32.737Z\",\n  \"matches\": []\n}"}]
+
+**tool_use** `mcp__genealogy__extraction_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "sourceDescription": {"title": "Household of David Bagley, \"United States, Census, 1820\"", "url": "https://www.familysearch.org/ark:/61903/1:1:XHLG-T8R"}, "ops": [{"section": "sources", "op": "append", "entry": {"citation": "\"United States, Census, 1820,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:XHLG-T8R : accessed 2026-07-27), entry for David Bagley, Topsham, Orang...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_003\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_022\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_023\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_024\"\n    },\n ...
+
+**tool_use** `mcp__genealogy__record_person_matches` — args: {"id": "p_10418027755"}
+
+**tool_result:** {"error":"Unrecognized id \"p_10418027755\". Expected a personId (e.g. \"KNDX-MKG\") or a full FamilySearch ARK."}
+
+**tool_result:** [{"type": "text", "text": "**STOP \u2014 Record identity mismatch. No assertions persisted.**\n\nThe ARK `ark:/61903/1:1:XHLG-T9Q` does not resolve to a David Bagley 1830 census record. The live read returned:\n\n- **Person:** John Brown\n- **Record type:** 1820 U.S. Census (not 1830)\n- **Place:** Corinth, Orange, Vermont (not Topsham)\n\nThis is a completely different record \u2014 wrong head, wrong year, wrong town. Persisting it as David Bagley's 1830 Topsham census entry would be a fabri...
+
+**tool_use** `mcp__genealogy__record_person_matches` — args: {"id": "ark:/61903/1:1:XHLG-T8R"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"queryArk\": \"ark:/61903/1:1:XHLG-T8R\",\n  \"resultCount\": 1,\n  \"returned\": 1,\n  \"title\": \"Matches for ark:/61903/1:1:XHLG-T8R\",\n  \"updated\": \"2024-03-08T17:17:36.234Z\",\n  \"matches\": [\n    {\n      \"ark\": \"ark:/61903/4:1:LVDV-DBC\",\n      \"pid\": \"LVDV-DBC\",\n      \"arkType\": \"4:1:\",\n      \"confidence\": 4,\n      \"score\": 0.8798159,\n      \"title\": \"\",\n      \"status\": \"accepted\",\n      \"collection\": \"https://fam...
+
+**tool_result:** [{"type": "text", "text": "All done. Here is the summary:\n\n**Source:** src_003 / S3 \u2014 created (new). 1820 U.S. Federal Census, David Bagley, Topsham, Orange, Vermont.\n\n**Assertions written (4 total, all for head_of_household persona p_10418027755):**\n- a_022: name \u2014 \"David Bagley\" (direct, primary, q_001)\n- a_023: sex \u2014 \"Male\" (direct, primary, q_001)\n- a_024: residence \u2014 Topsham, Orange, Vermont, 1820 (direct, primary, witness/enumerator, q_001)\n- a_025: censu...
+
+**tool_use** `Glob` — args: {"pattern": "**/*person-evidence*", "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** No files found
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__record_search,mcp__genealogy__rank_search_matches", "max_results": 2}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__record_search"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__rank_search_matches"}]
+
+**tool_use** `Glob` — args: {"pattern": ".claude/skills/*/skill.md", "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** No files found
+
+**tool_use** `Glob` — args: {"pattern": ".claude/skills/**/*.md", "path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_result:** .claude/skills/check-warnings/SKILL.md
+.claude/skills/check-warnings/references/assumption-categories.md
+.claude/skills/check-warnings/references/warning-checks.md
+.claude/skills/check-warnings/references/warnings-as-identity-signals.md
+.claude/skills/citation/SKILL.md
+.claude/skills/citation/references/gps-citation-standards.md
+.claude/skills/citation/references/validation-protocol.md
+.claude/skills/conflict-resolution/SKILL.md
+.claude/skills/conflict-resolution/references/historical-contrad...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/person-evidence/SKILL.md"}
+
+**tool_result:** 1	---
+2	name: person-evidence
+3	model: claude-sonnet-4-6
+4	description: >-
+5	  Links assertions to GedcomX persons — identity resolution. Evaluates whether
+6	  a record's person matches a tree person, creates person_evidence entries with
+7	  confidence and rationale, and creates stub persons when none match. Also
+8	  reviews/audits existing person_evidence links, and builds out a record's
+9	  household skeleton in the tree from extracted assertions. GPS Step 3 —
+10	  Analysis and Correlation....
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__materialize_facts,mcp__genealogy__tree_edit,mcp__genealogy__same_person,mcp__genealogy__research_query", "max_results": 4}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__materialize_facts"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__tree_edit"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__same_person"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_query"}]
+
+**assistant:** Now I'll query the current assertions to verify what was extracted, then proceed with person-evidence work:
+
+**tool_use** `mcp__genealogy__research_query` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "assertions", "recordId": "ark:/61903/1:1:QPQP-R8T8"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"assertions\",\n  \"count\": 10,\n  \"items\": [\n    {\n      \"id\": \"a_001\",\n      \"record_id\": \"ark:/61903/1:1:QPQP-R8T8\",\n      \"record_persona_id\": \"p_104363515691\",\n      \"record_role\": \"deceased\",\n      \"fact_type\": \"name\",\n      \"value\": \"William A. Bagley\",\n      \"structured_value\": {\n        \"given\": \"William A\",\n        \"surname\": \"Bagley\"\n      },\n      \"information_quality\"...
+
+**tool_use** `mcp__genealogy__research_query` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "assertions", "recordId": "ark:/61903/1:1:QPQP-24HR"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"assertions\",\n  \"count\": 11,\n  \"items\": [\n    {\n      \"id\": \"a_011\",\n      \"record_id\": \"ark:/61903/1:1:QPQP-24HR\",\n      \"record_persona_id\": \"p_104363376565\",\n      \"record_role\": \"deceased\",\n      \"fact_type\": \"name\",\n      \"value\": \"William A. Bagley\",\n      \"structured_value\": {\n        \"given\": \"William A\",\n        \"surname\": \"Bagley\"\n      },\n      \"information_quality\"...
+
+**tool_use** `mcp__genealogy__research_query` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "assertions", "recordId": "ark:/61903/1:1:XHLG-T8R"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"assertions\",\n  \"count\": 4,\n  \"items\": [\n    {\n      \"id\": \"a_022\",\n      \"record_id\": \"ark:/61903/1:1:XHLG-T8R\",\n      \"record_persona_id\": \"p_10418027755\",\n      \"record_role\": \"head_of_household\",\n      \"fact_type\": \"name\",\n      \"value\": \"David Bagley\",\n      \"structured_value\": {\n        \"given\": \"David\",\n        \"surname\": \"Bagley\"\n      },\n      \"information_quality\": \...
+
+**assistant:** Good — all 25 assertions confirmed. Now proceeding with person-evidence. First read the tree to identify existing person IDs so I can predict the next synthetic ID for David Bagley:
+
+**tool_use** `mcp__genealogy__research_query` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "person_evidence"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"person_evidence\",\n  \"count\": 0,\n  \"items\": [],\n  \"truncated\": false\n}"}]
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/tree.gedcomx.json", "limit": 30}
+
+**tool_result:** 1	{
+2	  "persons": [
+3	    {
+4	      "id": "MJDL-Q8B",
+5	      "gender": "Male",
+6	      "living": false,
+7	      "names": [
+8	        {
+9	          "id": "N1",
+10	          "given": "William A.",
+11	          "surname": "Bagley"
+12	        }
+13	      ],
+14	      "facts": [
+15	        {
+16	          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+17	          "type": "Birth",
+18	          "date": "Abt 1815",
+19	          "standard_date": "Abt 1815",
+20	          "place": "West Topsham, Orange, ...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/tree.gedcomx.json", "limit": 50, "offset": 30}
+
+**tool_result:** 30	        },
+31	        {
+32	          "id": "28119bdf-00ed-4c5f-a9fc-9b39c096b055",
+33	          "type": "Residence",
+34	          "date": "1850",
+35	          "standard_date": "1850",
+36	          "place": "Topsham, Orange, Vermont, United States",
+37	          "standard_place": "Topsham, Orange, Vermont, United States"
+38	        }
+39	      ]
+40	    },
+41	    {
+42	      "id": "L528-9HM",
+43	      "gender": "Female",
+44	      "living": false,
+45	      "names": [
+46	        {
+47	          "...
+
+**assistant:** No person_evidence entries yet. Proceeding to materialize all personas in one batch — creating David Bagley (new person I1) from both death-record father_of_deceased roles and the 1820 census, and enriching William and Sarah with their sourced facts:
+
+**tool_use** `mcp__genealogy__materialize_facts` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "ops": [{"personId": "I1", "recordId": "ark:/61903/1:1:QPQP-R8T8", "recordRole": "father_of_deceased"}, {"personId": "I1", "recordId": "ark:/61903/1:1:QPQP-24HR", "recordRole": "father_of_deceased"}, {"personId": "I1", "recordId": "ark:/61903/1:1:XHLG-T8R", "recordRole": "head_of_household"}, {"personId": "MJDL-Q8B", "recordId": "ark:/61903/1:1:QPQP-R8T8", "recordRole": "deceased"}, {"p...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"personId\": \"I1\",\n      \"created\": true,\n      \"factsAdded\": 0,\n      \"factsEnriched\": 0,\n      \"namesAdded\": 1,\n      \"refsAttached\": 1,\n      \"conflicts_surfaced\": []\n    },\n    {\n      \"personId\": \"I1\",\n      \"created\": false,\n      \"factsAdded\": 0,\n      \"factsEnriched\": 0,\n      \"namesAdded\": 0,\n      \"refsAttached\": 1,\n      \"conflicts_surfaced\": []\n    },\n    {...
+
+**assistant:** David Bagley (I1) created — name + 1820 Topsham residence facts materialized. William and Sarah enriched with sourced refs. No conflicts. Now writing all person_evidence entries in one batch:
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "ops": [{"section": "person_evidence", "op": "append", "entry": {"assertion_id": "a_001", "person_id": "MJDL-Q8B", "confidence": "confident", "match_score": null, "rationale": "William A. Bagley (deceased) named in Vermont Town Clerk vital record, 31 May 1884. Name, death date, and death place in Topsham all match tree subject MJDL-Q8B exactly. This is the research subject found by sear...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_001\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_002\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_003\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId...
+
+**assistant:** All 30 pe_ entries written (pe_001–pe_030). Person-evidence phase complete:
+- William A. Bagley (MJDL-Q8B): confident links on all assertions
+- David Bagley (I1, new stub): probable links on all assertions
+- Sarah Sally Andrews / Bagley (LVDV-6MK): probable links corroborating her as mother
+
+Now mark the completed plan items and route to research-exhaustiveness. The evidence plausibly answers q_001 — the exhaustiveness check will determine if more items must run:
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "ops": [{"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_001", "fields": {"status": "completed"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_002", "fields": {"status": "completed"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_003", "fields": {"status": "completed"}}]}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_001\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_002\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_003\"\n    }\n  ],\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n  ...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/research-exhaustiveness/SKILL.md"}
+
+**tool_result:** 1	---
+2	name: research-exhaustiveness
+3	model: claude-sonnet-4-6
+4	description: Evaluates whether research on a question is reasonably
+5	  exhaustive — applies the five threshold questions and the 7-point
+6	  stop criteria, then either writes the exhaustive_declaration on the
+7	  question or explains what's missing. GPS Step 1 — Reasonably
+8	  Exhaustive Research. Use when the user says "is this research
+9	  exhaustive?", "are we done?", "have we searched enough?", "can we
+10	  declare exhaus...
+
+**assistant:** The exhaustiveness skill requires all plan items to be completed or skipped before evaluation. pli_004–pli_010 are still "planned." Per the parentage decisiveness rule, the baptism record (pli_005), a parent's probate (pli_006), and the parents' marriage (pli_004) are gateway records that must be searched before declaring. Running the most critical remaining items in parallel:
+
+**tool_use** `mcp__genealogy__record_search` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "surname": "Andrews", "spouseSurname": "Bagley", "residencePlace": "Vermont", "marriageYearFrom": 1795, "marriageYearTo": 1820, "recordType": "marriage", "count": 50}
+
+**tool_use** `mcp__genealogy__record_search` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "surname": "Bagley", "residencePlace": "Orange County, Vermont", "recordType": "probate", "count": 50}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\",\n    \"surname\": \"Andrews\",\n    \"spouseSurname\": \"Bagley\",\n    \"residencePlace\": \"Vermont\",\n    \"marriageYearFrom\": 1795,\n    \"marriageYearTo\": 1820,\n    \"recordType\": \"marriage\",\n    \"count\": 50\n  },\n  \"totalMatches\": 160,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 50,\n  \"offset\": 0,\n  \"hasM...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\",\n    \"surname\": \"Bagley\",\n    \"residencePlace\": \"Orange County, Vermont\",\n    \"recordType\": \"probate\",\n    \"count\": 50\n  },\n  \"totalMatches\": 1,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 1,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [\n    {\n      \"recordId\": \"ark:/61903/1:1:QPR5-62QD\",\...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "surname": "Bagley", "givenName": "David", "residencePlace": "Topsham, Vermont", "residenceYearFrom": 1840, "residenceYearTo": 1840, "recordType": "census", "count": 50}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\",\n    \"surname\": \"Bagley\",\n    \"givenName\": \"David\",\n    \"residencePlace\": \"Topsham, Vermont\",\n    \"residenceYearFrom\": 1840,\n    \"residenceYearTo\": 1840,\n    \"recordType\": \"census\",\n    \"count\": 50\n  },\n  \"totalMatches\": 2,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 2,\n  \"offset\": 0,\n  \"hasM...
+
+**assistant:** Strong 1840 census hit — David Bagley household, Topsham, 1840 (×2 indexings). Marriage search negative at top 50. Probate search returned only an unrelated South Africa result. Ranking the 1840 census, running follow-up marriage/probate searches and the Topsham full-text search in parallel:
+
+**tool_use** `mcp__genealogy__rank_search_matches` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "stagedResultsRef": "results/.staging/c3c42b9d-0bdc-4ad8-b2f3-ebd28c048d5b.json", "subjectId": "I1", "checkAttachments": true}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"subjectId\": \"I1\",\n  \"scoredCount\": 2,\n  \"returnedCount\": 2,\n  \"scoringErrors\": 0,\n  \"scoreLogError\": null,\n  \"matches\": [\n    {\n      \"matchRank\": 1,\n      \"searchRank\": 1,\n      \"recordId\": \"ark:/61903/1:1:XHRB-V42\",\n      \"matchScore\": 0.15053548,\n      \"primaryId\": \"p_10421422430\",\n      \"personName\": \"David Bagley\",\n      \"collectionTitle\": \"United States, Census, 1840\",\n      \"recordArk\": \"ark:/61903/1:...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "surname": "Bagley", "givenName": "David", "spouseGivenName": "Sarah", "residencePlace": "Vermont", "marriageYearFrom": 1795, "marriageYearTo": 1820, "recordType": "marriage", "count": 50}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\",\n    \"surname\": \"Bagley\",\n    \"givenName\": \"David\",\n    \"spouseGivenName\": \"Sarah\",\n    \"residencePlace\": \"Vermont\",\n    \"marriageYearFrom\": 1795,\n    \"marriageYearTo\": 1820,\n    \"recordType\": \"marriage\",\n    \"count\": 50\n  },\n  \"totalMatches\": 10,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 1...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "surname": "Bagley", "givenName": "David", "residencePlace": "Vermont", "recordType": "probate", "anyYearFrom": 1820, "anyYearTo": 1870, "count": 50}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\",\n    \"surname\": \"Bagley\",\n    \"givenName\": \"David\",\n    \"residencePlace\": \"Vermont\",\n    \"recordType\": \"probate\",\n    \"anyYearFrom\": 1820,\n    \"anyYearTo\": 1870,\n    \"count\": 50\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"r...
+
+**assistant:** 1840 census confirms David Bagley was in Topsham in 1840. Marriage search shows no Sarah Andrews + Bagley marriage in indexed records; the "David Bagley + Voda Page" hit needs a date check. Probate: zero results for David Bagley in Vermont. Reading the 1840 record and running the Topsham full-text search in parallel with logging:
+
+**tool_use** `mcp__genealogy__record_search` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "collectionId": "4337554", "surname": "Bagley", "residencePlace": "Topsham, Vermont", "count": 50}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\",\n    \"collectionId\": \"4337554\",\n    \"surname\": \"Bagley\",\n    \"residencePlace\": \"Topsham, Vermont\",\n    \"count\": 50\n  },\n  \"totalMatches\": 0,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 0,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\": [],\n  \"staged\": null\n}"}]
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "ops": [{"planItemId": "pli_004", "tool": "record_search", "query": {"surname": "Andrews", "spouseSurname": "Bagley", "residencePlace": "Vermont", "marriageYearFrom": 1795, "marriageYearTo": 1820, "recordType": "marriage", "count": 50}, "outcome": "negative", "resultsExamined": 50, "resultsAvailable": 160, "stagedResultsRef": "results/.staging/71f54920-3322-456c-97e5-301c1b65dc40.json",...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"logId\": \"log_005\",\n      \"performed\": \"2026-07-27T19:32:07.015Z\",\n      \"resultsRef\": \"results/log_005.json\",\n      \"returnedCount\": 50\n    },\n    {\n      \"logId\": \"log_006\",\n      \"performed\": \"2026-07-27T19:32:07.021Z\",\n      \"resultsRef\": \"results/log_006.json\",\n      \"returnedCount\": 10\n    },\n    {\n      \"logId\": \"log_007\",\n      \"performed\": \"2026-07-27T19:32:07...
+
+**assistant:** Logs written (log_005–log_009). Now read the 1840 census record and run the Topsham full-text search:
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__fulltext_search", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__fulltext_search"}]
+
+**tool_use** `mcp__genealogy__record_search` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "surname": "Bagley", "residencePlace": "Topsham, Vermont", "recordType": "census", "residenceYearFrom": 1840, "residenceYearTo": 1840, "count": 50}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\",\n    \"surname\": \"Bagley\",\n    \"residencePlace\": \"Topsham, Vermont\",\n    \"recordType\": \"census\",\n    \"residenceYearFrom\": 1840,\n    \"residenceYearTo\": 1840,\n    \"count\": 50\n  },\n  \"totalMatches\": 18,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 18,\n  \"offset\": 0,\n  \"hasMore\": false,\n  \"results\":...
+
+**assistant:** Key finding: **Wm A Bagley** (XHRB-KZL) is a separate 1840 Topsham household head — William A. Bagley had his own household by 1840 when ~25. David Bagley also in Topsham. Now running full-text search on Topsham town records and reading both census households in parallel:
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "keywords": "+Bagley", "imageGroupNumber": "005464260", "count": 50}
+
+**tool_result:** Error: result (109,336 characters across 4,344 lines) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt.
+Format: Plain text
+- For targeted searches (find a line, locate a string): use grep on the file directly.
+- For analysis or summarization that requires reading the ful...
+
+**tool_use** `mcp__genealogy__record_search` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "recordId": "ark:/61903/1:1:XHRB-V42", "surname": "Bagley", "count": 1}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"query\": {\n    \"projectPath\": \"/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2\",\n    \"recordId\": \"ark:/61903/1:1:XHRB-V42\",\n    \"surname\": \"Bagley\",\n    \"count\": 1\n  },\n  \"totalMatches\": 1172591,\n  \"paginationCappedAt\": 4999,\n  \"returned\": 1,\n  \"offset\": 0,\n  \"hasMore\": true,\n  \"results\": [\n    {\n      \"recordId\": \"ark:/61903/1:1:XS7S-YYH\",\n      \"events\": [\n        {\n   ...
+
+**assistant:** The full-text results are in a file — spawning an agent to process it, while reading the 1840 census records directly:
+
+**tool_use** `Agent` — args: {"description": "Analyze Topsham full-text search results", "prompt": "Read the file at `/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt` in chunks of ~677 lines using offset/limit until you have read all 4,344 lines.\n\nThis is the result of a FamilySearch full-text search for \"+Bagley\" in imageGroup 005464260 (Topsham Tow...
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__record_read", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__record_read"}]
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt", "limit": 677, "offset": 0}
+
+**tool_result:** 0	{
+1	  "query": {
+2	    "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+3	    "keywords": "+Bagley",
+4	    "imageGroupNumber": "005464260",
+5	    "count": 50
+6	  },
+7	  "totalResults": 110,
+8	  "returned": 50,
+9	  "offset": 0,
+10	  "hasMore": true,
+11	  "results": [
+12	    {
+13	      "id": "ark:/61903/3:1:3QS7-8999-L4XM",
+14	      "sourceUrl": "https://www.familysearch.org/ark:/61903/3:1:3QS7-8999-L4XM",
+15	      "collectionId": "M9J...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt", "limit": 677, "offset": 677}
+
+**tool_result:** 677	        "Calleton",
+678	        "County Grand",
+679	        "Town Juners"
+680	      ],
+681	      "dates": [
+682	        "1839"
+683	      ],
+684	      "highlightTerms": [
+685	        "Bagley"
+686	      ]
+687	    },
+688	    {
+689	      "id": "ark:/61903/3:1:3QSQ-G999-LH9L",
+690	      "sourceUrl": "https://www.familysearch.org/ark:/61903/3:1:3QSQ-G999-LH9L",
+691	      "collectionId": "M9J1-72F",
+692	      "collectionTitle": "United States, Vermont, Legal, from 1583 to 2005",
+693	      "title...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt", "limit": 677, "offset": 1354}
+
+**tool_result:** 1354	        "Daniel McCalloway",
+1355	        "Carliss"
+1356	      ],
+1357	      "places": [
+1358	        "County Grand Chase"
+1359	      ],
+1360	      "highlightTerms": [
+1361	        "Bagley"
+1362	      ]
+1363	    },
+1364	    {
+1365	      "id": "ark:/61903/3:1:3QSQ-G999-L4KT",
+1366	      "sourceUrl": "https://www.familysearch.org/ark:/61903/3:1:3QSQ-G999-L4KT",
+1367	      "collectionId": "M9J1-72F",
+1368	      "collectionTitle": "United States, Vermont, Legal, from 1583 to 2005",
+1369	    ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt", "limit": 677, "offset": 2031}
+
+**tool_result:** 2031	      "highlightTerms": [
+2032	        "Bagley"
+2033	      ]
+2034	    },
+2035	    {
+2036	      "id": "ark:/61903/3:1:3QSQ-G999-L47Z",
+2037	      "sourceUrl": "https://www.familysearch.org/ark:/61903/3:1:3QSQ-G999-L47Z",
+2038	      "collectionId": "M9J1-72F",
+2039	      "collectionTitle": "United States, Vermont, Legal, from 1583 to 2005",
+2040	      "title": "Topsham, Orange, Vermont, United States Town 1819",
+2041	      "recordDate": "1819",
+2042	      "recordType": "Town",
+2043	      "...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt", "limit": 677, "offset": 2708}
+
+**tool_result:** 2708	        "Chaser",
+2709	        "Levi Jaber",
+2710	        "James F George",
+2711	        "Thomas J Currier",
+2712	        "Wm Rogers",
+2713	        "Moses A. Dustin",
+2714	        "Hal Graw",
+2715	        "Thomas Eastman",
+2716	        "Charles Graw",
+2717	        "Hanson Rogers",
+2718	        "Chase",
+2719	        "Calvin Taber",
+2720	        "David Baghhase ",
+2721	        "Samuel Batchelder",
+2722	        "Amos Garland",
+2723	        "Daniel R Sargent",
+2724	        "Chase McKeeth",
+2...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt", "limit": 677, "offset": 3385}
+
+**tool_result:** 3385	        "Ma Wallace",
+3386	        "Rebecca Gale",
+3387	        "James",
+3388	        "M Samuel Gibson",
+3389	        "Betsey Cartman",
+3390	        "Geo Campbell",
+3391	        "George K Bagley",
+3392	        "Susan M Worthley",
+3393	        "John Andrews",
+3394	        "Elizabeth Sanborn",
+3395	        "Ophir Shipman",
+3396	        "M William Gentleman Jr",
+3397	        "Rachel Sylle",
+3398	        "Ophin Shipman",
+3399	        "Cyrus R Lawgay",
+3400	        "Susan Gardan",
+3401	      ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180757077.txt", "limit": 677, "offset": 4062}
+
+**tool_result:** 4062	      ]
+4063	    },
+4064	    {
+4065	      "id": "ark:/61903/3:1:3QS7-8999-LWKQ",
+4066	      "sourceUrl": "https://www.familysearch.org/ark:/61903/3:1:3QS7-8999-LWKQ",
+4067	      "collectionId": "M9J1-72F",
+4068	      "collectionTitle": "United States, Vermont, Legal, from 1583 to 2005",
+4069	      "title": "Topsham, Orange, Vermont, United States Town 1853",
+4070	      "recordDate": "1853",
+4071	      "recordType": "Town",
+4072	      "recordPlace": "Topsham, Orange, Vermont, United State...
+
+**tool_result:** [{"type": "text", "text": "I have now read all 4,344 lines. Here is my full report:\n\n---\n\n## 1. Total Results / Hits\n\n- **totalResults: 110** (the query matched 110 pages in the volume)\n- **returned: 50** (only the first 50 are included in this file; the query had `hasMore: true`)\n- No `transcriptText` or `text` fields are present in any result \u2014 these are index/metadata records only, listing extracted `names`, `places`, and `dates` per page image. There is no verbatim transcript...
+
+**assistant:** Critical finding: the 1813 Topsham town record contains **"Sophia Andrews Bagley"** and **"David Bagley"** on the same page — a Bagley child with "Andrews" as a middle name strongly corroborates Sarah Andrews married David Bagley. Also "David Bayley Jr" and "Wm A Bagley" appear together in 1853. Now reading the 1840 census households and fetching the remaining 60 full-text results in parallel:
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:XHRB-V42", "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "resultsRef": "results/log_009.json"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_10421422430\",\n      \"ark\": \"ark:/61903/1:1:XHRB-V42\",\n      \"names\": [\n        {\n          \"type\": \"BirthName\",\n          \"surname\": \"Bagley\",\n          \"given\": \"David\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"type\": \"Census\",\n          \"primary\": true,\n          \"date\": \"1840\",\n          \"standard_date\": \"1840\",\n          \"place\": \"Topsham, Orange, Ve...
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:XHRB-KZL"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_10421423421\",\n      \"ark\": \"ark:/61903/1:1:XHRB-KZL\",\n      \"names\": [\n        {\n          \"id\": \"69456c29-c10a-4e2f-818e-f6957df8a509\",\n          \"type\": \"BirthName\",\n          \"given\": \"Wm A\",\n          \"surname\": \"Bagley\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"2c9d51fc-a151-429d-957a-73512835d293\",\n          \"type\": \"Census\",\n          \"primary\":...
+
+**tool_use** `mcp__genealogy__fulltext_search` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "keywords": "+Bagley", "imageGroupNumber": "005464260", "count": 60, "offset": 50}
+
+**tool_result:** Error: result (109,735 characters across 4,353 lines) exceeds maximum allowed tokens. Output has been saved to /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt.
+Format: Plain text
+- For targeted searches (find a line, locate a string): use grep on the file directly.
+- For analysis or summarization that requires reading the ful...
+
+**tool_use** `Agent` — args: {"description": "Analyze second fulltext search file for Topsham vital records", "prompt": "Read the file at `/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt` and extract ALL entries that mention any of the following names: Bagley, Baley, Bayley, Andrews, David, William, Sarah, Sophia. \n\nThis is a full-text search result fr...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json", "limit": 100}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_bagley_father_1884",
+4	    "objective": "Who was the father of William A. Bagley, born about 1815 and died 31 May 1884 in Topsham, Orange County, Vermont?",
+5	    "subject_person_ids": [
+6	      "MJDL-Q8B"
+7	    ],
+8	    "status": "active",
+9	    "created": "2026-07-27",
+10	    "updated": "2026-07-27"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level": "intermediate",
+14	    "subscriptions": [],
+15	    "narration_guidance": "concise"
+16	  },
+17...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt"}
+
+**tool_result:** File content (38485 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.
+
+**tool_use** `Grep` — args: {"pattern": "Bagley|Baley|Bayley", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt", "output_mode": "content", "context": 8, "head_limit": 0, "-i": true}
+
+**tool_result:** <persisted-output>
+Output too large (65.5KB). Full output saved to: /Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/toolu_019MEfXkswdGSVJTnASevZoT.txt
+
+Preview (first 2KB):
+1-{
+2-  "query": {
+3:    "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+4:    "keywords": "+Bagley",
+5-    "imageGroupNumber": "005464260",
+6-...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/toolu_019MEfXkswdGSVJTnASevZoT.txt"}
+
+**tool_result:** File content (27021 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/toolu_019MEfXkswdGSVJTnASevZoT.txt", "limit": 400}
+
+**tool_result:** 1	1-{
+2	2-  "query": {
+3	3:    "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+4	4:    "keywords": "+Bagley",
+5	5-    "imageGroupNumber": "005464260",
+6	6-    "count": 60,
+7	7-    "offset": 50
+8	8-  },
+9	9-  "totalResults": 110,
+10	10-  "returned": 60,
+11	11-  "offset": 50,
+12	12-  "hasMore": false,
+13	--
+14	59-        "Chase Wm Wood",
+15	60-        "Samuel Labor",
+16	61-        "Daniel Jones",
+17	62-        "Ebenezer White",
+18	63-  ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/toolu_019MEfXkswdGSVJTnASevZoT.txt", "offset": 400, "limit": 400}
+
+**tool_result:** 400	764-        "John Lord",
+401	765-        "Richard H Huntley",
+402	766-        "Chase Lemuel Tabor Town",
+403	767-        "Chase Harris McLaughlin",
+404	768-        "Samuel Butterfield"
+405	769-      ],
+406	770-      "places": [
+407	--
+408	773-        "Lemuel",
+409	774-        "Topsham"
+410	775-      ],
+411	776-      "dates": [
+412	777-        "1805",
+413	778-        "1806"
+414	779-      ],
+415	780-      "highlightTerms": [
+416	781:        "Bagley"
+417	782-      ]
+418	783-    },
+419	784-  ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/toolu_019MEfXkswdGSVJTnASevZoT.txt", "offset": 800, "limit": 400}
+
+**tool_result:** 800	1407-        "Duncan M. Ruth",
+801	1408-        "Carliss",
+802	1409-        "Moses Dustin",
+803	1410:        "David Bagley",
+804	1411-        "John R Dusten",
+805	1412-        "Lea Tabor",
+806	1413-        "Charles Grass",
+807	1414-        "James Chamberlain",
+808	1415-        "Wilber Butterfield",
+809	1416-        "Samuel Easton",
+810	1417-        "Thomas Eastman",
+811	1418-        "Jonathan Baldwin",
+812	--
+813	1445-        "Defray Town",
+814	1446-        "Exton",
+815	1447-        "Roug...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/toolu_019MEfXkswdGSVJTnASevZoT.txt", "offset": 1200, "limit": 400}
+
+**tool_result:** 1200	2162-      "sourceUrl": "https://www.familysearch.org/ark:/61903/3:1:3QS7-L999-LWY6",
+1201	2163-      "collectionId": "M9J1-72F",
+1202	2164-      "collectionTitle": "United States, Vermont, Legal, from 1583 to 2005",
+1203	2165-      "title": "Topsham, Orange, Vermont, United States Town 1826",
+1204	--
+1205	2178-        "Popham",
+1206	2179-        "Mary",
+1207	2180-        "Jonathan Tenness",
+1208	2181-        "Samuel Bachelder",
+1209	2182-        "Daniel James",
+1210	2183-        "Copham...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/toolu_019MEfXkswdGSVJTnASevZoT.txt", "offset": 1600, "limit": 400}
+
+**tool_result:** 1600	2905-        "Erastus Fairbanks",
+1601	2906-        "Lawrence Brainard",
+1602	2907-        "Jefferson P Kidder",
+1603	2908-        "William Kitridge",
+1604	2909-        "William M Pingry",
+1605	2910-        "Samuel Hutchins",
+1606	2911-        "Frasier",
+1607	--
+1608	2953-        "State of Vermont"
+1609	2954-      ],
+1610	2955-      "dates": [
+1611	2956-        "1853",
+1612	2957-        "1833",
+1613	2958-        "1679"
+1614	2959-      ],
+1615	2960-      "highlightTerms": [
+1616	2961:    ...
+
+**tool_use** `Grep` — args: {"pattern": "Andrews|Sarah|Sophia", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt", "output_mode": "content", "context": 5, "head_limit": 0, "-i": true}
+
+**tool_result:** 108-        "John Bagleys",
+109-        "Henry Bagley",
+110-        "Sargan Bagly",
+111-        "Michael Thompson",
+112-        "Mary Bishop Thompson",
+113:        "Sarah Johnston",
+114-        "Thompson Corn",
+115-        "Jesse",
+116-        "Harris",
+117-        "Eldridge Findley",
+118-        "Barn Patram",
+--
+136-        "M. Ruth Wilson",
+137-        "Thomas Crown",
+138-        "Elizabeth Crown",
+139-        "Hannah Crown",
+140-        "Jesse Crown",
+141:        "Sarah N Crown",
+142-    ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt", "limit": 200}
+
+**tool_result:** 1	{
+2	  "query": {
+3	    "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2",
+4	    "keywords": "+Bagley",
+5	    "imageGroupNumber": "005464260",
+6	    "count": 60,
+7	    "offset": 50
+8	  },
+9	  "totalResults": 110,
+10	  "returned": 60,
+11	  "offset": 50,
+12	  "hasMore": false,
+13	  "results": [
+14	    {
+15	      "id": "ark:/61903/3:1:3QSQ-G999-L44F",
+16	      "sourceUrl": "https://www.familysearch.org/ark:/61903/3:1:3QSQ-G999-L44F",
+17	  ...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt", "offset": 200, "limit": 300}
+
+**tool_result:** 200	      "names": [
+201	        "Samuel Tabor",
+202	        "Samuel Butterfield",
+203	        "Moses Wallace",
+204	        "Daniel Jones",
+205	        "John George",
+206	        "James George",
+207	        "Samuel Dickerman",
+208	        "John Brown",
+209	        "Huntley",
+210	        "Isaac Tabor",
+211	        "David Bagley",
+212	        "Edmund George",
+213	        "Jonathan Sanburn",
+214	        "Blanchard",
+215	        "Daniel Jonesin ",
+216	        "John Ford",
+217	        "Elen White"...
+
+**tool_use** `Grep` — args: {"pattern": "Sophia A. Bagley|David Bagley Selectman|G W Bagley|George R. Bagley|William H Bagley|John M Bagley|Wm A Bagley|Charles Bagley|Dee David Bagley|Ephraim Bagley|Enoch Bagley|Moses Bagley|John Bagley|Aaron Bagley|Elijah Bagley|Peter Bagley|Aaron Bagley", "path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt", "out...
+
+**tool_result:** 105-        "May R",
+106-        "Joseph Smith",
+107-        "Burton Smith",
+108:        "John Bagleys",
+109-        "Henry Bagley",
+110-        "Sargan Bagly",
+111-        "Michael Thompson",
+--
+257-        "Sheep Marks",
+258-        "Cartman",
+259-        "John Crown",
+260:        "Aaron Bagley",
+261-        "Corless",
+262-        "Ebenezer Fenton",
+263-        "Wm Davidson"
+--
+357-        "William",
+358-        "Chillis",
+359-        "Mary",
+360:        "Aaron Bagley",
+361-        "Sheep M...
+
+**tool_use** `Read` — args: {"file_path": "/Users/dallan/.claude/projects/-private-var-folders-tv-yzyl0n517xj5v54fgn0c0j3h0000gn-T-e2e-bagley-father-1884-p2bn27l2/19d8b55f-7223-428e-ac48-8cb06bd475bb/tool-results/mcp-genealogy-fulltext_search-1785180941684.txt", "offset": 1220, "limit": 200}
+
+**tool_result:** 1220	        "Levi Jaban",
+1221	        "Freeman",
+1222	        "John Dustin",
+1223	        "Chase Jonathan Kenness",
+1224	        "Josiah Butler",
+1225	        "Henry Clin",
+1226	        "Samuel Crafts",
+1227	        "Josiah Dana",
+1228	        "Benjamin Swan",
+1229	        "Merrell",
+1230	        "John Roberts",
+1231	        "George Worthington",
+1232	        "Leman",
+1233	        "Benjamin Deming"
+1234	      ],
+1235	      "places": [
+1236	        "Topsham",
+1237	        "Depray Town",
+1238...
+
+**tool_result:** [{"type": "text", "text": "Now I have all the information I need. Let me compile the complete findings.\n\nHere is the complete report of every hit mentioning Bagley, Baley, Bayley, and the co-occurring Andrews/Sarah/Sophia names from this result set (offset 50, items 51\u2013110, imageGroup 005464260):\n\n---\n\nCOMPLETE BAGLEY / BALEY / BAYLEY HITS (items 51\u2013110)\n\nEach entry is from collection M9J1-72F, \"United States, Vermont, Legal, from 1583 to 2005,\" Topsham, Orange, Vermont. T...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json", "offset": 100, "limit": 200}
+
+**tool_result:** 100	        {
+101	          "id": "pli_006",
+102	          "sequence": 6,
+103	          "record_type": "probate",
+104	          "jurisdiction": "Orange County, Vermont",
+105	          "date_range": "1800-1860",
+106	          "repository": "FamilySearch",
+107	          "rationale": "Search Vermont Probate Files 1800-1921 (collection 1435692, 10,225 records indexed + 204K images) for a Bagley estate in Orange County. If William's father died after 1800, an estate or will naming William as a son...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json", "offset": 300, "limit": 200}
+
+**tool_result:** 300	      "results_available": 1,
+301	      "notes": "1 result: Sidney Albert Bagley, probate in Transvaal, South Africa, 1930 — born Braintree, Orange, Vermont 1896, but completely unrelated to David Bagley circa 1820-1860. No Orange County Vermont probate for any Bagley of the right era found in this indexed search."
+302	    },
+303	    {
+304	      "id": "log_008",
+305	      "plan_item_id": "pli_006",
+306	      "performed": "2026-07-27T19:32:07.024Z",
+307	      "tool": "record_search",
+308	 ...
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__research_append,mcp__genealogy__research_log_append", "max_results": 2}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__research_append"}, {"type": "tool_reference", "tool_name": "mcp__genealogy__research_log_append"}]
+
+**assistant:** Updating plan item statuses and logging both fulltext searches.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "ops": [{"section": "plan_items", "op": "update", "entryId": "pli_004", "fields": {"status": "completed"}}, {"section": "plan_items", "op": "update", "entryId": "pli_005", "fields": {"status": "completed"}}, {"section": "plan_items", "op": "update", "entryId": "pli_006", "fields": {"status": "completed"}}, {"section": "plan_items", "op": "update", "entryId": "pli_007", "fields": {"statu...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"ops[0]: section 'plan_items' requires a 'planId'\",\n    \"worked example for 'plan_items':\\nresearch_append({\\n  projectPath: \\\"<absolute-path-to-project-directory>\\\",\\n  section: \\\"plan_items\\\",\\n  op: \\\"update\\\",\\n  planId: \\\"pl_001\\\",\\n  entryId: \\\"<existing-id>\\\",\\n  fields: { /* only the fields you are changing */ }\\n})\"\n  ],\n  \"opsReceived\": 7\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "ops": [{"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_004", "fields": {"status": "completed"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_005", "fields": {"status": "completed"}}, {"section": "plan_items", "op": "update", "planId": "pl_001", "entryId": "pli_006", "fields": {"status": "completed"}}, {"section": "plan_ite...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_004\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_005\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_006\"\n    },\n    {\n      \"section\": \"plan_items\",\n      \"op\": \"update\",\n      \"entryId\": \"pli_007\"\n...
+
+**assistant:** Now logging the two pli_005 fulltext searches.
+
+**tool_use** `mcp__genealogy__research_log_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "ops": [{"tool": "fulltext_search", "planItemId": "pli_005", "query": {"imageGroupNumber": "005464260", "searchTerms": "Bagley", "offset": 0, "count": 50}, "outcome": "partial", "resultsExamined": 50, "resultsAvailable": 110, "stagedResultsRef": null, "notes": "Full-text search of Topsham Town Records 1771-1860 (imageGroup 005464260), 50 results at offset 0. Key findings: (1) 1813 town ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"logId\": \"log_010\",\n      \"performed\": \"2026-07-27T19:44:16.990Z\",\n      \"resultsRef\": null,\n      \"returnedCount\": null\n    },\n    {\n      \"logId\": \"log_011\",\n      \"performed\": \"2026-07-27T19:44:16.990Z\",\n      \"resultsRef\": null,\n      \"returnedCount\": null\n    }\n  ],\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\"...
+
+**assistant:** Now extracting the 1840 David Bagley census record.
+
+**tool_use** `Agent` — args: {"description": "Extract 1840 David Bagley census record", "subagent_type": "record-extractor", "prompt": "Extract all assertions from this 1840 census record into research.json and tree.gedcomx.json.\n\n**Project path:** `/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2`\n\n**Record ID:** `ark:/61903/1:1:XHRB-V42`\n\n**Log entry ID:** `log_009`\n\n**Question this is extracted for:** `q_001` \u2014 \"Who was the father of William A. Bagley (born about 1...
+
+**tool_use** `mcp__genealogy__project_context` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2"}
+
+**tool_use** `mcp__genealogy__record_read` — args: {"recordId": "ark:/61903/1:1:XHRB-V42"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"projectStatus\": \"active\",\n  \"openQuestions\": [\n    {\n      \"id\": \"q_001\",\n      \"question\": \"Who was the father of William A. Bagley (born about 1815, Topsham, Orange County, Vermont; died 31 May 1884, Topsham, Orange County, Vermon\u2026\"\n    }\n  ],\n  \"persons\": [\n    {\n      \"id\": \"MJDL-Q8B\",\n      \"name\": \"William A. Bagley\",\n      \"gender\": \"Male\",\n      \"sourceRefs\": [\n        \"S1\",\n        \"...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"persons\": [\n    {\n      \"id\": \"p_10421422430\",\n      \"ark\": \"ark:/61903/1:1:XHRB-V42\",\n      \"names\": [\n        {\n          \"id\": \"3923965b-4837-4e00-9c4c-45a9b3d26c1e\",\n          \"type\": \"BirthName\",\n          \"surname\": \"Bagley\",\n          \"given\": \"David\"\n        }\n      ],\n      \"facts\": [\n        {\n          \"id\": \"b9bde81c-3ec4-4979-91cd-444eb74dbe64\",\n          \"type\": \"Census\",\n          \"primary\"...
+
+**tool_use** `mcp__genealogy__extraction_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "sourceDescription": {"title": "Household of David Bagley, \"United States, Census, 1840\"", "url": "https://www.familysearch.org/ark:/61903/1:1:XHRB-V42"}, "ops": [{"section": "sources", "op": "append", "entry": {"citation": "\"United States, Census, 1840,\" FamilySearch (https://www.familysearch.org/ark:/61903/1:1:XHRB-V42 : accessed 2026-07-27), entry for David Bagley, Topsham, Orang...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"sources\",\n      \"op\": \"append\",\n      \"entryId\": \"src_004\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_026\"\n    },\n    {\n      \"section\": \"assertions\",\n      \"op\": \"append\",\n      \"entryId\": \"a_027\"\n    }\n  ],\n  \"sourceDescriptionId\": \"S4\",\n  \"sourceReuse\": {\n    \"action\": \"created\",\n    \"srcId\": \...
+
+**tool_result:** [{"type": "text", "text": "Extraction complete.\n\n**Source:** src_004 / S4 \u2014 created (new source)\n\n**Assertions written:** 2 assertions for `head_of_household` (David Bagley)\n- a_026: `name` \u2014 \"David Bagley\" (primary, direct, q_001)\n- a_027: `residence` \u2014 Topsham, Orange, Vermont, 1840 (primary/witness, indirect, q_001)\n\n**Key findings:**\n- Record is an original 1840 federal census schedule. Pre-1850, so only the head of household is named; all other occupants are tal...
+
+**assistant:** Now I need to link the new assertions to person I1 via person-evidence.
+
+**tool_use** `Skill` — args: {"skill": "person-evidence"}
+
+**tool_result:** Launching skill: person-evidence
+
+**assistant:** Linking assertions a_026 and a_027 (1840 David Bagley census) to I1. Since I1 is an existing stub with no FamilySearch ARK, `same_person` would return a degenerate score — relying on qualitative correlation: name "David Bagley" + Topsham, Orange, Vermont 1840 is a strong match to I1's established identity. Materializing the 1840 residence onto I1, then linking.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__materialize_facts", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__materialize_facts"}]
+
+**tool_use** `mcp__genealogy__materialize_facts` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "personId": "I1", "recordId": "ark:/61903/1:1:XHRB-V42", "recordRole": "head_of_household"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"personId\": \"I1\",\n  \"created\": false,\n  \"factsAdded\": 1,\n  \"factsEnriched\": 0,\n  \"namesAdded\": 0,\n  \"refsAttached\": 2,\n  \"conflicts_surfaced\": [],\n  \"filesWritten\": [\n    \"tree.gedcomx.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** 1840 Topsham residence added to I1. Now linking assertions to I1.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "ops": [{"section": "person_evidence", "op": "append", "entry": {"assertion_id": "a_026", "person_id": "I1", "confidence": "probable", "match_score": null, "rationale": "The 1840 census head of household 'David Bagley' in Topsham, Orange, Vermont matches I1 (David Bagley) by name and location. I1 is already corroborated by two 1884 Vermont death records naming 'David Bagley' as William ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_031\"\n    },\n    {\n      \"section\": \"person_evidence\",\n      \"op\": \"append\",\n      \"entryId\": \"pe_032\"\n    }\n  ],\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** All plan items completed or skipped. All assertions linked. Now evaluating exhaustiveness.
+
+**tool_use** `Skill` — args: {"skill": "research-exhaustiveness"}
+
+**tool_result:** Launching skill: research-exhaustiveness
+
+**assistant:** Reading the exhaustiveness framework before evaluating.
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/research-exhaustiveness/references/research-exhaustiveness.md"}
+
+**tool_result:** 1	# Exhaustiveness Evaluation
+2	
+3	Guidance for determining when research on a question qualifies as
+4	"reasonably exhaustive" under GPS Component 1.
+5	
+6	## What "Reasonably Exhaustive" Means
+7	
+8	Reasonably exhaustive research is systematic investigation that
+9	searches all available and relevant sources — not just the ones
+10	that are easiest to access or most popular. The standard requires
+11	looking broadly across record types, repositories, and time periods
+12	to ensure no significant s...
+
+**assistant:** **Precondition check — all clear:**
+- All assertions for q_001 carry valid `information_quality` and `evidence_type` (set at extraction)
+- Both key persons (MJDL-Q8B = William, I1 = David Bagley) have linked identity assertions
+- No tentative values ([?] / [tentative]) in any linked assertion
+
+**Five threshold questions:**
+
+1. **Answered?** YES — Two Vermont Town Clerk death record indexings directly name David Bagley as William A. Bagley's father; census records corroborate David Bagley's Topsham presence 1820–1840.
+2. **Broad record types?** YES — Census (1820, 1830, 1840), vital records (birth index + death/town-clerk), marriage records (indexed), probate (indexed), and full-text search of Topsham town records 1771–1860. Land records and browse-only Bradford District probate are noted gaps.
+3. **All relevant strategies?** YES — Name variants (Bagley/Bayley/Baley), FAN-cluster (town records full-text showing David Bagley + Andrews co-occurrences), multiple jurisdictions (Vermont statewide + Topsham-specific).
+4. **Originals accessed?** YES — Vermont Town Clerk entries are original records; censuses are original government schedules. No derivative relied upon for the parentage conclusion.
+5. **Conflicts resolved?** YES (none exist) — No source names an alternative father.
+
+**7-Point Stop Criteria — assessed:**
+
+| Criterion | Assessment |
+|---|---|
+| `goal_alignment` | Two Vermont death records explicitly name David Bagley as father; 1820 and 1840 censuses corroborate his Topsham presence across decades. Convincing answer obtained. |
+| `repository_breadth` | FamilySearch census, Vermont vital (birth index + town-clerk), Vermont marriage, Vermont probate indexed, Topsham town records full-text all searched. Bradford District browse-only probate (75K images, 0% indexed) is genuinely inaccessible. Ancestry local history and land records skipped; noted as minor gaps unlikely to contradict established direct evidence. |
+| `original_substitution` | Both death records are original Vermont Town Clerk entries; 1820 and 1840 censuses are original government schedules. No derivative source carries the parentage claim. |
+| `independent_verification` | QPQP-R8T8 and QPQP-24HR are two indexings of ONE original — one evidence unit (direct, secondary information). The 1820 census (XHLG-T8R) and 1840 census (XHRB-V42) are independent units from different record-creation events and informants, providing indirect corroboration. Two independent evidence units confirm the conclusion. |
+| `evidence_class` | Vermont Town Clerk death entry is original; for the parentage fact it contains secondary information (informant not present at William's 1815 birth) but is direct evidence (the record explicitly states the relationship). Original + direct class achieved. |
+| `conflict_resolution` | No conflicting information across any searched source. No alternative candidate father appeared. |
+| `overturn_risk` | Low. The Bradford District probate (inaccessible) might corroborate but is unlikely to contradict. Land records not searched — a small residual risk — but no evidence anywhere suggests a different father. The explicit naming in the death record plus 20+ years of consistent Topsham census presence make overturn highly implausible. |
+
+**Decision: DECLARE EXHAUSTIVE.** All criteria met.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "questions", "op": "update", "entryId": "q_001", "fields": {"status": "exhaustive_declared", "exhaustive_declaration": {"declared": true, "justification": "Searched Vermont Town Clerk vital records (death entries directly naming David Bagley as father), federal census 1820 and 1840 (David Bagley in Topsham both years), Vermont birth index, Vermont marriage records (indexed), ...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"questions\",\n  \"op\": \"update\",\n  \"entryId\": \"q_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Research declared reasonably exhaustive. Routing to proof-conclusion.
+
+**tool_use** `Skill` — args: {"skill": "proof-conclusion"}
+
+**tool_result:** Launching skill: proof-conclusion
+
+**assistant:** Reading GPS proof-writing guidance and gathering source citations.
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/.claude/skills/proof-conclusion/references/gps-proof-writing.md"}
+
+**tool_result:** 1	# GPS Proof Writing Reference
+2	
+3	This reference provides detailed guidance for writing genealogical
+4	proof conclusions that conform to the Genealogical Proof Standard.
+5	
+6	## The Five GPS Components (All Required for Proof)
+7	
+8	A conclusion qualifies as "proved" ONLY when all five are satisfied:
+9	
+10	1. **Reasonably exhaustive research** — Every record type and
+11	   repository that could plausibly contain relevant information has
+12	   been searched. Not every record ever created, bu...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json", "offset": 346, "limit": 80}
+
+**tool_result:** 346	      "plan_item_id": "pli_008",
+347	      "performed": "2026-07-27T19:32:07.024Z",
+348	      "tool": "record_search",
+349	      "query": {
+350	        "surname": "Bagley",
+351	        "givenName": "David",
+352	        "residencePlace": "Topsham, Vermont",
+353	        "residenceYearFrom": 1840,
+354	        "residenceYearTo": 1840,
+355	        "recordType": "census",
+356	        "count": 50
+357	      },
+358	      "outcome": "positive",
+359	      "results_examined": 2,
+360	      "external_s...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json", "offset": 430, "limit": 50}
+
+**tool_result:** 430	        "where_within": "Entry for William A Bagley and David Bagley, 31 May 1884"
+431	      },
+432	      "source_classification": "original",
+433	      "repository": "FamilySearch",
+434	      "access_date": "2026-07-27",
+435	      "url": "https://www.familysearch.org/ark:/61903/1:1:QPQP-24HR",
+436	      "notes": "Second indexing of the same original document as ark:/61903/1:1:QPQP-R8T8. This indexing captures the death place (Topsham, Orange, Vermont) and indexes both William A. Bagley a...
+
+**assistant:** Now I have all source citations verbatim. Proceeding to write the proof conclusion.
+
+**Preconditions — all pass:**
+- All assertions for q_001 carry valid `information_quality` / `evidence_type` (set at extraction)
+- MJDL-Q8B (William) identified by pe_001; I1 (David Bagley) identified by pe_009/pe_027/pe_031
+- No conflicts exist
+
+**Tier: `probable`** — The Vermont Town Clerk death entry provides direct evidence of parentage but as *secondary information* (the 1884 informant was not present at William's ~1815 birth). Two indexings of one original = one evidence unit for the parentage claim; the 1820 and 1840 censuses provide independent indirect corroboration via David Bagley's consistent Topsham residence. GPS Component 1 (exhaustiveness) is declared; Components 2–4 are met; Component 5 will be written. The absence of a marriage record for David Bagley + Sarah Andrews and the primary-information gap in the direct parentage source prevent "proved."
+
+**Form: `summary`** — Multiple sources, correlation needed, minor informant-quality limitations to explain.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__tree_edit", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__tree_edit"}]
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/tree.gedcomx.json", "limit": 60}
+
+**tool_result:** 1	{
+2	  "persons": [
+3	    {
+4	      "id": "MJDL-Q8B",
+5	      "gender": "Male",
+6	      "living": false,
+7	      "names": [
+8	        {
+9	          "id": "N1",
+10	          "given": "William A.",
+11	          "surname": "Bagley"
+12	        },
+13	        {
+14	          "id": "N7",
+15	          "type": "BirthName",
+16	          "given": "William A",
+17	          "surname": "Bagley",
+18	          "sources": [
+19	            {
+20	              "ref": "S1",
+21	              "quality": 3
+22	      ...
+
+**assistant:** Writing the proof summary, then encoding the concluded ParentChild relationship.
+
+**tool_use** `mcp__genealogy__research_append` — args: {}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"research.json not found in projectPath\"\n  ]\n}"}]
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "proof_summaries", "op": "append", "entry": {"question_id": "q_001", "tier": "probable", "vehicle": "summary", "supporting_assertion_ids": ["a_005", "a_015", "a_024", "a_025", "a_027"], "resolved_conflict_ids": [], "exhaustive_search_summary": "Research encompassed Vermont Town Clerk vital records (FamilySearch collection 1987653 \u2014 yielded two indexings of the 1884 Topsh...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"proof_summaries\",\n  \"op\": \"append\",\n  \"entryId\": \"ps_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Proof summary ps_001 written. Now encoding the ParentChild relationship in the tree.
+
+**tool_use** `mcp__genealogy__tree_edit` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "operation": "add_relationship", "relationship": {"type": "ParentChild", "parent": "I1", "child": "MJDL-Q8B"}, "sourceAssertionId": "a_005"}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"operation\": \"add_relationship\",\n  \"filesWritten\": [\n    \"tree.gedcomx.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  },\n  \"assignedIds\": {\n    \"relationship\": \"R7\"\n  }\n}"}]
+
+**assistant:** Now setting primary: true on William's concluded birth and death facts.
+
+**tool_use** `ToolSearch` — args: {"query": "select:mcp__genealogy__tree_correct", "max_results": 1}
+
+**tool_result:** [{"type": "tool_reference", "tool_name": "mcp__genealogy__tree_correct"}]
+
+**tool_use** `mcp__genealogy__tree_correct` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "ops": [{"operation": "update_fact", "personId": "MJDL-Q8B", "factId": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100", "fact": {"primary": true}}, {"operation": "update_fact", "personId": "MJDL-Q8B", "factId": "ddb21ddf-0042-4808-af3c-5b2e94e08922", "fact": {"primary": true}}]}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"results\": [\n    {\n      \"operation\": \"update_fact\"\n    },\n    {\n      \"operation\": \"update_fact\"\n    }\n  ],\n  \"filesWritten\": [\n    \"tree.gedcomx.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** ParentChild R7 (I1 → MJDL-Q8B) written; primary set on birth and death facts. Stamping project updated, then routing to the mandatory proof-critique gate.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "project", "op": "update", "fields": {}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"project\",\n  \"op\": \"update\",\n  \"entryId\": \"project\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Now running the mandatory `proof-critique` mentor gate on ps_001.
+
+**tool_use** `Agent` — args: {"description": "GPS mentor proof-critique of ps_001", "subagent_type": "gps-mentor", "prompt": "Please conduct a mandatory `proof-critique` evaluation of proof summary **ps_001** for question q_001 in the research project at:\n\n**Project path:** `/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2`\n\n**Context:** This is the required post-proof-conclusion mentor gate. The proof summary ps_001 was just written (tier: probable, vehicle: summary). It concl...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json"}
+
+**tool_result:** File content (28268 tokens) exceeds maximum allowed tokens (25000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json", "offset": 1, "limit": 100}
+
+**tool_result:** 1	{
+2	  "project": {
+3	    "id": "rp_bagley_father_1884",
+4	    "objective": "Who was the father of William A. Bagley, born about 1815 and died 31 May 1884 in Topsham, Orange County, Vermont?",
+5	    "subject_person_ids": [
+6	      "MJDL-Q8B"
+7	    ],
+8	    "status": "active",
+9	    "created": "2026-07-27",
+10	    "updated": "2026-07-27"
+11	  },
+12	  "researcher_profile": {
+13	    "experience_level": "intermediate",
+14	    "subscriptions": [],
+15	    "narration_guidance": "concise"
+16	  },
+17...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json", "offset": 100, "limit": 250}
+
+**tool_result:** 100	          "sequence": 4,
+101	          "record_type": "vital_record",
+102	          "jurisdiction": "Vermont",
+103	          "date_range": "1790-1820",
+104	          "repository": "FamilySearch",
+105	          "rationale": "Dedicated search for the marriage of Sarah Sally Andrews to a Bagley — the parents' marriage record. Per the record-type guide, a parentage plan requires a separate item for the parents' marriage: it (a) establishes the couple as a unit, (b) supplies the mother's maide...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json", "offset": 350, "limit": 250}
+
+**tool_result:** 350	        "surname": "Bagley",
+351	        "givenName": "David",
+352	        "residencePlace": "Topsham, Vermont",
+353	        "residenceYearFrom": 1840,
+354	        "residenceYearTo": 1840,
+355	        "recordType": "census",
+356	        "count": 50
+357	      },
+358	      "outcome": "positive",
+359	      "results_examined": 2,
+360	      "external_site": null,
+361	      "results_ref": "results/log_009.json",
+362	      "results_available": 2,
+363	      "notes": "Found 2 results — both are 'H...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json", "offset": 600, "limit": 250}
+
+**tool_result:** 600	    },
+601	    {
+602	      "id": "a_007",
+603	      "record_id": "ark:/61903/1:1:QPQP-R8T8",
+604	      "record_persona_id": "p_104363515697",
+605	      "record_role": "father_of_deceased",
+606	      "fact_type": "name",
+607	      "value": "David Bagley",
+608	      "structured_value": {
+609	        "given": "David",
+610	        "surname": "Bagley"
+611	      },
+612	      "information_quality": "secondary",
+613	      "informant": "unknown household member or family informant",
+614	      "inf...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json", "offset": 850, "limit": 250}
+
+**tool_result:** 850	      "id": "a_020",
+851	      "record_id": "ark:/61903/1:1:QPQP-24HR",
+852	      "record_persona_id": "p_104363376577",
+853	      "record_role": "mother_of_deceased",
+854	      "fact_type": "sex",
+855	      "value": "Female",
+856	      "information_quality": "secondary",
+857	      "informant": "unknown family or community informant",
+858	      "informant_proximity": "family_not_present",
+859	      "evidence_type": "direct",
+860	      "informant_bias_notes": "Sex stated by role (mother) a...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/research.json", "offset": 1100, "limit": 250}
+
+**tool_result:** 1100	      "confidence": "probable",
+1101	      "match_score": null,
+1102	      "rationale": "Sex=Male for David Bagley (father_of_deceased, QPQP-R8T8) consistent with tree person I1 (male). Same identification as a_007.",
+1103	      "created": "2026-07-27"
+1104	    },
+1105	    {
+1106	      "id": "pe_011",
+1107	      "assertion_id": "a_009",
+1108	      "person_id": "LVDV-6MK",
+1109	      "confidence": "probable",
+1110	      "match_score": null,
+1111	      "rationale": "Sarah A. Bagley (mother...
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/tree.gedcomx.json", "limit": 1}
+
+**tool_result:** 1	{
+
+**tool_use** `Read` — args: {"file_path": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2/tree.gedcomx.json"}
+
+**tool_result:** 1	{
+2	  "persons": [
+3	    {
+4	      "id": "MJDL-Q8B",
+5	      "gender": "Male",
+6	      "living": false,
+7	      "names": [
+8	        {
+9	          "id": "N1",
+10	          "given": "William A.",
+11	          "surname": "Bagley"
+12	        },
+13	        {
+14	          "id": "N7",
+15	          "type": "BirthName",
+16	          "given": "William A",
+17	          "surname": "Bagley",
+18	          "sources": [
+19	            {
+20	              "ref": "S1",
+21	              "quality": 3
+22	      ...
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "evaluations", "op": "append", "verdict": {"focus": "proof-critique", "target_id": "ps_001", "target_type": "proof_summary", "verdict": "address_first", "strengths": ["ps_001 correctly treats the two FamilySearch indexings of the 1884 death entry (src_001/S1, src_002/S2, assertions a_005/a_015) as a single evidence unit and explicitly disqualifies the conclusion from 'Proved'...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"evaluations\",\n  \"op\": \"append\",\n  \"entryId\": \"ev_001\",\n  \"filesWritten\": [\n    \"research.json\",\n    \"evaluations/proof-critique-ps_001-2026-07-27T20-15-00.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**tool_result:** [{"type": "text", "text": "The verdict is written and validated. Here's the review:\n\n# Mentor review: proof-critique on ps_001\n\n## What you've done well\nYou handled the two-indexings-of-one-document problem exactly right: a_005 and a_015 are both drawn from the same original 1884 town-clerk entry, and you counted them as *one* evidence unit rather than pretending two indexings equal two witnesses. That's the discipline behind Standard 46, and it's exactly why you correctly capped the tie...
+
+**assistant:** The mentor's verdict (ev_001) flags two must-address items: (1) the 1820 census tally-mark claim was inferred but never image-verified; (2) the David Bagley Jr./Sr. distinction (found in log_010's full-text results) was not structurally reasoned through. Addressing both before completing. First, adding a hypothesis entry on the Jr./Sr. question; then updating the proof narrative.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "hypotheses", "op": "append", "entry": {"question_id": "q_001", "hypothesis": "David Bagley Jr. \u2014 a second David Bagley documented in Topsham by 1839 \u2014 is William A. Bagley's father rather than David Bagley Sr.", "status": "rejected", "evidence_for": [], "evidence_against": ["a_025", "a_027"], "rationale": "The full-text search of Topsham Town Records 1771-1860 (log...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": false,\n  \"errors\": [\n    \"research.json/hypotheses[0]: missing required field 'claim'\",\n    \"research.json/hypotheses[0]: missing required field 'supporting_assertion_ids'\",\n    \"research.json/hypotheses[0]: missing required field 'contradicting_assertion_ids'\",\n    \"research.json/hypotheses[0]: missing required field 'ruled_out'\",\n    \"research.json/hypotheses[0]: missing required field 'related_question_ids'\",\n    \"research.json/hy...
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "hypotheses", "op": "append", "entry": {"claim": "David Bagley Jr. \u2014 a second David Bagley documented in Topsham by 1839 \u2014 is William A. Bagley's father rather than David Bagley Sr.", "status": "ruled_out", "supporting_assertion_ids": [], "contradicting_assertion_ids": ["a_025", "a_027"], "ruled_out": true, "ruled_out_reason": "The full-text search of Topsham Town R...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"hypotheses\",\n  \"op\": \"append\",\n  \"entryId\": \"h_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Hypothesis h_001 written (David Bagley Jr. ruled out). Now updating the proof narrative to fix the census overstatement and cite h_001.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "proof_summaries", "op": "update", "entryId": "ps_001", "fields": {"narrative_markdown": "# Proof Summary: Father of William A. Bagley (born about 1815, died 31 May 1884, Topsham, Orange County, Vermont)\n\n## Conclusion\n\nThe preponderance of available evidence strongly suggests that **David Bagley** was the father of William A. Bagley (born about 1815, died 31 May 1884, To...
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"proof_summaries\",\n  \"op\": \"update\",\n  \"entryId\": \"ps_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** Both mentor corrections addressed — census overstatement fixed, David Jr./Sr. candidate ruled out in h_001 and cited in the narrative. The proof summary (ps_001) and hypothesis (h_001) are both persisted. Tree-encoding gate passes (ParentChild R7 is in the tree). Mentor gate passes (ev_001 on record). Now routing to question-selection to close q_001 and complete the project.
+
+**tool_use** `Skill` — args: {"skill": "question-selection"}
+
+**tool_result:** Launching skill: question-selection
+
+**assistant:** Reviewing project state from context. The objective is "Who was the father of William A. Bagley..." — q_001 is the sole question, now at `exhaustive_declared` with proof summary ps_001 at `probable` tier. ParentChild R7, mentor gate ev_001, and hypothesis h_001 are all on record. Per Step 1b, the objective is answered at a defensible tier — marking q_001 resolved and returning the completion signal.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "questions", "op": "update", "entryId": "q_001", "fields": {"status": "resolved", "resolved": "2026-07-27", "resolution_assertion_ids": ["a_005", "a_015"]}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"questions\",\n  \"op\": \"update\",\n  \"entryId\": \"q_001\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** All questions resolved. Both completion gates verified — ParentChild R7 is in the tree, ev_001 is on record. Writing `project.status = "completed"`.
+
+**tool_use** `mcp__genealogy__research_append` — args: {"projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/e2e-bagley-father-1884-p2bn27l2", "section": "project", "op": "update", "fields": {"status": "completed"}}
+
+**tool_result:** [{"type": "text", "text": "{\n  \"ok\": true,\n  \"section\": \"project\",\n  \"op\": \"update\",\n  \"entryId\": \"project\",\n  \"filesWritten\": [\n    \"research.json\"\n  ],\n  \"validation\": {\n    \"valid\": true,\n    \"warnings\": []\n  }\n}"}]
+
+**assistant:** The project is complete. Here is a summary of what was found and done:
+
+---
+
+**Answer: David Bagley was highly probably the father of William A. Bagley.**
+
+**Evidence base:**
+- **Primary (direct):** Two FamilySearch indexings of the same 31 May 1884 Vermont Town Clerk death entry (QPQP-R8T8 / QPQP-24HR) explicitly name "David Bagley" as William A. Bagley's father — original record, secondary information (the informant was not present at William's ~1815 birth), direct evidence. This is one evidence unit.
+- **Corroborating (indirect):** 1820 federal census (XHLG-T8R) places David Bagley in Topsham when William was ~5; 1840 federal census (XHRB-V42) places him there when William was ~25 — original records, primary information, independent evidence unit.
+- **Circumstantial:** Full-text search of Topsham town records 1771–1860 found "Sophia Andrews Bagley" in an 1813 entry, consistent with David Bagley having married Sarah Andrews (William's known mother).
+
+**Tier: `probable`** — Single direct-evidence document (secondary information); two census records provide independent indirect corroboration. A second primary-information source (probate will, land deed, or birth record) would be needed to reach `proved`.
+
+**Tree:** ParentChild relationship R7 (I1 David Bagley → MJDL-Q8B William A. Bagley) written to `tree.gedcomx.json`.
+
+**Proof summary:** ps_001 in `research.json`; full narrative in `proof_summaries[0].narrative_markdown`.
+
+**Remaining path to `proved`:** The Bradford District estate files (FamilySearch collection 1807377, 75,694 unindexed images) or Topsham land records could yield a David Bagley probate or deed naming William as a son.

--- a/eval/tests/e2e/bagley-father-1884/README.md
+++ b/eval/tests/e2e/bagley-father-1884/README.md
@@ -46,10 +46,15 @@ cheap and its answer unambiguous.
 ## Expected difficulty
 
 easy — the father's name is stated directly on a single vital record
-tied to William's own death entry. No competing candidates, no
-surname-spelling problem beyond the ordinary variants already visible
-in the source titles ("Bagley" vs "Willaim A. Bagley"), no FAN
-research needed.
+tied to William's own death entry. No surname-spelling problem beyond
+the ordinary variants already visible in the source titles ("Bagley"
+vs "Willaim A. Bagley"), no FAN research needed. **Correction (see
+"First live run" below): this originally said "no competing
+candidates" — that was wrong.** Topsham has a contemporary "David
+Bagley Jr." the authoring pass never surfaced; recovering the father's
+*name* is easy, but pinning that name to a specific, identity-scored
+individual (distinct from the Jr.) is not as trivial as the original
+authoring made it look.
 
 ## Notes for reviewers
 
@@ -63,3 +68,39 @@ and William himself (`ebe0d4fe-...`/`ddb21ddf-...`, renamed with a
 `-KHY4` suffix on Ann's copies) and an invalid lowercase `"cemetery"`
 fact type on David Bagley (removed — it duplicated information already
 present on his `Burial` fact).
+
+## First live run (2026-07-27)
+
+`run-2026-07-27_20-01-40` — judge scored **pass** (proof_quality 3/3),
+but the blind annotation (`run-2026-07-27_20-01-40.ann.json`)
+downgrades it to **partial**: David Bagley is correctly added as a new
+person with a `ParentChild` link to William, sourced to the 1884
+death entry, but the person is not pinned to an identity — no birth
+fact (expected 22 Feb 1777, Newton, Rockingham, NH), no death fact —
+and the agent's own narrative surfaces a co-resident **"David Bagley
+Jr."** in Topsham that the tree as written does not distinguish from
+the father. This is a real confounder on FamilySearch that the
+original authoring pass (this README's "no competing candidates"
+line) missed — recovering the *name* "David Bagley" is genuinely easy;
+confirming *which* David Bagley, with a pinned birth/death and an
+explicit ruling-out of the Jr., is not, and this fixture's expected
+findings don't currently require it.
+
+Separately, the same run is the source example for
+`docs/plan/research-guardrail-bypass-plan.md`'s §9 and GitHub issues
+[#911](https://github.com/PioneerAIAcademy/cowork-genealogy/issues/911)
+and
+[#913](https://github.com/PioneerAIAcademy/cowork-genealogy/issues/913):
+the father was linked across 13 `person_evidence` entries entirely
+inline (never through `person-evidence`), with `same_person` called
+zero times in the whole run. That bug and this identity-pinning gap
+are independent findings from the same run, not the same issue — fixing
+the orchestration bypass does not by itself fix the Jr./Sr. confusion,
+which is a separate, ordinary research-quality gap.
+
+Not yet decided: whether to add a required finding for the birth/death
+facts and the Jr. disambiguation (raising this fixture's real
+difficulty above "easy"), or leave it as encountered and accept
+"partial" as this fixture's realistic ceiling until person-evidence's
+identity-scoring gap (the orchestration bug) is fixed. Revisit once a
+run exists that goes through `same_person` properly for this record.

--- a/eval/tests/e2e/bagley-father-1884/README.md
+++ b/eval/tests/e2e/bagley-father-1884/README.md
@@ -1,0 +1,65 @@
+# Find the father of William A. Bagley (Topsham, VT, 1815-1884)
+
+**Source PID:** `MJDL-Q8B`
+**William A. Bagley is deceased.** (b. abt 1815, West Topsham, Orange
+County, Vermont; d. 31 May 1884, Topsham, Orange County, Vermont.)
+FamilySearch ToS requires all committed e2e fixtures to be about
+deceased persons. His father David Bagley (b. 1777, d. 1854) and
+mother Sarah "Sally" Andrews (b. 1777, d. 1847) are also long
+deceased, as is his wife Ann Tillotson (b. 1826, d. 1876).
+
+## Research question
+
+> Who was the father of William A. Bagley, born about 1815 and died
+> 31 May 1884 in Topsham, Orange County, Vermont?
+
+## Expected answer
+
+- **Father:** David Bagley — b. 22 February 1777, Newton, Rockingham
+  County, New Hampshire; d. 5 October 1854, West Topsham, Orange
+  County, Vermont.
+
+David Bagley is named directly as father on William's own entry in
+*Vermont, Town Clerk, Vital and Town Records, 1732-2005*, recorded at
+William's death, 31 May 1884, Topsham. This is a single-record answer
+— no cross-record reasoning or FAN research is required, which is a
+deliberate authoring choice (see Notes).
+
+## What was removed from the starting tree
+
+- Removed person LVDV-DBC: David Bagley
+- Removed relationship R2 (Couple LVDV-DBC/LVDV-6MK): cascaded from a removed person
+- Removed relationship R3 (ParentChild LVDV-DBC/MJDL-Q8B): cascaded from a removed person
+- Removed source 92ND-NS5: Willaim A. Bagley, "Vermont Vital Records, 1760-1954"
+- Removed source SCYG-11X: William A Bagley, "Vermont, Town Clerk, Vital and Town Records, 1732-2005"
+- Removed source SCYG-1X5: William A Bagley, "Vermont, Town Clerk, Vital and Town Records, 1732-2005"
+
+William's mother, Sarah "Sally" Andrews, is deliberately **left in the
+starting tree** (only the father was stripped). She has no
+independently attested source connecting her to William as his
+mother in this snapshot, so a "who were the parents" (both) question
+would reproduce the same unrecoverable-mother problem seen in other
+fixtures (e.g. `john-richardson-parents`) — not what this fixture is
+for. Scoping the question to the father alone keeps this fixture
+cheap and its answer unambiguous.
+
+## Expected difficulty
+
+easy — the father's name is stated directly on a single vital record
+tied to William's own death entry. No competing candidates, no
+surname-spelling problem beyond the ordinary variants already visible
+in the source titles ("Bagley" vs "Willaim A. Bagley"), no FAN
+research needed.
+
+## Notes for reviewers
+
+Authored to exercise the changes in
+`docs/plan/research-guardrail-bypass-plan.md` end to end against a
+real, cheap `/research` run — not as a benchmark stress case. The
+authoring source data had two data-quality issues fixed by hand in
+`unstripped-tree.gedcomx.json` before `strip`/`validate` would accept
+it: two duplicate fact ids shared between William's wife Ann Tillotson
+and William himself (`ebe0d4fe-...`/`ddb21ddf-...`, renamed with a
+`-KHY4` suffix on Ann's copies) and an invalid lowercase `"cemetery"`
+fact type on David Bagley (removed — it duplicated information already
+present on his `Burial` fact).

--- a/eval/tests/e2e/bagley-father-1884/expected-findings.json
+++ b/eval/tests/e2e/bagley-father-1884/expected-findings.json
@@ -1,0 +1,21 @@
+{
+  "findings": [
+    {
+      "id": "f1",
+      "type": "relationship",
+      "description": "William A. Bagley's father is David Bagley",
+      "details": {
+        "subject_person": "William A. Bagley (PID MJDL-Q8B)",
+        "relation": "parent",
+        "target_person": {
+          "name": "David Bagley",
+          "birth": "22 February 1777, Newton, Rockingham, New Hampshire"
+        }
+      },
+      "supporting_sources": [
+        "Vermont, Town Clerk, Vital and Town Records, 1732-2005 — entry for William A Bagley naming father David Bagley, recorded at William's death, 31 May 1884, Topsham, Orange County, Vermont"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/eval/tests/e2e/bagley-father-1884/fixture.json
+++ b/eval/tests/e2e/bagley-father-1884/fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "bagley-father-1884",
+  "name": "Find the father of William A. Bagley (Topsham, VT, 1815-1884)",
+  "genre": "strip",
+  "source_pid": "MJDL-Q8B",
+  "captured": "2026-07-27",
+  "researcher_question": "Who was the father of William A. Bagley, born about 1815 and died 31 May 1884 in Topsham, Orange County, Vermont?",
+  "tags": {
+    "question_type": "parents",
+    "era": "1810s-1880s",
+    "geography": "US-VT"
+  },
+  "model": {
+    "agent": "claude-sonnet-4-6",
+    "judge": "claude-haiku-4-5-20251001"
+  },
+  "difficulty": "easy",
+  "notes": "Father named directly on William's own 1884 death-record town-clerk entry; single-record answer, no cross-record reasoning required. Authored to exercise the research-guardrail-bypass-plan changes end to end, not as a benchmark stress case."
+}

--- a/eval/tests/e2e/bagley-father-1884/starting-research.json
+++ b/eval/tests/e2e/bagley-father-1884/starting-research.json
@@ -1,0 +1,28 @@
+{
+  "project": {
+    "id": "rp_bagley_father_1884",
+    "objective": "Who was the father of William A. Bagley, born about 1815 and died 31 May 1884 in Topsham, Orange County, Vermont?",
+    "subject_person_ids": [
+      "MJDL-Q8B"
+    ],
+    "status": "active",
+    "created": "2026-07-27",
+    "updated": "2026-07-27"
+  },
+  "researcher_profile": {
+    "experience_level": "intermediate",
+    "subscriptions": [],
+    "narration_guidance": "concise"
+  },
+  "questions": [],
+  "plans": [],
+  "log": [],
+  "sources": [],
+  "assertions": [],
+  "person_evidence": [],
+  "conflicts": [],
+  "hypotheses": [],
+  "timelines": [],
+  "proof_summaries": [],
+  "evaluations": []
+}

--- a/eval/tests/e2e/bagley-father-1884/starting-tree.gedcomx.json
+++ b/eval/tests/e2e/bagley-father-1884/starting-tree.gedcomx.json
@@ -1,0 +1,325 @@
+{
+  "persons": [
+    {
+      "id": "MJDL-Q8B",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "William A.",
+          "surname": "Bagley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "Abt 1815",
+          "standard_date": "Abt 1815",
+          "place": "West Topsham, Orange, Vermont",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "31 May 1884",
+          "standard_date": "31 May 1884",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "28119bdf-00ed-4c5f-a9fc-9b39c096b055",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        }
+      ]
+    },
+    {
+      "id": "L528-9HM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Eva Belle",
+          "surname": "Bagley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "c65fd7c9-7586-4a5c-98b1-27981c8f4ed3",
+          "type": "Birth",
+          "date": "29 July 1847",
+          "standard_date": "29 Jul 1847",
+          "place": "Barre, Barre, Washington, Vermont, United States",
+          "standard_place": "Barre City, Washington, Vermont, United States"
+        },
+        {
+          "id": "56040e10-989e-42e1-9470-cf3a7d385136",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "8a8e2950-70c9-42c0-955a-3ebaac83ae4e",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Vermont, United States",
+          "standard_place": "Vermont, United States"
+        },
+        {
+          "id": "926a74b0-628f-430a-85a8-fc5862acc2b9",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "cc5e47c1-61b1-44ba-ac2c-fd5777bdc0d3",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Barre town, north side (excl. Barre city), Washington, Vermont, United States",
+          "standard_place": "Barre Town, Washington, Vermont, United States"
+        },
+        {
+          "id": "4f2dc707-d54e-4d9b-b186-ec63924623b5",
+          "type": "Death",
+          "date": "7 March 1925",
+          "standard_date": "7 Mar 1925",
+          "place": "Barre, Barre, Washington, Vermont, United States",
+          "standard_place": "Barre City, Washington, Vermont, United States"
+        },
+        {
+          "id": "01b023a0-dc7f-441f-bc65-f846e51e9477",
+          "type": "Burial",
+          "place": "West Topsham Cemetery, West Topsham, Orange, Vermont, United States of America",
+          "standard_place": "West Topsham Cemetery, Topsham, Orange, Vermont, United States"
+        }
+      ]
+    },
+    {
+      "id": "KHY4-7VP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Ann",
+          "surname": "Tillotson"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100-KHY4",
+          "type": "Birth",
+          "date": "1826",
+          "standard_date": "1826",
+          "place": "Topsham, Orange, Vt.",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "5bad4ac9-d8e9-4a9b-a820-af1dc0708089",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "716108d5-252f-4c2b-9eaa-0d98e8a7434a",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Vermont, United States",
+          "standard_place": "Vermont, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922-KHY4",
+          "type": "Death",
+          "date": "30 Apr 1876",
+          "standard_date": "30 Apr 1876",
+          "place": "Vermont, United States",
+          "standard_place": "Vermont, United States"
+        },
+        {
+          "id": "c0d5bbc8-4524-4880-9947-245327865519",
+          "type": "Burial",
+          "date": "1876",
+          "standard_date": "1876",
+          "place": "West Topsham, Orange, Vermont, United States of America",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        }
+      ]
+    },
+    {
+      "id": "LVDV-6MK",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Sarah Sally",
+          "surname": "Andrews"
+        }
+      ],
+      "facts": [
+        {
+          "id": "377e6373-a54b-4d9c-8dbb-21e46d2d96e2",
+          "type": "Birth",
+          "date": "1777",
+          "standard_date": "1777",
+          "place": "Gloucester, Essex, Massachusetts, United States",
+          "standard_place": "Gloucester, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "fb32b179-b61e-42ac-a43f-192eae4a6c1b",
+          "type": "Christening",
+          "date": "7 December 1777",
+          "standard_date": "7 Dec 1777",
+          "place": "Gloucester, Essex, Massachusetts, United States",
+          "standard_place": "Gloucester, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "af27bdb3-0190-4145-8100-880432d43893",
+          "type": "Death",
+          "date": "19 March 1847",
+          "standard_date": "19 Mar 1847",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "fc30de70-823f-4852-91a3-ec94704349dc",
+          "type": "Burial",
+          "date": "March 1947",
+          "standard_date": "Mar 1947",
+          "place": "Old West Topsham Cemetery, Topsham, Orange, Vermont, USA",
+          "standard_place": "West Topsham Cemetery, Topsham, Orange, Vermont, United States"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "MJDL-Q8B",
+      "person2": "KHY4-7VP",
+      "facts": [
+        {
+          "id": "2519e746-0a0a-4421-8726-7d1c729c22b8",
+          "type": "Marriage",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        }
+      ]
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "LVDV-6MK",
+      "child": "MJDL-Q8B",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "MJDL-Q8B",
+      "child": "L528-9HM"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "KHY4-7VP",
+      "child": "L528-9HM"
+    }
+  ],
+  "sources": [
+    {
+      "id": "31KH-KNQ",
+      "title": "William A Bagley, \"United States, Census, 1850\"",
+      "citation": "\"United States, Census, 1850\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:MC26-77Q : Sun Oct 19 18:25:15 UTC 2025), Entry for William A Bagley and Ann Bagley, 1850.",
+      "url": "https://familysearch.org/ark:/61903/1:1:MC26-77Q"
+    },
+    {
+      "id": "3PJB-YFV",
+      "title": "Wm A Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQP-JBTG : Fri Mar 08 23:31:40 UTC 2024), Entry for Andrew Thurston and Eva Ann Bagley.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQP-JBYH"
+    },
+    {
+      "id": "S8BB-N5D",
+      "title": "William Bugby, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQG-NCL1 : Sun Mar 10 04:53:23 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 November 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQR-3PN5"
+    },
+    {
+      "id": "S8BB-N2L",
+      "title": "William Bugby, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQ5-76SN : Sat Mar 09 09:59:37 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 November 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQ5-6Q6G"
+    },
+    {
+      "id": "S8BB-NNT",
+      "title": "William Bugby, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQK-7V5H : Fri Mar 08 04:46:12 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 November 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQV-NR2M"
+    },
+    {
+      "id": "S8BB-N8N",
+      "title": "William Bugby, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQP-LGDS : Sat Mar 09 10:13:38 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 November 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQ5-KDX4"
+    },
+    {
+      "id": "S8BB-FRM",
+      "title": "William Bugbee, \"Vermont, Vital Records, 1760-1954\"",
+      "citation": "\"Vermont, Vital Records, 1760-1954\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XFVQ-L5R : Thu Mar 07 02:55:48 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 Nov 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XFVQ-L5Y"
+    },
+    {
+      "id": "S8BB-FL6",
+      "title": "Wm A Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q28Q-6HTN : Sat Mar 09 19:35:29 UTC 2024), Entry for Andrew Thurston and Andrew Thurston, 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q28Q-6CM7"
+    },
+    {
+      "id": "SCBT-5CN",
+      "title": "William A Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQL-XX78 : Sat Mar 09 22:59:33 UTC 2024), Entry for Andrew Thurston and Eva Ann Bagley, 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQL-XX7V"
+    },
+    {
+      "id": "9NCT-WB5",
+      "title": "William Bagley, \"United States, Census, 1870\"",
+      "citation": "\"United States, Census, 1870\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:M6RC-8PY : Thu Jan 09 15:19:37 UTC 2025), Entry for William Bagley and Ann Bagley, 1870.",
+      "url": "https://familysearch.org/ark:/61903/1:1:M6RC-8PY"
+    },
+    {
+      "id": "9N3F-5LL",
+      "title": "William Bagley, \"Vermont, Vital Records, 1760-2008\"",
+      "citation": "\"Vermont, Vital Records, 1760-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KN9Y-4CM : Wed Jan 29 23:19:38 UTC 2025), Entry for Evie Viel Thurston and William Bagley, 07 Mar 1925.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KN9Y-4C9"
+    },
+    {
+      "id": "9N38-6C4",
+      "title": "William Bagley, \"Vermont, Vital Records, 1760-1954\"",
+      "citation": "\"Vermont, Vital Records, 1760-1954\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:2V7S-65V : Fri Mar 08 22:22:28 UTC 2024), Entry for Evie Vill Thurston and William Bagley, 07 Mar 1925.",
+      "url": "https://familysearch.org/ark:/61903/1:1:2V7S-65K"
+    },
+    {
+      "id": "MSV2-K72",
+      "title": "Wm A Bagley, \"Vermont, Vital Records, 1760-1954\"",
+      "citation": "\"Vermont, Vital Records, 1760-1954\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XFFP-JM2 : Sun Mar 10 11:10:53 UTC 2024), Entry for Andrew Thurston and Eva Ann Bagley, 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XFFP-JMG"
+    }
+  ]
+}

--- a/eval/tests/e2e/bagley-father-1884/unstripped-tree.gedcomx.json
+++ b/eval/tests/e2e/bagley-father-1884/unstripped-tree.gedcomx.json
@@ -1,0 +1,452 @@
+{
+  "persons": [
+    {
+      "id": "MJDL-Q8B",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N1",
+          "given": "William A.",
+          "surname": "Bagley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100",
+          "type": "Birth",
+          "date": "Abt 1815",
+          "standard_date": "Abt 1815",
+          "place": "West Topsham, Orange, Vermont",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922",
+          "type": "Death",
+          "date": "31 May 1884",
+          "standard_date": "31 May 1884",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "28119bdf-00ed-4c5f-a9fc-9b39c096b055",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        }
+      ]
+    },
+    {
+      "id": "L528-9HM",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N2",
+          "given": "Eva Belle",
+          "surname": "Bagley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "c65fd7c9-7586-4a5c-98b1-27981c8f4ed3",
+          "type": "Birth",
+          "date": "29 July 1847",
+          "standard_date": "29 Jul 1847",
+          "place": "Barre, Barre, Washington, Vermont, United States",
+          "standard_place": "Barre City, Washington, Vermont, United States"
+        },
+        {
+          "id": "56040e10-989e-42e1-9470-cf3a7d385136",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "8a8e2950-70c9-42c0-955a-3ebaac83ae4e",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Vermont, United States",
+          "standard_place": "Vermont, United States"
+        },
+        {
+          "id": "926a74b0-628f-430a-85a8-fc5862acc2b9",
+          "type": "Residence",
+          "date": "1880",
+          "standard_date": "1880",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "cc5e47c1-61b1-44ba-ac2c-fd5777bdc0d3",
+          "type": "Residence",
+          "date": "1900",
+          "standard_date": "1900",
+          "place": "Barre town, north side (excl. Barre city), Washington, Vermont, United States",
+          "standard_place": "Barre Town, Washington, Vermont, United States"
+        },
+        {
+          "id": "4f2dc707-d54e-4d9b-b186-ec63924623b5",
+          "type": "Death",
+          "date": "7 March 1925",
+          "standard_date": "7 Mar 1925",
+          "place": "Barre, Barre, Washington, Vermont, United States",
+          "standard_place": "Barre City, Washington, Vermont, United States"
+        },
+        {
+          "id": "01b023a0-dc7f-441f-bc65-f846e51e9477",
+          "type": "Burial",
+          "place": "West Topsham Cemetery, West Topsham, Orange, Vermont, United States of America",
+          "standard_place": "West Topsham Cemetery, Topsham, Orange, Vermont, United States"
+        }
+      ]
+    },
+    {
+      "id": "KHY4-7VP",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N3",
+          "given": "Ann",
+          "surname": "Tillotson"
+        }
+      ],
+      "facts": [
+        {
+          "id": "ebe0d4fe-20f8-4dad-b4b8-c69c03d0f100-KHY4",
+          "type": "Birth",
+          "date": "1826",
+          "standard_date": "1826",
+          "place": "Topsham, Orange, Vt.",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "5bad4ac9-d8e9-4a9b-a820-af1dc0708089",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "716108d5-252f-4c2b-9eaa-0d98e8a7434a",
+          "type": "Residence",
+          "date": "1870",
+          "standard_date": "1870",
+          "place": "Vermont, United States",
+          "standard_place": "Vermont, United States"
+        },
+        {
+          "id": "ddb21ddf-0042-4808-af3c-5b2e94e08922-KHY4",
+          "type": "Death",
+          "date": "30 Apr 1876",
+          "standard_date": "30 Apr 1876",
+          "place": "Vermont, United States",
+          "standard_place": "Vermont, United States"
+        },
+        {
+          "id": "c0d5bbc8-4524-4880-9947-245327865519",
+          "type": "Burial",
+          "date": "1876",
+          "standard_date": "1876",
+          "place": "West Topsham, Orange, Vermont, United States of America",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        }
+      ]
+    },
+    {
+      "id": "LVDV-DBC",
+      "gender": "Male",
+      "living": false,
+      "names": [
+        {
+          "id": "N4",
+          "given": "David",
+          "surname": "Bagley"
+        }
+      ],
+      "facts": [
+        {
+          "id": "79622560-b979-4204-98bf-34e4f965d5b7",
+          "type": "Birth",
+          "date": "22 February 1777",
+          "standard_date": "22 Feb 1777",
+          "place": "Newton, Rockingham, New Hampshire, United States",
+          "standard_place": "Newton, Rockingham, New Hampshire, United States"
+        },
+        {
+          "id": "e2a4eab7-854a-49bb-b680-4395c2cf8e1a",
+          "type": "Residence",
+          "date": "1790",
+          "standard_date": "1790",
+          "place": "Newton, Rockingham, New Hampshire, United States",
+          "standard_place": "Newton, Rockingham, New Hampshire, United States"
+        },
+        {
+          "id": "8a78b4a5-45e2-497f-8097-1ad4714b7649",
+          "type": "Residence",
+          "date": "1800",
+          "standard_date": "1800",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "26860c08-122c-4978-b602-305aab199fca",
+          "type": "Residence",
+          "date": "1820",
+          "standard_date": "1820",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "98a38921-074f-4117-a3dd-0eebb808e6c4",
+          "type": "Residence",
+          "date": "1830",
+          "standard_date": "1830",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "31b84c05-8ea4-4711-8882-b630b35067b0",
+          "type": "Residence",
+          "date": "1840",
+          "standard_date": "1840",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "a3ca8aea-4b58-4dbf-aecf-8fd8437e7791",
+          "type": "Residence",
+          "date": "1850",
+          "standard_date": "1850",
+          "place": "Topsham, Orange, Vermont",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "f1e514fe-d22c-45c0-ae4b-c14cb21b15a0",
+          "type": "Death",
+          "date": "5 October 1854",
+          "standard_date": "5 Oct 1854",
+          "place": "West Topsham, Topsham, Orange, Vermont, United States",
+          "standard_place": "West Topsham, Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "52a19080-3339-40df-9b3f-b80fb7b9b521",
+          "type": "Burial",
+          "date": "October 1854",
+          "standard_date": "Oct 1854",
+          "place": "Old West Topsham Cemetery, West Topsham, Orange, Vermont, USA",
+          "standard_place": "West Topsham Cemetery, Topsham, Orange, Vermont, United States"
+        }
+      ]
+    },
+    {
+      "id": "LVDV-6MK",
+      "gender": "Female",
+      "living": false,
+      "names": [
+        {
+          "id": "N5",
+          "given": "Sarah Sally",
+          "surname": "Andrews"
+        }
+      ],
+      "facts": [
+        {
+          "id": "377e6373-a54b-4d9c-8dbb-21e46d2d96e2",
+          "type": "Birth",
+          "date": "1777",
+          "standard_date": "1777",
+          "place": "Gloucester, Essex, Massachusetts, United States",
+          "standard_place": "Gloucester, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "fb32b179-b61e-42ac-a43f-192eae4a6c1b",
+          "type": "Christening",
+          "date": "7 December 1777",
+          "standard_date": "7 Dec 1777",
+          "place": "Gloucester, Essex, Massachusetts, United States",
+          "standard_place": "Gloucester, Essex, Massachusetts, United States"
+        },
+        {
+          "id": "af27bdb3-0190-4145-8100-880432d43893",
+          "type": "Death",
+          "date": "19 March 1847",
+          "standard_date": "19 Mar 1847",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        },
+        {
+          "id": "fc30de70-823f-4852-91a3-ec94704349dc",
+          "type": "Burial",
+          "date": "March 1947",
+          "standard_date": "Mar 1947",
+          "place": "Old West Topsham Cemetery, Topsham, Orange, Vermont, USA",
+          "standard_place": "West Topsham Cemetery, Topsham, Orange, Vermont, United States"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "id": "R1",
+      "type": "Couple",
+      "person1": "MJDL-Q8B",
+      "person2": "KHY4-7VP",
+      "facts": [
+        {
+          "id": "2519e746-0a0a-4421-8726-7d1c729c22b8",
+          "type": "Marriage",
+          "place": "Topsham, Orange, Vermont, United States",
+          "standard_place": "Topsham, Orange, Vermont, United States"
+        }
+      ]
+    },
+    {
+      "id": "R2",
+      "type": "Couple",
+      "person1": "LVDV-DBC",
+      "person2": "LVDV-6MK",
+      "facts": [
+        {
+          "id": "F1",
+          "type": "Marriage",
+          "date": "1797",
+          "standard_date": "1797",
+          "place": "New Hampshire, United States",
+          "standard_place": "New Hampshire, United States"
+        }
+      ]
+    },
+    {
+      "id": "R3",
+      "type": "ParentChild",
+      "parent": "LVDV-DBC",
+      "child": "MJDL-Q8B",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R4",
+      "type": "ParentChild",
+      "parent": "LVDV-6MK",
+      "child": "MJDL-Q8B",
+      "subtype": "Biological"
+    },
+    {
+      "id": "R5",
+      "type": "ParentChild",
+      "parent": "MJDL-Q8B",
+      "child": "L528-9HM"
+    },
+    {
+      "id": "R6",
+      "type": "ParentChild",
+      "parent": "KHY4-7VP",
+      "child": "L528-9HM"
+    }
+  ],
+  "sources": [
+    {
+      "id": "31KH-KNQ",
+      "title": "William A Bagley, \"United States, Census, 1850\"",
+      "citation": "\"United States, Census, 1850\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:MC26-77Q : Sun Oct 19 18:25:15 UTC 2025), Entry for William A Bagley and Ann Bagley, 1850.",
+      "url": "https://familysearch.org/ark:/61903/1:1:MC26-77Q"
+    },
+    {
+      "id": "3PJB-YFV",
+      "title": "Wm A Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQP-JBTG : Fri Mar 08 23:31:40 UTC 2024), Entry for Andrew Thurston and Eva Ann Bagley.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQP-JBYH"
+    },
+    {
+      "id": "S8BB-N5D",
+      "title": "William Bugby, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQG-NCL1 : Sun Mar 10 04:53:23 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 November 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQR-3PN5"
+    },
+    {
+      "id": "S8BB-N2L",
+      "title": "William Bugby, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQ5-76SN : Sat Mar 09 09:59:37 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 November 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQ5-6Q6G"
+    },
+    {
+      "id": "S8BB-NNT",
+      "title": "William Bugby, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQK-7V5H : Fri Mar 08 04:46:12 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 November 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQV-NR2M"
+    },
+    {
+      "id": "S8BB-N8N",
+      "title": "William Bugby, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQP-LGDS : Sat Mar 09 10:13:38 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 November 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQ5-KDX4"
+    },
+    {
+      "id": "S8BB-FRM",
+      "title": "William Bugbee, \"Vermont, Vital Records, 1760-1954\"",
+      "citation": "\"Vermont, Vital Records, 1760-1954\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XFVQ-L5R : Thu Mar 07 02:55:48 UTC 2024), Entry for Andrew Thurston and Eva B Bugby, 11 Nov 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XFVQ-L5Y"
+    },
+    {
+      "id": "S8BB-FL6",
+      "title": "Wm A Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:Q28Q-6HTN : Sat Mar 09 19:35:29 UTC 2024), Entry for Andrew Thurston and Andrew Thurston, 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:Q28Q-6CM7"
+    },
+    {
+      "id": "SCBT-5CN",
+      "title": "William A Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQL-XX78 : Sat Mar 09 22:59:33 UTC 2024), Entry for Andrew Thurston and Eva Ann Bagley, 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQL-XX7V"
+    },
+    {
+      "id": "SCYG-11X",
+      "title": "William A Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQP-24HR : Sat Mar 09 16:01:36 UTC 2024), Entry for William A Bagley and David Bagley, 31 May 1884.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQP-24HR"
+    },
+    {
+      "id": "SCYG-1X5",
+      "title": "William A Bagley, \"Vermont, Town Clerk, Vital and Town Records, 1732-2005\"",
+      "citation": "\"Vermont, Town Clerk, Vital and Town Records, 1732-2005\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:QPQP-R8T8 : Fri Mar 08 08:57:46 UTC 2024), Entry for William A Bagley and David Bagley, 31 May 1884.",
+      "url": "https://familysearch.org/ark:/61903/1:1:QPQP-R8T8"
+    },
+    {
+      "id": "9NCT-WB5",
+      "title": "William Bagley, \"United States, Census, 1870\"",
+      "citation": "\"United States, Census, 1870\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:M6RC-8PY : Thu Jan 09 15:19:37 UTC 2025), Entry for William Bagley and Ann Bagley, 1870.",
+      "url": "https://familysearch.org/ark:/61903/1:1:M6RC-8PY"
+    },
+    {
+      "id": "9N3F-5LL",
+      "title": "William Bagley, \"Vermont, Vital Records, 1760-2008\"",
+      "citation": "\"Vermont, Vital Records, 1760-2008\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:KN9Y-4CM : Wed Jan 29 23:19:38 UTC 2025), Entry for Evie Viel Thurston and William Bagley, 07 Mar 1925.",
+      "url": "https://familysearch.org/ark:/61903/1:1:KN9Y-4C9"
+    },
+    {
+      "id": "9N38-6C4",
+      "title": "William Bagley, \"Vermont, Vital Records, 1760-1954\"",
+      "citation": "\"Vermont, Vital Records, 1760-1954\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:2V7S-65V : Fri Mar 08 22:22:28 UTC 2024), Entry for Evie Vill Thurston and William Bagley, 07 Mar 1925.",
+      "url": "https://familysearch.org/ark:/61903/1:1:2V7S-65K"
+    },
+    {
+      "id": "MSV2-K72",
+      "title": "Wm A Bagley, \"Vermont, Vital Records, 1760-1954\"",
+      "citation": "\"Vermont, Vital Records, 1760-1954\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XFFP-JM2 : Sun Mar 10 11:10:53 UTC 2024), Entry for Andrew Thurston and Eva Ann Bagley, 1863.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XFFP-JMG"
+    },
+    {
+      "id": "92ND-NS5",
+      "title": "Willaim A. Bagley, \"Vermont Vital Records, 1760-1954\"",
+      "citation": "\"Vermont, Vital Records, 1760-1954\", <i>FamilySearch</i> (https://www.familysearch.org/ark:/61903/1:1:XF8X-MVK : Fri Mar 08 11:49:43 UTC 2024), Entry for Willaim A. Bagley and David Bagley, 1884.",
+      "url": "https://familysearch.org/ark:/61903/1:1:XF8X-MVK"
+    }
+  ]
+}

--- a/packages/engine/mcp-server/src/tools/research-append.ts
+++ b/packages/engine/mcp-server/src/tools/research-append.ts
@@ -174,6 +174,37 @@ function personEvidenceInvariants(entry: any, research: any): string[] {
   ];
 }
 
+/** Tier/exhaustiveness cross-field guardrail (docs/plan/research-guardrail-bypass-plan.md
+ *  §4.2). `proved`/`disproved` claim the research is reasonably exhaustive by
+ *  definition, so either tier requires the referenced question's
+ *  `exhaustive_declaration.declared` to already be `true` — checked against
+ *  `preCallExhaustiveDeclared`, a snapshot taken BEFORE this call's ops began
+ *  applying, never the live-mutating `research` object. Checking the live
+ *  object would let one batch call both declare exhaustiveness and consume it
+ *  for a tier in the same atomic write — `applyOne` mutates `research` in
+ *  place per op, so an earlier op in the same batch has already "happened" by
+ *  the time a later op in that batch is checked. This function only runs when
+ *  the *current* op is the one setting/changing `tier` (see call site), so an
+ *  unrelated update to an already-legitimately-proved entry (proved in an
+ *  earlier, separate call) never re-triggers it. */
+function proofSummaryInvariants(
+  entry: any,
+  preCallExhaustiveDeclared: Map<string, boolean> | undefined,
+): string[] {
+  const tier = entry?.tier;
+  if (tier !== "proved" && tier !== "disproved") return [];
+  const declaredBeforeThisCall = preCallExhaustiveDeclared?.get(entry?.question_id) === true;
+  if (!declaredBeforeThisCall) {
+    return [
+      `tier '${tier}' requires question '${entry?.question_id}' to already carry ` +
+        `exhaustive_declaration.declared === true from BEFORE this call (a batch may not ` +
+        `declare exhaustiveness and consume it for a tier in the same call) — invoke ` +
+        `research-exhaustiveness first, in its own call.`,
+    ];
+  }
+  return [];
+}
+
 export type ResearchAppendSection = keyof typeof SECTIONS | string;
 
 /** One mutation. The body of a single call, or one element of a batch `ops`. */
@@ -538,7 +569,12 @@ function validateNegativeEvidenceRole(entry: Record<string, unknown>): void {
   }
 }
 
-function applyOne(research: any, op: ResearchAppendOp, appendedThisBatch?: Set<string>): AppliedOp {
+function applyOne(
+  research: any,
+  op: ResearchAppendOp,
+  appendedThisBatch?: Set<string>,
+  preCallExhaustiveDeclared?: Map<string, boolean>,
+): AppliedOp {
   const section = op.section;
   const config = SECTIONS[section];
   if (!config) {
@@ -738,6 +774,16 @@ function applyOne(research: any, op: ResearchAppendOp, appendedThisBatch?: Set<s
   // to "confident"; the helper no-ops for every other confidence value.
   if (section === "person_evidence") {
     invariantErrors.push(...personEvidenceInvariants(resultEntry, research));
+  }
+  // Only when THIS op is the one setting/changing tier — append always sets it;
+  // update only when `fields` names it. An unrelated update to an entry already
+  // legitimately proved (in an earlier, separate call) must not re-trigger this.
+  if (section === "proof_summaries") {
+    const tierTouchedThisOp =
+      op.op === "append" || Object.prototype.hasOwnProperty.call(op.fields ?? {}, "tier");
+    if (tierTouchedThisOp) {
+      invariantErrors.push(...proofSummaryInvariants(resultEntry, preCallExhaustiveDeclared));
+    }
   }
   if (invariantErrors.length > 0) {
     throw new ResearchAppendError(invariantErrors);
@@ -1384,6 +1430,15 @@ export async function researchAppend(
 
   try {
     const research = await readJson(projectPath, "research.json");
+    // Snapshot BEFORE any op in this call/batch applies — see
+    // proofSummaryInvariants. Must be taken here, not read off `research`
+    // later, since applyOne mutates `research` in place per op.
+    const preCallExhaustiveDeclared = new Map<string, boolean>(
+      (Array.isArray(research.questions) ? research.questions : []).map((q: any) => [
+        q?.id,
+        q?.exhaustive_declaration?.declared === true,
+      ]),
+    );
     // Heal legacy tree shapes in memory; the healed document is what a
     // composite write persists (same one-shot migration as tree_edit). A
     // research-only call still never writes the tree.
@@ -1448,7 +1503,7 @@ export async function researchAppend(
     const appendedThisBatch = new Set<string>();
     for (let i = 0; i < ops.length; i++) {
       try {
-        applied.push(applyOne(research, ops[i], appendedThisBatch));
+        applied.push(applyOne(research, ops[i], appendedThisBatch, preCallExhaustiveDeclared));
       } catch (e) {
         if (e instanceof ResearchAppendError) {
           // Identify the failing op; nothing has been written.

--- a/packages/engine/mcp-server/tests/tools/research-append.test.ts
+++ b/packages/engine/mcp-server/tests/tools/research-append.test.ts
@@ -734,6 +734,150 @@ describe("research_append (Phase 3)", () => {
     expect(r.ok && r.entryId).toBe("ps_001");
   });
 
+  // docs/plan/research-guardrail-bypass-plan.md §4.2 — tier/exhaustiveness cross-field guardrail.
+  it("rejects tier 'proved' when the question's exhaustive_declaration.declared is false", async () => {
+    await writeProject(); // phase3Research(): q_001 defaults to exhaustive_declaration.declared: false
+    const before = await readFile(join(dir, "research.json"), "utf-8");
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "proof_summaries",
+      op: "append",
+      entry: {
+        question_id: "q_001",
+        tier: "proved",
+        vehicle: "summary",
+        supporting_assertion_ids: ["a_001"],
+        resolved_conflict_ids: [],
+        exhaustive_search_summary: "Searched census + vitals",
+        narrative_markdown: "## Conclusion\n...",
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/exhaustive_declaration\.declared === true/);
+    expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
+  });
+
+  it("rejects a single batch that declares exhaustiveness and consumes it for tier 'proved' in the same call (TOCTOU)", async () => {
+    await writeProject();
+    const before = await readFile(join(dir, "research.json"), "utf-8");
+    const r = await researchAppend({
+      projectPath: dir,
+      ops: [
+        {
+          section: "questions",
+          op: "update",
+          entryId: "q_001",
+          fields: {
+            exhaustive_declaration: { declared: true, log_entry_ids: ["log_001"], stop_criteria: {} },
+          },
+        },
+        {
+          section: "proof_summaries",
+          op: "append",
+          entry: {
+            question_id: "q_001",
+            tier: "proved",
+            vehicle: "summary",
+            supporting_assertion_ids: ["a_001"],
+            resolved_conflict_ids: [],
+            exhaustive_search_summary: "Searched census + vitals",
+            narrative_markdown: "## Conclusion\n...",
+          },
+        },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.join(" ")).toMatch(/exhaustive_declaration\.declared === true/);
+    // All-or-nothing: neither op landed, including the exhaustiveness declaration.
+    expect(await readFile(join(dir, "research.json"), "utf-8")).toBe(before);
+  });
+
+  const fullStopCriteria = () => ({
+    goal_alignment: true,
+    repository_breadth: true,
+    original_substitution: true,
+    independent_verification: true,
+    evidence_class: true,
+    conflict_resolution: true,
+    overturn_risk: true,
+  });
+  const declaredExhaustiveLog = () => [
+    {
+      id: "log_001",
+      plan_item_id: null,
+      performed: "2026-01-01T00:00:00Z",
+      tool: "record_search",
+      query: {},
+      outcome: "negative",
+      results_examined: 0,
+      external_site: null,
+      results_ref: null,
+    },
+  ];
+
+  it("allows tier 'proved' when exhaustive_declaration.declared was already true from an earlier, separate call", async () => {
+    const r0 = phase3Research();
+    r0.questions = [
+      {
+        ...validQuestion("q_001"),
+        status: "exhaustive_declared",
+        exhaustive_declaration: { declared: true, log_entry_ids: ["log_001"], stop_criteria: fullStopCriteria() },
+      },
+    ];
+    r0.log = declaredExhaustiveLog();
+    await writeProject(r0);
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "proof_summaries",
+      op: "append",
+      entry: {
+        question_id: "q_001",
+        tier: "proved",
+        vehicle: "summary",
+        supporting_assertion_ids: ["a_001"],
+        resolved_conflict_ids: [],
+        exhaustive_search_summary: "Searched census + vitals",
+        narrative_markdown: "## Conclusion\n...",
+      },
+    });
+    expect(r.ok && r.entryId).toBe("ps_001");
+  });
+
+  it("does not re-trigger the tier guardrail on an unrelated update to an already-proved entry", async () => {
+    const r0 = phase3Research();
+    r0.questions = [
+      {
+        ...validQuestion("q_001"),
+        status: "exhaustive_declared",
+        exhaustive_declaration: { declared: true, log_entry_ids: ["log_001"], stop_criteria: fullStopCriteria() },
+      },
+    ];
+    r0.log = declaredExhaustiveLog();
+    r0.proof_summaries = [
+      {
+        id: "ps_001",
+        question_id: "q_001",
+        tier: "proved",
+        vehicle: "summary",
+        supporting_assertion_ids: ["a_001"],
+        resolved_conflict_ids: [],
+        exhaustive_search_summary: "Searched census + vitals",
+        narrative_markdown: "## Conclusion\n...",
+      },
+    ];
+    await writeProject(r0);
+    const r = await researchAppend({
+      projectPath: dir,
+      section: "proof_summaries",
+      op: "update",
+      entryId: "ps_001",
+      fields: { narrative_markdown: "## Conclusion\nRevised wording." },
+    });
+    expect(r.ok).toBe(true);
+  });
+
   it("appends an evaluation and stamps `timestamp` (datetime)", async () => {
     await writeProject();
     const r = await researchAppend({


### PR DESCRIPTION
## Summary

Autonomous `/research` sometimes lets `research-exhaustiveness`/
`proof-conclusion`/`person-evidence`/`conflict-resolution` get bypassed —
their effect lands in the project files without the skill ever being
invoked, either via an untyped `Agent` call or by reading the skill's own
`SKILL.md` and improvising inline. Prose fixes to `research/SKILL.md` have
been tried twice (this bug, in PR #893; and a prior `person-evidence`
incident) and failed both times.

Full writeup, rejected alternatives, and adversarial review notes:
`docs/plan/research-guardrail-bypass-plan.md`.

## What's in this PR

- **Cross-field validation** (`research-append.ts`) — `tier: proved/disproved`
  now requires `exhaustive_declaration.declared === true` from *before* the
  call started, closing a same-batch TOCTOU hole a batch could otherwise use
  to both declare exhaustiveness and consume it in one atomic write.
- **`Write`/`Edit` lockdown** (e2e harness) — direct writes to
  `research.json`/`tree.gedcomx.json` are now denied, not just
  prose-forbidden. Hygiene; neither observed bypass shape used this route.
- **`harness/skill_invocation.py`** (new) — shared detection logic: which
  guardrail skill owns a given write (including tree-side writes:
  `materialize_facts` minting a new person, `tree_edit`/`tree_correct`'s
  primary-fact and `ParentChild`/`Couple` encoding), whether it was
  recently/ever successfully invoked, and whether `gps-mentor`'s
  proof-critique verdict is on record.
- **Shadow-mode recency-window check** — logs (never denies) protected
  writes with no recent matching `Skill` invocation, persisted per-run as
  `guardrail_shadow_violations` for calibration (tracked in #911).
- **Hard e2e detector** — forces `verdict: fail` when a guardrail skill's
  effect is present with no invocation anywhere in the run, a resolved
  question's proof summary has no mandatory mentor verdict, or a brand-new
  tree person receives a `person_evidence` link with zero `same_person`
  calls anywhere in the run (the last one added after the finding below).
- **`eval.guardrail_shadow_report`** (new) — retroactive calibration tool;
  replays the shadow-mode check against every already-committed e2e runlog
  for free. Surfaced that this bug is far more pervasive in the historical
  corpus than expected (see #913).
- **`bagley-father-1884`** — new, real e2e fixture (live FamilySearch PID,
  confirmed deceased) authored to exercise this fix end to end. First run
  caught a live instance of the exact bug: a brand-new tree person (the
  father) linked across 13 `person_evidence` entries entirely inline, with
  `same_person` never called. Independently corroborated by the blind human
  annotation, which downgraded the judge's `pass` to `partial` over an
  unrelated identity-pinning gap (a "David Bagley Jr." confounder) surfaced
  by the same run.
- **`docs/TODOs.md`** — 4 new entries for gaps this PR doesn't close: the
  hosted/production path, `gps-mentor`'s own gate skippability, the
  batch-ordering audit beyond the one TOCTOU case found, and whether
  `Skill`-tool content injection survives compaction (cross-referenced
  against the `feedback-2026-07-27-perf` branch's independent compaction-decay
  finding).

## Explicitly out of scope (see plan §5)

- Hosted/production port (`apps/server/app/agent/real_agent.py`).
- Graduating the shadow-mode hook to real denial — tracked in
  [#911](https://github.com/PioneerAIAcademy/cowork-genealogy/issues/911),
  pending calibration.
- Agent conversion of any of the four guardrail skills — issue #702 found
  on-demand `Read` of sibling reference files unreliable from an agent
  context, and most of these four would need substantial inlining to avoid
  that.

See also [#913](https://github.com/PioneerAIAcademy/cowork-genealogy/issues/913)
— a confirmed historical e2e run (`alvro-taylor-marriage-1931`) that
bypassed all four guardrail skills entirely and still scored `pass`. Tracked
separately since it's about historical verdict trust, not this PR's fix.

## Test plan

- [x] `eval/harness`: 1244 passed
- [x] `packages/engine/mcp-server`: 1662 passed, clean `tsc` build
- [x] `make e2e-run TEST=bagley-father-1884` — real live run, graded
  (`run-2026-07-27_20-01-40.ann.json`), retroactively confirmed to trip the
  new `same_person`-absence check
- [x] `uv run python -m e2e.guardrail_shadow_report` against the full
  committed corpus (99 runs) — see plan doc §10 for results

🤖 Generated with [Claude Code](https://claude.com/claude-code)