### PR TITLE
ci: run the five gating checks on every PR so they can be required

### DIFF
--- a/.github/workflows/check-e2e-fixtures.yml
+++ b/.github/workflows/check-e2e-fixtures.yml
@@ -17,28 +17,57 @@ name: Check e2e fixtures + grading
 # This check only reads committed files; it does NOT run a live e2e test
 # (those are too expensive to gate PRs — see spec §12).
 
+# Runs on EVERY pull request — no `paths:` filter — so this check always
+# reports a conclusion and can be required by branch protection. A workflow
+# skipped by `paths:` reports nothing at all, and a required check that never
+# reports leaves its PR stuck on "Expected — waiting for status to be reported"
+# with no way forward except a ruleset bypass. The path scope moved into the
+# first job step; what this check does when it applies is unchanged.
 on:
   pull_request:
-    paths:
-      - 'eval/tests/e2e/**'
-      - 'eval/runlogs/e2e/**'
-      - 'eval/harness/scripts/check_e2e_fixtures.py'
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
-  check:
+  # Renamed from `check`: check-runlogs.yml also had a job named `check`, so
+  # with both now running on every PR two distinct contexts would share one
+  # name and a required-status-check rule could not tell them apart.
+  e2e-fixtures:
     runs-on: ubuntu-latest
     steps:
+      - name: Does this PR touch e2e fixtures or run logs?
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PATTERNS: '^eval/tests/e2e/|^eval/runlogs/e2e/|^eval/harness/scripts/check_e2e_fixtures\.py$|^\.github/workflows/check-e2e-fixtures\.yml$'
+        run: |
+          set -euo pipefail
+          files="$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+                     --paginate --jq '.[].filename')"
+          if printf '%s\n' "$files" | grep -qE "$PATTERNS"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No e2e fixture or run-log path changed; reporting success without running the gate."
+          fi
+
       - name: Check out PR with full history
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
       - name: Check e2e grading gate (blocking)
+        if: steps.scope.outputs.relevant == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/check-engine-lockfile.yml
+++ b/.github/workflows/check-engine-lockfile.yml
@@ -15,25 +15,49 @@ name: check-engine-lockfile
 #
 # The build itself uses `npm ci` (never writes the lock, on any npm); this job is
 # the separate check that catches a deliberate dep change made with the wrong npm.
+# Runs on EVERY pull request — no `paths:` filter — so this check always
+# reports a conclusion and can be required by branch protection. A workflow
+# skipped by `paths:` reports nothing at all, and a required check that never
+# reports leaves its PR stuck on "Expected — waiting for status to be reported"
+# with no way forward except a ruleset bypass. The path scope moved into the
+# first job step; what this check does when it applies is unchanged.
 on:
   pull_request:
-    paths:
-      - 'packages/engine/mcp-server/package.json'
-      - 'packages/engine/mcp-server/package-lock.json'
 permissions:
   contents: read
+  pull-requests: read
 jobs:
   lockfile-drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - name: Does this PR touch the engine manifest or lockfile?
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PATTERNS: '^packages/engine/mcp-server/package(-lock)?\.json$|^\.github/workflows/check-engine-lockfile\.yml$'
+        run: |
+          set -euo pipefail
+          files="$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+                     --paginate --jq '.[].filename')"
+          if printf '%s\n' "$files" | grep -qE "$PATTERNS"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Neither package.json nor package-lock.json changed; reporting success without running the drift check."
+          fi
+
+      - if: steps.scope.outputs.relevant == 'true'
+        uses: actions/checkout@v5
 
       - name: Set up Node
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '22'
 
       - name: Install the pinned npm (from the packageManager field)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # Node 22 bundles npm 10.x; install the exact npm the engine pins so
           # this gate checks the lock against the canonical version. The version
@@ -43,6 +67,7 @@ jobs:
           echo "Using npm $(npm --version)"
 
       - name: Fail if `npm install` would rewrite the lockfile
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: packages/engine/mcp-server
         run: |
           npm install --no-audit --no-fund --ignore-scripts

