### PR TITLE
docs: make the TODOs retention rule discoverable, fix a stale tool path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,15 @@ mocks (no E2B/Anthropic/OAuth needed).
 - `docs/specs/` — Finalized specs (what the tool must do). Specs are the
   source of truth the `spec-review` agent checks implementations against.
   This is the durable tier; a live tool must have a live spec.
+- `docs/TODOs.md` — the open-work list: deferred items, known gaps, and the
+  residuals a shipped PR leaves behind. Every deferred item gets an entry in
+  the same PR that defers it. The file is **open-only** — when an item ships,
+  **delete** its entry rather than checking it off or moving it to a "Done"
+  section. Durable rationale ("don't re-derive X", "the original premise was
+  wrong") goes to the spec or this file; a residual gap becomes its own entry.
+  Git history keeps the prose. This is the same rule `docs/plan/` follows, and
+  it is not bookkeeping: a Done tier is how the file reached 932 lines with 29
+  open items filed underneath it (#953).
 - **Verification is automated, not a manual playbook.** New tools are
   verified by the eval harness (`eval/`, `make test`, `eval/tests/e2e/`)
   and by `packages/engine/mcp-server/dev/try-*.ts` smoke scripts — **not**

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -621,7 +621,9 @@ sized by the Phase-0 latency analysis and are not covered by the parent plan's p
   advertised in `tool-schemas.ts` but is the only live tool with **no spec**, so
   `spec-review` cannot check it. The 2026-05-07 timeline-distances design doc was the
   de facto stand-in and has been retired; the behavior is currently defined only by
-  `src/tools/place-distance.ts` and its use in `timeline/SKILL.md`.
+  `src/tools/distance.ts` (which exports both `placeDistanceTool` and
+  `placeDistanceToolSchema` — there is no `place-distance.ts`) and its use in
+  `timeline/SKILL.md`.
 
 - [ ] **Optional `site`/`host` filter param on `external_links_search`** — deferred from
   the search-shaping work (option B) as unnecessary while the count cap holds. File it


### PR DESCRIPTION
Two follow-ups to #953, both found by checking rather than re-reading.

### 1. The retention rule wasn't discoverable

`CLAUDE.md`'s doc-tier list defines `docs/plan/` (with its deletion rule) and `docs/specs/`, but `docs/TODOs.md` appeared only *inside* the plan bullet, as a destination. So #953's retention rule lived only in the file it governs — an agent consulting the operating manual to decide where something belongs would never see it, which is exactly how the Done tier accumulated in the first place. Now it's a sibling bullet, stated where the other two tiers are.

### 2. A stale tool path

The `place_distance` spec entry pointed at `src/tools/place-distance.ts`. That file does not exist — the tool is `src/tools/distance.ts`, which exports both `placeDistanceTool` and `placeDistanceToolSchema`. Whoever picked up that spec would have started by failing to find the implementation.

The rest of the entry is accurate: the schema *is* imported into `tool-schemas.ts` and the tool *is* in `manifest.json`, so "advertised but unspecced" still holds.

Found by link-checking all 64 file paths referenced in the restructured TODOs.md. This was the only real miss — the other three non-resolving tokens are two file *suffixes* (`.ann.json`, `.transcript.md`) and `place-distance-tool-spec.md` itself, which is absent by design since that entry is "write this spec."

🤖 Generated with [Claude Code](https://claude.com/claude-code)