### PR TITLE
fix(ci): genealogist-queue never labelled anything — it counted its own check run, and nothing watched CI

### DIFF
--- a/.github/workflows/genealogist-queue.yml
+++ b/.github/workflows/genealogist-queue.yml
@@ -51,6 +51,14 @@ name: genealogist-queue
 # goes green while doing nothing. When touching the readiness rules, verify
 # against a real approved PR, not just a dispatch dry run — the dispatch path
 # does not exercise the self-filter at all.
+#
+# 2026-07-30, same investigation: THE EVENTS ALONE CANNOT KEEP THE QUEUE CURRENT.
+# `check_suite` never fires (see the trigger below), so nothing observes CI
+# turning green. A PR approved WHILE CI is still running gets its last event at
+# approval time and is never re-evaluated — #924 hit this within minutes of the
+# fix above. Hence the `schedule` sweep: the events are the fast path, the sweep
+# is what makes the queue eventually correct. If you ever remove the schedule,
+# something else must answer "what re-checks a PR after CI finishes?"
 
 on:
   pull_request:
@@ -58,7 +66,27 @@ on:
   pull_request_review:
     types: [submitted, dismissed]
   check_suite:
+    # DEAD TRIGGER, kept only to document that it is dead. Every check suite in
+    # this repo is created by an Actions workflow using `GITHUB_TOKEN`, and
+    # GitHub does not start a workflow run from a `GITHUB_TOKEN`-triggered
+    # event. Confirmed 2026-07-30: 0 `check_suite` runs in this workflow's
+    # entire history (66 pull_request, 33 pull_request_review, 1
+    # workflow_dispatch). The `schedule` below is what actually covers
+    # "CI turned green after the last PR event".
     types: [completed]
+  schedule:
+    # WHY A SWEEP AND NOT JUST EVENTS. The per-PR triggers cannot see CI turning
+    # green: the only events left are `pull_request` and `pull_request_review`
+    # (see the dead `check_suite` above), so a PR approved WHILE CI is still
+    # running gets its last event at approval time and is never re-evaluated.
+    # #924 hit exactly that on 2026-07-30. The events are the low-latency path;
+    # this sweep is the one that guarantees the queue converges.
+    #
+    # Every 30 min: a human review queue does not need finer, and it halves the
+    # run-list clutter versus */15. Scheduled runs are best-effort — GitHub
+    # delays or drops them under load — which is fine for a converging
+    # add-only sweep and is the other reason not to rely on the schedule alone.
+    - cron: "*/30 * * * *"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -77,10 +105,13 @@ permissions:
   contents: read
 
 concurrency:
+  # Per-PR events serialize per PR. Sweeps share ONE key ('sweep') so a cron run
+  # that GitHub delayed cannot race the next one; they are add-only and
+  # idempotent, so queueing rather than cancelling costs nothing.
   group: >-
     genealogist-queue-${{ github.event.pull_request.number
       || github.event.check_suite.id
-      || github.run_id }}
+      || 'sweep' }}
   cancel-in-progress: false
 
 jobs:
@@ -113,8 +144,13 @@ jobs:
             const { owner, repo } = context.repo;
 
             // ---- which PRs to evaluate --------------------------------------
+            // `schedule` and `workflow_dispatch` sweep every open PR; both lack a
+            // `pull_request` payload, so neither may reach the single-PR branch.
+            const sweep = context.eventName === 'schedule'
+                       || context.eventName === 'workflow_dispatch';
+
             let numbers = [];
