### PR TITLE
Stop an empty node_modules from failing as five cryptic TS2307 errors

### DIFF
--- a/eval/RunTests.bat
+++ b/eval/RunTests.bat
@@ -12,14 +12,34 @@ if "%SKILL%"=="" (
   exit /b 1
 )
 
-if not exist ..\packages\engine\mcp-server\node_modules\ (
-  echo.
-  echo ERROR: mcp-server dependencies are not installed.
-  echo The build step needs ..\packages\engine\mcp-server\node_modules to exist.
-  echo Please run Setup.bat once to install everything, then retry.
-  pause
-  exit /b 1
-)
+REM Check that the deps are actually THERE, not merely that the folder exists.
+REM `npm ci` deletes node_modules before repopulating it, so an install that was
+REM interrupted (Ctrl-C, closed window, dropped network) leaves an EMPTY folder
+REM behind. `if not exist ...\node_modules\` passes on that folder, so the run
+REM used to continue and die in the build step with five cryptic
+REM "TS2307: Cannot find module" errors instead of this message.
+REM `dir /b` prints nothing when there is no visible entry, so errorlevel 1 from
+REM findstr means "no packages". Note there is NO /a switch: npm writes a hidden
+REM .package-lock.json into node_modules early in the install, so a half-done
+REM install leaves that one hidden file and no packages. `dir /b /a` would list
+REM it and the folder would look populated; plain `dir /b` skips hidden entries
+REM and sees the folder for what it is.
+if not exist ..\packages\engine\mcp-server\node_modules\ goto :nodeps
+dir /b ..\packages\engine\mcp-server\node_modules 2>nul | findstr "." >nul
+if errorlevel 1 goto :nodeps
+goto :depsok
+
+:nodeps
+echo.
+echo ERROR: mcp-server dependencies are not installed.
+echo The build step needs ..\packages\engine\mcp-server\node_modules to contain
+echo the installed packages. The folder is missing or empty — an interrupted
+echo install leaves it empty.
+echo Please run Setup.bat once to install everything, then retry.
+pause
+exit /b 1
+
+:depsok
 
 echo.
 echo Building MCP server (picks up any code changes from the last git pull)...

--- a/scripts/link-worktree.sh
+++ b/scripts/link-worktree.sh
@@ -39,6 +39,25 @@ for rel in $SHARED_PATHS; do
   src="$main/$rel"
   dst="$here/$rel"
   [ -e "$src" ] || continue                  # primary doesn't have it → skip
+  # An EMPTY directory in the primary is worse than a missing one: it exists,
+  # so it links cleanly, and every worktree then inherits an unusable
+  # node_modules that fails as `TS2307 Cannot find module` rather than as
+  # "deps not installed". `npm ci` deletes node_modules before repopulating it,
+  # so any interrupted install leaves exactly this state — and because the link
+  # is shared, one broken primary silently breaks every worktree at once.
+  # Refuse to link it and name the fix instead.
+  #
+  # Deliberately plain `ls`, NOT `ls -A`: npm writes `.package-lock.json` into
+  # node_modules early in the install, so a half-installed directory contains
+  # that one dotfile and nothing else. `ls -A` sees it and reads the directory
+  # as populated — which is the exact live state this guard was written for.
+  # Only a non-hidden entry (a real package, or an `@scope` dir) counts.
+  if [ -d "$src" ] && [ -z "$(ls "$src/" 2>/dev/null)" ]; then
+    echo "link-worktree: SKIPPING $rel — it exists in the primary worktree but is EMPTY."
+    echo "link-worktree:   Run 'make install' in $main to populate it, then re-run"
+    echo "link-worktree:   'make worktree-link' here."
+    continue
+  fi
   if [ -e "$dst" ] && [ ! -L "$dst" ]; then   # real file/dir already here → keep
     echo "link-worktree: keeping existing $rel (not a symlink)"
     continue

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,17 +1,65 @@
 #!/usr/bin/env bash
 # Run all project test suites. Exits non-zero if any suite fails.
+#
+# The two npm suites DELEGATE to their Makefile targets instead of invoking
+# `npm test` directly. Those targets carry the dependency prerequisites
+# ($(ENGINE_DEPS) / $(EVAL_APP_DEPS)), which install-and-stamp before running.
+# Calling `npm test` straight — what this script used to do — is what let an
+# empty packages/engine/mcp-server/node_modules surface as five cryptic
+# TS2307 "Cannot find module" errors instead of "deps not installed", on the
+# one command the PR template tells every contributor to run.
+#
+# The harness suite stays a direct `uv run`: uv auto-syncs its venv, so it has
+# no equivalent failure mode, and `make harness-test` deliberately runs a
+# NARROWER set (`-m 'not e2e'`). Delegating it would silently shrink this
+# gate's coverage.
 
-set -euo pipefail
+set -uo pipefail   # not -e: run every suite, then report all failures together
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 failed=0
 
+# --- preflight ---------------------------------------------------------------
+# Name the missing piece up front. Each of these otherwise fails deep inside a
+# suite with an error that never mentions which tool is absent.
+missing=""
+for tool in make npm uv; do
+  command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
+done
+if [ -n "$missing" ]; then
+  echo "ERROR: required tool(s) not on PATH:$missing" >&2
+  echo "  make / npm — see DEVELOPMENT.md 'Build commands'" >&2
+  echo "  uv         — https://docs.astral.sh/uv/getting-started/installation/" >&2
+  exit 1
+fi
+
+# In a linked worktree, packages/engine/mcp-server/node_modules is a SYMLINK to
+# the primary worktree's copy (scripts/link-worktree.sh). A dependency install
+# triggered from here therefore writes THROUGH the link into the primary, where
+# every other worktree shares it. That is the intended design — one install for
+# all worktrees — but say it out loud, because `npm ci` deletes the directory
+# before repopulating it, so an install interrupted here leaves the primary and
+# every sibling worktree with an empty node_modules.
+#
+# Plain `ls`, not `ls -A`, on purpose: npm writes `.package-lock.json` into
+# node_modules early in the install, so a half-installed directory holds that
+# lone dotfile and no packages. `ls -A` would read it as populated.
+engine_modules="$ROOT/packages/engine/mcp-server/node_modules"
+if [ -L "$engine_modules" ] && [ -z "$(ls "$engine_modules/" 2>/dev/null)" ]; then
+  echo "NOTE: the engine's node_modules is a symlink to the primary worktree, and is empty."
+  echo "      Installing now writes into $(readlink "$engine_modules"),"
+  echo "      which every worktree shares. Let it finish — interrupting it leaves"
+  echo "      the primary worktree broken too."
+  echo ""
+fi
+
+# --- suites ------------------------------------------------------------------
 echo "=== MCP server tests (vitest) ==="
-(cd "$ROOT/packages/engine/mcp-server" && npm test) || failed=1
+make -C "$ROOT" engine-test || failed=1
 
 echo ""
 echo "=== Eval app tests (vitest) ==="
-(cd "$ROOT/eval/app" && npm test) || failed=1
+make -C "$ROOT" eval-ui-test || failed=1
 
 echo ""
 echo "=== Eval harness tests (pytest) ==="


### PR DESCRIPTION
## Summary

`packages/engine/mcp-server/node_modules` in the primary worktree has been empty since 2026-07-27, and nothing in the repo said so. `scripts/test.sh` — the one command the PR template tells every contributor to run — died with five `TS2307: Cannot find module` lines that never mention dependencies.

`npm ci` deletes `node_modules` before repopulating it, so **any interrupted install leaves exactly this state**. Three sites then conspired to keep it that way.

## The three sites

**1. `scripts/test.sh` bypassed every guard.** It invoked `npm test` directly, skipping the Makefile's `$(ENGINE_DEPS)` / `$(EVAL_APP_DEPS)` prerequisites — which already install-and-stamp correctly. Every *other* entry point (`make engine-test`, `make eval-skill`, `make e2e-run`) goes through them; the documented one did not.

Now delegates to `make engine-test` / `make eval-ui-test`, so the broken state self-heals. The harness suite deliberately stays a direct `uv run --frozen pytest` — uv auto-syncs its venv, and `make harness-test` runs a **narrower** set (`-m 'not e2e'`) that would silently shrink this gate's coverage.

**2. `scripts/link-worktree.sh` checked existence, not usability.**

```sh
[ -e "$src" ] || continue        # an EMPTY dir passes this
```

So one broken primary silently broke every worktree at once — and no worktree could self-heal, because installing there writes back *through* the symlink into the primary. Now refuses to link an unusable directory and names the fix.

**3. `eval/RunTests.bat` had the identical bug** — and it's the path the Windows genealogist team actually uses. `if not exist ...\node_modules\` passes on an empty folder, so the run continued and died in the build step with the same cryptic errors. Now checks for real content.

## One subtlety worth reviewing closely

The emptiness test is deliberately plain `ls` / `dir /b`, **not** `ls -A` / `dir /b /a`.

npm writes `.package-lock.json` into `node_modules` early in the install, so a half-installed directory holds that lone dotfile and no packages. An `-A`-style check reads it as populated.

This is not theoretical — the first cut of this guard used `ls -A` and **did not fire** when tested against the live broken state:

```
                                    ls   ls -A   verdict
