### PR TITLE
ci: rename the queue label to `ready-for-senior`

### DIFF
--- a/.github/workflows/genealogist-queue.yml
+++ b/.github/workflows/genealogist-queue.yml
@@ -1,8 +1,8 @@
 name: genealogist-queue
 
-# Labels a PR `ready-for-genealogist` once it is actually ready for senior
-# review: CI green, an approving review from someone other than the author, and
-# no outstanding changes-requested.
+# Labels a PR `ready-for-senior` once it is actually ready for senior review:
+# CI green, an approving review from someone other than the author, and no
+# outstanding changes-requested.
 #
 # WHY. `.github/CODEOWNERS` is `* @PioneerAIAcademy/senior-genealogists`, so
 # GitHub requests the team the instant a PR opens — when CI is usually red and
@@ -11,7 +11,7 @@ name: genealogist-queue
 # is therefore accurate as "a PR exists" and useless as "this needs you". The
 # label is the signal that means the second thing:
 #
-#   is:open is:pr label:ready-for-genealogist
+#   is:open is:pr label:ready-for-senior
 #
 # WHY A LABEL AND NOT THE REVIEW REQUEST. The obvious design is to strip the
 # team's review request on open and re-add it when ready, so the existing
@@ -82,7 +82,7 @@ jobs:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
         with:
           script: |
-            const LABEL = 'ready-for-genealogist';
+            const LABEL = 'ready-for-senior';
             // This workflow's own check run is always in progress while it
             // runs; counting it would mean CI is never "green".
             const SELF  = 'genealogist-queue';


### PR DESCRIPTION
Follow-up to #944. One-word rename, no behaviour change.

`ready-for-genealogist` → **`ready-for-senior`**. The label names the reviewer role, and "senior" is what we call it everywhere else — the CODEOWNERS team, the review requirement, the asks in #familysearch-help.

The saved search becomes:

```
is:open is:pr label:ready-for-senior
```

## Nothing to migrate

No PR carries the old label. The workflow has run three times since #944 merged — on `grade-on-invariant-rule`, `guardrail-conflict-check`, and its own PR — and correctly found none of them ready (no peer approval yet). The 22 pre-existing PRs simply haven't had a triggering event since the merge, which is why the queue looks empty rather than broken.

The stale `ready-for-genealogist` label gets deleted from the repo once this lands; the workflow recreates the new one on its first promotion.

## After merge

Dispatching `genealogist-queue` on `main` with `dry_run: false` labels every currently-eligible PR in one pass, rather than waiting for each to get its next push. As of now that's **#935, #931, #928, #917, #885**.

Verified: YAML parses, the embedded `github-script` body syntax-checks, and no `ready-for-genealogist` reference survives anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)