-            if (context.eventName === 'workflow_dispatch') {
+            if (sweep) {
               const open = await github.paginate(github.rest.pulls.list,
                 { owner, repo, state: 'open', per_page: 100 });
               numbers = open.map(p => p.number);
@@ -205,8 +241,7 @@ jobs:
             // try/catch that downgraded failure to a warning. The API then
             // no-op'd with HTTP 200 and the job went green while doing nothing.
             // So: no catch, and read the label back to confirm it landed.
-            const rows = [];
-            for (const n of numbers) {
+            async function act(n) {
               const { pr, labeled, ready, reasons } = await evaluate(n);
               let action;
 
@@ -234,7 +269,31 @@ jobs:
               }
 
               core.info(`#${n} ${action}${reasons.length ? ' — ' + reasons.join('; ') : ''}`);
-              rows.push([`#${n}`, pr.user.login, action, reasons.join('; ') || '—']);
+              return [`#${n}`, pr.user.login, action, reasons.join('; ') || '—'];
+            }
+
+            const rows = [];
+            const errors = [];
+            for (const n of numbers) {
+              if (!sweep) { rows.push(await act(n)); continue; }
+              // A sweep must not lose the other 17 PRs to one PR's transient API
+              // error. This catch is NOT the one the note above warns about: it
+              // never decides whether a label write succeeded — that is settled by
+              // the read-back inside act() — and every error caught here still
+              // fails the job via setFailed below. Nothing is downgraded to a
+              // warning; the sweep just finishes before it reports.
+              try {
+                rows.push(await act(n));
+              } catch (e) {
+                errors.push(`#${n}: ${e.message}`);
+                core.error(`#${n} errored — ${e.message}`);
+                rows.push([`#${n}`, '—', 'ERRORED', e.message]);
+              }
+            }
+            if (errors.length) {
+              core.setFailed(
+                `${errors.length} of ${numbers.length} PR(s) errored during the sweep; ` +
+                `the rest were evaluated. ${errors.join(' | ')}`);
             }
 
             await core.summary

--- a/.github/workflows/genealogist-queue.yml
+++ b/.github/workflows/genealogist-queue.yml
@@ -37,6 +37,20 @@ name: genealogist-queue
 # V1 IS ADD-ONLY. Once labeled a PR stays labeled, even if it later goes red.
 # Demotion would make PRs flicker out of the queue while someone is mid-review.
 # Revisit after a week of real use.
+#
+# 2026-07-30: THE WORKFLOW COUNTED ITSELF AS RUNNING CI. `SELF` was set to the
+# WORKFLOW's name, but a check run is named after the JOB — which was `promote`,
+# since the job had no `name:`. So the self-filter matched nothing, every run saw
+# its own in-progress check run, and `reasons` always contained "CI still running
+# (1)". No automatic trigger ever labelled anything: the only PRs that got the
+# label were the 5 promoted by a manual `workflow_dispatch` sweep, which is spared
+# because a dispatch's check run lands on the default branch's sha, not on any
+# PR's head. PR #921 is the witness — CI green, peer-approved, and still
+# `#921 not ready — CI still running (1)` with its own check run the only thing
+# in flight. Third instance of the same class of failure in this file: the job
+# goes green while doing nothing. When touching the readiness rules, verify
+# against a real approved PR, not just a dispatch dry run — the dispatch path
+# does not exercise the self-filter at all.
 
 on:
   pull_request:
@@ -70,7 +84,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # The job name IS the check-run name, and the script below excludes its own
+  # check run by that name. Keep the two in sync — see SELF.
   promote:
+    name: genealogist-queue
     runs-on: ubuntu-latest
     # Fork PRs get a read-only token; the label write would 403.
     if: >-
@@ -84,7 +101,9 @@ jobs:
           script: |
             const LABEL = 'ready-for-senior';
             // This workflow's own check run is always in progress while it
-            // runs; counting it would mean CI is never "green".
+            // runs; counting it would mean CI is never "green". SELF must equal
+            // the JOB's name (the check-run name), not the workflow's — see the
+            // `name:` above and the 2026-07-30 note in the header.
             const SELF  = 'genealogist-queue';
 
             const BAD     = new Set(['failure', 'cancelled', 'timed_out', 'action_required', 'stale']);
@@ -139,7 +158,15 @@ jobs:
                   { owner, repo, ref: pr.head.sha, per_page: 100 }),
                 github.rest.repos.getCombinedStatusForRef({ owner, repo, ref: pr.head.sha }),
               ]);
-              const others   = checks.filter(c => !(c.name || '').startsWith(SELF));
+              // Drop this workflow's own check runs. Two mechanisms, both load-
+              // bearing: the run-id match is exact but only covers THIS run, and
+              // an EARLIER genealogist-queue run on the same sha that ended in
+              // `failure` would otherwise read as "CI failing" — the name prefix
+              // is what catches that one.
+              const isSelf = c =>
+                (c.details_url || '').includes(`/actions/runs/${context.runId}/`)
+                || (c.name || '').startsWith(SELF);
+              const others   = checks.filter(c => !isSelf(c));
               const failed   = others.filter(c => BAD.has(c.conclusion));
               const running  = others.filter(c => PENDING.has(c.status));
               const statuses = status.data.statuses || [];


### PR DESCRIPTION
Two independent bugs, both of which end in the same place: `ready-for-senior` never gets applied and the job goes green anyway.

## 1. The workflow counted itself as running CI

`SELF` was set to the **workflow's** name, but a check run is named after the **job** — and the job had no `name:`, so its check run was `promote`. The `startsWith(SELF)` filter matched nothing, every run counted its own in-progress check run, and `reasons` always contained `CI still running (1)`.

