### PR TITLE
Ship §4.3's lockdown as a plugin hook, so it reaches Cowork too (#940)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,26 @@ long as at least one resolves.
 of defence keeping `record-extractor` off the broad `research_append` — and
 a deny naming one spelling silently fails to bind under the other.
 
+### Plugin hooks (`packages/engine/plugin/hooks/`)
+
+The plugin ships a `PreToolUse` hook — the **only** guardrail that reaches
+Cowork. `hooks=` is an SDK argument the hosted control plane can set and Cowork
+cannot be made to; a plugin-shipped `hooks/hooks.json` binds in both. Verified
+live in Cowork 2026-07-30 (issue #940): the hook loads, fires for `Write` and
+`Bash` under either matcher form, and its `deny` is honored. Two things that
+run counter to the upstream issues — check behavior, don't trust the threads:
+`SessionStart` hooks do **not** fire in Cowork, and the reported drop of plugin
+`PreToolUse` command hooks (anthropics/claude-code#34573) does not reproduce.
+Cowork runs `permission_mode: "default"`; the hosted path runs
+`bypassPermissions`; a hook binds under both.
+
+Hook scripts run in the VM: **stdlib-only Python, no network** — the same rule
+as skill `scripts/`. A hook must never raise; every failure path falls through
+to allowing the call, because an exception here fails a tool call the user was
+entitled to make. `scripts/package-plugin.mjs`'s `INCLUDE` list must carry
+`"hooks"` or the directory never ships, which looks identical to the runtime
+refusing to load it — asserted by `tests/packaging/plugin-hooks.test.ts`.
+
 **Allow-lists are subtractive; hooks are not.** A per-agent `tools:` list can
 only narrow what the session already holds — the session's tool set is always a
 superset — so no allow-list can deny the *main thread* a tool one of its

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -173,8 +173,8 @@ create. Google is gone. Follow-ups (`docs/plan/familysearch-login-plan.md`):
 
 ## Guardrail enforcement in production
 Plan: `docs/plan/research-guardrail-bypass-plan.md`. The eval-side mechanisms
-have proven out; only §4.3 reaches the hosted web workbench, and none of them
-reach Cowork.
+have proven out. Only §4.3 reaches production — everywhere, via the plugin hook;
+§4.1's caller-id gate and §4.4's detectors are still harness-only.
 
 - [ ] **§4.3's lockdown covers `Write`/`Edit`/`NotebookEdit`, not `Bash`.**
   `real_agent._pretool_hook` matches on `file_path`, so the shell route around it
@@ -187,21 +187,23 @@ reach Cowork.
   open only because nothing has forced that tradeoff: no bypass in the corpus has
   used the shell. Close it if one shows up in a runlog or a feedback case.
 
-- [ ] **Cowork has no hook seam — and the plugin route that would give it one is
-  unverified.** The hosted fix is an SDK-level `hooks=` argument
-  (`real_agent.build_options`), and Cowork's session options are not ours to set.
-  The only artifact that could bind all four environments is a plugin-shipped
-  `packages/engine/plugin/hooks/hooks.json`, which is the least-supported cell
-  upstream: anthropics/claude-code **#16288** is open (plugin `hooks/hooks.json`
-  never loaded; a 2026-07-05 comment has Cowork loading `SessionStart` but *not*
-  the prompt-lifecycle hooks from the same file, suspected tied to Cowork spawning
-  the CLI with `--setting-sources user`), and **#34573** reports plugin
-  `PreToolUse`/`PostToolUse` **command** hooks silently dropped while `prompt`
-  hooks on the same events fire (closed by the stale bot, not fixed). Two reported
-  workarounds, both unverified here: inline the `hooks` object in `plugin.json`,
-  or inject into `settings.json`. Settle it with one live Cowork run the way #939
-  was settled, not a repo read. A `prompt` handler is no substitute: an LLM call
-  per tool use, non-deterministic, unfit for a hard deny.
+- [ ] **§4.3's rule is enforced in two places, and one of them is only there
+  because the other is unproven.** `packages/engine/plugin/hooks/hooks.json` is
+  verified live in Cowork; the hosted path also loads the plugin, so it *should*
+  bind there too and make `real_agent._pretool_hook` redundant — but "the plugin
+  loader does what you'd expect in the hosted path" is exactly the assumption
+  #939 disproved for agents. Confirm with one hosted run (write to
+  `research.json` via `Write` with the SDK hook removed) before deleting the
+  Python copy. Until then both fire, which is harmless: they deny the same thing
+  with the same reason.
+
+- [ ] **`SessionStart` plugin hooks do not fire in Cowork.** Measured 2026-07-30
+  in the same probe that confirmed `PreToolUse` works: no invocation, and the
+  `additionalContext` never reached the session. Nothing depends on this today —
+  recorded because it is the natural place to put per-session setup (seeding
+  state, injecting project context) and it silently would not run. It is also the
+  inverse of the Cowork report in anthropics/claude-code#16288, so that thread is
+  not a reliable guide to current behavior.
 
 - [ ] **Whether `Skill`-tool content injection survives compaction is
   unverified — and there's now real reason to suspect it doesn't.**

