### PR TITLE
eval-harness: fix flaky ut_validate_schema_007/008 (judge before-state truncated the source-id list)

### DIFF
--- a/eval/harness/harness/orchestrator.py
+++ b/eval/harness/harness/orchestrator.py
@@ -1090,7 +1090,7 @@ def _summarize_before_state_sources(sources: Any) -> dict[str, Any]:
     return {
         "count": len(items),
         "all_ids": ids,
-        "detail": _summarize_response(sources, string_max=_BEFORE_STATE_STRING_MAX),
+        "detail": _summarize_response(items, string_max=_BEFORE_STATE_STRING_MAX),
     }
 
 
@@ -1102,12 +1102,14 @@ def _summarize_before_state(before_snapshot: dict[str, Any] | None) -> str:
     that on-file source text was absent or invented — when it had no view of
     the pre-existing state. Surfacing the before-run `sources` (research.json,
     `src_` ids) and source descriptions (tree.gedcomx.json, `S` ids) makes
-    such claims checkable against what was actually on file. The full id list
-    always survives (see `_summarize_before_state_sources`); only the heavy
-    per-source content is sampled.
+    such claims checkable against what was actually on file.
 
-    Bounded per-field and overall so a large project can't blow the prompt.
-    Returns "(none)" when there was no prior state (e.g. an empty-project
+    The complete `count` + `all_ids` for every block is rendered first and is
+    never truncated — that is the existence-check ground truth, and clipping it
+    is exactly what revived the fabrication misgrade (ut_validate_schema_007/008).
+    The `_BEFORE_STATE_MAX_CHARS` prompt-size cap is spent only on the expendable
+    heavy `detail` sample, which is dropped (never the ids) when the budget runs
+    out. Returns "(none)" when there was no prior state (e.g. an empty-project
     scenario) — itself the correct signal: nothing was on file, so any
     "altered/removed an existing source" claim is unfounded.
     """
@@ -1118,36 +1120,52 @@ def _summarize_before_state(before_snapshot: dict[str, Any] | None) -> str:
     research_sources = research.get("sources") if isinstance(research, dict) else None
     tree_sources = tree.get("sources") if isinstance(tree, dict) else None
 
-    blocks: list[str] = []
+    labelled: list[tuple[str, dict[str, Any]]] = []
     if research_sources:
-        blocks.append(
-            "research.json sources on file before this run (src_ ids):\n"
-            + json.dumps(
+        labelled.append(
+            (
+                "research.json sources on file before this run (src_ ids)",
                 _summarize_before_state_sources(research_sources),
-                ensure_ascii=False,
-                indent=2,
             )
         )
     if tree_sources:
-        blocks.append(
-            "tree.gedcomx.json source descriptions on file before this run "
-            "(S ids):\n"
-            + json.dumps(
+        labelled.append(
+            (
+                "tree.gedcomx.json source descriptions on file before this run "
+                "(S ids)",
                 _summarize_before_state_sources(tree_sources),
-                ensure_ascii=False,
-                indent=2,
             )
         )
-    if not blocks:
+    if not labelled:
         return "(none)"
-    rendered = "\n\n".join(blocks)
-    if len(rendered) > _BEFORE_STATE_MAX_CHARS:
-        rendered = (
-            rendered[:_BEFORE_STATE_MAX_CHARS]
-            + f"\n[before-state truncated by harness for prompt size; "
-            f"full length {len(rendered)} chars]"
+
+    # ids first — complete and never clipped (see docstring).
+    id_blocks = [
+        f"{label}:\n"
+        + json.dumps(
+            {"count": summary["count"], "all_ids": summary["all_ids"]},
+            ensure_ascii=False,
+            indent=2,
         )
-    return rendered
+        for label, summary in labelled
+    ]
+    id_section = "\n\n".join(id_blocks)
+
+    # heavy per-source sample after — this is what the prompt-size cap trims.
+    detail_blocks = [
+        f"{label} — sample detail (heavy fields truncated):\n"
+        + json.dumps(summary["detail"], ensure_ascii=False, indent=2)
+        for label, summary in labelled
+    ]
+    detail_section = "\n\n".join(detail_blocks)
+    budget = _BEFORE_STATE_MAX_CHARS - len(id_section)
+    if len(detail_section) > budget:
+        detail_section = (
+            detail_section[: max(budget, 0)]
+            + f"\n[detail truncated by harness for prompt size; "
+            f"full detail length {len(detail_section)} chars — ids above are complete]"
+        )
+    return id_section + "\n\n" + detail_section
 
 
 def _load_scenario_readme(scenarios_dir: Path, scenario: str | None) -> str:

--- a/eval/harness/harness/orchestrator.py
+++ b/eval/harness/harness/orchestrator.py
@@ -1071,6 +1071,29 @@ _BEFORE_STATE_STRING_MAX = 4_000
 _BEFORE_STATE_MAX_CHARS = 40_000
 
 
+def _summarize_before_state_sources(sources: Any) -> dict[str, Any]:
+    """Summarize one before-state source array for the judge, keeping the
+    COMPLETE list of ids.
+
+    The judge uses the before-state block to check "references an id that isn't
+    on file" / "fabricated a source" claims, and that check is only sound if it
+    can see *every* id that was on file. The generic `_summarize_response`
+    samples a list down to its first `_RESPONSE_ARRAY_SAMPLE` (=3) entries —
+    which silently dropped the 4th+ source and made the judge (and human
+    annotators reading the same block) flag a correctly-cited later source
+    (`src_004` / `S4`) as fabricated. That is the exact failure this block was
+    written to prevent. So emit the full id list explicitly and only sample the
+    heavy per-source content (citations, notes) for prompt size.
+    """
+    items = sources if isinstance(sources, list) else []
+    ids = [s["id"] for s in items if isinstance(s, dict) and s.get("id")]
+    return {
+        "count": len(items),
+        "all_ids": ids,
+        "detail": _summarize_response(sources, string_max=_BEFORE_STATE_STRING_MAX),
+    }
+
+
 def _summarize_before_state(before_snapshot: dict[str, Any] | None) -> str:
     """Render the source entries that existed BEFORE the skill ran, so the
     judge can mechanically check "not on file" / "fabricated" claims.
@@ -1079,7 +1102,9 @@ def _summarize_before_state(before_snapshot: dict[str, Any] | None) -> str:
     that on-file source text was absent or invented — when it had no view of
     the pre-existing state. Surfacing the before-run `sources` (research.json,
     `src_` ids) and source descriptions (tree.gedcomx.json, `S` ids) makes
-    such claims checkable against what was actually on file.
+    such claims checkable against what was actually on file. The full id list
+    always survives (see `_summarize_before_state_sources`); only the heavy
+    per-source content is sampled.
 
     Bounded per-field and overall so a large project can't blow the prompt.
     Returns "(none)" when there was no prior state (e.g. an empty-project
@@ -1095,20 +1120,23 @@ def _summarize_before_state(before_snapshot: dict[str, Any] | None) -> str:
 
     blocks: list[str] = []
     if research_sources:
-        summarized = _summarize_response(
-            research_sources, string_max=_BEFORE_STATE_STRING_MAX
-        )
         blocks.append(
             "research.json sources on file before this run (src_ ids):\n"
-            + json.dumps(summarized, ensure_ascii=False, indent=2)
+            + json.dumps(
+                _summarize_before_state_sources(research_sources),
+                ensure_ascii=False,
+                indent=2,
+            )
         )
     if tree_sources:
-        summarized = _summarize_response(
-            tree_sources, string_max=_BEFORE_STATE_STRING_MAX
-        )
         blocks.append(
             "tree.gedcomx.json source descriptions on file before this run "
-            "(S ids):\n" + json.dumps(summarized, ensure_ascii=False, indent=2)
+            "(S ids):\n"
+            + json.dumps(
+                _summarize_before_state_sources(tree_sources),
+                ensure_ascii=False,
+                indent=2,
+            )
         )
     if not blocks:
         return "(none)"

--- a/eval/harness/tests/unit/test_before_state.py
+++ b/eval/harness/tests/unit/test_before_state.py
@@ -1,0 +1,87 @@
+"""Regression tests for the judge before-state summary.
+
+`_summarize_before_state` exists so the judge can mechanically check
+"references an id that isn't on file" / "fabricated a source" claims. That
+check is only sound if the block shows *every* source id that was on file.
+
+The generic `_summarize_response` samples any list longer than
+`_RESPONSE_ARRAY_SAMPLE` (=3) down to its first three entries. Feeding the
+before-state `sources` array through it unmodified silently dropped the 4th+
+source, so the judge (and human annotators reading the same block) flagged a
+correctly-cited later source — `src_004` / `S4` — as fabricated and failed
+base Correctness. That was the root cause of flaky ut_validate_schema_007 /
+ut_validate_schema_008. These tests pin the fix: the full id list must survive
+regardless of how many sources exist.
+"""
+
+from harness.judge import _RESPONSE_ARRAY_SAMPLE
+from harness.orchestrator import (
+    _summarize_before_state,
+    _summarize_before_state_sources,
+)
+
+
+def _sources(prefix: str, n: int) -> list[dict]:
+    # Give each source a long field so the per-string cap could plausibly bite;
+    # the ids must survive regardless.
+    return [
+        {"id": f"{prefix}{i:03d}", "citation": "x" * 100, "notes": "y" * 100}
+        for i in range(1, n + 1)
+    ]
+
+
+def test_all_ids_survive_beyond_array_sample():
+    n = _RESPONSE_ARRAY_SAMPLE + 1  # the boundary that used to drop the last id
+    summary = _summarize_before_state_sources(_sources("src_", n))
+    assert summary["count"] == n
+    assert summary["all_ids"] == [f"src_{i:03d}" for i in range(1, n + 1)]
+    # The last id — the one the array-sampler dropped — is present.
+    assert f"src_{n:03d}" in summary["all_ids"]
+
+
+def test_full_id_list_present_for_large_project():
+    summary = _summarize_before_state_sources(_sources("src_", 25))
+    assert summary["count"] == 25
+    assert len(summary["all_ids"]) == 25
+
+
+def test_before_state_block_shows_fourth_source_id():
+    # The exact ut_validate_schema_007/008 shape: research.json has 4 src_ ids,
+    # tree.gedcomx.json has 4 S ids. The 4th of each must be visible to the
+    # judge or it will call a correct citation a fabrication.
+    before = {
+        "research_json": {"sources": _sources("src_", 4)},
+        "tree_gedcomx_json": {"sources": _sources("S", 4)},
+    }
+    rendered = _summarize_before_state(before)
+    assert "src_004" in rendered
+    assert "S004" in rendered
+
+
+def test_short_lists_still_complete():
+    summary = _summarize_before_state_sources(_sources("src_", 2))
+    assert summary["count"] == 2
+    assert summary["all_ids"] == ["src_001", "src_002"]
+
+
+def test_non_list_and_empty_are_safe():
+    assert _summarize_before_state_sources([]) == {
+        "count": 0,
+        "all_ids": [],
+        "detail": [],
+    }
+    # Defensive: a malformed (non-list) sources value must not raise.
+    weird = _summarize_before_state_sources({"unexpected": "shape"})
+    assert weird["count"] == 0
+    assert weird["all_ids"] == []
+
+
+def test_sources_without_ids_are_counted_not_listed():
+    summary = _summarize_before_state_sources([{"citation": "no id here"}])
+    assert summary["count"] == 1
+    assert summary["all_ids"] == []
+
+
+def test_none_before_state_returns_none_sentinel():
+    assert _summarize_before_state(None) == "(none)"
+    assert _summarize_before_state({}) == "(none)"

--- a/eval/harness/tests/unit/test_before_state.py
+++ b/eval/harness/tests/unit/test_before_state.py
@@ -70,10 +70,12 @@ def test_non_list_and_empty_are_safe():
         "all_ids": [],
         "detail": [],
     }
-    # Defensive: a malformed (non-list) sources value must not raise.
+    # Defensive: a malformed (non-list) sources value must not raise, and every
+    # field must agree — count/all_ids/detail all derive from the type-guarded
+    # `items`, so a non-list yields an internally consistent empty block (not
+    # count:0 with a populated detail).
     weird = _summarize_before_state_sources({"unexpected": "shape"})
-    assert weird["count"] == 0
-    assert weird["all_ids"] == []
+    assert weird == {"count": 0, "all_ids": [], "detail": []}
 
 
 def test_sources_without_ids_are_counted_not_listed():
@@ -85,3 +87,29 @@ def test_sources_without_ids_are_counted_not_listed():
 def test_none_before_state_returns_none_sentinel():
     assert _summarize_before_state(None) == "(none)"
     assert _summarize_before_state({}) == "(none)"
+
+
+def test_ids_render_before_detail():
+    before = {"research_json": {"sources": _sources("src_", 4)}}
+    rendered = _summarize_before_state(before)
+    # The complete id list must come before the (clippable) heavy detail sample.
+    assert rendered.index("all_ids") < rendered.index("sample detail")
+
+
+def test_all_ids_survive_when_detail_blows_the_prompt_budget(monkeypatch):
+    # The prompt-size cap must trim the heavy detail, never the ids — otherwise
+    # a late source id gets stranded and the fabrication misgrade returns. Shrink
+    # the cap so the detail section overruns it while the ids stay complete.
+    from harness import orchestrator
+
+    monkeypatch.setattr(orchestrator, "_BEFORE_STATE_MAX_CHARS", 200)
+    before = {
+        "research_json": {"sources": _sources("src_", 10)},
+        "tree_gedcomx_json": {"sources": _sources("S", 10)},
+    }
+    rendered = orchestrator._summarize_before_state(before)
+    for i in range(1, 11):
+        assert f"src_{i:03d}" in rendered
+        assert f"S{i:03d}" in rendered
+    assert "detail truncated by harness" in rendered
+    assert "ids above are complete" in rendered


### PR DESCRIPTION
## Summary

- Fixes flaky `ut_validate_schema_007` (dangling-reference) and `ut_validate_schema_008` (cross-file reference), which passed on some runs and failed on others.
- Root cause was a **harness** bug, not a skill/rubric/fixture defect: `orchestrator._summarize_before_state` fed the before-state `sources` array through `judge._summarize_response`, which samples any list longer than `_RESPONSE_ARRAY_SAMPLE` (=3) down to its first 3 elements. Both fixtures have **4** sources (`src_001–src_004` / `S1–S4`), so the judge saw only the first three ids and — running exactly the "fabricated / not on file" check this block exists to support — flagged the skill's correct reference to the 4th source as a fabrication, sinking base **Correctness**. The skill's output was accurate all along. (A human annotator reading the same truncated block repeated the miscount, so the agreeing `.ann` wasn't proof of a real defect — confirmed against the run-log's embedded snapshot, which has shown 4 sources since the fixture was created.)
- Fix: `_summarize_before_state_sources` now always emits the **complete** `all_ids` list. The renderer emits every block's `count`+`all_ids` first and **unclipped** (the existence-check ground truth), and spends the `_BEFORE_STATE_MAX_CHARS` prompt-size budget only on the expendable heavy `detail` sample — so the id list survives even for a pathologically large project.
- Added `eval/harness/tests/unit/test_before_state.py` (9 cases) pinning: the 4th id surviving, the complete id list for a large project, ids-before-detail ordering, id-survival when the detail sample overruns the budget, and internally consistent handling of empty/malformed input.

## Test plan

- [x] I ran `scripts/test.sh` and it passed. (1264 passed; MCP vitest + eval-app vitest + harness pytest all green.)
- [ ] For every skill whose files I changed ... committed an all-pass runlog.
      N/A — this PR changes only `eval/harness/` code, which is deliberately **not** part of the run-log snapshot (see `eval/CLAUDE.md`), so it flips no run log inactive and the `check-runlogs` gate requires no fresh, re-annotated runlog. Verified behaviorally instead: `ut_validate_schema_007` and `ut_validate_schema_008` each run **3×** through the real harness → **6/6 pass**, with base Correctness now `3` ("No fabricated material").