--- a/.github/workflows/check-runlogs.yml
+++ b/.github/workflows/check-runlogs.yml
@@ -28,20 +28,17 @@ on:
     # types (opened, synchronize, reopened) are listed explicitly because
     # naming any type replaces the defaults.
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths:
-      - 'eval/runlogs/unit/**'
-      - 'eval/tests/unit/**'
-      - 'packages/engine/plugin/skills/**'
-      # agents/** so the frontmatter lint (check_skill_frontmatter.py) gates
-      # plugin agent descriptions too, not just skills.
-      - 'packages/engine/plugin/agents/**'
-      - 'eval/fixtures/**'
-      - 'eval/harness/**'
-      # MCP source (packages/engine/mcp-server/src/**) is intentionally not a
-      # trigger: it is no longer embedded in the run-log snapshot, so a
-      # src-only change cannot affect run-log activeness (rule 2).
+    # No `paths:` filter — this check runs on EVERY pull request so it always
+    # reports a conclusion and can be required by branch protection. A workflow
+    # skipped by `paths:` reports nothing at all, and a required check that
+    # never reports leaves its PR stuck on "Expected — waiting for status to be
+    # reported" with no way forward except a ruleset bypass. The former filter
+    # moved verbatim into the `scope` step below; what this check does when it
+    # applies is unchanged.
 
 # `issues: write` lets the auto-strip step remove the bypass label from the PR.
+# `pull-requests: read` is additionally needed by the `scope` step, and is
+# implied by the `write` already granted here.
 permissions:
   contents: read
   issues: write
@@ -55,11 +52,36 @@ permissions:
 # commit it was approved for — the senior must re-apply after each push. The
 # label must exist in the repo once: `gh label create eval-cosmetic-skip`.
 jobs:
-  check:
+  # Renamed from `check`: check-e2e-fixtures.yml also had a job named `check`,
+  # so with both now running on every PR two distinct contexts would share one
+  # name and a required-status-check rule could not tell them apart.
+  runlogs:
     runs-on: ubuntu-latest
     steps:
+      # The former `paths:` filter, moved into the job. `agents/**` is here so
+      # the frontmatter lint gates plugin agent descriptions too, not just
+      # skills. MCP source (packages/engine/mcp-server/src/**) is intentionally
+      # absent: it is no longer embedded in the run-log snapshot, so a src-only
+      # change cannot affect run-log activeness (rule 2).
+      - name: Does this PR touch run logs, unit tests, skills, agents, fixtures, or the harness?
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PATTERNS: '^eval/runlogs/unit/|^eval/tests/unit/|^packages/engine/plugin/skills/|^packages/engine/plugin/agents/|^eval/fixtures/|^eval/harness/|^\.github/workflows/check-runlogs\.yml$'
+        run: |
+          set -euo pipefail
+          files="$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+                     --paginate --jq '.[].filename')"
+          if printf '%s\n' "$files" | grep -qE "$PATTERNS"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No run-log, unit-test, skill, agent, fixture, or harness path changed; reporting success without running the discipline checks."
+          fi
+
       - name: Drop stale cosmetic-skip label on new commits
-        if: github.event.action == 'synchronize'
+        if: steps.scope.outputs.relevant == 'true' && github.event.action == 'synchronize'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -68,6 +90,7 @@ jobs:
             --remove-label "eval-cosmetic-skip" || true
 
       - name: Resolve cosmetic-skip state
+        if: steps.scope.outputs.relevant == 'true'
         id: cosmetic
         env:
           GH_TOKEN: ${{ github.token }}
@@ -84,16 +107,19 @@ jobs:
           fi
 
       - name: Check out PR with full history
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
       - name: Run runlog discipline checks
+        if: steps.scope.outputs.relevant == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -101,6 +127,7 @@ jobs:
         run: python eval/harness/scripts/check_runlogs.py
 
       - name: Check skill tool-coverage drift (warn-only)
+        if: steps.scope.outputs.relevant == 'true'
         run: python eval/harness/scripts/check_tool_coverage.py
 
       # Blocking on hard rules (bad/mismatched name, or a description that
@@ -109,4 +136,5 @@ jobs:
       # they catch a long or `<bracketed>` value on a continuation line. Soft
       # rules (unknown key, unresolvable tool) only warn. The corpus passes today.
       - name: Lint skill + agent frontmatter
+        if: steps.scope.outputs.relevant == 'true'
         run: python eval/harness/scripts/check_skill_frontmatter.py

