### PR TITLE
ci: label PRs `ready-for-genealogist` when green + peer-approved

### DIFF
--- a/.github/scripts/consolidate-branch-protection.sh
+++ b/.github/scripts/consolidate-branch-protection.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# Consolidate `main` protection onto the `protect-main` ruleset, retire the
+# overlapping classic branch-protection rule, and (optionally) require status
+# checks to pass before merge.
+#
+# WHY CONSOLIDATE. As of 2026-07-29 both mechanisms guard `main` and disagree:
+#
+#                              classic protection    protect-main ruleset
+#   required approvals                 2                      1
+#   require_last_push_approval       false                   true
+#   require_code_owner_review         true                   true
+#   dismiss_stale_reviews            false                   false
+#
+# GitHub applies the most restrictive of the two, so the effective policy is
+# 2 approvals + code owner + last-push-approval. Correct, but unreadable:
+# anyone checking `/branches/main/protection` concludes last-push-approval is
+# off, and anyone checking the ruleset concludes one approval is enough.
+#
+# ORDER MATTERS. The ruleset requires only 1 approval today. Deleting classic
+# protection first would drop `main` from 2 approvals to 1 until the ruleset is
+# raised. This script raises the ruleset first and refuses to delete until it
+# has verified the new value landed.
+#
+# NOT LOST BY DELETING CLASSIC PROTECTION. Force pushes and branch deletion are
+# already covered by the ruleset's `non_fast_forward` and `deletion` rules.
+# Every other classic toggle (signatures, linear history, conversation
+# resolution, block creations, lock branch) is currently disabled.
+#
+# MAINTAINER CAN STILL MERGE RED PRs. The ruleset has one bypass actor —
+# user 240745 (DallanQ), mode `always`. Bypass covers every rule in the
+# ruleset, required status checks included, so adding them in step 4 blocks
+# the team on red CI without blocking the maintainer. This is the reason the
+# checks belong in the RULESET and not in classic protection, whose
+# `enforce_admins: false` we are deleting.
+#
+# Usage:
+#   ./.github/scripts/consolidate-branch-protection.sh                    # dry run
+#   APPLY=1 ./.github/scripts/consolidate-branch-protection.sh            # steps 1-3
+#   APPLY=1 REQUIRE_CHECKS=1 ./.github/scripts/consolidate-branch-protection.sh
+#                                                                         # + step 4
+
+set -euo pipefail
+
+REPO="${REPO:-PioneerAIAcademy/cowork-genealogy}"
+RULESET_ID="${RULESET_ID:-17125816}"
+BRANCH="${BRANCH:-main}"
+WANT_APPROVALS="${WANT_APPROVALS:-2}"
+APPLY="${APPLY:-0}"
+REQUIRE_CHECKS="${REQUIRE_CHECKS:-0}"
+
+# Contexts to require in step 4. MUST be checks that report on EVERY pull
+# request — see the preflight in step 4 for why, and read it before editing
+# this list.
+REQUIRED_CONTEXTS="${REQUIRED_CONTEXTS:-pytest check vitest scan}"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+say() { printf '\n=== %s ===\n' "$1"; }
+
+say "current: ruleset $RULESET_ID"
+gh api "repos/$REPO/rulesets/$RULESET_ID" \
+  --jq '.rules[] | select(.type=="pull_request") | .parameters'
+
+say "current: classic protection on $BRANCH"
+gh api "repos/$REPO/branches/$BRANCH/protection" \
+  --jq '.required_pull_request_reviews // "none"' 2>/dev/null \
+  || echo "none (already removed)"
+
+if [ "$APPLY" != "1" ]; then
+  cat <<EOF
+
+DRY RUN. Would:
+  1. set ruleset $RULESET_ID pull_request.required_approving_review_count = $WANT_APPROVALS
+  2. verify that value round-trips
+  3. DELETE classic branch protection on $BRANCH
+$([ "$REQUIRE_CHECKS" = "1" ] && echo "  4. require status checks: $REQUIRED_CONTEXTS")
+
+Re-run with APPLY=1 to execute.
+EOF
+  exit 0
+fi
+
+# --- 1. raise the ruleset -----------------------------------------------------
+# Fetch and patch rather than hand-authoring the body, so bypass_actors,
+# conditions, and the deletion/non_fast_forward rules survive untouched.
+say "step 1: raising ruleset to $WANT_APPROVALS approvals"
+gh api "repos/$REPO/rulesets/$RULESET_ID" > "$tmp/current.json"
+
+jq --argjson n "$WANT_APPROVALS" '{
+  name, target, enforcement, bypass_actors, conditions,
+  rules: (.rules | map(
+    if .type == "pull_request"
+    then .parameters.required_approving_review_count = $n
+    else . end
+  ))
+}' "$tmp/current.json" > "$tmp/next.json"
+
+gh api --method PUT "repos/$REPO/rulesets/$RULESET_ID" --input "$tmp/next.json" > /dev/null
+
+# --- 2. verify before doing anything destructive ------------------------------
+say "step 2: verifying"
+got="$(gh api "repos/$REPO/rulesets/$RULESET_ID" \
+  --jq '.rules[] | select(.type=="pull_request") | .parameters.required_approving_review_count')"
+
+if [ "$got" != "$WANT_APPROVALS" ]; then
+  echo "ABORT: ruleset reports $got approvals, wanted $WANT_APPROVALS." >&2
+  echo "Classic protection left in place; main is still guarded." >&2
+  exit 1
+fi
+echo "ruleset now requires $got approvals"
+
+# --- 3. retire classic protection --------------------------------------------
+say "step 3: deleting classic branch protection on $BRANCH"
+gh api --method DELETE "repos/$REPO/branches/$BRANCH/protection" 2>/dev/null \
+  && echo "deleted" || echo "already absent"
+
+# --- 4. required status checks (opt-in) ---------------------------------------
+if [ "$REQUIRE_CHECKS" != "1" ]; then
+  cat <<'EOF'
+
+STEP 4 SKIPPED (REQUIRE_CHECKS=1 to enable).
+
+No status check is required to merge today, so a PR with failing CI can be
+merged on approvals alone. Before turning that on, read the preflight note in
+step 4 of this script: most of our checks are path-filtered, and a required
+check that never reports blocks its PR forever.
+EOF
+  exit 0
+fi
+
+say "step 4 preflight: do the required contexts report on every open PR?"
+
+# A required status check that never reports leaves the PR stuck on
+# "Expected — waiting for status to be reported", with no way forward except a
+# bypass actor. Four of our PR workflows are path-filtered
+# (check-e2e-fixtures, check-engine-lockfile, check-runlogs, engine-tests,
+# eval-harness-tests), so `pytest`/`check`/`vitest` are absent from any PR that
+# touches none of their paths — a docs-only change, an apps/web change, or a
+# .github-only change. Requiring them before those workflows run unconditionally
+# would deadlock exactly those PRs.
+#
+# So: refuse unless every required context is currently reporting on every open
+# PR. This is a necessary condition, not a sufficient one — it can still pass by
+# luck if every open PR happens to touch the filtered paths. The real fix is to
+# drop `paths:` from those workflows and early-exit inside the job instead, so
+# the check always reports a conclusion.
+
+missing=0
+for pr in $(gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --jq '.[].number'); do
+  sha="$(gh api "repos/$REPO/pulls/$pr" --jq '.head.sha')"
+  have="$(gh api "repos/$REPO/commits/$sha/check-runs" --jq '[.check_runs[].name] | unique | join(" ")')"
+  for ctx in $REQUIRED_CONTEXTS; do
+    case " $have " in
+      *" $ctx "*) ;;
+      *) echo "  #$pr is missing '$ctx' (has: $have)"; missing=1 ;;
+    esac
+  done
+done
+
+if [ "$missing" = "1" ]; then
+  cat <<EOF >&2
+
+ABORT: at least one open PR would never receive a required check, and would be
+unmergeable by anyone except a bypass actor.
+
+Fix first, in a separate PR: for each path-filtered workflow, remove the
+\`paths:\` filter so it runs on every pull_request, and move the filter to an
+early-exit guard inside the job. The check then always reports a conclusion,
+and requiring it is safe.
+
+Steps 1-3 completed successfully; nothing about this failure has left main
+under-protected.
+EOF
+  exit 1
+fi
+
+echo "  all required contexts present on all open PRs"
+
+say "step 4: requiring $REQUIRED_CONTEXTS"
+gh api "repos/$REPO/rulesets/$RULESET_ID" > "$tmp/pre-checks.json"
+
+# shellcheck disable=SC2086
+checks_json="$(printf '%s\n' $REQUIRED_CONTEXTS | jq -R '{context: .}' | jq -s '.')"
+
+jq --argjson checks "$checks_json" '{
+  name, target, enforcement, bypass_actors, conditions,
+  rules: (
+    (.rules | map(select(.type != "required_status_checks")))
+    + [{
+        type: "required_status_checks",
+        parameters: {
+          # false: do not force every branch to be up to date with main before
+          # merge. With 22 PRs open that would mean a rebase storm.
+          strict_required_status_checks_policy: false,
+          do_not_enforce_on_create: false,
+          required_status_checks: $checks
+        }
+      }]
+  )
+}' "$tmp/pre-checks.json" > "$tmp/with-checks.json"
+
+gh api --method PUT "repos/$REPO/rulesets/$RULESET_ID" --input "$tmp/with-checks.json" > /dev/null
+
+say "final state"
+gh api "repos/$REPO/rulesets/$RULESET_ID" --jq '.rules[] | {(.type): .parameters}'

--- a/.github/workflows/genealogist-queue.yml
+++ b/.github/workflows/genealogist-queue.yml
@@ -58,7 +58,7 @@ jobs:
       github.event_name != 'pull_request'
       || github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         env:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
         with:
@@ -165,8 +165,11 @@ jobs:
                 action = dryRun ? 'WOULD promote' : 'promoted';
                 if (!dryRun) {
                   try {
+                    // `reviewers` is required by both endpoints even when only
+                    // teams are involved; omitting it 422s with
+                    // `"reviewers" wasn't supplied`.
                     await github.rest.pulls.requestReviewers({
-                      owner, repo, pull_number: n, team_reviewers: [TEAM] });
+                      owner, repo, pull_number: n, reviewers: [], team_reviewers: [TEAM] });
                   } catch (e) {
                     core.warning(`#${n}: could not request ${TEAM}: ${e.message}`);
                   }