half-installed (the live state)      0     1     SKIP (unusable)   <- ls -A would say "populated"
populated (real package + dotfile)   1     2     LINK (usable)
```

## Also added

- A `test.sh` preflight naming a missing `make`/`npm`/`uv` up front, instead of failing deep inside a suite with an error that never says which tool is absent.
- A warning when an install is about to write through a worktree symlink into the shared primary — that is the intended design (one install for all worktrees), but interrupting it breaks the primary and every sibling, so it should not be silent.

## Test plan

- [x] **`./scripts/test.sh` now installs and passes all three suites from the broken state** — MCP server **1679 passed** (72 files), eval app **134 passed** (13 files), harness **1255 passed**. Before this change the first suite could not run at all on that same state.
- [x] `sh -n` / `bash -n` clean on both shell scripts.
- [x] `link-worktree.sh` exercised against the real half-installed directory: correctly skips it and still links `eval/.env` + `apps/server/.env`.
- [x] Preflight verified by running with a stripped `PATH` — reports the missing tools by name.
- [ ] `RunTests.bat` is Windows-only and could not be executed here; the batch logic is reviewed but unrun. **Worth a second pair of eyes from someone on Windows.**

## Scope note

CI is unaffected — it installs dependencies itself, which is why `vitest` has been green on GitHub throughout while failing locally. This is entirely a local-dev and Windows-genealogist papercut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