--- a/.github/workflows/engine-tests.yml
+++ b/.github/workflows/engine-tests.yml
@@ -18,21 +18,48 @@ name: Engine tests
 # not strictly need but the tool-dispatch tests do — it also fails the job fast
 # on a type error, before vitest starts.
 
+#
+# Runs on EVERY pull request — no `paths:` filter — so this check always
+# reports a conclusion and can be required by branch protection. A workflow
+# skipped by `paths:` reports nothing at all, and a required check that never
+# reports leaves its PR stuck on "Expected — waiting for status to be reported"
+# with no way forward except a ruleset bypass. The path scope above moved into
+# the first job step verbatim; what this check does when it applies is
+# unchanged, and an unrelated PR pays one ~5s step instead of a full suite.
 on:
   pull_request:
-    paths:
-      - 'packages/engine/mcp-server/**'
-      - 'packages/engine/plugin/**'
-      - '.github/workflows/engine-tests.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   vitest:
     runs-on: ubuntu-latest
     steps:
+      - name: Does this PR touch the engine or the plugin?
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PATTERNS: '^packages/engine/mcp-server/|^packages/engine/plugin/|^\.github/workflows/engine-tests\.yml$'
+        run: |
+          set -euo pipefail
+          files="$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+                     --paginate --jq '.[].filename')"
+          if printf '%s\n' "$files" | grep -qE "$PATTERNS"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No engine or plugin path changed; reporting success without running vitest."
+          fi
+
       - name: Check out PR
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/checkout@v5
 
       - name: Set up Node
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -40,6 +67,7 @@ jobs:
           cache-dependency-path: packages/engine/mcp-server/package-lock.json
 
       - name: Install the pinned npm (from the packageManager field)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # Node 22 bundles npm 10.x; the engine's .npmrc sets engine-strict with
           # an npm >=11.12 bound, so install the pinned npm before any engine
@@ -49,9 +77,11 @@ jobs:
           echo "Using npm $(npm --version)"
 
       - name: Install dependencies
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: packages/engine/mcp-server
         run: npm ci
 
       - name: Run vitest (pretest builds first)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: packages/engine/mcp-server
         run: npm test

--- a/.github/workflows/eval-harness-tests.yml
+++ b/.github/workflows/eval-harness-tests.yml
@@ -29,24 +29,48 @@ name: Eval harness tests
 # removing an API claude-agent-sdk calls, and there was no lockfile to catch
 # it before merge. See the mcp pin + comment in eval/harness/pyproject.toml.
 
+#
+# Runs on EVERY pull request — no `paths:` filter — so this check always
+# reports a conclusion and can be required by branch protection. A workflow
+# skipped by `paths:` reports nothing at all, and a required check that never
+# reports leaves its PR stuck on "Expected — waiting for status to be reported"
+# with no way forward except a ruleset bypass. The path scope above moved into
+# the first job step verbatim; what this check does when it applies is
+# unchanged, and an unrelated PR pays one ~5s step instead of a full suite.
 on:
   pull_request:
-    paths:
-      - 'eval/harness/**'
-      - 'packages/engine/plugin/skills/**'
-      - 'eval/fixtures/**'
-      - 'eval/tests/**'
-      - 'docs/specs/schemas/**'
-      - 'packages/engine/mcp-server/**'
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   pytest:
     runs-on: ubuntu-latest
     steps:
+      - name: Does this PR touch the harness, skills, fixtures, tests, or schemas?
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PATTERNS: '^eval/harness/|^packages/engine/plugin/skills/|^eval/fixtures/|^eval/tests/|^docs/specs/schemas/|^packages/engine/mcp-server/|^\.github/workflows/eval-harness-tests\.yml$'
+        run: |
+          set -euo pipefail
+          files="$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+                     --paginate --jq '.[].filename')"
+          if printf '%s\n' "$files" | grep -qE "$PATTERNS"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No harness, skill, fixture, test, or schema path changed; reporting success without running pytest."
+          fi
+
       - name: Check out PR
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/checkout@v5
 
       - name: Set up Node
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -54,6 +78,7 @@ jobs:
           cache-dependency-path: packages/engine/mcp-server/package-lock.json
 
       - name: Install the pinned npm (from the packageManager field)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # Node 22 bundles npm 10.x; the engine's .npmrc sets engine-strict with
           # an npm >=11.12 bound, so install the pinned npm before any engine