@@ -181,7 +184,7 @@ jobs:
                 if (!dryRun) {
                   try {
                     await github.rest.pulls.removeRequestedReviewers({
-                      owner, repo, pull_number: n, team_reviewers: [TEAM] });
+                      owner, repo, pull_number: n, reviewers: [], team_reviewers: [TEAM] });
                   } catch (e) {
                     core.warning(`#${n}: could not remove ${TEAM}: ${e.message}`);
                   }

--- a/.github/workflows/genealogist-queue.yml
+++ b/.github/workflows/genealogist-queue.yml
@@ -1,0 +1,202 @@
+name: genealogist-queue
+
+# Defers the senior-genealogist review request until a PR is actually ready for
+# them: CI green, at least one approving review from someone other than the
+# author, and no outstanding "changes requested".
+#
+# WHY. `.github/CODEOWNERS` is `* @PioneerAIAcademy/senior-genealogists`, so
+# GitHub requests the team the instant a PR opens — when CI is usually red and
+# nobody has read it. On 2026-07-29 that put all 22 open PRs in their queue,
+# including 5 with failing CI and 2 blocked on their authors. The request is
+# therefore accurate as "a PR exists" and useless as "this needs you".
+#
+# WHAT CHANGES. Only the *request* — and so the notification and the queue.
+# Merge enforcement is untouched: `require_code_owner_review` in the
+# `protect-main` ruleset gates the merge whether or not the team is currently
+# requested. Nobody can merge past a genealogist because of this workflow.
+#
+# WHY REMOVING ONCE IS ENOUGH. GitHub does not re-request code owners on push.
+# Verified 2026-07-29 against PR #924: 7 `committed` events, exactly one
+# `review_requested` event for the team. `ready_for_review` is handled below
+# because a draft going ready *does* trigger a fresh code-owner request.
+#
+# V1 IS ADD-ONLY. Once a PR is promoted it stays promoted, even if it later
+# goes red. Demotion would make PRs flicker in and out of the queue while a
+# genealogist is mid-review. Revisit after a week of real use.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  check_suite:
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report what would change across all open PRs, without touching any"
+        type: boolean
+        default: true
+
+permissions:
+  pull-requests: write
+  checks: read
+  contents: read
+
+concurrency:
+  group: >-
+    genealogist-queue-${{ github.event.pull_request.number
+      || github.event.check_suite.id
+      || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    # Fork PRs get a read-only token; every write below would 403.
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+        with:
+          script: |
+            const TEAM  = 'senior-genealogists';
+            const LABEL = 'ready-for-genealogist';
+            // This workflow's own check run is always in progress while it
+            // runs; counting it would mean CI is never "green".
+            const SELF  = 'genealogist-queue';
+
+            const BAD     = new Set(['failure', 'cancelled', 'timed_out', 'action_required', 'stale']);
+            const PENDING = new Set(['queued', 'in_progress', 'waiting', 'pending', 'requested']);
+
+            const dryRun = process.env.DRY_RUN === 'true';
+            const { owner, repo } = context.repo;
+
+            // ---- which PRs to evaluate --------------------------------------
+            let numbers = [];
+            if (context.eventName === 'workflow_dispatch') {
+              const open = await github.paginate(github.rest.pulls.list,
+                { owner, repo, state: 'open', per_page: 100 });
+              numbers = open.map(p => p.number);
+            } else if (context.eventName === 'check_suite') {
+              numbers = (context.payload.check_suite.pull_requests || []).map(p => p.number);
+              if (numbers.length === 0) {
+                // check_suite payloads omit PRs in some cases; match on head sha.
+                const sha = context.payload.check_suite.head_sha;
+                const open = await github.paginate(github.rest.pulls.list,
+                  { owner, repo, state: 'open', per_page: 100 });
+                numbers = open.filter(p => p.head.sha === sha).map(p => p.number);
+              }
+            } else {
+              numbers = [context.payload.pull_request.number];
+            }
+
+            // ---- readiness ---------------------------------------------------
+            async function evaluate(number) {
+              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: number });
+              const promoted = pr.labels.map(l => l.name).includes(LABEL);
+
+              if (pr.state !== 'open') return { pr, promoted, ready: false, reasons: ['not open'] };
+              if (pr.draft)            return { pr, promoted, ready: false, reasons: ['draft'] };
+
+              // Peer review: latest standing per reviewer, author excluded.
+              // Any non-author approval counts — deliberately not checking team
+              // membership, which would need a token with `read:org`.
+              const reviews = await github.paginate(github.rest.pulls.listReviews,
+                { owner, repo, pull_number: number, per_page: 100 });
+              const latest = new Map();
+              for (const r of reviews) {
+                if (!r.user || r.user.login === pr.user.login) continue;
+                if (r.state === 'COMMENTED') continue;  // a comment changes nothing
+                latest.set(r.user.login, r.state);
+              }
+              const standings = [...latest.values()];
+
+              // CI on the head sha: both check runs and legacy commit statuses.
+              const [checks, status] = await Promise.all([
+                github.paginate(github.rest.checks.listForRef,
+                  { owner, repo, ref: pr.head.sha, per_page: 100 }),
+                github.rest.repos.getCombinedStatusForRef({ owner, repo, ref: pr.head.sha }),
+              ]);
+              const others   = checks.filter(c => !(c.name || '').startsWith(SELF));
+              const failed   = others.filter(c => BAD.has(c.conclusion));
+              const running  = others.filter(c => PENDING.has(c.status));
+              const statuses = status.data.statuses || [];
+              const statusFailed = statuses.filter(s => s.state === 'failure' || s.state === 'error');
+
+              const reasons = [];
+              if (!standings.includes('APPROVED'))        reasons.push('no peer approval');
+              if (standings.includes('CHANGES_REQUESTED')) reasons.push('changes requested');
+              if (failed.length)       reasons.push(`CI failing: ${failed.map(c => c.name).join(', ')}`);
+              if (statusFailed.length) reasons.push(`status failing: ${statusFailed.map(s => s.context).join(', ')}`);
+              if (running.length)      reasons.push(`CI still running (${running.length})`);
+              if (others.length === 0 && statuses.length === 0) reasons.push('no CI has reported');
+
+              return { pr, promoted, ready: reasons.length === 0, reasons };
+            }
+
+            // ---- label bootstrap --------------------------------------------
+            async function ensureLabel() {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: LABEL });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+                if (dryRun) return core.info(`would create label ${LABEL}`);
+                await github.rest.issues.createLabel({
+                  owner, repo, name: LABEL, color: '0E8A16',
+                  description: 'CI green + peer-approved; awaiting senior genealogist',
+                });
+              }
+            }
+            await ensureLabel();
+
+            // ---- act ---------------------------------------------------------
+            const rows = [];
+            for (const n of numbers) {
+              const { pr, promoted, ready, reasons } = await evaluate(n);
+              let action;
+
+              if (ready && promoted) {
+                action = 'already queued';
+              } else if (ready) {
+                action = dryRun ? 'WOULD promote' : 'promoted';
+                if (!dryRun) {
+                  try {
+                    await github.rest.pulls.requestReviewers({
+                      owner, repo, pull_number: n, team_reviewers: [TEAM] });
+                  } catch (e) {
+                    core.warning(`#${n}: could not request ${TEAM}: ${e.message}`);
+                  }
+                  await github.rest.issues.addLabels({
+                    owner, repo, issue_number: n, labels: [LABEL] });
+                }
+              } else if (promoted) {
+                // v1 is add-only: never pull a PR back out of the queue.
+                action = 'not ready, left queued (v1 add-only)';
+              } else {
+                action = dryRun ? 'WOULD defer' : 'deferred';
+                if (!dryRun) {
+                  try {
+                    await github.rest.pulls.removeRequestedReviewers({
+                      owner, repo, pull_number: n, team_reviewers: [TEAM] });
+                  } catch (e) {
+                    core.warning(`#${n}: could not remove ${TEAM}: ${e.message}`);
+                  }
+                }
+              }
+
+              core.info(`#${n} ${action}${reasons.length ? ' — ' + reasons.join('; ') : ''}`);
+              rows.push([`#${n}`, pr.user.login, action, reasons.join('; ') || '—']);
+            }
+
+            await core.summary
+              .addHeading(dryRun ? 'genealogist-queue (dry run)' : 'genealogist-queue', 3)
+              .addTable([
+                [{ data: 'PR', header: true }, { data: 'Author', header: true },
+                 { data: 'Action', header: true }, { data: 'Blocking', header: true }],
+                ...rows,
+              ])
+              .write();

