### PR TITLE
hosted path: register plugin agents under their bare names (#939)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,22 @@ orchestrator auto-delegates to the agent. Agents run in fresh context
 explicitly specced otherwise. The first such agent is `gps-mentor`
 (spec: `docs/specs/gps-mentor-agent-spec.md`).
 
+**How each environment loads them, and why the hosted path is the odd one.**
+Both eval harnesses stage `agents/*.md` into the workspace's `.claude/agents/`
+(`eval/harness/harness/workspace.py`, `eval/harness/e2e/orchestrator.py`) and
+load them via `setting_sources=["project"]`. Cowork loads the plugin as a
+plugin. The hosted control plane does **both**: it passes
+`plugins=[{"type": "local", …}]` for the *skills* and separately stages the
+*agents* into the project (`real_agent.stage_plugin_agents`). That is not
+redundancy — SDK plugin loading registers agents **only** under the namespaced
+name `genealogy-research:<agent>`, while every SKILL.md delegates by the bare
+name (`@plugin:record-extractor`), so without the staging the Task call errors
+and the model silently falls back to a general-purpose stand-in that binds none
+of the `tools:`/`disallowedTools:` below (issue #939; skills are unaffected —
+the loader registers *those* under bare names). If you change how the hosted
+agent is configured, run `make agent-smoke`: it is the only check that reads
+what the runtime actually resolved, and no CI job covers this path.
+
 **Dual-spelled tool names.** In `tools:` — and in `disallowedTools:` —
 every MCP tool **must** be listed twice, once under each server spelling:
 

--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,17 @@ test-js: $(JS_DEPS) ## JS workspace tests — web, electron, viewer-ui, schema (
 server-test: ## Control-plane tests — apps/server (FastAPI, pytest; uv auto-syncs the venv)
 	cd apps/server && uv run pytest -q
 
+.PHONY: agent-smoke
+agent-smoke: $(ENGINE_BUILD) ## Live check that the hosted path registers the plugin agents under their bare names (issue #939; no model call, bills nothing)
+	# The one thing no offline test can see: what the RUNTIME resolves the
+	# hosted options to. It reads the SDK init handshake's agent list — no
+	# query, so it costs nothing but a CLI process start. The key comes from
+	# $$ANTHROPIC_API_KEY, else this repo's eval/.env, and is passed under a
+	# distinct name because tests/conftest.py blanks ANTHROPIC_API_KEY.
+	cd apps/server && \
+	  LIVE_ANTHROPIC_API_KEY="$${ANTHROPIC_API_KEY:-$$(grep -E '^ANTHROPIC_API_KEY=' $(EVAL_ENV) | cut -d= -f2-)}" \
+	  uv run pytest tests/test_plugin_agents.py -q -rs
+
 .PHONY: engine-test
 engine-test: $(ENGINE_DEPS) ## Genealogy engine tests — packages/engine/mcp-server (vitest)
 	cd $(ENGINE_DIR) && npm test

--- a/apps/server/app/agent/real_agent.py
+++ b/apps/server/app/agent/real_agent.py
@@ -16,10 +16,12 @@ conversation from the on-disk transcript (which survives the E2B pause). See
 docs/plan/ably-realtime-migration.md is unrelated; the resume contract is
 sandbox-provider-interface.md decision #1.
 
-Config (build_options) — two load-bearing choices: do NOT set skills="all" (the
+Config (build_options) — three load-bearing choices: do NOT set skills="all" (the
 SDK turns it into `--allowedTools Skill`, restricting to only the Skill tool);
 append the project path via system_prompt so the agent reads research.json from
-cwd, not HOME.
+cwd, not HOME; and stage the plugin's agents into the project rather than letting
+plugin discovery name them (see stage_plugin_agents — plugin loading registers
+them ONLY as `genealogy-research:<agent>`, which no SKILL.md asks for).
 
 The Anthropic key comes from the per-connect secrets file, NOT from this
 process's env (see current_api_key + app/agent_secrets.py). A sandbox's env is
@@ -32,6 +34,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import sys
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -59,6 +62,52 @@ def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
+def stage_plugin_agents(project_dir: Path) -> list[str]:
+    """Copy the plugin's agent definitions into ``<project>/.claude/agents/``.
+
+    Returns the bare agent names now registered (one per staged file).
+
+    ``plugins=[{"type": "local", …}]`` below **does** discover
+    ``packages/engine/plugin/agents/*.md`` — but it registers each one under the
+    plugin-NAMESPACED name ``genealogy-research:<agent>``, and nothing under the
+    bare name. Every SKILL.md delegates by the bare name
+    (``@plugin:record-extractor``), so on the plugin path the Task call
+    hard-errors — "Agent type 'record-extractor' not found" — and the model then
+    improvises: guess the namespaced spelling, fall back to ``general-purpose``,
+    or do the work inline. The fallback is the dangerous one, because a
+    general-purpose stand-in holds the session's whole tool set instead of the
+    agent's ``tools:`` allow-list and binds none of its ``disallowedTools:``
+    denies — the deny being the only thing keeping ``record-extractor`` off the
+    broad ``research_append`` under ``bypassPermissions`` (issue #695).
+
+    Staging into ``.claude/agents/`` is exactly what both eval harnesses do
+    (``eval/harness/harness/workspace.py``, ``eval/harness/e2e/orchestrator.py``)
+    and ``setting_sources=["project"]`` is what loads them, so after this the
+    bare name resolves in every environment we run. The plugin stays loaded for
+    its skills; the namespaced agent names remain registered too and resolve to
+    these same definitions, so either spelling is now correct.
+
+    Verified live against CLI 2.1.220 and guarded by
+    ``tests/test_plugin_agents.py``. Issue #939.
+    """
+    src = Path(_PLUGIN_DIR) / "agents"
+    if not src.is_dir():
+        _log(f"[agent] no plugin agents at {src} — subagent delegation will miss")
+        return []
+    dest = project_dir / ".claude" / "agents"
+    staged: list[str] = []
+    try:
+        dest.mkdir(parents=True, exist_ok=True)
+        for agent_file in sorted(src.glob("*.md")):
+            shutil.copy(agent_file, dest / agent_file.name)
+            staged.append(agent_file.stem)
+    except OSError as exc:
+        # Loud, not silent: an unstaged agent degrades to a general-purpose
+        # stand-in, which is precisely the failure this function exists to stop.
+        _log(f"[agent] FAILED to stage plugin agents into {dest}: {exc}")
+    return staged
+
+
 def current_api_key() -> str:
     """The operator's Anthropic key for the next turn.
 
@@ -78,6 +127,14 @@ def current_api_key() -> str:
 
 def build_options(project_dir: Path, resume: str | None = None, api_key: str | None = None):
     from claude_agent_sdk import ClaudeAgentOptions
+
+    # Side effect, deliberately here: the plugin's agents are registered by
+    # staging their .md files into the project, not by plugin discovery (see
+    # stage_plugin_agents). Doing it on every client build keeps a resumed or
+    # rebuilt session on the current definitions after an engine upgrade.
+    staged = stage_plugin_agents(project_dir)
+    if staged:
+        _log(f"[agent] staged plugin agents: {', '.join(staged)}")
 
     project_note = (
         "You are the hosted genealogy research agent. The active research "

--- a/apps/server/tests/test_plugin_agents.py
+++ b/apps/server/tests/test_plugin_agents.py
@@ -1,0 +1,161 @@
+"""Plugin agents must spawn as THEMSELVES in the hosted path — issue #939.
+
+The hosted control plane was the only environment that loaded the plugin's
+agents through `plugins=[{"type": "local", …}]`. That mechanism registers them
+only as `genealogy-research:<agent>`; every SKILL.md delegates by the bare name
+(`@plugin:record-extractor`), so the Task call errored and the model fell back
+to a general-purpose stand-in — one holding the session's full tool set and
+none of the agent's `disallowedTools:` denies. Neither eval harness could see
+it: both stage into `.claude/agents/`, so a green suite was not evidence.
+
+Three guards, cheapest first:
+
+1. ``test_build_options_stages_*`` — the fix itself, offline.
+2. ``test_skills_delegate_to_agents_that_exist`` — the SKILL.md ↔ agent-name
+   contract, offline. Catches a rename on either side.
+3. ``test_bare_agent_names_are_registered`` — the one that would have caught
+   #939. Connects a real SDK client with the hosted options and reads the
+   registered agent list out of the init handshake. No model call, so it costs
+   nothing but a process start; skipped when its prerequisites are absent.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from pathlib import Path
+
+import pytest
+
+from app.agent import real_agent
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_DIR = REPO_ROOT / "packages" / "engine" / "plugin"
+AGENTS_DIR = PLUGIN_DIR / "agents"
+SKILLS_DIR = PLUGIN_DIR / "skills"
+
+
+def _frontmatter_name(agent_file: Path) -> str:
+    """The name the runtime registers the agent under (frontmatter `name:`)."""
+    for line in agent_file.read_text(encoding="utf-8").splitlines():
+        m = re.match(r"^name:\s*(\S+)\s*$", line)
+        if m:
+            return m.group(1)
+    raise AssertionError(f"{agent_file.name} has no `name:` in its frontmatter")
+
+
+def _shipped_agents() -> list[Path]:
+    files = sorted(AGENTS_DIR.glob("*.md"))
+    assert files, f"no agent definitions under {AGENTS_DIR}"
+    return files
+
+
+# ── 1. the fix: bare-name registration via project staging ───────
+
+def test_build_options_stages_plugin_agents_into_the_project(tmp_path, monkeypatch):
+    monkeypatch.setattr(real_agent, "_PLUGIN_DIR", str(PLUGIN_DIR))
+    real_agent.build_options(tmp_path)
+
+    staged = tmp_path / ".claude" / "agents"
+    assert sorted(p.name for p in staged.glob("*.md")) == [
+        p.name for p in _shipped_agents()
+    ]
+
+
+def test_staged_agent_name_matches_its_filename(tmp_path, monkeypatch):
+    # `.claude/agents/` registers by frontmatter `name:`, while every caller —
+    # SKILL.md, both harnesses, this test — reasons about the filename. They
+    # must agree or the bare name still misses.
+    monkeypatch.setattr(real_agent, "_PLUGIN_DIR", str(PLUGIN_DIR))
+    names = real_agent.stage_plugin_agents(tmp_path)
+
+    assert names == [p.stem for p in _shipped_agents()]
+    for agent_file in _shipped_agents():
+        assert _frontmatter_name(agent_file) == agent_file.stem
+
+
+def test_staging_refreshes_a_stale_definition(tmp_path, monkeypatch):
+    # A session resumed after an engine upgrade must get the new body, not the
+    # copy staged by the run that created the project.
+    monkeypatch.setattr(real_agent, "_PLUGIN_DIR", str(PLUGIN_DIR))
+    stale = tmp_path / ".claude" / "agents" / "record-extractor.md"
+    stale.parent.mkdir(parents=True)
+    stale.write_text("stale\n", encoding="utf-8")
+
+    real_agent.stage_plugin_agents(tmp_path)
+
+    assert stale.read_text(encoding="utf-8") != "stale\n"
+
+
+def test_missing_plugin_agents_dir_is_survivable(tmp_path, monkeypatch):
+    monkeypatch.setattr(real_agent, "_PLUGIN_DIR", str(tmp_path / "nope"))
+    assert real_agent.stage_plugin_agents(tmp_path) == []
+
+
+# ── 2. the SKILL.md ↔ agent-name contract ────────────────────────
+
+def test_skills_delegate_to_agents_that_exist():
+    shipped = {p.stem for p in _shipped_agents()}
+    referenced: dict[str, str] = {}
+    for skill in sorted(SKILLS_DIR.glob("*/SKILL.md")):
+        for name in re.findall(r"@plugin:([a-z0-9-]+)", skill.read_text(encoding="utf-8")):
+            referenced.setdefault(name, skill.parent.name)
+
+    assert referenced, "no @plugin: delegation found — did the convention change?"
+    unknown = {n: s for n, s in referenced.items() if n not in shipped}
+    assert not unknown, f"SKILL.md delegates to agents that do not ship: {unknown}"
+
+
+# ── 3. the live guard (deterministic, no model call) ─────────────
+
+_ENGINE_BUILD = Path(
+    os.environ.get(
+        "ENGINE_MCP_BUILD",
+        str(REPO_ROOT / "packages/engine/mcp-server/build/index.js"),
+    )
+)
+
+
+# Opt-in, and NOT via ANTHROPIC_API_KEY: conftest.py blanks that var on import
+# to keep the operator key out of test assertions. `make agent-smoke` sources
+# eval/.env and exports it under this name. Setting it is the opt-in.
+_LIVE_KEY = os.environ.get("LIVE_ANTHROPIC_API_KEY", "")
+
+
+@pytest.mark.skipif(
+    not _LIVE_KEY, reason="live check — run `make agent-smoke` (sets LIVE_ANTHROPIC_API_KEY)"
+)
+@pytest.mark.skipif(
+    not _ENGINE_BUILD.exists(), reason="needs the compiled engine (make engine-build)"
+)
+@pytest.mark.skipif(shutil.which("node") is None, reason="needs node for the MCP server")
+async def test_bare_agent_names_are_registered(tmp_path, monkeypatch):
+    """Start a real SDK client with the hosted options and assert every shipped
+    agent is registered under its BARE name.
+
+    `get_server_info()` returns the init handshake, which carries the runtime's
+    resolved agent list — the ground truth a Task call is matched against, read
+    without spending a token. Before the fix this list held only
+    `genealogy-research:record-extractor` and friends.
+
+    This spawns a CLI process but issues NO query, so it bills nothing; the key
+    is needed only because the CLI refuses to start without one.
+    """
+    from claude_agent_sdk import ClaudeSDKClient
+
+    monkeypatch.setattr(real_agent, "_PLUGIN_DIR", str(PLUGIN_DIR))
+    monkeypatch.setattr(real_agent, "_MCP_BUILD", str(_ENGINE_BUILD))
+
+    client = ClaudeSDKClient(options=real_agent.build_options(tmp_path, api_key=_LIVE_KEY))
+    await client.connect()
+    try:
+        info = await client.get_server_info() or {}
+    finally:
+        await client.disconnect()
+
+    registered = {a["name"] for a in info.get("agents", [])}
+    missing = {p.stem for p in _shipped_agents()} - registered
+    assert not missing, (
+        f"plugin agents not registered under their bare names: {sorted(missing)}; "
+        f"runtime offers {sorted(registered)}"
+    )

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -675,6 +675,43 @@ sized by the Phase-0 latency analysis and are not covered by the parent plan's p
   ToolSearch path. Ignore-unrecognized-if-one-resolves is therefore the real
   behavior, and the dual-spelling approach is sound.
 
+- [x] **Plugin agents did not spawn as themselves in the hosted path — FIXED
+  (#939, 2026-07-29).** `apps/server/app/agent/real_agent.py` held the repo's
+  only `plugins=[{"type": "local", …}]` call site, and that mechanism registers
+  the plugin's **agents** under the namespaced name `genealogy-research:<agent>`
+  and nothing else. Every SKILL.md delegates by the bare name
+  (`@plugin:record-extractor`), so the hosted Task call hard-errored — *"Agent
+  type 'record-extractor' not found. Available agents: … genealogy-research:
+  record-extractor …"* — after which the model improvised: guess the namespaced
+  spelling, fall back to `general-purpose`, or inline the work. The fallback is
+  the damaging one, since a general-purpose stand-in carries the session's whole
+  tool set and binds none of the agent's `disallowedTools:` — so #695's
+  `extraction_append` lane split was inert in the one environment that runs
+  `bypassPermissions`. Verified live against CLI 2.1.220 before and after.
+  **Only the hosted path was affected**: Cowork spawns `@plugin:<agent>` fine
+  (the entry above is a live confirmation), and both harnesses stage into
+  `.claude/agents/`. Note the loader's asymmetry — plugin **skills** register
+  under bare names (`research`, `record-extraction`, …); only agents are
+  namespaced.
+  Fix: `build_options` stages `packages/engine/plugin/agents/*.md` into
+  `<project>/.claude/agents/` on every client build — the mechanism both
+  harnesses already use — and `setting_sources=["project"]` loads them. The
+  plugin stays loaded for its skills, and both spellings now resolve to the same
+  definition. Guard: `make agent-smoke`.
+
+- [ ] **`make agent-smoke` is a manual gate — no CI job can catch hosted-path
+  agent-loading drift.** The guard added with #939
+  (`apps/server/tests/test_plugin_agents.py::test_bare_agent_names_are_registered`)
+  reads the runtime's resolved agent list out of the SDK init handshake, which
+  is the only signal that distinguishes "registered" from "registered under a
+  name nobody asks for". It issues no query, so it **bills nothing** — but it
+  still needs a key to start the CLI, plus node and a compiled engine, and CI
+  today neither holds an Anthropic key nor runs the `apps/server` suite at all.
+  The offline tests in the same file do run under `make server-test`, but they
+  only prove the staging happened, not what the runtime made of it. Wire
+  `agent-smoke` into CI if a key ever lands there; until then it is on whoever
+  touches `real_agent.build_options` to run it.
+
 - [ ] **Scope the record-extraction outage window.** `record-extractor` could
   not spawn in Cowork between 2026-07-12 (#650) and this fix. Because the
   runtime refuses rather than launching a toolless agent, the failure was loud


### PR DESCRIPTION
Fixes #939.

## What the live run showed

Settled with a real run against CLI 2.1.220, not a repo read. The report is real, but the mechanism is narrower than "the agents don't spawn at all" — under `plugins=[{"type": "local", …}]` they **are** discovered, just registered only under the namespaced name:

```
Agent type 'record-extractor' not found. Available agents: claude, Explore,
genealogy-research:gps-mentor, genealogy-research:image-reader,
genealogy-research:image-reader-opus, genealogy-research:record-extractor,
general-purpose, Plan, statusline-setup
```

Every SKILL.md delegates by the bare name (`@plugin:record-extractor`), so the Task call hard-errors and the model then improvises: guess the namespaced spelling, fall back to `general-purpose`, or inline the work. The fallback is the damaging branch — a general-purpose stand-in carries the session's whole tool set and binds none of the agent's `disallowedTools:`, so #695's `extraction_append` lane split was inert in the one environment that runs `bypassPermissions`.

Three corrections to the issue as filed:

- **Two loading mechanisms, not three.** `orchestrator.py:1323`'s `subagents=` is the `E2eResult` field for captured subagent transcripts, not an SDK argument. The e2e harness stages into `.claude/agents/` at `orchestrator.py:370`, same as the unit harness.
- **The loader is asymmetric.** Plugin *skills* register under bare names (`research`, `record-extraction`, `person-evidence`, …). Only agents get namespaced — which is why this hid for so long.
- **Cowork is unaffected.** `docs/TODOs.md` already records a live Cowork run where `@plugin:image-reader` spawned normally. The hosted path was the only broken one.

## The fix

`real_agent.build_options` stages `packages/engine/plugin/agents/*.md` into `<project>/.claude/agents/` on every client build (`stage_plugin_agents`) — the same mechanism both harnesses use — and `setting_sources=["project"]` loads them. `plugins=[…]` stays for the skills; both spellings now resolve to the same definition. No E2B image rebuild: the image already bakes `agents/`.

Confirmed live post-fix: bare `record-extractor` spawns and its allow-list binds (the subagent reported `NO_BASH`, Bash not being in its `tools:`).

## The regression guard

`make agent-smoke` → `apps/server/tests/test_plugin_agents.py::test_bare_agent_names_are_registered`. It reads the runtime's resolved agent list out of the **SDK init handshake** — the ground truth a Task call is matched against — so it issues no query and bills nothing (the key is only needed to start the CLI). Verified to fail pre-fix with exactly the #939 diagnosis:

```
AssertionError: plugin agents not registered under their bare names:
['gps-mentor', 'image-reader', 'image-reader-opus', 'record-extractor'];
runtime offers [… 'genealogy-research:record-extractor' …]
```

Three offline tests in the same file run under the default `make server-test`: the staging happens, frontmatter `name:` matches the filename (they must agree or the bare name still misses), and every `@plugin:<name>` in a SKILL.md names an agent that ships.

## Out of scope

The `bypassPermissions` gap in the hosted path, as the issue specifies — that stays with the guardrail-hook port.

## Docs

Two `docs/TODOs.md` entries — the fix, and the residual gap that CI runs neither the `apps/server` suite nor any keyed job, so `agent-smoke` is a manual gate on whoever touches `build_options`. Plus a CLAUDE.md paragraph on how each environment loads agents.

## Sequencing

**#940 is unblocked.** #942's premise — `agent_id` present only inside a Task-spawned subagent — now holds in the hosted path too, so its "out of scope: hosted path" section is a deferral again rather than a statement about what is possible.

## Test plan

- `make server-test` — 110 passed, 1 skipped
- `make agent-smoke` — 6 passed (including the live registration check)
- Live spawn by bare name under the fixed hosted options, allow-list confirmed bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)