### PR TITLE
Make harness-test build the engine it actually executes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,8 +283,21 @@ agent-smoke: $(ENGINE_BUILD) ## Live check that the hosted path registers the pl
 engine-test: $(ENGINE_DEPS) ## Genealogy engine tests — packages/engine/mcp-server (vitest)
 	cd $(ENGINE_DIR) && npm test
 
+# $(ENGINE_BUILD) is a real prerequisite here, not a convenience. The mock MCP
+# server (eval/harness/harness/mock_mcp.py) shells out to the COMPILED build/
+# for its live tool handlers and for the production tool catalog, so part of
+# this suite genuinely executes build/**. CI already builds before running the
+# same pytest (.github/workflows/eval-harness-tests.yml); only this target and
+# scripts/test.sh were missing it.
+#
+# build/ is gitignored, so a freshly-added worktree has none — and
+# link-worktree.sh deliberately does NOT link it (each worktree must compile its
+# own src/, or a branch would silently test another branch's build). Without the
+# prereq the run failed inside test_mock_mcp.py on "AssertionError: staging must
+# still happen": a missing build wearing the costume of a code regression.
+# Python deps still need no stamp — `uv run` auto-syncs the venv.
 .PHONY: harness-test
-harness-test: ## Eval harness tests — eval/harness (pytest, excludes e2e; uv auto-syncs the venv)
+harness-test: $(ENGINE_BUILD) ## Eval harness tests — eval/harness (pytest, excludes e2e; uv auto-syncs the venv)
 	cd eval/harness && uv run pytest -m 'not e2e' -q
 
 .PHONY: eval-skill

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,10 +9,10 @@
 # TS2307 "Cannot find module" errors instead of "deps not installed", on the
 # one command the PR template tells every contributor to run.
 #
-# The harness suite stays a direct `uv run`: uv auto-syncs its venv, so it has
-# no equivalent failure mode, and `make harness-test` deliberately runs a
-# NARROWER set (`-m 'not e2e'`). Delegating it would silently shrink this
-# gate's coverage.
+# The harness suite stays a direct `uv run` — `make harness-test` deliberately
+# runs a NARROWER set (`-m 'not e2e'`), so delegating it would silently shrink
+# this gate's coverage — but it is preceded by `make engine-build`, because part
+# of that suite really does execute the compiled build/ (see below).
 
 set -uo pipefail   # not -e: run every suite, then report all failures together
 
@@ -63,6 +63,14 @@ make -C "$ROOT" eval-ui-test || failed=1
 
 echo ""
 echo "=== Eval harness tests (pytest) ==="
+# The harness's mock MCP server shells out to the COMPILED
+# packages/engine/mcp-server/build/ for its live tool handlers, so the build is
+# a real dependency of this suite. build/ is gitignored and link-worktree.sh
+# does not link it, so a freshly-added worktree has none and the run fails on
+# "AssertionError: staging must still happen" — a missing build wearing the
+# costume of a code regression. `make engine-build` is a no-op once the build
+# is current.
+make -C "$ROOT" engine-build || failed=1
 (cd "$ROOT/eval/harness" && uv run --frozen pytest) || failed=1
 
 echo ""


### PR DESCRIPTION
## Symptom

`make harness-test` in a **freshly-added git worktree** fails:

```
FAILED tests/unit/test_mock_mcp.py::test_record_search_folds_in_ranked_when_subject_given
E       AssertionError: staging must still happen
E       assert None
1 failed, 1270 passed, 2 skipped, 1 deselected in 7.66s
```

Nothing in that output mentions a build. It reads as a real regression in
`record_search` staging, so the next person goes looking for one. Running
`npm run build` in the engine fixes it — but nothing tells you that.

## Root cause

The harness's mock MCP server is not purely in-process. `mock_mcp.py` shells
out to the **compiled** `packages/engine/mcp-server/build/`:

- `_stage_search_results()` imports `build/utils/results-staging.js`
- `_load_build_tool_catalog()` imports `build/tool-schemas.js`

Both degrade silently — every failure path is a bare `return None` / `return {}`,
by design, so a broken build can't abort a paid eval run. With no build,
`staged` is never set, and the assertion two steps downstream is what fails.

`build/` is gitignored, so a new worktree has none. `scripts/link-worktree.sh`
deliberately does **not** link it, and shouldn't: each worktree has to compile
its own `src/`, or a branch would silently test another branch's build. (This is
independent of the `node_modules` link, which is currently being skipped anyway
because the primary worktree's copy is empty — the guard from 62fea1a4 firing as
designed. Fixing the link wouldn't have fixed this.)

The build is already a declared dependency **everywhere else this suite runs**:
`.github/workflows/eval-harness-tests.yml` compiles the engine before the
identical `pytest -m 'not e2e'`, and every other build-consuming Make target
carries `$(ENGINE_BUILD)`. Only the two local entry points were missing it —
which is exactly why CI stayed green while a fresh worktree could not.

Two harness tests already skip cleanly on a missing build
(`test_build_schema_advertised_for_fixture_backed_tool`,
`test_live_tool_advertises_build_schema`) and `test_cli.py` monkeypatches the
staleness gate away, citing "a fresh git worktree; the link-worktree hook links
node_modules but not build/". The knowledge was in the repo; the dependency
edge was not.

## Fix

Two lines, one cause — declare the dependency rather than explain the failure:

- **`Makefile`** — `harness-test: $(ENGINE_BUILD)`. `make test-all` inherits it.
- **`scripts/test.sh`** — `make -C "$ROOT" engine-build` before the harness
  suite. The suite itself stays a direct `uv run --frozen pytest`, so its wider
  (e2e-inclusive) coverage is unchanged — this is the command the PR template
  tells every contributor to run.

Both are no-ops in steady state: `$(ENGINE_BUILD)` recompiles only when the
engine's `src/` or deps change.

Scoped deliberately. `apps/server`'s engine-dependent test already skips with a
named reason (`"needs the compiled engine (make engine-build)"`), and
`run_tests.py` / `skill_gate.py` already hard-fail with `Fix: cd
packages/engine/mcp-server && npm run build`. No other target has the gap.

## Verification

In a **throwaway worktree created fresh from this branch** — no `build/`, no
`node_modules`, no manual `npm run build` at any point.

Before (the old recipe, run verbatim in that clean worktree):

```
$ cd eval/harness && uv run pytest -m 'not e2e' -q
FAILED tests/unit/test_mock_mcp.py::test_record_search_folds_in_ranked_when_subject_given
1 failed, 1270 passed, 2 skipped, 1 deselected in 7.66s
```

After, same worktree, same clean state:

```
$ make harness-test
cd packages/engine/mcp-server && npm ci
cd packages/engine/mcp-server && npm run build
cd eval/harness && uv run pytest -m 'not e2e' -q
1273 passed, 1 deselected in 5.95s
```

Then `rm -rf packages/engine/mcp-server/build` and the other entry point:

```
$ ./scripts/test.sh
...
============================ 1274 passed in 40.58s =============================
All test suites passed
```

A second `make harness-test` re-runs only pytest — the build prereq is a no-op
once current. Throwaway worktree removed afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)