### PR TITLE
eval-harness: fire the guardrail check on conflict-resolution's analysis, not just status

### DIFF
--- a/eval/harness/harness/skill_invocation.py
+++ b/eval/harness/harness/skill_invocation.py
@@ -207,6 +207,49 @@ def find_unguarded_protected_writes(
     return violations
 
 
+# The four optional `conflict` fields that are conflict-resolution's analytical
+# PRODUCT rather than the mere record that a conflict exists. Several skills
+# legitimately open a conflicts entry — person-evidence (#738's mandatory entry
+# when identity rests on one uncorroborated read), proof-conclusion,
+# question-selection, research-plan, timeline, init-project — but they write only
+# the schema's required fields (id / conflict_type / description /
+# competing_assertion_ids / status / blocks_question_ids). These four are
+# optional in `research.schema.json` and, across the whole plugin, are written
+# ONLY by `conflict-resolution/SKILL.md` and by `research/SKILL.md` — i.e. the
+# orchestrator that is supposed to *delegate* to it. So their presence is the
+# effect, and their absence is why "a conflict was recorded" alone must not fire.
+CONFLICT_ANALYSIS_FIELDS = (
+    "independence_analysis",
+    "weighing_analysis",
+    "preferred_assertion_id",
+    "resolution_rationale",
+)
+
+
+def _is_conflict_resolution_product(conflict: Any) -> bool:
+    """Whether a `conflicts[]` entry carries conflict-resolution's own output.
+
+    Two independent signals, either sufficient:
+
+    - any of `CONFLICT_ANALYSIS_FIELDS` populated (non-empty, non-null), or
+    - `status == "resolved"` — resolving is the skill's job whatever fields it
+      left behind.
+
+    Checking status ALONE (the original rule) under-fires: `unresolved` is a
+    legitimate *outcome* of a full weighing — the skill ran, analysed, and
+    concluded the conflict stands. The `eulogia-gatica-burial` run
+    (run-2026-07-28_17-07-48) is the live case: the router wrote c_001 with a
+    full `independence_analysis` and `weighing_analysis`, never invoked
+    conflict-resolution, and slipped past the status check because it left the
+    conflict `unresolved` — then stamped the proof `proved` over it.
+    """
+    if not isinstance(conflict, dict):
+        return False
+    if conflict.get("status") == "resolved":
+        return True
+    return any(conflict.get(f) for f in CONFLICT_ANALYSIS_FIELDS)
+
+
 def find_effects_without_invocation(
     tool_calls: list[dict[str, Any]],
     research: dict[str, Any] | None,
@@ -226,6 +269,10 @@ def find_effects_without_invocation(
     fixture's starting tree) and flag only NEW persons or persons that GAINED
     facts this run — without it, every already-linked-by-nothing seed person
     would read as a violation. Best-effort and may over-flag when omitted.
+
+    Each arm keys on a *product* of the skill, never on the skill's mere
+    footprint — see `_is_conflict_resolution_product` for why the
+    conflict-resolution arm cannot key on `status` alone.
     """
     research = research or {}
     tree = tree or {}
@@ -300,12 +347,13 @@ def find_effects_without_invocation(
         )
 
     conflicts = research.get("conflicts") if isinstance(research.get("conflicts"), list) else []
-    if any(isinstance(c, dict) and c.get("status") == "resolved" for c in conflicts) and (
+    if any(_is_conflict_resolution_product(c) for c in conflicts) and (
         "conflict-resolution" not in invoked
     ):
         violations.append(
-            "research.json has a resolved conflict but 'conflict-resolution' was never "
-            "successfully invoked in this run"
+            "research.json has a conflict carrying conflict-resolution's analytical product "
+            f"({', '.join(CONFLICT_ANALYSIS_FIELDS)}, or status='resolved') but "
+            "'conflict-resolution' was never successfully invoked in this run"
         )
 
     return violations

--- a/eval/harness/tests/unit/test_skill_invocation.py
+++ b/eval/harness/tests/unit/test_skill_invocation.py
@@ -4,7 +4,10 @@ docs/plan/research-guardrail-bypass-plan.md §4.1/§4.4 — pure matching logic
 over the harness's `tool_calls` list shape, no I/O, no SDK types.
 """
 
+import pytest
+
 from harness.skill_invocation import (
+    CONFLICT_ANALYSIS_FIELDS,
     GUARDRAIL_SKILLS,
     find_effects_without_invocation,
     find_missing_mentor_verdicts,
@@ -295,7 +298,55 @@ def test_flags_a_resolved_conflict_with_no_conflict_resolution_invocation():
 
 
 def test_unresolved_conflict_does_not_require_invocation():
+    """A bare record that a conflict EXISTS is not conflict-resolution's product.
+
+    person-evidence (#738), proof-conclusion, question-selection, research-plan,
+    timeline and init-project all legitimately open a conflicts entry with only
+    the schema's required fields. Firing here would flag every one of them.
+    """
     research = {"conflicts": [{"id": "c_001", "status": "unresolved"}]}
+    assert find_effects_without_invocation([], research, {}) == []
+
+
+@pytest.mark.parametrize("field", CONFLICT_ANALYSIS_FIELDS)
+def test_flags_an_unresolved_conflict_carrying_the_analysis_product(field):
+    """Regression for eulogia-gatica-burial run-2026-07-28_17-07-48.
+
+    The router wrote a full independence/weighing analysis into c_001, never
+    invoked conflict-resolution, and left `status: unresolved` — which the
+    status-only rule read as "nothing to see here". It then stamped the proof
+    `proved` over the open conflict. Each analysis field alone must fire.
+    """
+    research = {"conflicts": [{"id": "c_001", "status": "unresolved", field: "a_004"}]}
+    violations = find_effects_without_invocation([], research, {})
+    assert any("conflict-resolution" in v for v in violations)
+
+
+def test_analysis_product_is_satisfied_by_invoking_conflict_resolution():
+    research = {
+        "conflicts": [
+            {"id": "c_001", "status": "unresolved", "weighing_analysis": "the 1862 baptism wins"}
+        ]
+    }
+    calls = [_skill_call("conflict-resolution")]
+    assert not any("conflict-resolution" in v for v in find_effects_without_invocation(calls, research, {}))
+
+
+def test_empty_analysis_fields_do_not_fire():
+    """Null/empty is the schema's own default for these optional fields — a
+    writer that spells them out as empty has still produced no analysis."""
+    research = {
+        "conflicts": [
+            {
+                "id": "c_001",
+                "status": "unresolved",
+                "independence_analysis": None,
+                "weighing_analysis": "",
+                "preferred_assertion_id": None,
+                "resolution_rationale": None,
+            }
+        ]
+    }
     assert find_effects_without_invocation([], research, {}) == []
 
 


### PR DESCRIPTION
## Summary

- `find_effects_without_invocation`'s conflict-resolution arm keyed on `status == "resolved"`, which under-fires: `unresolved` is a legitimate *outcome* of a full weighing, so a router that does the analysis itself and leaves the conflict open slipped straight through the §4.4 hard check.
- Key on the skill's analytical **product** instead — `independence_analysis`, `weighing_analysis`, `preferred_assertion_id`, `resolution_rationale` — keeping the `status == "resolved"` arm as an independent signal.
- Closes the gap the `eulogia-gatica-burial` run exposed, where §4.1's shadow check caught the write and §4.4's hard check did not.

## The live case

`eval/runlogs/e2e/eulogia-gatica-burial/run-2026-07-28_17-07-48` (committed in #935). Across 83 tool calls the router invoked question-selection, locality-guide, research-plan, search-records, record-extraction and person-evidence — and **never** proof-conclusion, research-exhaustiveness, conflict-resolution or gps-mentor. It wrote all of their outputs itself via 17 direct `research_append` calls.

For conflicts specifically it produced a full `independence_analysis` and `weighing_analysis` on `c_001`, left `status: "unresolved"`, and then stamped the proof `proved` over the open 1862/1865 birth-year conflict. §4.1 logged it as shadow violation index 79; §4.4 said nothing.

## Why keying on the analysis fields is safe

Those four fields are optional in `research.schema.json`, and across the whole plugin they are written **only** by `conflict-resolution/SKILL.md` and `research/SKILL.md` — the orchestrator that is supposed to delegate to it.

Six skills legitimately open a conflicts entry — person-evidence (#738's mandatory entry when identity rests on one uncorroborated read), proof-conclusion, question-selection, research-plan, timeline, init-project — but they write only the schema's *required* fields (`id` / `conflict_type` / `description` / `competing_assertion_ids` / `status` / `blocks_question_ids`). So a bare "this conflict exists" record still does not fire, and the existing `test_unresolved_conflict_does_not_require_invocation` passes unchanged.

## Verification

**Replayed the real run** through the patched detector: **2 violations → 3**, the new one being conflict-resolution.

**Swept all 102 committed e2e runs** that have a final `research.json` for false positives. Two newly fire, and I checked both by hand — each has a full independence + weighing analysis with `conflict-resolution` absent from the whole run, so both are genuine:

| Run | Current verdict |
|---|---|
| `cruz-corona-ancestry/run-2026-07-13_04-12-41` | partial |
| `hole-parents-negative/run-2026-07-22_11-27-49` | **pass** |

Committed runlogs keep their recorded verdicts, so **no historical grade changes and nothing goes red in CI** — the detector runs at grade time on a new run's artifacts, and nothing re-scores a committed log.

The change is purely forward-looking: *if* a future run repeats this behaviour — writing the weighing analysis without invoking conflict-resolution — it now fails where it would previously have passed. Whether any given re-run does so is undetermined: the agent is non-deterministic, and §4.1's hook is still shadow-mode, so nothing actively prevents a recurrence. Posted on #913 as corpus-audit evidence.

## Test plan

- [ ] ~~I ran `scripts/test.sh` and it passed.~~ — **two of three suites pass; the third cannot run on this machine.** Eval harness pytest **1259 passed, 2 skipped**; eval app vitest **134 passed**. The MCP-server vitest suite fails to compile because `packages/engine/mcp-server/node_modules` is **empty** in the checkout — a pre-existing environment state, not this branch (it fails identically on clean `main`). This diff is Python-only and cannot affect that suite.
- [x] No skill files changed (harness-only), so no `RunTests.bat` runlog applies.

## Related

- #914 — added the §4.4 hard check this extends
- #913 — historical corpus audit; two data points added
- #911 — shadow-window calibration
- `docs/plan/research-guardrail-bypass-plan.md` §4.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