--- a/packages/engine/mcp-server/tests/packaging/plugin-hooks.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/plugin-hooks.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The plugin's PreToolUse hook is the ONLY guardrail that reaches Cowork.
+//
+// A per-agent `tools:` allow-list is subtractive — it can only narrow what a
+// subagent inherits — so nothing but a hook can restrain the main thread. And
+// `hooks=` is an SDK argument, which the hosted control plane can set but
+// Cowork cannot be made to. A plugin-shipped hooks/hooks.json is the one
+// artifact that binds both (verified live in Cowork; see
+// hooks/guard_project_files.py's docstring).
+//
+// Every failure mode below is SILENT in production — an unshipped directory, a
+// command naming a script that isn't there, a script that stops denying — so
+// each gets an assertion here.
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..", "..", "..", "..", "..");
+const PLUGIN_DIR = join(REPO_ROOT, "packages", "engine", "plugin");
+const HOOKS_JSON = join(PLUGIN_DIR, "hooks", "hooks.json");
+const GUARD = join(PLUGIN_DIR, "hooks", "guard_project_files.py");
+
+type HookEntry = { type: string; command?: string };
+type Matcher = { matcher?: string; hooks: HookEntry[] };
+
+function loadHooks(): Record<string, Matcher[]> {
+  return JSON.parse(readFileSync(HOOKS_JSON, "utf-8")).hooks;
+}
+
+/** Run the guard script the way the runtime does: payload on stdin, JSON out. */
+function runGuard(payload: unknown): any {
+  const out = execFileSync("python3", [GUARD], {
+    input: JSON.stringify(payload),
+    encoding: "utf-8",
+  });
+  return JSON.parse(out);
+}
+
+describe("plugin hooks are packaged and wired", () => {
+  it("ships the hooks directory in the zip", () => {
+    // Without "hooks" in INCLUDE the directory is silently absent from the
+    // artifact, which looks exactly like Cowork refusing to load it.
+    const packager = readFileSync(join(REPO_ROOT, "scripts", "package-plugin.mjs"), "utf-8");
+    const include = packager.match(/const INCLUDE = \[(.*?)\];/s)?.[1] ?? "";
+    expect(include).toContain('"hooks"');
+  });
+
+  it("names a command that exists in the plugin", () => {
+    for (const matcher of loadHooks().PreToolUse) {
+      for (const hook of matcher.hooks) {
+        expect(hook.type).toBe("command");
+        // ${CLAUDE_PLUGIN_ROOT} is the only portable way to reference a
+        // bundled script; a relative path resolves against the session's cwd.
+        expect(hook.command).toContain("${CLAUDE_PLUGIN_ROOT}");
+        const rel = hook.command!.split("${CLAUDE_PLUGIN_ROOT}/")[1]?.trim();
+        expect(existsSync(join(PLUGIN_DIR, rel))).toBe(true);
+      }
+    }
+  });
+
+  it("matches every tool the guard script itself denies", () => {
+    // A matcher that omits a tool the script would have caught is a hole the
+    // script can never close — the hook is not invoked at all.
+    const matcher = loadHooks().PreToolUse[0].matcher ?? "";
+    for (const tool of ["Write", "Edit", "NotebookEdit"]) {
+      expect(new RegExp(`^(${matcher})$`).test(tool)).toBe(true);
+    }
+  });
+});
+
+describe("the guard script's decisions", () => {
+  it.each([
+    ["Write", "/project/research.json"],
+    ["Edit", "/project/tree.gedcomx.json"],
+    ["NotebookEdit", "research.json"],
+    // Windows separators: splitting on "/" alone made the e2e copy of this
+    // rule a silent no-op on the platform the genealogist team runs.
+    ["Write", "C:\\Users\\Dell\\project\\research.json"],
+  ])("denies %s on %s", (tool, file_path) => {
+    const out = runGuard({ tool_name: tool, tool_input: { file_path } });
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+    // The reason is the model's only feedback, so it must name the way out.
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain("research_append");
+    // No stopReason — a denied write is recoverable and the turn continues.
+    expect(out.stopReason).toBeUndefined();
+  });
+
+  it.each([
+    ["Read", { file_path: "/project/research.json" }],
+    ["mcp__genealogy__research_append", { file_path: "/project/research.json" }],
+    ["Bash", { command: "cat /project/research.json" }],
+    ["Write", { file_path: "/project/results/log_001.json" }],
+    ["Write", { file_path: "/project/research.json.bak" }],
+    ["Write", {}],
+  ])("has no opinion on %s", (tool_name, tool_input) => {
+    expect(runGuard({ tool_name, tool_input })).toEqual({});
+  });
+
+  it("allows the call rather than erroring on a malformed payload", () => {
+    // A hook that throws would fail a tool call the user was entitled to make.
+    expect(runGuard(null)).toEqual({});
+    expect(
+      JSON.parse(execFileSync("python3", [GUARD], { input: "not json", encoding: "utf-8" })),
+    ).toEqual({});
+  });
+});