The 5 PRs that carried the label (#935, #931, #928, #917, #885) were all promoted inside one 30-second window by the manual `workflow_dispatch` sweep of 2026-07-29T14:25Z. Dispatch is the one path the bug spares, because a dispatch's own check run lands on the default branch's sha rather than on any PR's head. **That also means a dispatch dry run cannot detect this** — it never exercises the self-filter.

**The witness, #921:** not a draft, peer-approved by a non-author, all 10 checks green — and the run fired by that approval ([30485092760](https://github.com/PioneerAIAcademy/cowork-genealogy/actions/runs/30485092760)) logged `#921 not ready — CI still running (1)`. Timings on head sha `577c1fa3` confirm what the 1 was: `pytest` (the last real check) finished 19:35:25Z, and `promote` evaluated at 19:35:51Z inside its own 19:35:47–19:35:53Z window.

Fix:

- **Name the job `genealogist-queue`**, so the check-run name matches `SELF` as the comment always claimed. `promote` is not a required status check in `protect-main` (`pytest`, `runlogs`, `e2e-fixtures`, `vitest`, `lockfile-drift`, `scan`), so the rename gates nothing.
- **Also exclude by run id** (`details_url` contains `/actions/runs/<runId>/`) — exact, and immune to a future rename. Both mechanisms are load-bearing: run-id covers only *this* run, while an **earlier** `genealogist-queue` run on the same sha that ended in `failure` would read as `CI failing: genealogist-queue`.

## 2. Nothing was watching CI, so the queue couldn't stay current

Fixing #1 makes promotion possible; it doesn't make the queue correct. **`check_suite: completed` has never fired** — 0 runs across this workflow's whole history (66 `pull_request`, 33 `pull_request_review`, 1 `workflow_dispatch`), because every check suite here is created by an Actions workflow using `GITHUB_TOKEN`, and GitHub won't start a workflow run from a `GITHUB_TOKEN`-triggered event.

So a PR **approved while CI is still running** takes its last event at approval time and is never re-evaluated. #924 demonstrated this within four minutes of the sweep below: promotable in the dry run, then a reviewer requested changes, and under v1 add-only it now waits for an event that may never arrive.

- **`schedule: */30` sweeps every open PR.** Events stay the low-latency path; the sweep is what makes the queue *eventually correct*. 30 min suits a human review queue and halves run-list clutter versus `*/15`.
- `check_suite` is kept but **documented as dead**, so nobody counts it again as the thing that watches CI.
- **PR selection**: `schedule` + `workflow_dispatch` now share one `sweep` branch. Required, not cosmetic — `schedule` has no `pull_request` payload, so the old `else` arm would have thrown `TypeError: Cannot read properties of undefined (reading 'number')` on the first scheduled run.
- **Per-PR error isolation, sweep mode only**: one PR's transient 5xx used to abort the loop and silently strand every PR after it. Errors are now collected and the job still fails via `setFailed`. This is *not* the try/catch the header warns about — it never decides whether a label write succeeded (the read-back does), and nothing is downgraded to a warning.
- Sweeps share one **concurrency** key so a delayed cron run can't race the next one.

⚠️ The schedule only takes effect once this is on `main` — GitHub runs cron from the default branch only.

**Enforcement is unchanged throughout.** `require_code_owner_review` still gates the merge; this workflow only decides what shows up in a queue.

## Test plan

No automated coverage exists for `.github/workflows/` in this repo (no workflow tests, no actionlint), so verification is explicit:

- [x] YAML parses; the extracted `github-script` body passes `node --check`.
- [x] **Replayed bug #1 over the real check-run payload** for #921's head sha, with its own check run restored to `in_progress`:
      ```
      BEFORE (name=promote)  | others=10 | CI reasons: CI still running (1)
      AFTER  (fix)           | others=9  | CI reasons: (none — CI green)
      ```
- [x] **Live proof of #1.** The dispatch sweep I ran on this branch put its own check run on *this PR's* head sha while in flight, and #968 came back `not ready — no peer approval` with **no** phantom running check. Bug reproduced and fixed against real data.
- [x] Check run on this PR now appears as **`genealogist-queue`**, not `promote`.
- [x] Confirmed `promote` is absent from `protect-main`'s required status checks.
- [x] **Ran the script against a mock** `github`/`context`/`core`:
      - `schedule` event → swept both PRs, labeled only the ready one, ignored its own in-progress check run
      - old selection logic → confirmed `TypeError` on a `schedule` event
      - injected 502 on one PR → the other still evaluated, job still failed loudly
- [x] **Caught up the stuck backlog** with a `workflow_dispatch` sweep. Queue went 0 → 9 open PRs: #964, #962, #957, #954, #936, #929, #927, #925, #921. Spot-checked three by hand (incl. #929, whose `CHANGES_REQUESTED` was correctly superseded by the same reviewer's later `APPROVED`).
- [ ] Post-merge: confirm the first cron run appears within ~30 min and reports sensibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)