--- a/.github/workflows/genealogist-queue.yml
+++ b/.github/workflows/genealogist-queue.yml
@@ -1,28 +1,42 @@
 name: genealogist-queue
 
-# Defers the senior-genealogist review request until a PR is actually ready for
-# them: CI green, at least one approving review from someone other than the
-# author, and no outstanding "changes requested".
+# Labels a PR `ready-for-genealogist` once it is actually ready for senior
+# review: CI green, an approving review from someone other than the author, and
+# no outstanding changes-requested.
 #
 # WHY. `.github/CODEOWNERS` is `* @PioneerAIAcademy/senior-genealogists`, so
 # GitHub requests the team the instant a PR opens — when CI is usually red and
 # nobody has read it. On 2026-07-29 that put all 22 open PRs in their queue,
-# including 5 with failing CI and 2 blocked on their authors. The request is
-# therefore accurate as "a PR exists" and useless as "this needs you".
+# including 5 with failing CI and 2 blocked on their authors. The review-request
+# is therefore accurate as "a PR exists" and useless as "this needs you". The
+# label is the signal that means the second thing:
 #
-# WHAT CHANGES. Only the *request* — and so the notification and the queue.
-# Merge enforcement is untouched: `require_code_owner_review` in the
-# `protect-main` ruleset gates the merge whether or not the team is currently
-# requested. Nobody can merge past a genealogist because of this workflow.
+#   is:open is:pr label:ready-for-genealogist
 #