--- a/packages/engine/plugin/hooks/guard_project_files.py
+++ b/packages/engine/plugin/hooks/guard_project_files.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Deny raw Write/Edit/NotebookEdit on research.json and tree.gedcomx.json.
+
+Every write to those two files must go through the MCP writer tools
+(`research_append`, `research_log_append`, `tree_edit`, `tree_correct`), which
+validate before persisting. A direct file write never validates.
+`research/SKILL.md` has forbidden it in prose since the beginning and no
+skill's `allowed-tools` lists bare Write/Edit; this is the same rule as a
+denial. See `docs/plan/research-guardrail-bypass-plan.md` §4.3, issue #940.
+
+**Why this ships in the plugin rather than only in the host.** A `PreToolUse`
+hook is the only instrument that can restrain the MAIN THREAD — a per-agent
+`tools:` allow-list is subtractive and can only narrow what a subagent
+inherits. But `hooks=` is an SDK argument, and Cowork's session options are not
+ours to set, so a host-side hook can never reach Cowork. A plugin-shipped
+`hooks/hooks.json` does: verified live in Cowork (a canary write was
+hard-denied and the agent surfaced this script's own reason text), after the
+upstream reports that plugin PreToolUse command hooks are dropped
+(anthropics/claude-code#34573) were found not to reproduce on the current
+build. Cowork runs `permission_mode: "default"`; the hosted path runs
+`bypassPermissions`, and a hook binds under both.
+
+Contract, from the hook protocol: read the payload as JSON on stdin, print a
+decision to stdout, exit 0. Printing `{}` means "no opinion" — the normal
+permission flow applies.
+
+Stdlib only (it runs in the VM, which has no third-party packages) and it must
+never raise: an exception here would be an error on a tool call the user was
+entitled to make. Every failure path falls through to allowing the call, which
+is the same posture the prose rule had.
+"""
+import json
+import sys
+
+# Matched on the basename, so an absolute or relative path is caught alike.
+PROTECTED_PROJECT_FILES = ("research.json", "tree.gedcomx.json")
+
+REASON = (
+    "{tool} on {name} is disabled — all writes to research.json/tree.gedcomx.json "
+    "must go through the writer tools (research_append, research_log_append, "
+    "tree_edit, tree_correct), which validate before persisting. Direct file "
+    "writes never validate."
+)
+
+
+def protected_target(tool_name: str, tool_input: dict) -> str | None:
+    """The protected filename this call targets, or None.
+
+    Only the file-write tools are candidates — the MCP writer tools are a
+    different code path and are the sanctioned route. Both path separators are
+    handled: splitting on "/" alone made the e2e copy of this rule a silent
+    no-op on Windows, where the model composes `C:\\...\\research.json`.
+    """
+    if tool_name not in ("Write", "Edit", "NotebookEdit"):
+        return None
+    file_path = str((tool_input or {}).get("file_path") or "")
+    name = file_path.replace("\\", "/").rsplit("/", 1)[-1]
+    return name if name in PROTECTED_PROJECT_FILES else None
+
+
+def decision(payload: dict) -> dict:
+    """The hook's stdout payload: a deny, or `{}` for no opinion."""
+    tool_input = payload.get("tool_input")
+    name = protected_target(
+        str(payload.get("tool_name") or ""),
+        tool_input if isinstance(tool_input, dict) else {},
+    )
+    if name is None:
+        return {}
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            # The model's only feedback, so it names the way out rather than
+            # just refusing. No stopReason: a denied write is a recoverable
+            # mistake and the turn should continue so it can pivot to the
+            # writer tool.
+            "permissionDecisionReason": REASON.format(
+                tool=payload.get("tool_name") or "This tool", name=name
+            ),
+        },
+    }
+
+
+def main() -> None:
+    try:
+        payload = json.loads(sys.stdin.read() or "{}")
+    except (json.JSONDecodeError, OSError, ValueError):
+        payload = {}
+    print(json.dumps(decision(payload if isinstance(payload, dict) else {})))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/engine/plugin/hooks/hooks.json
+++ b/packages/engine/plugin/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Raw writes to research.json / tree.gedcomx.json must go through the MCP writer tools, which validate before persisting.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/guard_project_files.py",
+            "timeout": 20
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/package-plugin.mjs
+++ b/scripts/package-plugin.mjs
@@ -16,8 +16,11 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const PLUGIN = join(ROOT, "packages", "engine", "plugin");
 const RELEASES = join(ROOT, "releases");
 const OUT = join(RELEASES, "genealogy-plugin.zip");