@@ -63,12 +88,14 @@ jobs:
           echo "Using npm $(npm --version)"
 
       - name: Build mcp-server (harness CLI loads compiled JS from build/)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: packages/engine/mcp-server
         run: |
           npm ci
           npm run build
 
       - name: Install uv (+ pinned Python)
+        if: steps.scope.outputs.relevant == 'true'
         uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.11'
@@ -76,9 +103,11 @@ jobs:
           cache-dependency-glob: 'eval/harness/uv.lock'
 
       - name: Sync dependencies
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: eval/harness
         run: uv sync --frozen
 
       - name: Run harness unit tests (excludes live-API e2e)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: eval/harness
         run: uv run --frozen pytest -m 'not e2e'


### PR DESCRIPTION
Prerequisite for enabling required status checks. Companion to #944.

## The problem

Nothing requires a status check to pass before merge today — a PR with failing CI can be merged on approvals alone. #929 currently sits with two red checks, two approvals away from mergeable.

Requiring them is blocked by a GitHub property: **a required status check that never reports leaves its PR on "Expected — waiting for status to be reported" forever**, with no way forward except a ruleset bypass. Five of our PR workflows are path-filtered, so `pytest`, `check`, `vitest`, and `lockfile-drift` never report on a docs-only, `apps/web`, `packages/schema`, or `.github`-only PR. Turning required checks on today would deadlock exactly those PRs — starting with #944, which gets only `coauthor-warn` and `scan`.

## The change

Drop `paths:` from all five workflows so they always run, and move each filter verbatim into a first job step that sets `relevant`. Every later step is gated on it.

The check now always reports a conclusion. **What it does when it applies is unchanged** — an unrelated PR pays one ~5s API call instead of a full suite.

## Job renames

`check-e2e-fixtures` and `check-runlogs` both had a job named `check`. Harmless while they were mutually exclusive by path; now that both run on every PR they'd be two distinct contexts sharing one name, which a required-check rule cannot disambiguate.

| workflow | before | after |
|---|---|---|
| `check-e2e-fixtures.yml` | `check` | `e2e-fixtures` |
| `check-runlogs.yml` | `check` | `runlogs` |

## Verified

- All five parse as valid YAML; no `paths:` survives; **0 ungated steps across 31** after the guard.
- Replaying the patterns over representative file lists reproduces the old routing exactly:

```
case                 e2e-fixtu engine-lo  runlogs   engine   eval-harn
docs-only              skip      skip      skip      skip      skip
this PR (.github)       RUN       RUN       RUN       RUN       RUN
PR #944 (.github)      skip      skip      skip      skip      skip
eval unit PR           skip      skip       RUN       RUN       RUN
e2e fixture PR          RUN      skip      skip      skip       RUN
apps/web PR            skip      skip      skip      skip      skip
dep bump               skip       RUN      skip       RUN       RUN
```

- **This PR trips all five** (each pattern matches its own workflow file), so CI here exercises every check's real path rather than only the skip path.

## Why the guard is inlined rather than a shared action

A local composite action needs a checkout before it can be used, and the guard has to run *before* the checkout to save anything. A `@main` reference would not resolve until this merged. Five copies of ~10 lines beat either.

## After this merges

Required checks can be turned on:

```
APPLY=1 REQUIRE_CHECKS=1 \
  REQUIRED_CONTEXTS="pytest runlogs e2e-fixtures vitest lockfile-drift scan" \
  ./.github/scripts/consolidate-branch-protection.sh
```

The script preflights every open PR and refuses if any would never receive a required context, so it will tell you rather than deadlock the team.

Two notes:
- `REQUIRED_CONTEXTS` in #944's script still defaults to the pre-rename `pytest check vitest scan`. It needs updating to the list above once both PRs land — passing it explicitly (as shown) works in the meantime.
- `coauthor-warn` is deliberately omitted: it is warn-only and always exits 0, so requiring it adds nothing.

Because the rule lives in the `protect-main` ruleset, whose bypass actor is `DallanQ` with mode `always`, red PRs are blocked for the team but still mergeable by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)