-# WHY REMOVING ONCE IS ENOUGH. GitHub does not re-request code owners on push.
-# Verified 2026-07-29 against PR #924: 7 `committed` events, exactly one
-# `review_requested` event for the team. `ready_for_review` is handled below
-# because a draft going ready *does* trigger a fresh code-owner request.
+# WHY A LABEL AND NOT THE REVIEW REQUEST. The obvious design is to strip the
+# team's review request on open and re-add it when ready, so the existing
+# review-requests inbox becomes the queue. That is not possible: while
+# `require_code_owner_review` is active, GitHub will not let you remove a team
+# review request that CODEOWNERS mandates. `DELETE /pulls/{n}/requested_reviewers`
+# returns HTTP 200 and does nothing — no error, no `review_request_removed`
+# timeline event, the team still listed on a fresh read. Verified 2026-07-29 on
+# PR #944 three ways: via `GITHUB_TOKEN`, via an org-admin PAT, and with a
+# hand-written JSON body. Do not re-attempt this without first re-testing that
+# endpoint; the failure mode is silent success, which reads as working.
 #
-# V1 IS ADD-ONLY. Once a PR is promoted it stays promoted, even if it later
-# goes red. Demotion would make PRs flicker in and out of the queue while a
-# genealogist is mid-review. Revisit after a week of real use.
+# The known alternative, unverified: the ruleset's `pull_request` rule has a
+# `required_reviewers` parameter (currently `[]`). If it can name a team, senior
+# approval could be enforced there instead of via CODEOWNERS, CODEOWNERS could
+# be dropped, and nothing would mandate the request. Worth checking before
+# anyone tries the request-stripping approach again.
+#
+# ENFORCEMENT IS UNCHANGED either way. `require_code_owner_review` in the
+# `protect-main` ruleset gates the merge. This workflow only decides what is
+# visible in a queue; it cannot let anything merge that could not merge before.
+#
+# V1 IS ADD-ONLY. Once labeled a PR stays labeled, even if it later goes red.
+# Demotion would make PRs flicker out of the queue while someone is mid-review.
+# Revisit after a week of real use.
 
 on:
   pull_request:
@@ -39,6 +53,11 @@ on:
         default: true
 
 permissions:
+  # `issues: write` is what actually authorizes labelling (labels live on the
+  # issues API even for PRs); `pull-requests: write` is granted alongside it
+  # because the mapping between the two is inconsistent enough that relying on
+  # one alone has bitten other repos.
+  issues: write
   pull-requests: write
   checks: read
   contents: read
@@ -53,7 +72,7 @@ concurrency:
 jobs:
   promote:
     runs-on: ubuntu-latest
-    # Fork PRs get a read-only token; every write below would 403.
+    # Fork PRs get a read-only token; the label write would 403.
     if: >-
       github.event_name != 'pull_request'
       || github.event.pull_request.head.repo.full_name == github.repository
@@ -63,7 +82,6 @@ jobs:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
         with:
           script: |
-            const TEAM  = 'senior-genealogists';
             const LABEL = 'ready-for-genealogist';
             // This workflow's own check run is always in progress while it
             // runs; counting it would mean CI is never "green".
@@ -97,10 +115,10 @@ jobs:
             // ---- readiness ---------------------------------------------------
             async function evaluate(number) {
               const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: number });
-              const promoted = pr.labels.map(l => l.name).includes(LABEL);
+              const labeled = pr.labels.map(l => l.name).includes(LABEL);
 