-// Mirrors the old `zip -r` include list (and order).
-const INCLUDE = [".claude-plugin", "agents", "skills"];
+// Mirrors the old `zip -r` include list (and order). "hooks" is load-bearing:
+// without it the plugin's hooks/ directory is not in the zip at all, and a hook
+// that never shipped is indistinguishable from a hook the runtime refused to
+// load. Asserted by tests/packaging/plugin-hooks.test.ts.
+const INCLUDE = [".claude-plugin", "agents", "skills", "hooks"];
 
 // Gate: validate skill + agent frontmatter (description <=1024 chars, no angle
 // brackets, valid name) BEFORE building a zip Cowork would reject at install


### PR DESCRIPTION
Stacked on #984 — review that first.

#984 closed the raw-write hole in the hosted control plane. Cowork still had nothing: `hooks=` is an SDK argument, and Cowork's session options are not ours to set. A plugin-shipped `hooks/hooks.json` reaches both.

## Verified live, not assumed

Given #939, "the plugin loader does what you'd expect" is not something to build on. A throwaway probe (branch `cowork-hook-probe`) was installed in Cowork and exercised in a fresh session:

| Signal | Result |
|---|---|
| `hooks/hooks.json` loads | yes |
| `PreToolUse` **command** hook fires | yes — `Write` and `Bash`, under both matcher forms |
| A `deny` is honored | yes — canary write blocked, agent surfaced the hook's own reason text |
| `SessionStart` fires | **no** |
| `PostToolUse` | undetermined |

So anthropics/claude-code#34573 (plugin PreToolUse command hooks silently dropped) does not reproduce on the current build, and the Cowork data point in the still-open #16288 is inverted — there `SessionStart` was the one that worked. Both threads are stale for our purposes; posted the finding upstream on #16288.

**Bonus fact:** Cowork runs `permission_mode: "default"`, not `bypassPermissions`. We had only ever inferred that. It narrows the "nothing restrains the main thread" note in `docs/TODOs.md` to the hosted path specifically.

## What landed

- `packages/engine/plugin/hooks/hooks.json` + `guard_project_files.py` — stdlib-only, never raises, falls through to allowing the call on any malformed input (an exception here would fail a tool call the user was entitled to make).
- `scripts/package-plugin.mjs` — `INCLUDE` gains `"hooks"`. Without it the directory never ships, which looks exactly like the runtime refusing to load it.
- `tests/packaging/plugin-hooks.test.ts` — 14 tests covering the four silent failure modes: unshipped directory, a command naming a script that isn't there, a matcher narrower than what the script denies, and the script's own decisions (including Windows separators and the malformed-payload path).
- `CLAUDE.md` — a plugin-hooks section: stdlib-only/no-network/never-raise, the `INCLUDE` requirement, and the two Cowork behaviors that contradict the upstream issues.

## Deliberately not done

- **`real_agent._pretool_hook` stays.** The hosted path also loads the plugin, so it should be redundant — but that is the exact assumption #939 disproved for agents. TODO filed, gated on one hosted run with the SDK hook removed. Both firing is harmless: same rule, same reason string.
- **`Bash` still isn't covered.** We now know `PreToolUse` fires for it in Cowork, so it is closable in principle; the false-deny risk that deferred it (plan §6) is unchanged. Existing TODO.

## Testing

- `tests/packaging` — 88 passed
- `make plugin` — zip contains `hooks/hooks.json` + `hooks/guard_project_files.py`
- Cowork — the probe run above

🤖 Generated with [Claude Code](https://claude.com/claude-code)