-              if (pr.state !== 'open') return { pr, promoted, ready: false, reasons: ['not open'] };
-              if (pr.draft)            return { pr, promoted, ready: false, reasons: ['draft'] };
+              if (pr.state !== 'open') return { pr, labeled, ready: false, reasons: ['not open'] };
+              if (pr.draft)            return { pr, labeled, ready: false, reasons: ['draft'] };
 
               // Peer review: latest standing per reviewer, author excluded.
               // Any non-author approval counts — deliberately not checking team
@@ -135,13 +153,14 @@ jobs:
               if (running.length)      reasons.push(`CI still running (${running.length})`);
               if (others.length === 0 && statuses.length === 0) reasons.push('no CI has reported');
 
-              return { pr, promoted, ready: reasons.length === 0, reasons };
+              return { pr, labeled, ready: reasons.length === 0, reasons };
             }
 
             // ---- label bootstrap --------------------------------------------
             async function ensureLabel() {
               try {
                 await github.rest.issues.getLabel({ owner, repo, name: LABEL });
+                core.info(`label ${LABEL} exists`);
               } catch (e) {
                 if (e.status !== 404) throw e;
                 if (dryRun) return core.info(`would create label ${LABEL}`);
@@ -149,46 +168,42 @@ jobs:
                   owner, repo, name: LABEL, color: '0E8A16',
                   description: 'CI green + peer-approved; awaiting senior genealogist',
                 });
+                core.info(`created label ${LABEL}`);
               }
             }
             await ensureLabel();
 
             // ---- act ---------------------------------------------------------
+            // The first version of this workflow wrapped its write in a
+            // try/catch that downgraded failure to a warning. The API then
+            // no-op'd with HTTP 200 and the job went green while doing nothing.
+            // So: no catch, and read the label back to confirm it landed.
             const rows = [];
             for (const n of numbers) {
-              const { pr, promoted, ready, reasons } = await evaluate(n);
+              const { pr, labeled, ready, reasons } = await evaluate(n);
               let action;
 
-              if (ready && promoted) {
+              if (ready && labeled) {
                 action = 'already queued';
+              } else if (ready && dryRun) {
+                action = 'WOULD promote';
               } else if (ready) {
-                action = dryRun ? 'WOULD promote' : 'promoted';
-                if (!dryRun) {
-                  try {
-                    // `reviewers` is required by both endpoints even when only
-                    // teams are involved; omitting it 422s with
-                    // `"reviewers" wasn't supplied`.
-                    await github.rest.pulls.requestReviewers({
-                      owner, repo, pull_number: n, reviewers: [], team_reviewers: [TEAM] });
-                  } catch (e) {
-                    core.warning(`#${n}: could not request ${TEAM}: ${e.message}`);
-                  }
-                  await github.rest.issues.addLabels({
-                    owner, repo, issue_number: n, labels: [LABEL] });
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: n, labels: [LABEL] });
+
+                const { data: after } = await github.rest.issues.listLabelsOnIssue({
+                  owner, repo, issue_number: n });
+                if (!after.some(l => l.name === LABEL)) {
+                  core.setFailed(
+                    `#${n}: addLabels returned success but ${LABEL} is not on the PR. ` +
+                    `Treat this as a permissions or API-behaviour change, not a transient error.`);
+                  action = 'FAILED to label';
+                } else {
+                  action = 'promoted';
                 }
-              } else if (promoted) {
-                // v1 is add-only: never pull a PR back out of the queue.
-                action = 'not ready, left queued (v1 add-only)';
               } else {
-                action = dryRun ? 'WOULD defer' : 'deferred';
-                if (!dryRun) {
-                  try {
-                    await github.rest.pulls.removeRequestedReviewers({
-                      owner, repo, pull_number: n, reviewers: [], team_reviewers: [TEAM] });
-                  } catch (e) {
-                    core.warning(`#${n}: could not remove ${TEAM}: ${e.message}`);
-                  }
-                }
+                // v1 is add-only: a labelled PR is never unlabelled.
+                action = labeled ? 'not ready, left queued (v1 add-only)' : 'not ready';
               }
 
               core.info(`#${n} ${action}${reasons.length ? ' — ' + reasons.join('; ') : ''}`);
@@ -197,6 +212,7 @@ jobs:
 
             await core.summary
               .addHeading(dryRun ? 'genealogist-queue (dry run)' : 'genealogist-queue', 3)
+              .addRaw(`Queue: \`is:open is:pr label:${LABEL}\``)
               .addTable([
                 [{ data: 'PR', header: true }, { data: 'Author', header: true },
                  { data: 'Action', header: true }, { data: 'Blocking', header: true }],


### PR DESCRIPTION
## What

- **`.github/workflows/genealogist-queue.yml`** — labels a PR `ready-for-genealogist` once it is green, has an approving review from someone other than the author, and has no outstanding changes-requested.
- **`.github/scripts/consolidate-branch-protection.sh`** — retires the classic branch-protection rule that overlapped the `protect-main` ruleset, and optionally adds required status checks. **Already run**; `main` is now governed by the ruleset alone (2 approvals + code owner + last-push-approval).

The queue is one saved search:

```
is:open is:pr label:ready-for-genealogist
```

## Why

`.github/CODEOWNERS` is `* @PioneerAIAcademy/senior-genealogists`, so GitHub requests the team the instant a PR opens — when CI is usually red and nobody has read it. Today that puts **all 22 open PRs** in their queue, including 5 with failing CI and 2 blocked on their authors. That list is accurate as "a PR exists" and useless as "this needs you". The label is the signal that means the second thing.

**Enforcement does not change.** `require_code_owner_review` gates the merge either way. This workflow decides visibility only — it cannot let anything merge that could not merge before.

## Why a label and not the review request

The obvious design is to strip the team's request on open and re-add it when ready, so the existing review-requests inbox becomes the queue. That is not possible. While `require_code_owner_review` is active, GitHub will not let you remove a team review request that CODEOWNERS mandates: `DELETE /pulls/{n}/requested_reviewers` returns **HTTP 200 and does nothing** — no error, no `review_request_removed` timeline event, the team still present on a fresh read.

Verified on this PR three ways: via `GITHUB_TOKEN`, via an org-admin PAT, and with a hand-written JSON body. The failure mode is silent success, which is why the first version of this workflow went green while doing nothing. The header comment documents this so nobody rediscovers it.

Cost of the label approach: the CODEOWNERS request stays on every PR, exactly as today. That inbox was already noise; this doesn't make it worse, and it adds a list that is actually worth reading.

**One unverified alternative,** noted in the workflow header: the ruleset's `pull_request` rule has a `required_reviewers` parameter (currently `[]`). If it can name a team, senior approval could be enforced there instead of via CODEOWNERS, CODEOWNERS could be dropped, and the request-based design would become possible. Worth checking before anyone retries the original approach.

## Verified

Dispatched on this branch with `dry_run: true` — full evaluation across all 23 open PRs with the real `GITHUB_TOKEN` ([run](https://github.com/PioneerAIAcademy/cowork-genealogy/actions/runs/30458016976)):

- **5 would promote:** #935, #931, #928, #917, #885
- **18 not ready**, each with its reason — 5 on failing CI, 2 with changes requested, the rest lacking a peer approval

Also: only 5 open PRs have a peer *approval* at all. #933 and #926 look reviewed in the UI but are `COMMENTED`, which advances nothing toward merge.

## Two lessons from v1, baked in

- **No `try`/`catch` around the write.** The first version downgraded failure to a warning, so an API that no-op'd with HTTP 200 produced a green job that did nothing.
- **The label is read back after writing** and the job fails if it is absent, so a future silent no-op cannot masquerade as success.

## Notes for review

- **v1 is add-only.** A labeled PR is never unlabeled, so PRs don't flicker out of the queue mid-review.
- **Any non-author approval counts.** Distinguishing peers from genealogists needs a token with `read:org`; not worth it.
- **`CHANGES_REQUESTED` blocks promotion.** Slightly beyond "green + peer review" — #929 and #905 are blocked on their authors, not waiting on a genealogist. Changes no outcome today; easy to drop.
- The label write itself runs first on a real promotion; the read-back guard makes a failure loud rather than silent.

## Required status checks — not enabled, and why

Nothing requires a status check today, so a PR with failing CI can be merged on approvals alone.

Five PR workflows are path-filtered, so `pytest`, `check`, and `vitest` never report on a docs-only, `apps/web`, `packages/schema`, or `.github`-only PR — **including this one**, which gets only `coauthor-warn` and `scan`. A required check that never reports leaves its PR on "Expected — waiting for status to be reported" forever.

Step 4 of the script preflights every open PR and refuses rather than deadlocking the team. Run today it correctly aborted: this PR is missing `pytest`/`check`/`vitest`, and `vitest` is missing from 19 of 22 others.

The unblocker is a separate PR: drop `paths:` from those workflows and move the filter to an early-exit guard inside each job, so the check always reports a conclusion. After that, `APPLY=1 REQUIRE_CHECKS=1` enables the rule — and because it lives in the ruleset, whose bypass actor is `DallanQ` with mode `always`, red PRs are blocked for the team but still mergeable by you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)