### PR TITLE
eval(tree-edit): stop the corpus requiring a validate_research_schema call

### DIFF
--- a/eval/runlogs/unit/tree-edit/v1_2026-07-30_18-18-04.ann.json
+++ b/eval/runlogs/unit/tree-edit/v1_2026-07-30_18-18-04.ann.json
@@ -1,0 +1,638 @@
+{
+  "run_log": "v1_2026-07-30_18-18-04.json",
+  "annotator": "dallan@quass.org",
+  "corrections": [
+    {
+      "test_id": "ut_tree_edit_001",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_001",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_001",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Data preservation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Edit minimality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Merge correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_001",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence grounding",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_009",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_009",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_009",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Data preservation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Edit minimality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Merge correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_009",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence grounding",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_002",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_002",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_002",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Data preservation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Edit minimality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Merge correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_002",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence grounding",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_008",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_008",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_008",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Data preservation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Edit minimality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Merge correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_008",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence grounding",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_010",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_010",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_010",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Data preservation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Edit minimality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Merge correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_010",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence grounding",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_013",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_013",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_013",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 2,
+      "corrected_score": 2,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Data preservation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Edit minimality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Merge correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_013",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence grounding",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_012",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_012",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_012",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_011",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_011",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_011",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_003",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_003",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_003",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_006",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_006",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_006",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Data preservation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Edit minimality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Merge correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_006",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence grounding",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_005",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_005",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_005",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Data preservation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Edit minimality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Merge correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_005",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence grounding",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_004",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_004",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_004",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Data preservation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Edit minimality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Merge correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_004",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence grounding",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_007",
+      "dimension_source": "base",
+      "dimension_name": "Correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_007",
+      "dimension_source": "base",
+      "dimension_name": "Completeness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_007",
+      "dimension_source": "base",
+      "dimension_name": "Tool Arguments",
+      "llm_score": null,
+      "corrected_score": null,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Data preservation",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Edit minimality",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Merge correctness",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    },
+    {
+      "test_id": "ut_tree_edit_007",
+      "dimension_source": "rubric",
+      "dimension_name": "Evidence grounding",
+      "llm_score": 3,
+      "corrected_score": 3,
+      "comment": null
+    }
+  ]
+}

--- a/eval/runlogs/unit/tree-edit/v1_2026-07-30_18-18-04.json
+++ b/eval/runlogs/unit/tree-edit/v1_2026-07-30_18-18-04.json
@@ -1,0 +1,3552 @@
+{
+  "schema_version": 2,
+  "skill": "tree-edit",
+  "version": 1,
+  "released": false,
+  "releasable": true,
+  "invocation": "skill",
+  "timestamp": "2026-07-30_18-18-04",
+  "harness_version": "0.1.0",
+  "model": "claude-sonnet-4-6",
+  "judge_prompt_hash": "30747842dbdfcdff202d93d99ea66de1c10b451448690694462a40baa86d2a3e",
+  "snapshot": {
+    "packages/engine/plugin/skills/tree-edit/SKILL.md": "---\nname: tree-edit\nmodel: claude-sonnet-4-6\ndescription: Direct edits to tree.gedcomx.json \u2014 add fact, correct value,\n  create person, add relationship, merge two persons (confirmed\n  identical via proof-conclusion), verify the tree already reflects a\n  known fact (no-op), check FamilySearch record matches/hints, or check\n  for possible duplicates. Use when the user says \"correct this name\",\n  \"change birth year\", \"add occupation\", \"merge these two persons\",\n  \"fix this fact\", \"add a relationship\", \"verify the tree reflects\n  this\", \"check the tree\", \"make sure the tree shows\", \"confirm this\n  fact is in the tree\", \"what records are attached\", \"what hints does\n  FamilySearch have\", \"check record matches\". Do NOT use to search\n  records (search-records), write a conclusion (proof-conclusion), link\n  assertions to persons or build out a household from a record's\n  assertions (person-evidence), or extract facts from a newly-found\n  record (record-extraction \u2014 sourced facts materialize onto tree\n  persons via person-evidence, then proof-conclusion sets the concluded\n  value).\nallowed-tools:\n  - place_search\n  - place_search_all\n  - tree_edit\n  - tree_correct\n  - merge_tree_persons\n  - person_record_matches\n  - person_person_matches\n---\n\n# Tree Edit\n\n**Narration:** Read `researcher_profile.narration_guidance` from `research.json` and apply it as your narration style for this invocation. If absent, default to a one-line preamble per action.\n\n**Places:** When resolving or writing places, follow `references/places-guidance.md` \u2014 resolve with `place_search` / `place_search_all` and record the `standardPlace` (and `standard_place` on persisted facts/assertions/events).\n\nHandles direct modifications to `tree.gedcomx.json`. Two use cases: **ad-hoc corrections** (fixing typos, updating dates, adding facts not from the formal pipeline) and **person merging** (combining two GedcomX persons confirmed identical by proof-conclusion, with full referential integrity across both project files).\n\n## References\n\n- `references/evidence-grounded-edits.md` \u2014 When edits are justified, source support requirements\n- `references/relationship-accuracy.md` \u2014 Relationship types, merge implications\n\n## Ad-hoc edits\n\nEach ad-hoc edit is one tool call: **additions** (`add_*`) go through `tree_edit`; **corrections and removals** (`update_*`, `remove`) go through `tree_correct` \u2014 same batched `ops[]`, id rules, validate-on-write, and `.bak` semantics, split only by op authority. Supply content WITHOUT ids \u2014 the tool assigns the next `F`/`N`/`I`/`R` id, swaps primary/preferred, resolves `standard_place`, validates the whole project, and writes only `tree.gedcomx.json`. On `{ ok: false, errors }` nothing is written \u2014 surface those errors rather than retrying.\n\n**Actually call `tree_edit`/`tree_correct` \u2014 do not describe the edit or print a summary of what you \"would\" write.** The change isn't real until the tool call returns `ok: true`; narrate the result only from that returned summary, never from a fabricated one.\n\n```\ntree_edit({\n  projectPath: \"<absolute-path-to-project-directory>\",\n  operation: \"add_fact\",\n  personId: \"KWCJ-RN4\",\n  fact: {\n    type: \"Occupation\",\n    date: \"1870\",\n    place: \"Schuylkill County, Pennsylvania\",\n    sources: [{ ref: \"S2\", page: \"1870 Census, dwelling 201\" }]\n  }\n})\n```\n\nOther additions via `tree_edit`: `add_person` \u00b7 `add_relationship` \u00b7 `add_source`. Corrections and removals via **`tree_correct`**: `update_fact` (by `factId`) \u00b7 `update_name` (by `nameId`) \u00b7 `update_person` (gender/ark) \u00b7 `update_source` (by `sourceId`) \u00b7 `remove` (factId or relationshipId only \u2014 the one permitted deletion, when proof-conclusion withdrew a conclusion; never removes a person). For corrections pass only the changed fields \u2014 e.g. fix a wrong death date with `tree_correct({ projectPath, operation: \"update_fact\", personId: \"I1\", factId: \"F2\", fact: { date: \"1908-03-12\" } })`. When something already exists at that id, use `update_*` via `tree_correct` rather than adding a duplicate.\n\n### Writing facts correctly\n\n- **Dates must be GedcomX-parseable.** Write a bare year (`1773`), an ISO date (`1908-03-12`), or a spelled date (`12 March 1908`); record any approximation in the source `page` or your reply, not in the `date` string.\n- **Couple-event facts go on the `Couple` relationship, not on a person.** Marriage, Divorce, and other couple events belong in the relationship's `facts` array \u2014 supply them in the `add_relationship` call itself: `relationship: { type: \"Couple\", person1, person2, facts: [{ type: \"Marriage\", date, place, sources }] }`. A Marriage written as a person `add_fact` misplaces the event. See `references/relationship-accuracy.md`.\n\n## Person merging\n\nWhen proof-conclusion confirms two persons are the same individual, execute the merge here. The tool does all clerical work (folding names/facts, repointing relationships, repointing every `research.json` reference, removing the collapsed person); your job is to pick the survivor and confirm pairs.\n\n**Survivor-selection:** prefer the FamilySearch ID over a synthetic stub; otherwise the most complete record; otherwise the id in `project.subject_person_ids`.\n\n- **Both persons in the tree:** call `merge_tree_persons({ projectPath, merges: [[survivorId, collapsedId]] })` \u2014 returns a compact summary of folded name/fact counts and `researchRefsUpdated`.\n\n(Folding a record's personas into the tree is **not** a merge here \u2014 that is person-evidence's job, per-persona via `materialize_facts`. This skill only collapses two persons already in the tree.)\n\n**Once you've picked the survivor and gotten the user's go-ahead, actually call the merge tool \u2014 do not stop at a plan or report a merge you haven't executed.** The merge is real only when the tool returns `ok: true`; narrate the folded counts from that returned summary, never from a description of what you intend to do.\n\nOn `{ ok: false, errors }` the merge writes nothing \u2014 surface the errors.\n\n## Record and duplicate checking\n\nWhen the user asks what records are attached or what hints exist, call `person_record_matches({ id: \"KWCJ-RN4\" })` \u2014 returns accepted, pending, and rejected matches.\n\nWhen the user asks about possible duplicates or merge candidates, call `person_person_matches({ id: \"KWCJ-RN4\" })` \u2014 returns possible-duplicate tree persons. This surfaces candidates only; merge decisions still require proof-conclusion.\n\nBoth tools require a FamilySearch ID (`4:1:` ARK or bare personId). Synthetic `I`-prefix ids are local stubs \u2014 FamilySearch has no match data for them.\n\n## Validation\n\n`tree_edit`, `tree_correct`, and `merge_tree_persons` all validate-before-persist; no separate `validate_research_schema` call is needed. After ANY edit or merge, run **`check-warnings`** to catch genealogical impossibilities the structural validator cannot (impossible dates, relationship loops, etc.).\n\n## Important rules\n\n- **Merges are irreversible in practice.** Present the merge plan and get confirmation before executing: \"I will merge I5 (James Flynn, stub) into KWCJ-RN7 (James Patrick Flynn). This will update 3 person_evidence entries and 1 timeline. Proceed?\"\n- **Only merge when proof-conclusion confirms identity.** The threshold is a `probable` or higher proof_summary confirming the two persons are the same. Never merge on a speculative link or unresolved hypothesis.\n- **Preserve the more complete record.** Keep the person with more data and the more authoritative ID (FamilySearch ID > synthetic).\n- **Ad-hoc edits should be rare.** Most tree updates come through the formal pipeline \u2014 record-extraction (assertions) \u2192 person-evidence (materializes sourced evidence facts onto tree persons) \u2192 proof-conclusion (sets the concluded `primary`/`preferred` value). Direct tree-edit edits are for ad-hoc corrections and confirmed merges, not for bypassing the GPS process.\n\n## Decision rules for ambiguous situations\n\n**Conflicting facts during merge:** Keep BOTH facts on the surviving person when no proof conclusion specifies which value is correct, and flag for proof-conclusion to resolve. Do not silently discard either value.\n\n**Relationship type unknown:** When a source shows a person in a household without clarifying the connection (biological, adoptive, step, foster), record the relationship without asserting a specific subtype. Do not default to biological.\n\n**Edit without source support:** Ask the user to identify the source. Typo corrections verifiable against an already-cited source may proceed; otherwise require at least one source reference before writing.\n\n**Relationship threshold not met:** Apply the two-layer threshold from `references/relationship-accuracy.md` \u2014 a sourced evidence edge materializes at link time carrying its source-ref; a *concluded* relationship that no single record states is proof-gated. If neither is met, explain what is needed and suggest proof-conclusion first.\n\n**Conflicting evidence not yet resolved:** Do not pick a side. Coexisting sourced evidence facts may both live in the tree, each carrying its own ref \u2014 what waits for proof-conclusion is the *concluded* value (`primary`/`preferred`), not the evidence itself. Do not set the concluded value until the conflict is resolved in proof-conclusion.\n\n**Requested state already satisfied:** If what the user asks for already exists in `tree.gedcomx.json` with the correct value and supporting source, make NO changes. Report: \"No edit needed \u2014 F1 already reflects this with source S1.\" Do NOT add `confidence`, `notes`, or any field not in `docs/specs/simplified-gedcomx-spec.md` \u00a74.2 \u2014 the audit trail belongs in your reply, not in tree fields.\n\n**Do not duplicate:** If the person, relationship, or fact already exists at an id, use `update_*` (via `tree_correct`) against that id rather than adding a second entry.\n\n## Re-invocation behavior\n\n**Writes:** persons, relationships, names, and facts in `tree.gedcomx.json` via `tree_edit`/`tree_correct` and the merge tools. A person merge additionally repoints every `research.json` reference to the deprecated id \u2014 `project.subject_person_ids`, `person_evidence[].person_id`, and `timelines[].person_ids` \u2014 onto the surviving person.\n\n**Re-running against existing state:** update in place; never duplicate. If the target person, relationship, or fact already exists at an id, use the matching `update_*` operation (via `tree_correct`) against that id rather than an `add_*`. If the requested value and its supporting source are already present, make no change and report the no-op (see \"Requested state already satisfied\" above).\n",
+    "packages/engine/plugin/skills/tree-edit/references/evidence-grounded-edits.md": "# Evidence-Grounded Tree Edits\n\nTree edits must be grounded in evidence \u2014 a **sourced piece of\nevidence** or a **proved/well-supported conclusion** \u2014 not speculative\nconnections. Every modification to the tree file represents a claim\nabout a real person's identity, life events, or family relationships.\nUnsubstantiated edits degrade the tree's reliability and can mislead\nfuture research.\n\nThe tree carries **two layers** (`research-schema-spec.md` \u00a78).\n**Sourced evidence facts materialize onto tree persons as research\nproceeds**, at identity-link time (via person-evidence's\n`materialize_facts`), each carrying a non-null source-ref \u2014 they do\n**not** wait for a proof conclusion. **Which value is *concluded*** \u2014\nthe `primary` fact / `preferred` name \u2014 is a separate, later act owned\nby proof-conclusion, and **upload to FamilySearch stays\nconclusion-gated** (only `primary`/proof-backed facts leave the working\ntree). The old \"nothing lands until proof \u2265 probable\" reading is relaxed\naccordingly: proof \u2265 probable gates the **conclusion** and the\n**upload**, not the sourced evidence.\n\n## When edits are justified\n\nA tree edit is justified when it fits one of the two layers:\n\n- **Sourced evidence** \u2014 the edit adds a fact, name, or relationship\n  extracted from a source and carrying a non-null source-ref. Evidence\n  facts materialize at identity-link time; a proof conclusion is **not**\n  required to land sourced evidence. (This is normally person-evidence's\n  `materialize_facts` path; ad-hoc, tree-edit may add such a fact when\n  its source is already linked \u2014 e.g. an occupation found in a census\n  record already cited.)\n- **A concluded value** \u2014 a proof conclusion at \"probable\" tier or\n  higher supports marking which value is `primary`/`preferred`, or\n  concluding a relationship no single record states. Setting the\n  concluded value is proof-gated; materializing the underlying evidence\n  is not.\n- **An objective-error correction** (typo, transcription mistake) that\n  is verifiable against the cited source.\n\nAn edit is NOT justified when:\n\n- The connection is speculative or based on name-matching alone\n- No source supports the fact and no reasonably thorough research\n  supports the claim\n- A value is *concluded* prematurely \u2014 coexisting sourced facts are\n  fine and expected, but marking one `primary` before the conflicting\n  evidence is examined and resolved is not\n- The edit assumes a relationship that documentation does not support\n\n## Avoiding premature conclusions\n\nMaterializing sourced evidence is not the same as committing to a\nconclusion. Sourced evidence facts accumulate on a person freely; what\nmust never be forced prematurely is the **concluded value**\n(`primary`/`preferred`) or an unsupported relationship. A tree file is a\nworking tool, not a finished publication. When the evidence does not yet\nsettle a *conclusion*:\n\n- Record the sourced evidence, and leave the concluded value\n  (`primary`/`preferred`) unset until proof-conclusion weighs it\n- Let conflicting sourced values coexist as separate facts rather than\n  picking a side\n- Leave relationship fields empty rather than guessing at a subtype\n- Flag uncertain conclusions for further research rather than treating\n  guesses as concluded facts\n\nThe tree should reflect the current state of **sourced evidence and\nproved conclusions**. It is better to have un-concluded evidence \u2014 or\ngaps \u2014 than wrong *conclusions* that become entrenched and difficult to\nundo.\n\n## Source support for every edit\n\nEvery fact, name, or relationship added to the tree should trace back\nto at least one source reference. When adding data:\n\n- Include a `sources` array pointing to the relevant source entry\n- Record enough citation detail (page, entry number, dwelling) for\n  someone else to locate the original\n- Distinguish between data that comes from original records with\n  firsthand information versus derivative or secondhand sources\n- When two sources disagree, the proof conclusion \u2014 not the tree\n  edit \u2014 is where the conflict resolution belongs\n",
+    "packages/engine/plugin/skills/tree-edit/references/places-guidance.md": "<!--\n  CANONICAL SOURCE \u2014 do not edit a copy in isolation.\n  This block is duplicated, byte-for-byte, into each place-using skill's\n  references/places-guidance.md (Claude Code can't reliably load a shared\n  reference across skills \u2014 issue #17741 \u2014 so each skill carries its own copy).\n  A drift lint (packages/engine/mcp-server/tests/packaging/skill-guidance.test.ts) fails if any\n  copy diverges from this source. To change the guidance: edit this file, then\n  re-copy it into every skill listed in that test.\n-->\n\n# Working with places (standard places)\n\nAbove the tool layer, places are always **names**, never IDs. The canonical\nname is the `standardPlace` from `place_search`.\n\n## Resolving a place\n\nCall `place_search` with the place name as `placeName` (optionally a\nhigher-level `contextName` to disambiguate):\n\n```\nplace_search({ placeName: \"Schuylkill County, Pennsylvania\" })\n```\n\nIt returns an array of matches; each match has a **`standardPlace`** field (the\nfully-qualified standardized name) plus `type`, `dateRange`, coordinates, and\nlinks. **Pick the best/first match and use its `standardPlace` verbatim** as the\nhandle for everything downstream. There are no place IDs in the output.\n\nUse **`place_search_all`** instead of `place_search` when jurisdictions or\nboundaries changed across the period you're researching \u2014 it returns *every*\nstandard place a location has belonged to over time, which informs where\nrecords were created and are now held.\n\n## Passing places to other tools\n\nThe place tools all take a `standardPlace` name (not an ID) and resolve it\ninternally \u2014 pass the `standardPlace` you got from `place_search`:\n\n- `place_population({ standardPlace, ... })`\n- `external_links_search({ standardPlace, ... })`\n- `collections_search({ standardPlace })` \u2014 lists record collections; it matches at the state level for the US/Canada/Mexico and the country level elsewhere (derived internally, returned as `scope`)\n- `place_distance({ standardPlace1, standardPlace2 })`\n- `wiki_place_page({ standardPlace, section })` \u2014 `section` is one of `home`, `getting_started`, `online_records`, `research_tips`\n- `volume_search({ standardPlace, ... })`\n\nFor `place_distance`, two events at the **same** `standard_place` are distance 0\n(no call needed); otherwise pass the two names.\n\n## Broadening to a parent jurisdiction\n\nEvery place tool returns results for the **exact** standardPlace you pass.\nA standardPlace is comma-delimited, most-specific-first\n(\"Schuylkill, Pennsylvania, United States\"), so its **parent jurisdiction is\nthe text after the first comma** (\"Pennsylvania, United States\", then\n\"United States\"). To broaden, drop the leading component and call again.\n\n- **Superseding resources** \u2014 `wiki_place_page`, `place_population`. One right\n  answer per place: the most-specific available. If a place has no page / no\n  data, climb to the parent and retry; **stop at the first hit.** A national\n  figure for a village is usually too generic to use \u2014 climb only as far as you\n  must.\n- **Additive resources** \u2014 `external_links_search`, `collections_search`,\n  `volume_search`. Each level holds *different* records (the county courthouse,\n  the state archive, the national index), so fetch the levels your research\n  actually needs and combine them. Bias to the specific end; the national level\n  is mostly generic collections the researcher already knows \u2014 pull it only on\n  first contact with a country or when the local levels are sparse.\n\n## Writing places to research.json / tree.gedcomx.json\n\nWhenever you persist a place on a fact, assertion, or timeline event, also set\nits **`standard_place`** companion (snake_case in the data formats) when one can\nbe found:\n\n- If the place came from a `record_read` / `record_search` / `person_read`\n  result, that fact already carries a converter-resolved `standard_place` \u2014\n  **copy it** (no tool call).\n- Otherwise call `place_search({ placeName: \"<place>\" })` and use the first\n  result's `standardPlace`. Resolve each distinct place once.\n- Leave `standard_place` null when `place` is null or nothing resolves.\n",
+    "packages/engine/plugin/skills/tree-edit/references/relationship-accuracy.md": "# Relationship Accuracy\n\nPlacing individuals accurately in families is a core genealogical\ncompetency. Tree edits that create or modify relationships carry\nspecial responsibility because they assert how real people were\nconnected to each other.\n\n## Distinguishing relationship types\n\nNot all parent-child or couple relationships are the same. When\nevidence supports it, the tree should distinguish among:\n\n- **Genetic (biological)** relationships \u2014 the parent is the\n  biological parent of the child\n- **Adoptive** relationships \u2014 the child was legally adopted\n- **Step** relationships \u2014 the parent is married to a biological\n  parent but is not the child's biological parent\n- **Foster** relationships \u2014 the child was placed in the household\n  but not legally adopted\n- **Other guardianship** \u2014 the child was raised by grandparents,\n  relatives, or other caretakers\n\nWhen the specific relationship type is unknown, record the\nrelationship without asserting a type rather than defaulting to\n\"biological.\" A household listing in a census may show a child\nliving with adults without clarifying whether the connection is\ngenetic, adoptive, or something else.\n\n## Couple-event facts belong on the relationship\n\nMarriage, divorce, and other couple events are facts of the **`Couple`\nrelationship**, not of either spouse. Record them in the relationship's\n`facts` array \u2014 supplied when you create the relationship \u2014 never as a\nperson-level fact. A marriage stored on a person record misplaces the\nevent; the couple relationship is its only correct home.\n\n## When to create relationships\n\nRelationships follow the same two layers as facts\n(`research-schema-spec.md` \u00a78): a **sourced evidence edge** materializes\nat identity-link time, while a **concluded** relationship is proof-gated.\n\nCreate a relationship **edge** (carrying a non-null source-ref) when:\n\n- Direct evidence from a reliable source states the relationship (e.g.,\n  a birth certificate naming parents, or a census listing a household).\n  This is sourced evidence and does **not** require a proof conclusion\n  first; the edge carries the relationship assertion's source-ref.\n- A proof conclusion confirms a parent-child or couple connection that\n  no single record states (the concluded relationship).\n\nA **pre-1880 census parent-child edge is *indirect*** evidence (a\nheadship/co-residence inference, not a stated relationship) \u2014 it still\nmaterializes with a source-ref, at a **lower ref quality** reflecting\nthe weaker evidence class. Correlating several indirect pieces into a\n*concluded* relationship remains proof-conclusion's act.\n\nDo NOT create a relationship entry when:\n\n- Two people share a surname and lived near each other (name +\n  proximity is neither evidence nor proof)\n- No source supports the connection at all\n- You are asserting a *concluded* relationship whose hypothesis has not\n  been tested against potentially conflicting evidence\n\n## Merge implications for relationships\n\nThe merge tool (`merge_tree_persons`)\nrepoints every relationship referencing the collapsed person to the\nsurvivor and drops the duplicate parent-child pairs that result \u2014 you do\nnot transfer or de-duplicate relationships by hand. What the tools\ncannot judge is genealogical plausibility: a merge can still leave the\nperson as both parent and child of the same individual, give them two\nsets of biological parents, or imply a child born before their parent.\nThis is why `check-warnings` must run after every merge.\n\n## Biographical context beyond vital statistics\n\nPersons in the tree benefit from facts beyond birth, marriage, and\ndeath. Occupation, residence, military service, religious\naffiliation, and other biographical details help distinguish\nindividuals who share names and approximate dates. They also\nprovide the historical context that makes each person's record\nmeaningful rather than a bare skeleton of dates and places.\n\nWhen sources provide biographical details, add them as facts on\nthe person rather than discarding them as \"non-essential.\" These\ndetails often become critical indirect evidence for resolving\nidentity questions later.\n",
+    "eval/tests/unit/tree-edit/add-birth-fact.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"tree-edit: confirm this fact is in the tree \u2014 Patrick Flynn's birth fact (F1) should show ~1845 in Ireland, matching the resolved birthplace conflict c_001. Check the tree and tell me whether F1 already reflects this, or whether an edit is needed.\"\n  },\n  \"judge_context\": [\n    \"Should confirm that F1 already shows `place: \\\"Ireland\\\"` and `date: \\\"~1845\\\"`, matching the conflict resolution c_001 (which preferred a_002/a_009 over a_012)\",\n    \"Should NOT modify other persons (Thomas Flynn I2) or other facts (F2 death fact) \u2014 edit-minimality requires touching only the requested target\",\n    \"Should explicitly tell the user the file is unchanged rather than silently completing \u2014 the user needs to know whether their request triggered an edit\"\n  ],\n  \"test\": {\n    \"id\": \"ut_tree_edit_001\",\n    \"skill\": \"tree-edit\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/tree-edit/add-occupation-fact-with-place.json": "{\n  \"execution\": {\n    \"max_wall_clock_seconds\": 600\n  },\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"tree-edit: add occupation \u2014 the 1860 census (source S2, already cited on R1) records Patrick Flynn's occupation as 'Coal miner' at Schuylkill County, Pennsylvania. Add an Occupation fact to Patrick (I1) with date 1860, the place from the source, and a source reference back to S2 with page 'dwelling 112'.\"\n  },\n  \"judge_context\": [\n    \"Should call place_search with placeName 'Schuylkill County, Pennsylvania' and copy the first result's standardPlace verbatim into the new fact's standard_place field (per places-guidance.md)\",\n    \"Should add a new Occupation fact to person I1 with: a fresh F-prefix id (next available \u2014 e.g., F4), type 'Occupation', date '1860', place 'Schuylkill County, Pennsylvania', standard_place matching place_search result, sources [{ ref: 'S2', page: 'dwelling 112' }]\",\n    \"Should NOT mark the new fact `primary: true` unless it's the primary Occupation (and only Occupation) for this person \u2014 the SKILL.md primary rule only applies when there are competing facts of the same type\",\n    \"Edit-minimality: no other facts on I1 are changed (F1 Birth and F2 Death stay byte-identical); no other person, relationship, or source is touched; research.json is not modified\",\n    \"Should NOT need a separate validate_research_schema call \u2014 tree_edit, tree_correct, and merge_tree_persons all validate-before-persist (SKILL.md \u00a7 Validation), and the tool is not in this skill's allowed-tools. Do not score down for omitting it; do not reward calling it.\",\n    \"Should reuse S2 (1860 census already in tree.sources) \u2014 must NOT create a duplicate S-prefix source entry\"\n  ],\n  \"mcp_fixtures\": [\n    \"place-search-schuylkill-county\"\n  ],\n  \"test\": {\n    \"id\": \"ut_tree_edit_009\",\n    \"skill\": \"tree-edit\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/tree-edit/add-relationship-after-proof.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"tree-edit: ps_001 is at `probable` tier. Verify the tree reflects this \u2014 make sure the tree shows the ParentChild relationship between Thomas (I2) and Patrick (I1), and tell me whether R1 already reflects this or whether an edit is needed.\"\n  },\n  \"judge_context\": [\n    \"GROUND TRUTH (mid-research-flynn scenario, verify against tree.gedcomx.json): R1 (parent I2 Thomas -> child I1 Patrick, type ParentChild) EXISTS and carries EXACTLY THREE source-refs \u2014 S1 (1850 U.S. Federal Census), S2 (1860 U.S. Federal Census), and S3 (Pennsylvania Death Certificates). All three source_descriptions S1, S2, and S3 ARE present in the tree. A run that reports R1 with these three sources and makes no edit is fully correct. Do NOT claim that S3 (or any of S1/S2/S3) is absent \u2014 it is present.\",\n    \"Should confirm R1 (Thomas I2 \u2192 Patrick I1, type ParentChild) already exists in tree.gedcomx.json \u2014 under the two-layer doctrine it was materialized by person-evidence at identity-link time carrying a source-ref (parent-child edges land when the relationship assertion is linked, not when a proof reaches `probable`)\",\n    \"Should verify R1's sources list is populated \u2014 the edge carries non-null source-refs (S1, S2, S3) resolved from the relationship assertion (the delta-scoped mandatory-ref guard requires a ref on any newly-authored edge)\",\n    \"Should make NO modifications if R1 is already in place and correctly sourced \u2014 edit-minimality is the right behavior. If sources are missing, ADD them but don't churn other fields\",\n    \"Should NOT delete R1 even if the proof tier were lowered later \u2014 tree edits to remove relationships require explicit re-evaluation, not automatic syncing with proof tier\",\n    \"CORRECTNESS GRADING NOTE for the judge: the core task is verifying R1 exists and is correctly sourced. The skill presenting R1's type/parent/child and its S1/S2/S3 source-refs in a table or prose summary DOES constitute showing the relationship object \u2014 it need not paste raw JSON, and reporting the sources from the file is not 'fabrication'. Score Correctness=pass when the reported R1 fields and sources match the ground truth above and no unnecessary edit was made. The skill may add tangential observations (e.g., that source refs on relationships carry a `quality` field that fact refs don't); those side comments are informational and MUST NOT drag Correctness below pass if the core verification is right.\"\n  ],\n  \"test\": {\n    \"id\": \"ut_tree_edit_002\",\n    \"skill\": \"tree-edit\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/tree-edit/correct-typo-death-date.json": "{\n  \"execution\": {\n    \"max_wall_clock_seconds\": 600\n  },\n  \"input\": {\n    \"scenario\": \"mid-research-flynn-typo\",\n    \"user_message\": \"tree-edit: change birth year \u2014 actually, fix this date. Patrick Flynn's death fact F2 currently shows `1908-03-21` in the tree, but the death certificate (S3, cert. no. 4521) records 12 March 1908. The tree has a day-swap typo. Correct F2.date to `1908-03-12` and leave everything else alone.\"\n  },\n  \"judge_context\": [\n    \"Should NOT need a separate validate_research_schema call \u2014 tree_edit, tree_correct, and merge_tree_persons all validate-before-persist (SKILL.md \u00a7 Validation), and the tool is not in this skill's allowed-tools. Do not score down for omitting it; do not reward calling it.\",\n    \"Should change ONLY F2.date in tree.gedcomx.json from `1908-03-21` to `1908-03-12`\",\n    \"Edit-minimality REQUIRED: no other field on F2 may change (place, sources, type, primary all stay byte-identical); no other fact (F1, F3) is touched; no other person (I2) is touched; no relationship (R1) is touched; research.json is not touched at all\",\n    \"Should NOT 'normalize' adjacent fields opportunistically (e.g., re-resolving F2.place via place_search when only the date was wrong)\",\n    \"Source-grounding requirement (per evidence-grounded-edits.md): the correction must be tied to S3 \u2014 the user cited it explicitly. The skill should reflect that in the explanation\",\n    \"Should report what was changed and confirm post-edit schema validity in the response\"\n  ],\n  \"test\": {\n    \"id\": \"ut_tree_edit_008\",\n    \"skill\": \"tree-edit\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/tree-edit/couple-marriage-fact-on-relationship.json": "{\n  \"execution\": {\n    \"max_wall_clock_seconds\": 600,\n    \"sdk_message_silence_seconds\": 600\n  },\n  \"input\": {\n    \"scenario\": \"flynn-couple-marriage\",\n    \"user_message\": \"tree-edit: the marriage of Thomas Flynn (I2) and Mary Flynn (I3) is documented in the church marriage register (assertion a_005, source src_005 / S5): married 12 May 1843 at St. Patrick's Church, Schuylkill County, Pennsylvania. Record this marriage in the tree.\"\n  },\n  \"judge_context\": [\n    \"The core behavior under test is fact PLACEMENT: a couple event must be written on the Couple relationship, not on a person. Grade Correctness primarily on that.\",\n    \"The correct edit creates a Couple relationship between I2 and I3 via add_relationship, with the Marriage fact supplied in the relationship's facts array in that same call \u2014 e.g. relationship: { type: 'Couple', person1: 'I2', person2: 'I3', sources: [{ ref: 'S5' }], facts: [{ type: 'Marriage', date: '12 May 1843', place: 'St. Patrick's Church, Schuylkill County, Pennsylvania', sources: [ ... S5 / src_005 ] }] }. Per the delta-scoped mandatory-ref guard, the newly-authored Couple edge itself carries a source-ref (S5), not only the Marriage fact\",\n    \"The Marriage date must be written as a GedcomX-parseable value ('12 May 1843' or '1843-05-12') \u2014 not an approximation string in the date field\",\n    \"It is WRONG to write the marriage as a person-level fact via add_fact on I2 or I3. A Marriage stored on a person record misplaces the event; the Couple relationship is its only correct home\",\n    \"The marriage IS evidence-grounded here: assertion a_005 / source src_005 (tree source S5) documents it as direct primary evidence. The skill should attach that source to the marriage fact AND to the new Couple edge, then proceed \u2014 it must NOT refuse or defer for lack of a source\",\n    \"There was no Couple relationship in the starting tree, so creating one is expected here (not a duplicate) \u2014 this is the fresh-create path, since tree_edit has no update_relationship operation to add facts to an existing relationship\",\n    \"Edit-minimality still applies: the skill should create exactly the one Couple relationship with the marriage fact and not churn the existing ParentChild relationships (RT1, RT2) or person facts\",\n    \"COMPLETENESS GRADING NOTE for the judge: this test targets the tree-edit WRITE (creating the Couple relationship with the Marriage fact correctly placed and sourced). The skill's standard post-edit check-warnings pass calls person_warnings, which is not available in the unit-test harness \u2014 the skill correctly attempts it and explains the tool is unavailable. Do NOT drag Completeness below pass because the check-warnings follow-up could not run: score Completeness on whether the requested marriage write was completed correctly, not on the unavailable downstream plausibility check\"\n  ],\n  \"test\": {\n    \"id\": \"ut_tree_edit_013\",\n    \"skill\": \"tree-edit\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/tree-edit/create-sibling-with-parentchild.json": "{\n  \"execution\": {\n    \"max_turns\": 30,\n    \"max_wall_clock_seconds\": 600\n  },\n  \"input\": {\n    \"scenario\": \"mid-research-flynn-merge-pending\",\n    \"user_message\": \"tree-edit: add a relationship. Per ps_003 (probable tier), Mary Flynn is Thomas's daughter. Create Mary in the tree with the next synthetic I-prefix id (gender Female, name 'Mary Flynn' as the preferred BirthName) and add a ParentChild relationship from Thomas (I2) to Mary with S1 as the source (page 'dwelling 84, family 91'). Do NOT add any facts to Mary's person record (no Birth fact, no Residence, nothing) \u2014 sourced facts are materialized onto the tree person by person-evidence's materialize_facts (record-extraction is assertion-only), not invented here. This call creates only the person stub + the ParentChild relationship.\"\n  },\n  \"judge_context\": [\n    \"Should create a new person with the next available I-prefix id. The merge-pending scenario currently has I1, I2, I3, I4 \u2014 so the next is I5. Use I5 for Mary\",\n    \"Mary's person record needs: id 'I5', gender 'Female', names (a single BirthName with the next N-prefix id \u2014 N6, given 'Mary', surname 'Flynn', preferred: true). Per simplified-gedcomx schema, preferred must be `true` (not `false`) on the one preferred name; secondary names omit the field. No facts required on the person itself \u2014 the supporting birth context lives in research.json (a_016)\",\n    \"Should add a ParentChild relationship with the next available R-prefix id (R2 \u2014 the scenario currently has R1 only). type 'ParentChild', parent 'I2', child 'I5', sources [{ ref: 'S1', page: 'dwelling 84, family 91' }]\",\n    \"Should NOT add a Birth fact to Mary directly from raw census data \u2014 materializing sourced facts onto a tree person is person-evidence's materialize_facts (record-extraction is assertion-only), not this ad-hoc tree-edit call. tree-edit creates the person stub + the sourced relationship edge; assertions in research.json remain the source of truth for facts\",\n    \"Edit-minimality: no existing person, relationship, fact, or source is modified. I3, I4, and the merge-pending state stay intact (this test does not perform the pending merge)\",\n    \"Should reference ps_003 as the proof authorization in the response \u2014 relationship-accuracy.md requires the threshold to be met before writing a relationship\",\n    \"Should NOT need a separate validate_research_schema call \u2014 tree_edit, tree_correct, and merge_tree_persons all validate-before-persist (SKILL.md \u00a7 Validation), and the tool is not in this skill's allowed-tools. Do not score down for omitting it; do not reward calling it.\"\n  ],\n  \"test\": {\n    \"id\": \"ut_tree_edit_010\",\n    \"skill\": \"tree-edit\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/tree-edit/negative-person-evidence.json": "{\n  \"execution\": {\n    \"max_wall_clock_seconds\": 300\n  },\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"Create a new person_evidence record linking assertion a_002 (Patrick Flynn birth ~1845, Ireland \u2014 from the 1850 census) to person I1. I want a person_evidence entry added to research.json that ties this assertion to Patrick.\"\n  },\n  \"judge_context\": [\n    \"Should route to person-evidence \u2014 the user is asking to create a person_evidence link, which is person-evidence's responsibility\",\n    \"Should NOT make any edit to tree.gedcomx.json \u2014 assertion-to-person links are in research.json, not the tree file\",\n    \"May briefly explain the difference between tree-edit (writes to tree.gedcomx.json: persons, facts, relationships) and person-evidence (writes to research.json's person_evidence section)\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"person-evidence\"\n    ],\n    \"explanation\": \"Creating or updating a person_evidence link between an assertion and a tree person is person-evidence's job \u2014 it writes to the research.json person_evidence section. tree-edit writes to tree.gedcomx.json. The skill description is explicit: 'Do NOT use when the user wants to link assertions to persons (use person-evidence).'\"\n  },\n  \"test\": {\n    \"id\": \"ut_tree_edit_012\",\n    \"skill\": \"tree-edit\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/tree-edit/negative-proof-conclusion.json": "{\n  \"execution\": {\n    \"max_wall_clock_seconds\": 300\n  },\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"I've been comparing Patrick Flynn (I1) and the FamilySearch tree person KWCJ-RN9 \u2014 same name, similar birth year, same county. Write the conclusion that these two are the same person so I can merge them.\"\n  },\n  \"judge_context\": [\n    \"Should route to proof-conclusion \u2014 the user is asking for a CONCLUSION to be written, not for the tree to be edited\",\n    \"Should NOT execute a person merge \u2014 there's no proof_summary at probable tier confirming I1 \u2261 KWCJ-RN9, and writing one is proof-conclusion's job\",\n    \"May briefly explain the difference between writing the identity argument (proof-conclusion) and executing the merge (tree-edit) so the genealogist understands the routing\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"proof-conclusion\"\n    ],\n    \"explanation\": \"Writing a conclusion that two persons are the same individual is analytical \u2014 proof-conclusion's responsibility. tree-edit's role is mechanical: execute the merge after proof-conclusion has written an identity argument at probable tier or higher. Skipping that analytical step would put unverified identity claims into the deliverable tree and violate the SKILL.md merge precondition.\"\n  },\n  \"test\": {\n    \"id\": \"ut_tree_edit_011\",\n    \"skill\": \"tree-edit\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/tree-edit/negative-record-extraction.json": "{\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"I just found the 1880 census for Patrick Flynn. Add the facts from that record to the tree.\"\n  },\n  \"judge_context\": [\n    \"Should route to record-extraction rather than write 1880 census facts directly to tree.gedcomx.json\",\n    \"NEGATIVE-TEST GRADING NOTE for the judge: the success criterion for this test is that tree-edit DOES NOT activate (no write to tree.gedcomx.json from a raw record). When activated=False and skills_invoked does not include tree-edit, the negative routing succeeded \u2014 score Correctness and Completeness as `pass` on that basis. The main session may either (a) hand off directly to record-extraction, OR (b) ask the user for the record's content before invoking record-extraction (a defensible mid-step when the prompt doesn't include the raw transcription). Both are acceptable; neither should drop the grade. Judges must NOT score down because the conversational handoff isn't phrased as an explicit 'I decline'\"\n  ],\n  \"negative\": {\n    \"correct_skill\": [\n      \"record-extraction\"\n    ],\n    \"explanation\": \"Facts from a newly-found record should be extracted as classified assertions in research.json (record-extraction's job), not written ad-hoc to tree.gedcomx.json. Those sourced facts reach the tree through person-evidence's materialize_facts at identity-link time (record-extraction is assertion-only). The routing-independent invariant this test enforces is that tree-edit does NOT write raw-record facts to the tree, gated deterministically by the tag-gated validator test_tree_edit_noop (eval/harness/validators/test_tree_edit.py, tree-edit-noop tag), which fails the run if tree.gedcomx.json changes. Graded via grade_on_invariant because the acceptable no-harm behaviors all leave the tree unchanged: the main session may hand off to record-extraction, OR (per this test's own judge note) ask the user for the record's content before invoking record-extraction. The original correct_skill: ['record-extraction'] routing gate failed the ask-the-user path even though the judge itself confirmed that path is correct; correct_skill is retained as documentation of the ideal route, but the invariant is what actually gates.\",\n    \"grade_on_invariant\": true\n  },\n  \"test\": {\n    \"id\": \"ut_tree_edit_003\",\n    \"skill\": \"tree-edit\",\n    \"type\": \"negative\"\n  }\n}\n",
+    "eval/tests/unit/tree-edit/person-merge-stub-into-fs-person.json": "{\n  \"execution\": {\n    \"max_wall_clock_seconds\": 600\n  },\n  \"input\": {\n    \"scenario\": \"mid-research-flynn-merge-pending\",\n    \"user_message\": \"tree-edit: merge data from I3 into I4 \u2014 but only as far as tree-edit can safely go. Per proof_summary ps_002, the synthetic stub I3 (\\\"James Flynn\\\") is the same individual as the FamilySearch tree person I4 (\\\"James Patrick Flynn\\\", ark .../KWCJ-JAM7). Consolidate names + facts onto I4 (keep both conflicting birth dates \u2014 no proof specifies which to drop). Do NOT delete I3 yet \u2014 research.json still references I3 in project.subject_person_ids, person_evidence pe_007, and timelines t_002, and those sections aren't owned by tree-edit. Present the I3-deletion plan + the cross-file rewrites as work the user needs to coordinate via the owning skills before the merge can finalize.\"\n  },\n  \"judge_context\": [\n    \"Per SKILL.md merge protocol: I4 is the keep person (has the FamilySearch ark); I3 is the deprecated person\",\n    \"Step 1 (merge person data): combine names \u2014 I3's 'James Flynn' is a subset of I4's 'James Patrick Flynn' (do not add a duplicate). Birth-fact conflict (~1849 vs ~1848) has no proof-specified value, so BOTH birth facts must survive on I4 \u2014 do NOT silently discard either\",\n    \"Should NOT delete I3 from tree.gedcomx.json persons[] in this call \u2014 research.json still references I3 in project.subject_person_ids, person_evidence pe_007, and timelines t_002. Deleting I3 would create dangling cross-file references that the test_cross_file_person_references_resolve validator catches. Tree-edit doesn't own those research.json sections per the harness OWNERSHIP_TABLE\",\n    \"Should explicitly present a coordination plan: which research.json sections need rewriting and which skills own them (project \u2192 init-project / proof-conclusion; person_evidence \u2192 person-evidence; timelines \u2192 timeline). The actual I3 deletion happens only after those rewrites are coordinated\",\n    \"MERGE-CORRECTNESS GRADING NOTE for the judge: the standard rubric clause 'every reference is rewritten' does NOT apply here because tree-edit lacks ownership of the research.json sections involved (per the harness OWNERSHIP_TABLE: project belongs to init-project / proof-conclusion, person_evidence to person-evidence, timelines to timeline). The CORRECT behavior in this test is consolidate-data-on-I4 + present-plan-for-coordinated-rewrites + do-not-delete-I3-yet. Judges MUST score Merge correctness as `pass` when the skill (a) consolidates data on I4 without dropping conflicting facts, (b) leaves I3 in place pending coordination, and (c) explicitly names the owning skills that need to do the research.json rewrites. Do NOT mark partial because the rewrites weren't done \u2014 that's the entire point of the test\",\n    \"Should NOT need a separate validate_research_schema call \u2014 tree_edit, tree_correct, and merge_tree_persons all validate-before-persist (SKILL.md \u00a7 Validation), and the tool is not in this skill's allowed-tools. Do not score down for omitting it; do not reward calling it.\",\n    \"Should present the merge plan to the user before executing \u2014 SKILL.md 'Important rules' requires confirmation since merges are irreversible in practice\"\n  ],\n  \"mcp_fixtures\": [\n    \"place-search-ireland\",\n    \"place-search-schuylkill-county\"\n  ],\n  \"test\": {\n    \"id\": \"ut_tree_edit_006\",\n    \"skill\": \"tree-edit\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/tree-edit/person-person-matches.json": "{\n  \"execution\": {\n    \"max_wall_clock_seconds\": 120\n  },\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"tree-edit: Check for possible duplicate persons for Patrick Flynn (FamilySearch ID LZNY-BRF). Are there any merge candidates in the tree I should know about?\"\n  },\n  \"judge_context\": [\n    \"Should call person_person_matches with id LZNY-BRF\",\n    \"Should report the one pending duplicate candidate (LZNY-QRS, confidence 3, score 0.71)\",\n    \"Should advise the user to confirm identity via proof-conclusion before merging \u2014 never merge on this tool's output alone\",\n    \"Should NOT make any edits to tree.gedcomx.json or research.json \u2014 this is a read-only duplicate check\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-person-matches-flynn\"\n  ],\n  \"test\": {\n    \"id\": \"ut_tree_edit_005\",\n    \"skill\": \"tree-edit\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/tree-edit/person-record-matches.json": "{\n  \"execution\": {\n    \"max_wall_clock_seconds\": 120\n  },\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"tree-edit: Check what records are attached to this person \u2014 Patrick Flynn, FamilySearch ID LZNY-BRF. What hints does FamilySearch have for this person? Tell me which matches are accepted and which are pending.\"\n  },\n  \"judge_context\": [\n    \"Should call person_record_matches with id LZNY-BRF (not a made-up ID)\",\n    \"Should clearly distinguish the accepted match (1850 census, confidence 5) from the two pending hints (1860 census confidence 3, Pennsylvania Death Certificates confidence 2)\",\n    \"Should NOT make any edits to tree.gedcomx.json or research.json \u2014 this is a read-only query, not an edit request\",\n    \"Should recommend the user review the two pending hints, especially the higher-confidence 1860 census match\"\n  ],\n  \"mcp_fixtures\": [\n    \"person-record-matches-flynn\",\n    \"person-record-matches-flynn-person-id\",\n    \"person-record-matches-flynn-personid\"\n  ],\n  \"test\": {\n    \"id\": \"ut_tree_edit_004\",\n    \"skill\": \"tree-edit\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/tree-edit/refuse-merge-without-proof.json": "{\n  \"execution\": {\n    \"max_wall_clock_seconds\": 300\n  },\n  \"input\": {\n    \"scenario\": \"mid-research-flynn\",\n    \"user_message\": \"tree-edit: merge these two persons \u2014 Patrick Flynn (I1) and Thomas Flynn (I2). They keep showing up together in records and I think they might be the same person. Just merge them and we'll figure out the details later.\"\n  },\n  \"judge_context\": [\n    \"Should REFUSE the merge \u2014 no proof_summary in research.json confirms I1 \u2261 I2. SKILL.md is explicit: 'Only merge when proof-conclusion confirms identity. Never merge based on a speculative person_evidence link.'\",\n    \"Should NOT make any edits to tree.gedcomx.json or research.json\",\n    \"Should explain WHY: the threshold is a proof-conclusion at `probable` tier or higher confirming the two persons are the same. ps_001 (the only proof_summary present) is about parentage, not identity\",\n    \"Should redirect the user to proof-conclusion to write an identity argument first if they genuinely believe these are the same individual \u2014 and should note that the existing R1 (Thomas \u2192 Patrick ParentChild, probable tier) is in fact evidence that they are NOT the same person\",\n    \"Should NOT capitulate even if the user says 'just merge them' \u2014 the safety gate is in the SKILL.md for a reason; merges are irreversible in practice\"\n  ],\n  \"test\": {\n    \"id\": \"ut_tree_edit_007\",\n    \"skill\": \"tree-edit\",\n    \"type\": \"positive\"\n  }\n}\n",
+    "eval/tests/unit/tree-edit/rubric.md": "# Tree Edit Rubric\n\nGrading dimensions for tree-edit unit tests. Evaluated by the LLM judge alongside the base rubric (correctness, completeness).\n\n## Data preservation\n\nDid the edit preserve all existing facts and sources from both the original and merged records? No data should be silently dropped during merges or edits.\n\n- **pass:** All facts, names, and source references from the input(s) survive into the output; merges combine fields without dropping data; edits change only the target field. For merges with conflicting facts that have no proof-specified value, BOTH conflicting facts survive on the keep person (per SKILL.md \u00a7\"Conflicting facts during merge\").\n- **partial:** Most data preserved but one secondary field (a less-preferred name, a tangential source reference) is silently dropped.\n- **fail:** Data systematically lost during the edit (multiple facts dropped, sources stripped), or merge collapses divergent fields into one without preserving alternates.\n\n## Edit minimality\n\nDid the skill make only the requested change without modifying unrelated data? Edits should be surgical \u2014 changing a birth date should not touch relationships or other persons.\n\n- **pass:** Only the requested fields/entries are modified; unrelated facts, persons, and relationships are byte-for-byte unchanged.\n- **partial:** Requested change is made but a tangential field is also touched (e.g., a name capitalization \"normalized\" while editing a birth date, or `standard_place` opportunistically re-resolved when only the date was wrong).\n- **fail:** Substantial collateral edits beyond the request, or the skill rewrites the whole file when only one entry needed changing.\n\n## Merge correctness\n\nFor person merges, did the skill rewrite ALL references to the deprecated person across BOTH project files, and remove the deprecated person from `tree.gedcomx.json` `persons[]`? A missed reference creates a broken foreign key that propagates silently until a downstream reader trips over it.\n\nThe full rewrite scope is enumerated in SKILL.md \u00a7\"Person merging\" Step 3:\n\n| File | Field |\n|---|---|\n| `tree.gedcomx.json` | `relationships[].parent` / `.child` / `.person1` / `.person2` |\n| `research.json` | `project.subject_person_ids` |\n| `research.json` | `person_evidence[].person_id` |\n| `research.json` | `timelines[].person_ids` |\n\nAfter the rewrite, the deprecated person must be deleted from `tree.gedcomx.json` `persons[]`, and both project files must be left structurally valid. `merge_tree_persons` validates before persisting, so a separate `validate_research_schema` call is neither required nor available to this skill (SKILL.md \u00a7 Validation).\n\n**When the test is NOT a merge** (no-op verify, value correction, add fact, create person, refuse-merge, negative routing, match-checking), this dimension has nothing to grade and scores `pass`. Judges must NOT score partial on a non-merge test for the absence of merge mechanics.\n\n- **pass:** Either (a) the test is not a merge and this dimension has nothing to grade, OR (b) every reference enumerated above is rewritten from the deprecated ID to the keep ID, the deprecated person is removed from `persons[]`, and no unresolved cross-file reference is left behind.\n- **partial:** Most references rewritten, but one location is missed (e.g., a relationship updated and `subject_person_ids` updated but a `timelines.person_ids` entry still references the deprecated ID).\n- **fail:** Multiple references unrewritten, OR the deprecated person remains in `persons[]` after the merge, OR an unresolved cross-file reference to the deprecated ID is left behind.\n\n## Evidence grounding\n\nPer `references/evidence-grounded-edits.md`, the tree carries **two layers**, and grounding is graded against the layer the edit touches \u2014 the old single \"nothing lands until proof \u2265 probable\" gate no longer applies to sourced evidence:\n\n- **Sourced-evidence layer \u2014 materializes at link time, NOT proof-gated.** A fact, name, or relationship edge extracted from a source lands on a tree person as research proceeds (at identity-link time, normally via person-evidence's `materialize_facts`); it does **not** wait for a proof conclusion. The gate here is **provenance, not proof tier**: every newly-authored **fact** and every newly-authored **`add_relationship` edge** carries a non-null source-ref (the delta-scoped mandatory-ref guard). Ad-hoc `add_name` / `add_person` **names** are ref-tolerant \u2014 hypothesis/oral/init stubs legitimately have no documentary source yet \u2014 so a bare name-only stub is grounded without a source-ref, but a fact or a new edge is not.\n- **Conclusion / upload / merge layer \u2014 still proof-gated at `probable`+.** Marking which value is `primary` (fact) / `preferred` (name), uploading to FamilySearch, and executing a **person merge** still require a `proof_summary` at `probable` tier or higher.\n\nThe skill's job is to gatekeep the deliverable \u2014 not every edit the user asks for is justified. An edit is grounded when it fits one of:\n- It materializes **sourced evidence** \u2014 a fact/name/edge whose source is already linked, carrying a source-ref on the fact/edge (a proof conclusion is NOT required to land sourced evidence; ad-hoc, tree-edit may add such a fact when its source is already cited on the person).\n- It **corrects an objective error** verifiable against an already-cited source.\n- It sets a **concluded value** (`primary`/`preferred`) or executes a **merge**, backed by a `probable`+ `proof_summary`.\n\nWhen none is met (speculative connection, a newly-authored fact/edge with no source-ref, a value concluded before conflicting evidence is resolved, a person merge without a `ps` confirming identity), the skill must refuse and explain what is missing. Coexisting sourced facts are expected and fine \u2014 it is marking one `primary` prematurely, not keeping both, that is refused.\n\n- **pass:** Edits made are grounded per the right layer \u2014 a sourced fact/edge (source-ref present; names may be ref-tolerant), a verifiable objective-error correction, OR a concluded/merge edit backed by a `probable`+ `ps`. Edits that don't qualify are refused with a clear explanation of what is needed (proof-conclusion, person-evidence, record-extraction, an additional source). For tests that aren't edit operations (e.g., match-checking, negative routing), this dimension scores `pass` \u2014 there's no edit to ground.\n- **partial:** The edit happens AND a source is referenced, but the source-support reasoning is shallow (e.g., source listed without checking whether the data is actually in it), OR the skill refuses the right thing but doesn't explain what threshold was missed, OR it **over-gates** \u2014 demands a `probable`-tier proof before materializing sourced *evidence* (evidence materializes at link time; only conclusion/upload/merge is proof-gated).\n- **fail:** A newly-authored **fact** or **relationship edge** is written with NO source-ref, OR a person merge executed without a `probable`-tier proof_summary confirming identity, OR a value is marked `primary`/`preferred` (or uploaded to FamilySearch) below the `probable` conclusion threshold, OR a relationship written without meeting the `relationship-accuracy.md` threshold.\n",
+    "eval/fixtures/scenarios/flynn-couple-marriage/README.md": "# Scenario: flynn-couple-marriage\n\nA variant of `flynn-record-matching` built specifically for the\n**tree-edit couple-event placement** case. It is identical to that\nscenario except that the tree holds **no `Couple` relationship** between\nthe parents \u2014 only the two `ParentChild` links.\n\n## State\n\n- **Subject:** Patrick Flynn (`I1`), b. ~1845 Ireland, Schuylkill County, PA.\n- **Parents in the tree:** Thomas (`I2`) and Mary (`I3`) Flynn, each linked\n  to Patrick by a `ParentChild` relationship (`RT1`, `RT2`).\n- **No `Couple` relationship yet.** Thomas and Mary are not connected to\n  each other. There is therefore nowhere to hang a couple-event fact until\n  the relationship is created.\n\n## What it exercises\n\n- tree-edit recording a documented **marriage** for Thomas and Mary. Because\n  there is no `update_relationship` operation, the only correct way to record\n  the event is a single `add_relationship` call that creates the `Couple`\n  relationship **with the `Marriage` fact in its `facts` array**.\n- The failure this guards against: writing the marriage as a person-level\n  `add_fact` on Thomas (`I2`) or Mary (`I3`). Couple events belong on the\n  `Couple` relationship, never on a person \u2014 see\n  `skills/tree-edit/references/relationship-accuracy.md`.\n\nCopied verbatim from `flynn-record-matching`: `research.json` and the\n`results/` sidecars (FK-consistent). Only `tree.gedcomx.json` differs \u2014\nthe `Couple` relationship `RT3` is removed.\n",
+    "eval/fixtures/scenarios/flynn-couple-marriage/research.json": "{\n  \"assertions\": [\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to the census enumerator\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4\",\n      \"record_persona_id\": \"P1\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_002\",\n      \"informant\": \"Officiating minister\",\n      \"informant_proximity\": \"official_duty\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:CFLT-9K2\",\n      \"record_persona_id\": \"CP1\",\n      \"record_role\": \"principal\",\n      \"source_id\": \"src_002\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_003\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to the census enumerator\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_003\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3\",\n      \"record_persona_id\": \"VP1\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flinn\"\n      },\n      \"value\": \"Patrick Flinn\"\n    },\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Thomas Flynn (testator)\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_004\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:FTXT-Q88\",\n      \"record_persona_id\": null,\n      \"record_role\": \"heir_1\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"testator\",\n        \"relationship_type\": \"son\"\n      },\n      \"value\": \"Named as 'my son Patrick Flynn' in the will of Thomas Flynn\"\n    },\n    {\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"marriage\",\n      \"id\": \"a_005\",\n      \"informant\": \"Officiating minister\",\n      \"informant_proximity\": \"official_duty\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"record_id\": \"https://www.familysearch.org/ark:/61903/1:1:MARR-8T3\",\n      \"record_persona_id\": null,\n      \"record_role\": \"principal\",\n      \"source_id\": \"src_005\",\n      \"structured_value\": {\n        \"date\": \"12 May 1843\",\n        \"place\": \"St. Patrick's Church, Schuylkill County, Pennsylvania\",\n        \"spouse\": \"Mary Doyle\"\n      },\n      \"value\": \"Thomas Flynn married Mary Doyle, 12 May 1843, St. Patrick's Church, Schuylkill County, Pennsylvania\"\n    }\n  ],\n  \"conflicts\": [],\n  \"evaluations\": [],\n  \"hypotheses\": [],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"1850 census household of Thomas Flynn; Patrick Flynn age 5, born Ireland. Clean candidate match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-04T10:00:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_available\": 1,\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_001.json\",\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_002\",\n      \"notes\": \"A Patrick Flynn baptism \u2014 name and county align, but the record gives the birthplace as Germany, conflicting with all other evidence (Ireland).\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-04T10:10:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"collection\": \"Church records\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_002.json\",\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_003\",\n      \"notes\": \"1850 census household of Thomas Flinn; Patrick Flinn age 5, born Ireland. Surname indexed as 'Flinn' \u2014 a likely transcription variant of Flynn.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-04T10:20:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"~Fl\"\n      },\n      \"results_available\": 1,\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_003.json\",\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Full-text probate hit \u2014 a will of Thomas Flynn bequeathing to 'my son Patrick Flynn'.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-04T10:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"keywords\": \"+Flynn +son\",\n        \"recordPlace2\": \"Schuylkill\"\n      },\n      \"results_available\": 1,\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_004.json\",\n      \"tool\": \"fulltext_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"St. Patrick's Church marriage register: Thomas Flynn married Mary Doyle, 12 May 1843, Schuylkill County. Direct primary evidence of the couple's marriage.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-04T10:40:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"collection\": \"Church marriage records\",\n        \"given\": \"Thomas\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_available\": 1,\n      \"results_examined\": 1,\n      \"results_ref\": \"results/log_005.json\",\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-04\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"The 1850 census places Patrick in a household, identifying candidate parents.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"in_progress\"\n        },\n        {\n          \"date_range\": \"1860-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Full-text search of probate records for a will naming Patrick as a son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"in_progress\"\n        },\n        {\n          \"date_range\": \"1840-1845\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Church marriage register to document the union of the parents Thomas Flynn and Mary Doyle.\",\n          \"record_type\": \"marriage\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-04\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn (b. ~1845, Ireland; resident Schuylkill County, Pennsylvania) \u2014 candidate records gathered, identity resolution pending\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-04\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845)?\",\n      \"rationale\": \"Primary research objective. Candidate records have been gathered; person-evidence must now resolve which record personas are the subject.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-04\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, Branch Township, Thomas Flynn household; digital image, FamilySearch.org, accessed 4 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-04\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Branch Township, Schuylkill County, Thomas Flynn household\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-04\",\n      \"citation\": \"Patrick Flynn baptism, Pennsylvania church and town records; digital image, FamilySearch.org, accessed 4 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Baptism register entry\",\n        \"when_accessed\": \"2026-05-04\",\n        \"when_created\": \"1845\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Patrick Flynn baptism entry\",\n        \"who\": \"Officiating minister\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Birthplace recorded as Germany \u2014 conflicts with the Ireland birthplace in every census record for the subject.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:CFLT-9K2\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-04\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, Branch Township, Thomas Flinn household; digital image, FamilySearch.org, accessed 4 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-04\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Branch Township, Schuylkill County, Thomas Flinn household\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_003\",\n      \"notes\": \"Surname indexed as 'Flinn'; likely a transcription variant of Flynn.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-04\",\n      \"citation\": \"Will of Thomas Flynn, Schuylkill County, Pennsylvania probate records; full-text image, FamilySearch.org, accessed 4 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Last will and testament\",\n        \"when_accessed\": \"2026-05-04\",\n        \"when_created\": \"1871\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Will of Thomas Flynn\",\n        \"who\": \"Thomas Flynn (testator)\"\n      },\n      \"gedcomx_source_description_id\": \"S4\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": \"Full-text search hit; the snippet names Patrick as a son but carries no structured GedcomX persona.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:FTXT-Q88\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-04\",\n      \"citation\": \"St. Patrick's Church (Schuylkill County, Pennsylvania), marriage register, Thomas Flynn-Mary Doyle, 12 May 1843; digital image, FamilySearch.org, accessed 4 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Church marriage register entry\",\n        \"when_accessed\": \"2026-05-04\",\n        \"when_created\": \"1843\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Thomas Flynn-Mary Doyle marriage entry\",\n        \"who\": \"Officiating minister\"\n      },\n      \"gedcomx_source_description_id\": \"S5\",\n      \"id\": \"src_005\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Direct primary evidence of the parents' marriage.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"transcription\": null,\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MARR-8T3\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": []\n}\n",
+    "eval/fixtures/scenarios/flynn-couple-marriage/results/log_001.json": "{\n  \"log_id\": \"log_001\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Patrick\",\n      \"surname\": \"Flynn\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4\",\n        \"birthDate\": \"1845\",\n        \"birthPlace\": \"Ireland\",\n        \"collectionId\": \"1401638\",\n        \"collectionTitle\": \"United States Census, 1850\",\n        \"events\": [],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1845\",\n                  \"id\": \"F1\",\n                  \"place\": \"Ireland\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"F2\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"P1\",\n              \"names\": [\n                {\n                  \"given\": \"Patrick\",\n                  \"id\": \"N1\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"F3\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"P2\",\n              \"names\": [\n                {\n                  \"given\": \"Thomas\",\n                  \"id\": \"N2\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"F4\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Female\",\n              \"id\": \"P3\",\n              \"names\": [\n                {\n                  \"given\": \"Mary\",\n                  \"id\": \"N3\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ],\n          \"relationships\": [\n            {\n              \"child\": \"P1\",\n              \"id\": \"R1\",\n              \"parent\": \"P2\",\n              \"type\": \"ParentChild\"\n            },\n            {\n              \"child\": \"P1\",\n              \"id\": \"R2\",\n              \"parent\": \"P3\",\n              \"type\": \"ParentChild\"\n            },\n            {\n              \"id\": \"R3\",\n              \"person1\": \"P2\",\n              \"person2\": \"P3\",\n              \"type\": \"Couple\"\n            }\n          ]\n        },\n        \"personId\": \"MXHY-TP4\",\n        \"personName\": \"Patrick Flynn\",\n        \"primaryId\": \"P1\",\n        \"recordId\": \"https://www.familysearch.org/ark:/61903/1:1:MXHY-TP4\",\n        \"recordTitle\": \"Patrick Flynn in household of Thomas Flynn\",\n        \"score\": 0.95,\n        \"sex\": \"Male\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"retrieved\": \"2026-05-04T10:00:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/scenarios/flynn-couple-marriage/results/log_002.json": "{\n  \"log_id\": \"log_002\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Patrick\",\n      \"surname\": \"Flynn\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:CFLT-9K2\",\n        \"birthDate\": \"1845\",\n        \"birthPlace\": \"Germany\",\n        \"collectionId\": \"1488411\",\n        \"collectionTitle\": \"Pennsylvania, Church and Town Records\",\n        \"events\": [],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1845\",\n                  \"id\": \"CF1\",\n                  \"place\": \"Germany\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"CF2\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"CP1\",\n              \"names\": [\n                {\n                  \"given\": \"Patrick\",\n                  \"id\": \"CN1\",\n                  \"preferred\": true,\n                  \"surname\": \"Flynn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ]\n        },\n        \"personId\": \"CFLT-9K2\",\n        \"personName\": \"Patrick Flynn\",\n        \"primaryId\": \"CP1\",\n        \"recordId\": \"https://www.familysearch.org/ark:/61903/1:1:CFLT-9K2\",\n        \"recordTitle\": \"Patrick Flynn, baptism\",\n        \"score\": 0.71,\n        \"sex\": \"Male\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"retrieved\": \"2026-05-04T10:10:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/scenarios/flynn-couple-marriage/results/log_003.json": "{\n  \"log_id\": \"log_003\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Patrick\",\n      \"surname\": \"~Fl\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3\",\n        \"birthDate\": \"1845\",\n        \"birthPlace\": \"Ireland\",\n        \"collectionId\": \"1401638\",\n        \"collectionTitle\": \"United States Census, 1850\",\n        \"events\": [],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1845\",\n                  \"id\": \"VF1\",\n                  \"place\": \"Ireland\",\n                  \"type\": \"Birth\"\n                },\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"VF2\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"VP1\",\n              \"names\": [\n                {\n                  \"given\": \"Patrick\",\n                  \"id\": \"VN1\",\n                  \"preferred\": true,\n                  \"surname\": \"Flinn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            },\n            {\n              \"facts\": [\n                {\n                  \"date\": \"1850\",\n                  \"id\": \"VF3\",\n                  \"place\": \"Branch Township, Schuylkill, Pennsylvania, United States\",\n                  \"type\": \"Residence\"\n                }\n              ],\n              \"gender\": \"Male\",\n              \"id\": \"VP2\",\n              \"names\": [\n                {\n                  \"given\": \"Thomas\",\n                  \"id\": \"VN2\",\n                  \"preferred\": true,\n                  \"surname\": \"Flinn\",\n                  \"type\": \"BirthName\"\n                }\n              ]\n            }\n          ],\n          \"relationships\": [\n            {\n              \"child\": \"VP1\",\n              \"id\": \"VR1\",\n              \"parent\": \"VP2\",\n              \"type\": \"ParentChild\"\n            }\n          ]\n        },\n        \"personId\": \"VRNT-7M3\",\n        \"personName\": \"Patrick Flinn\",\n        \"primaryId\": \"VP1\",\n        \"recordId\": \"https://www.familysearch.org/ark:/61903/1:1:VRNT-7M3\",\n        \"recordTitle\": \"Patrick Flinn in household of Thomas Flinn\",\n        \"score\": 0.66,\n        \"sex\": \"Male\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"retrieved\": \"2026-05-04T10:20:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/scenarios/flynn-couple-marriage/results/log_004.json": "{\n  \"log_id\": \"log_004\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"results\": [\n      {\n        \"collectionTitle\": \"Pennsylvania, Probate Records\",\n        \"highlightTerms\": [\n          \"Flynn\",\n          \"son\"\n        ],\n        \"id\": \"https://www.familysearch.org/ark:/61903/1:1:FTXT-Q88\",\n        \"names\": [\n          \"Thomas Flynn\",\n          \"Patrick Flynn\"\n        ],\n        \"places\": [\n          \"Branch Township\",\n          \"Schuylkill County\"\n        ],\n        \"recordPlace\": \"Schuylkill, Pennsylvania, United States\",\n        \"recordType\": \"Wills and Probate\",\n        \"textDocument\": \"...the said Thomas Flynn, of Branch Township, doth give and bequeath unto my son Patrick Flynn the sum of one hundred dollars, to be paid within one year of my decease...\"\n      }\n    ],\n    \"returned\": 1,\n    \"totalResults\": 1\n  },\n  \"retrieved\": \"2026-05-04T10:30:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"fulltext_search\"\n}\n",
+    "eval/fixtures/scenarios/flynn-couple-marriage/results/log_005.json": "{\n  \"log_id\": \"log_005\",\n  \"payload\": {\n    \"hasMore\": false,\n    \"offset\": 0,\n    \"paginationCappedAt\": 100,\n    \"query\": {\n      \"givenName\": \"Thomas\",\n      \"surname\": \"Flynn\"\n    },\n    \"results\": [\n      {\n        \"arkUrl\": \"https://www.familysearch.org/ark:/61903/1:1:MARR-8T3\",\n        \"birthDate\": \"\",\n        \"birthPlace\": \"\",\n        \"collectionId\": \"1682000\",\n        \"collectionTitle\": \"Pennsylvania Church Marriages\",\n        \"events\": [\n          {\n            \"date\": \"12 May 1843\",\n            \"place\": \"St. Patrick's Church, Schuylkill County, Pennsylvania\",\n            \"type\": \"Marriage\"\n          }\n        ],\n        \"gedcomx\": {\n          \"persons\": [\n            {\n              \"gender\": \"Male\",\n              \"id\": \"MP1\",\n              \"names\": [\n                {\n                  \"id\": \"MN1\",\n                  \"nameForms\": [\n                    {\n                      \"fullText\": \"Thomas Flynn\"\n                    }\n                  ],\n                  \"preferred\": true\n                }\n              ]\n            },\n            {\n              \"gender\": \"Female\",\n              \"id\": \"MP2\",\n              \"names\": [\n                {\n                  \"id\": \"MN2\",\n                  \"nameForms\": [\n                    {\n                      \"fullText\": \"Mary Doyle\"\n                    }\n                  ],\n                  \"preferred\": true\n                }\n              ]\n            }\n          ],\n          \"relationships\": [\n            {\n              \"facts\": [\n                {\n                  \"date\": {\n                    \"original\": \"12 May 1843\"\n                  },\n                  \"place\": {\n                    \"original\": \"St. Patrick's Church, Schuylkill County, Pennsylvania\"\n                  },\n                  \"type\": \"http://gedcomx.org/Marriage\"\n                }\n              ],\n              \"id\": \"MR1\",\n              \"person1\": {\n                \"resource\": \"#MP1\"\n              },\n              \"person2\": {\n                \"resource\": \"#MP2\"\n              },\n              \"type\": \"http://gedcomx.org/Couple\"\n            }\n          ]\n        },\n        \"personId\": \"MARR-8T3\",\n        \"personName\": \"Thomas Flynn\",\n        \"primaryId\": \"MP1\",\n        \"recordId\": \"https://www.familysearch.org/ark:/61903/1:1:MARR-8T3\",\n        \"recordTitle\": \"Thomas Flynn and Mary Doyle marriage\",\n        \"score\": 0.94,\n        \"sex\": \"Male\",\n        \"treeMatches\": []\n      }\n    ],\n    \"returned\": 1,\n    \"totalMatches\": 1\n  },\n  \"retrieved\": \"2026-05-04T10:40:00Z\",\n  \"returned_count\": 1,\n  \"tool\": \"record_search\"\n}\n",
+    "eval/fixtures/scenarios/flynn-couple-marriage/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F2\",\n          \"place\": \"Ireland\",\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Female\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"Mary\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"RT1\",\n      \"parent\": \"I2\",\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I1\",\n      \"id\": \"RT2\",\n      \"parent\": \"I3\",\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Census, Schuylkill County, Pennsylvania \u2014 Thomas Flynn household\"\n    },\n    {\n      \"id\": \"S2\",\n      \"title\": \"Pennsylvania church and town records \u2014 Patrick Flynn baptism\"\n    },\n    {\n      \"id\": \"S3\",\n      \"title\": \"1850 U.S. Census, Schuylkill County, Pennsylvania \u2014 Thomas Flinn household\"\n    },\n    {\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County, Pennsylvania probate records\"\n    },\n    {\n      \"id\": \"S5\",\n      \"title\": \"St. Patrick's Church, Schuylkill County, Pennsylvania \u2014 Thomas Flynn & Mary Doyle marriage register\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/README.md": "# mid-research-flynn\n\nPatrick Flynn parentage research, mid-project.\n\n- **Objective:** Identify the parents of Patrick Flynn (b. ~1845, d. 1908)\n- **Questions:** q_001 (parentage, in_progress), q_002 (1850 census placement, resolved)\n- **Plans:** pl_001 (1850 census search, completed), pl_002 (parentage evidence, active)\n- **Log:** 5 entries \u2014 1850 census on FamilySearch/Ancestry/MyHeritage, 1860 census, death cert\n- **Sources:** 4 sources (1850 census FS, 1850 census Ancestry, 1860 census, death cert)\n- **Assertions:** 13 assertions across 4 sources\n- **Person evidence:** 6 links (Patrick \u2192 I1, Thomas \u2192 I2)\n- **Conflicts:** 1 resolved (birthplace: Ireland vs Pennsylvania)\n- **Hypotheses:** h_001 (Thomas is Patrick's father, supported)\n- **Timelines:** t_001 (Patrick, 4 events, 1 gap)\n- **Proof summaries:** ps_001 (parentage, probable)\n- **GedcomX persons:** I1 (Patrick Flynn), I2 (Thomas Flynn), I3 (Mary Flynn, sister), I4 (James Flynn, brother)\n- **GedcomX relationships:** R1 (Thomas \u2192 Patrick), R2 (Thomas \u2192 Mary), R3 (Thomas \u2192 James) \u2014 all ParentChild\n- **Note on siblings:** Mary and James are stub entries (preferred name + gender only, no facts).\n  They are **prior-research children**: R2/R3 cite the St. Mary's baptismal registers (S5 \u2014\n  baptisms of 1841 and 1847), NOT the 1850 census. They represent the canonical shape Dallan\n  called for: when researching Patrick on a household census, already-documented siblings exist\n  as persons in `tree.gedcomx.json` so warnings like `relativesChildBirthRange40` and skills\n  like `person-evidence` can reach them. Mary and James do not appear in the 1850 census\n  household (which lists Bridget, Patrick, and John as children) \u2014 a record-vs-tree\n  discrepancy that is deliberate: extraction from that census should stub the new children and\n  surface the discrepancy as an identity question, never rename existing persons.\n",
+    "eval/fixtures/scenarios/mid-research-flynn/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have heard the name from a neighbor or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"St. Mary's Catholic Church, Pottsville, baptism of Patrick Flynn, 1845\",\n      \"citation_detail\": {\n        \"what\": \"Baptismal register, 1845\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1845\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Patrick Flynn entry\",\n        \"who\": \"St. Mary's Catholic Church, Pottsville\"\n      },\n      \"gedcomx_source_description_id\": \"S5\",\n      \"id\": \"src_005\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Missing volume/page locator and full repository chain.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HT-D1MQ-NZH\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-10\",\n      \"citation\": \"Schuylkill County will of Thomas Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Will of Thomas Flynn\",\n        \"when_accessed\": \"2026-05-10\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"will of Thomas Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S4\",\n      \"id\": \"src_006\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. Creator should be the court, not the courthouse. Missing Will Book volume and page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3Q9M-CS4V-7TXW\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"PA birth certificate, Mary Elizabeth Flynn, 1905\",\n      \"citation_detail\": {\n        \"what\": \"Birth certificate\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1905\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Mary Elizabeth Flynn entry\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S6\",\n      \"id\": \"src_007\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing certificate number (12455), birth date, and place.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:6JZX-VKQM\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Deed, Thomas Flynn to Patrick Flynn, 1881\",\n      \"citation_detail\": {\n        \"what\": \"Warranty deed\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1881\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"Thomas Flynn to Patrick Flynn\",\n        \"who\": \"Schuylkill County Courthouse\"\n      },\n      \"gedcomx_source_description_id\": \"S7\",\n      \"id\": \"src_008\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who should be the Recorder of Deeds (not the courthouse building); missing grantor/grantee, execution + recording dates, and Deed Book/page locator.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:3QS7-89WF-9KCT\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-12\",\n      \"citation\": \"Patrick Flynn obituary, Pottsville Republican, 1908\",\n      \"citation_detail\": {\n        \"what\": \"Obituary\",\n        \"when_accessed\": \"2026-05-12\",\n        \"when_created\": \"1908\",\n        \"where\": \"FamilySearch.org\",\n        \"where_within\": \"obituary notice\",\n        \"who\": \"FamilySearch\"\n      },\n      \"gedcomx_source_description_id\": \"S8\",\n      \"id\": \"src_009\",\n      \"log_entry_id\": null,\n      \"notes\": \"Rough working citation from record-extraction. who wrongly names the repository; missing the quoted article title, exact publication date, page, and column number.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/3:1:S3HY-6RKS-MGV\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Female\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"Mary\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"gender\": \"Male\",\n      \"id\": \"I4\",\n      \"names\": [\n        {\n          \"given\": \"James\",\n          \"id\": \"N4\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I3\",\n      \"id\": \"R2\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"Baptism of Mary Flynn, daughter of Thomas Flynn, 1841\",\n          \"quality\": 2,\n          \"ref\": \"S5\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    },\n    {\n      \"child\": \"I4\",\n      \"id\": \"R3\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"Baptism of James Flynn, son of Thomas Flynn, 1847\",\n          \"quality\": 2,\n          \"ref\": \"S5\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    },\n    {\n      \"author\": \"St. Mary's Catholic Church, Pottsville\",\n      \"id\": \"S5\",\n      \"title\": \"St. Mary's Catholic Church (Pottsville) Baptismal Registers\"\n    },\n    {\n      \"author\": \"Pennsylvania Department of Health\",\n      \"id\": \"S6\",\n      \"title\": \"Pennsylvania Birth Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Recorder of Deeds\",\n      \"id\": \"S7\",\n      \"title\": \"Schuylkill County Deed Books\"\n    },\n    {\n      \"author\": \"Pottsville Republican\",\n      \"id\": \"S8\",\n      \"title\": \"Pottsville Republican (newspaper)\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn-merge-pending/README.md": "# mid-research-flynn-merge-pending\n\nExtension of `mid-research-flynn` with a pending person merge plus a pending\nsibling-create. Used by `tree-edit` tests that exercise the skill's two most\ncomplex mutating operations (merge, create-person + relationship).\n\n## What this scenario adds vs. mid-research-flynn\n\n**New tree.gedcomx.json persons:**\n- `I3` \u2014 synthetic stub \"James Flynn\" extracted from Patrick's 1880 census\n  household (brother). Birth `~1849` Ireland.\n- `I4` \u2014 FamilySearch tree person \"James Patrick Flynn\"\n  (ark `https://familysearch.org/ark:/61903/4:1:KWCJ-JAM7`). Birth `~1848` in\n  Branch Township from the parish baptismal register.\n  **Conflicting birth year** with I3 \u2014 deliberate, to exercise the\n  keep-BOTH-conflicting-facts behavior during merge.\n\n**New research.json state supporting a merge:**\n- `subject_person_ids: [\"I1\", \"I3\"]` \u2014 was `[\"I1\"]`. Patrick + James are\n  co-researched siblings.\n- `pe_007` \u2014 person_evidence linking assertion `a_014` (1880 census brother\n  mention) to person `I3`.\n- `t_002` \u2014 timeline for `I3` with one event (1880 co-residence).\n- `q_003` \u2014 research question about whether I3 \u2261 KWCJ-JAM7.\n- `ps_002` \u2014 proof_summary at `probable` tier, vehicle `argument`, narrative\n  confirming the identity. **This is the proof gate that authorizes the merge.**\n\n**New research.json state supporting a create-sibling:**\n- `q_004` \u2014 research question about whether Mary Flynn is Patrick's sister.\n- `a_016` \u2014 assertion drawn from the 1850 Schuylkill County census\n  (`src_001`) where a 9-year-old female named Mary in Thomas Flynn's household\n  is consistent with a daughter.\n- `ps_003` \u2014 proof_summary at `probable` tier, vehicle `argument`,\n  authorizing tree-edit to create Mary as a person and a ParentChild\n  relationship from Thomas (I2). **Mary is NOT yet in tree.gedcomx.json** \u2014\n  that's what ut_010 creates.\n\n## Tests using this scenario\n\n- **`ut_tree_edit_006`** \u2014 merge I3 into I4 (full reference rewrite + keep\n  both conflicting birth dates).\n- **`ut_tree_edit_010`** \u2014 create Mary as person I5 + ParentChild Thomas \u2192 Mary\n  per ps_003.\n\n## Cross-references that a merge of I3 \u2192 I4 must rewrite\n\n| File | Field | Pre-merge | Post-merge |\n|------|-------|-----------|------------|\n| research.json | `project.subject_person_ids` | `[\"I1\", \"I3\"]` | `[\"I1\", \"I4\"]` |\n| research.json | `person_evidence[pe_007].person_id` | `\"I3\"` | `\"I4\"` |\n| research.json | `timelines[t_002].person_ids` | `[\"I3\"]` | `[\"I4\"]` |\n| tree.gedcomx.json | `persons[]` | I3 present | I3 deleted |\n| tree.gedcomx.json | `persons[I4].facts` | one Birth (~1848) | two Birth facts kept (~1848, ~1849) \u2014 conflict-handling |\n| tree.gedcomx.json | `persons[I4].names` | \"James Patrick Flynn\" + \"James Flynn\" AKA | name from I3 (\"James Flynn\") merged in if not duplicate |\n\nAfter the merge, `validate_research_schema` should pass and no reference to\n`I3` should remain anywhere in either file.\n",
+    "eval/fixtures/scenarios/mid-research-flynn-merge-pending/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have heard the name from a neighbor or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    },\n    {\n      \"date\": \"1880\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_003\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_014\",\n      \"informant\": \"Unknown \u2014 most likely Patrick Flynn as head of household, possibly his wife\",\n      \"informant_bias_notes\": \"The 1880 census was the first to record relationship explicitly; the enumerator wrote the relationship to the head, but the informant remains unidentified.\",\n      \"informant_proximity\": \"household_member\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_006\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:M880\",\n      \"record_persona_id\": null,\n      \"record_role\": \"household_member\",\n      \"source_id\": \"src_005\",\n      \"standard_place\": null,\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"brother\"\n      },\n      \"value\": \"Listed as brother of Patrick Flynn in 1880 Schuylkill Co. census, dwelling 142\"\n    },\n    {\n      \"date\": \"1848-03-22\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_003\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_015\",\n      \"informant\": \"Officiating priest, Rev. Patrick Murray\",\n      \"informant_bias_notes\": \"Officiant recorded the baptism at the time of the rite. Parents present.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_007\",\n      \"place\": \"Branch Township, Schuylkill County, Pennsylvania\",\n      \"record_id\": \"stpatricks:branchtwp:1848:047\",\n      \"record_persona_id\": null,\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_006\",\n      \"standard_place\": null,\n      \"structured_value\": {\n        \"place\": \"Branch Township, Schuylkill County, Pennsylvania\",\n        \"year\": 1848\n      },\n      \"value\": \"Baptized 22 March 1848, James Patrick Flynn, parents Thomas Flynn and Mary Brennan\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_004\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_016\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships. Mary's position in the household and shared surname are consistent with daughter, but not directly reported.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_persona_id\": null,\n      \"record_role\": \"household_member\",\n      \"source_id\": \"src_001\",\n      \"standard_place\": null,\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Female age 9, surname Flynn, listed in Thomas Flynn household, position consistent with daughter\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_006\",\n      \"notes\": \"Re-examined 1880 census to extract Patrick's brother James (age 31, b. Ireland). Same household, dwelling 142.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-05T11:00:00Z\",\n      \"plan_item_id\": null,\n      \"query\": {\n        \"birth_year\": 1849,\n        \"collection\": \"1880 Census\",\n        \"given\": \"James\",\n        \"place\": \"Schuylkill County, Pennsylvania\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 4,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_007\",\n      \"notes\": \"St. Patrick's RC Church register, entry 47, baptism of James Patrick Flynn 22 Mar 1848, parents Thomas Flynn and Mary Brennan.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-05T14:30:00Z\",\n      \"plan_item_id\": null,\n      \"query\": {\n        \"collection\": \"St. Patrick's Branch Township Baptismal Register\",\n        \"given\": \"James Patrick\",\n        \"surname\": \"Flynn\",\n        \"year_range\": \"1845-1852\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_014\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-05\",\n      \"id\": \"pe_007\",\n      \"match_score\": null,\n      \"person_id\": \"I3\",\n      \"rationale\": \"1880 census names Patrick's brother James in the same household. Recorded as synthetic stub I3 pending identity resolution against FamilySearch tree person KWCJ-JAM7.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\",\n      \"I3\"\n    ],\n    \"updated\": \"2026-05-08\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    },\n    {\n      \"exhaustive_search_summary\": \"Cross-referenced 1880 Schuylkill Co. census (Patrick Flynn household, brother James age 31, b. Ireland \u2014 log_006) against St. Patrick's RC Church baptismal register (1848 baptism of James Patrick Flynn, parents Thomas Flynn and Mary Brennan \u2014 log_007). Names, parish, parents, and birth-year range converge on a single individual.\",\n      \"id\": \"ps_002\",\n      \"narrative_markdown\": \"## Identity: I3 stub \u2261 KWCJ-JAM7 (James Patrick Flynn, ca. 1848)\\n\\nThe synthetic stub I3 (extracted from Patrick Flynn's 1880 census household as 'brother James, age 31, b. Ireland') is the same individual as FamilySearch tree person KWCJ-JAM7 (James Patrick Flynn, baptized 22 March 1848 at St. Patrick's in Branch Township, son of Thomas Flynn and Mary Brennan).\\n\\nThree independent agreements support the identity:\\n1. Same parish community (Branch Township, Schuylkill County).\\n2. Birth-year window 1848\u20131849 (1880 census age 31 \u2192 b. ca. 1849; baptism 1848) is within enumerator-error tolerance.\\n3. Same parents: Thomas Flynn is also Patrick's father (per ps_001).\\n\\nTier set to **probable** \u2014 direct evidence from the baptismal register, corroborated by 1880 census co-residence with Patrick. Tree-edit should now merge I3 into KWCJ-JAM7.\",\n      \"question_id\": \"q_003\",\n      \"resolved_conflict_ids\": [],\n      \"supporting_assertion_ids\": [\n        \"a_014\",\n        \"a_015\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"argument\"\n    },\n    {\n      \"exhaustive_search_summary\": \"1850 Schuylkill County census household composition shows a female child Mary, age 9, surname Flynn, in Thomas Flynn's household alongside Patrick. The 1850 census does not state relationships explicitly; identification rests on household position, shared surname, and age plausibility.\",\n      \"id\": \"ps_003\",\n      \"narrative_markdown\": \"## Mary Flynn as daughter of Thomas Flynn (ca. 1841 birth)\\n\\nThe 1850 Schuylkill County census household of Thomas Flynn (dwelling 84, family 91) lists a female named Mary, age 9, surname Flynn. Position in the household and shared surname are consistent with a daughter-of-head relationship. 1850 census does not name relationships explicitly, so this is indirect evidence \u2014 but absent a competing explanation (no second adult woman with a different surname in the household), the most parsimonious reading is daughter.\\n\\nTier set to **probable** \u2014 sufficient evidence for tree-edit to create person Mary and a ParentChild relationship Thomas \u2192 Mary, with the 1850 census as source.\",\n      \"question_id\": \"q_004\",\n      \"resolved_conflict_ids\": [],\n      \"supporting_assertion_ids\": [\n        \"a_016\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"argument\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    },\n    {\n      \"created\": \"2026-05-05\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_003\",\n      \"priority\": \"medium\",\n      \"question\": \"Is the synthetic stub I3 (\\\"James Flynn\\\", from the 1880 Schuylkill County census brother-of-Patrick mention) the same individual as FamilySearch tree person KWCJ-JAM7 (\\\"James Patrick Flynn\\\", baptized 1848 in Branch Township)?\",\n      \"rationale\": \"Patrick's 1880 census household lists his brother James, age 31, born Ireland. A separate FamilySearch tree person KWCJ-JAM7 baptized at St. Patrick's in 1848 (Branch Township) matches in name, age range, and parish. Resolving the identity is a prerequisite for any merge into the tree.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"new_evidence\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-06\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_004\",\n      \"priority\": \"low\",\n      \"question\": \"Was Mary Flynn a sibling of Patrick Flynn (daughter of Thomas Flynn) per the 1850 Schuylkill County census household composition?\",\n      \"rationale\": \"The 1850 census household listed two female children alongside Patrick. The eldest is recorded as Mary, age 9, surname Flynn. A ParentChild relationship between Thomas and Mary needs to be evaluated before being written to the tree.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"record_found_incidentally\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-05\",\n      \"citation\": \"1880 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 142, family 156, Patrick Flynn household; NARA microfilm publication T9, roll 1175; digital image, FamilySearch.org, accessed 5 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1880 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-05\",\n        \"when_created\": \"1880\",\n        \"where\": \"FamilySearch.org (NARA microfilm T9, roll 1175)\",\n        \"where_within\": \"Schuylkill County, dwelling 142, family 156\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S5\",\n      \"id\": \"src_005\",\n      \"log_entry_id\": \"log_006\",\n      \"notes\": \"1880 census names Patrick (35) as head with brother James (31) in household. 1880 is the first census recording explicit relationships.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:M880\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-05\",\n      \"citation\": \"St. Patrick's Roman Catholic Church baptismal register, James Patrick Flynn, 22 March 1848, Branch Township, Schuylkill County, Pennsylvania, entry 47.\",\n      \"citation_detail\": {\n        \"what\": \"Catholic baptismal register entry\",\n        \"when_accessed\": \"2026-05-05\",\n        \"when_created\": \"1848\",\n        \"where\": \"Branch Township, Schuylkill County, Pennsylvania\",\n        \"where_within\": \"St. Patrick's RC Church register, entry 47\",\n        \"who\": \"St. Patrick's Roman Catholic Church\"\n      },\n      \"gedcomx_source_description_id\": \"S6\",\n      \"id\": \"src_006\",\n      \"log_entry_id\": \"log_007\",\n      \"notes\": \"Parish register names parents as Thomas Flynn and Mary Brennan; ties Patrick's brother James to a contemporaneous Branch Township baptism.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": null,\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    },\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_014\"\n          ],\n          \"conflict_ids\": null,\n          \"conflict_note\": null,\n          \"date\": \"1880\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Listed as brother of Patrick Flynn (head), age 31, b. Ireland \u2014 dwelling 142\",\n          \"distance_from_previous_km\": null,\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"standard_place\": null\n        }\n      ],\n      \"gaps\": [],\n      \"generated\": \"2026-05-05T15:00:00Z\",\n      \"hypothesis_id\": null,\n      \"id\": \"t_002\",\n      \"impossibilities\": [],\n      \"label\": \"James Flynn (I3 stub) \u2014 sibling-of-Patrick context\",\n      \"person_ids\": [\n        \"I3\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn-merge-pending/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-12\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1849\",\n          \"id\": \"F4\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1880 U.S. Census, Schuylkill Co., dwelling 142 (Patrick Flynn household, brother 'James' age 31, b. Ireland)\",\n              \"ref\": \"S5\"\n            }\n          ],\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I3\",\n      \"names\": [\n        {\n          \"given\": \"James\",\n          \"id\": \"N3\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"ark\": \"https://familysearch.org/ark:/61903/4:1:KWCJ-JAM7\",\n      \"facts\": [\n        {\n          \"date\": \"~1848\",\n          \"id\": \"F5\",\n          \"place\": \"Branch Township, Schuylkill County, Pennsylvania\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"St. Patrick's RC Church baptismal register, 22 Mar 1848, entry 47\",\n              \"ref\": \"S6\"\n            }\n          ],\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I4\",\n      \"names\": [\n        {\n          \"given\": \"James Patrick\",\n          \"id\": \"N4\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        },\n        {\n          \"given\": \"James\",\n          \"id\": \"N5\",\n          \"surname\": \"Flynn\",\n          \"type\": \"AlsoKnownAs\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Dept. of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S5\",\n      \"title\": \"1880 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"St. Patrick's Roman Catholic Church\",\n      \"id\": \"S6\",\n      \"title\": \"St. Patrick's RC Church Baptismal Register (Branch Township)\"\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn-typo/README.md": "# mid-research-flynn-typo\n\nVariant of `mid-research-flynn` with **one intentional typo** in\n`tree.gedcomx.json`. Used by `ut_tree_edit_008` to test real value correction\n(the existing ut_001 + ut_002 cover the no-op verify path).\n\n## What differs from mid-research-flynn\n\n`tree.gedcomx.json` person `I1` (Patrick Flynn), fact `F2` (Death):\n- This scenario:    `date: \"1908-03-21\"` \u2190 typo (day swap)\n- mid-research-flynn: `date: \"1908-03-12\"`\n\nThe cited source is `S3` (Pennsylvania Death Certificate no. 4521), which\nrecords 12 March 1908. The tree shows 21 March 1908 \u2014 a transcription day-swap\nerror.\n\n## How `ut_tree_edit_008` exercises this\n\nThe user asks tree-edit to correct F2.date from `1908-03-21` to `1908-03-12`\n(matching the cited source). Tests:\n- **Edit minimality** \u2014 only `facts[].date` on F1 changes; every other byte\n  of both project files is unchanged.\n- **Data preservation** \u2014 no other fact, name, relationship, or source\n  reference is touched.\n- **Evidence grounding** \u2014 the correction is verifiable against an\n  already-cited source (S3), so it meets the SKILL.md \"ad-hoc edit\"\n  threshold.\n\nAfter the edit, `validate_research_schema` should pass and `F2.date` should\nread `1908-03-12`.\n",
+    "eval/fixtures/scenarios/mid-research-flynn-typo/research.json": "{\n  \"assertions\": [\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_001\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. The person who provided the name is unknown \u2014 most likely a household member, possibly a neighbor. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have heard the name from a neighbor or made an assumption \u2014 the name fact doesn't necessarily require active reporting the way age/birthplace does.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_002\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 someone had to tell the enumerator these facts. That informant was most likely a household member, but enumerators also took information from neighbors when residents were unavailable, and the census does not identify who answered. Proximity is 'unknown' because the informant cannot be established from the record.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"place\": \"Ireland\",\n        \"year\": 1845\n      },\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"residence\",\n      \"id\": \"a_003\",\n      \"informant\": \"Census enumerator (witness to residence by visiting the dwelling)\",\n      \"informant_bias_notes\": \"For residence facts specifically, the enumerator is a direct witness \u2014 they physically visited the dwelling and recorded who lived there. This distinguishes residence from other census facts where an unidentified informant (most likely a household member, possibly a neighbor) supplied the information.\",\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Schuylkill County, Pennsylvania\"\n    },\n    {\n      \"date\": \"1850\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_004\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1850 census\",\n      \"informant_bias_notes\": \"1850 census does not state relationships; this assertion is inferred from household position and shared surname, not directly reported by any informant. The relationship is indirect evidence constructed by the researcher, not information provided by a census informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_001\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position consistent with child\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_005\",\n      \"informant\": \"Unknown informant (likely Thomas Flynn himself) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. As head of household, Thomas likely provided his own name, but the 1850 census does not identify the informant.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_001\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MXYZ\",\n      \"record_role\": \"head_of_household\",\n      \"source_id\": \"src_001\",\n      \"value\": \"Thomas Flynn\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_006\",\n      \"informant\": \"Ancestry transcriber (derivative of census enumerator)\",\n      \"informant_bias_notes\": \"Derivative index \u2014 transcription errors possible\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": null,\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_002\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_007\",\n      \"informant\": \"Ancestry transcriber (derivative)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_002\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ancestry:8054:patrick-flynn-1850\",\n      \"record_role\": \"child_1\",\n      \"source_id\": \"src_002\",\n      \"value\": \"age 5\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"name\",\n      \"id\": \"a_008\",\n      \"informant\": \"Unknown informant (most likely a household member, possibly a neighbor) reporting to census enumerator\",\n      \"informant_bias_notes\": \"Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 \u2014 name facts don't necessarily require active reporting).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"Patrick Flynn\"\n    },\n    {\n      \"date\": \"~1845\",\n      \"date_certainty\": \"estimated\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_009\",\n      \"informant\": \"Unknown \u2014 most likely a household member (such as Thomas Flynn or his wife), but possibly a neighbor\",\n      \"informant_bias_notes\": \"Age and birthplace require active reporting by an informant \u2014 most likely a household member, possibly a neighbor (same reasoning as a_002).\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Ireland\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"value\": \"age 15\"\n    },\n    {\n      \"date\": \"1860\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"indirect\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_010\",\n      \"informant\": \"Inferred from household structure \u2014 no explicit informant for relationships in 1860 census\",\n      \"informant_bias_notes\": \"1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.\",\n      \"informant_proximity\": \"unknown\",\n      \"information_quality\": \"indeterminate\",\n      \"log_entry_id\": \"log_004\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MABC\",\n      \"record_role\": \"child_2\",\n      \"source_id\": \"src_003\",\n      \"structured_value\": {\n        \"related_person_role\": \"head_of_household\",\n        \"relationship_type\": \"child_inferred\"\n      },\n      \"value\": \"Listed in household of Thomas Flynn (head), position and age consistent with son\"\n    },\n    {\n      \"date\": \"1908-03-12\",\n      \"date_certainty\": \"exact\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [],\n      \"fact_type\": \"death\",\n      \"id\": \"a_011\",\n      \"informant\": \"Attending physician (signature on certificate)\",\n      \"informant_bias_notes\": null,\n      \"informant_proximity\": \"witness\",\n      \"information_quality\": \"primary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Schuylkill County, Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"value\": \"Died 12 March 1908\"\n    },\n    {\n      \"date\": \"1845\",\n      \"date_certainty\": \"approximate\",\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"birth\",\n      \"id\": \"a_012\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Son-in-law reporting birth facts decades after the event. Note: death cert says Pennsylvania, but census records say Ireland. Son-in-law may not have known Patrick was born in Ireland.\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": \"Pennsylvania\",\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"place\": \"Pennsylvania\",\n        \"year\": 1845\n      },\n      \"value\": \"Born 1845, Pennsylvania\"\n    },\n    {\n      \"date\": null,\n      \"date_certainty\": null,\n      \"evidence_type\": \"direct\",\n      \"extracted_for_question_ids\": [\n        \"q_001\"\n      ],\n      \"fact_type\": \"relationship\",\n      \"id\": \"a_013\",\n      \"informant\": \"James Brown (son-in-law)\",\n      \"informant_bias_notes\": \"Secondary information \u2014 son-in-law reporting what he was told about father-in-law's parentage\",\n      \"informant_proximity\": \"family_not_present\",\n      \"information_quality\": \"secondary\",\n      \"log_entry_id\": \"log_005\",\n      \"place\": null,\n      \"record_id\": \"ark:/61903/1:1:MDEF\",\n      \"record_role\": \"deceased\",\n      \"source_id\": \"src_004\",\n      \"structured_value\": {\n        \"related_person_role\": \"deceased\",\n        \"relationship_type\": \"father\"\n      },\n      \"value\": \"Father: Thomas Flynn\"\n    }\n  ],\n  \"conflicts\": [\n    {\n      \"blocks_question_ids\": [],\n      \"competing_assertion_ids\": [\n        \"a_002\",\n        \"a_009\",\n        \"a_012\"\n      ],\n      \"conflict_type\": \"fact\",\n      \"description\": \"Patrick Flynn's birthplace: Ireland (1850 and 1860 censuses) vs. Pennsylvania (1908 death certificate)\",\n      \"disputed_attribute\": \"birthplace\",\n      \"id\": \"c_001\",\n      \"identity_question\": null,\n      \"independence_analysis\": \"The two census records (1850, 1860) are independent original sources with different enumerators. The death certificate is a third independent original source. However, the census informants are likely the same household member (Thomas Flynn or wife), so the two census assertions may share a single informant \u2014 potentially not fully independent for this fact.\",\n      \"preferred_assertion_id\": \"a_002\",\n      \"resolution_rationale\": \"Ireland is accepted as the birthplace. The 1908 death certificate birthplace of 'Pennsylvania' is rejected as a likely error by the son-in-law informant, who may have confused Patrick's place of residence with his place of birth, or may not have known Patrick was born in Ireland before immigrating as a young child.\",\n      \"status\": \"resolved\",\n      \"weighing_analysis\": \"The census records are contemporary recordings made near the time of Patrick's birth, while the death certificate was created 63 years later. The census informant was likely a household member with firsthand knowledge (primary or indeterminate), while the death certificate informant (son-in-law) is clearly secondary for birth facts. Two contemporary sources outweigh one later recollection by a secondary informant.\"\n    }\n  ],\n  \"evaluations\": [],\n  \"hypotheses\": [\n    {\n      \"claim\": \"Patrick Flynn's father was Thomas Flynn of Schuylkill County, Pennsylvania\",\n      \"contradicting_assertion_ids\": [],\n      \"id\": \"h_001\",\n      \"notes\": \"Three independent pieces of evidence: 1850 census co-enumeration (indirect), 1860 census co-enumeration (indirect \u2014 relationship inferred from household position), death certificate naming Thomas as father (direct, secondary informant). Awaiting probate records for additional confirmation.\",\n      \"related_question_ids\": [\n        \"q_001\"\n      ],\n      \"ruled_out\": false,\n      \"ruled_out_reason\": null,\n      \"status\": \"supported\",\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ]\n    }\n  ],\n  \"log\": [\n    {\n      \"external_site\": null,\n      \"id\": \"log_001\",\n      \"notes\": \"Found Patrick Flynn age 5 in household of Thomas Flynn, dwelling 84, Schuylkill Co. Three other Flynn results examined \u2014 ages and locations don't match.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T10:15:00Z\",\n      \"plan_item_id\": \"pli_001\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1850 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 8,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"ancestry-1850-flynn-results.pdf\",\n        \"capture_received\": true,\n        \"site\": \"ancestry\",\n        \"url_generated\": \"https://www.ancestry.com/search/collections/8054/?name=Patrick_Flynn&birth=1845&birthplace=Pennsylvania\"\n      },\n      \"id\": \"log_002\",\n      \"notes\": \"Ancestry index confirms same household. Transcription matches FamilySearch except Ancestry reads dwelling as 84, FamilySearch as 84 \u2014 consistent.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-01T11:30:00Z\",\n      \"plan_item_id\": \"pli_002\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 12,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": {\n        \"capture_filename\": \"myheritage-1850-flynn-nil.pdf\",\n        \"capture_received\": true,\n        \"site\": \"myheritage\",\n        \"url_generated\": \"https://www.myheritage.com/research?action=query&first=Patrick&last=Flynn&birth_year=1845&birth_place=Pennsylvania\"\n      },\n      \"id\": \"log_003\",\n      \"notes\": \"MyHeritage returned no results for Patrick Flynn in 1850 Schuylkill County. Site may not have this collection indexed. Searched broader Pennsylvania \u2014 still no match.\",\n      \"outcome\": \"negative\",\n      \"performed\": \"2026-05-01T14:00:00Z\",\n      \"plan_item_id\": \"pli_003\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 0,\n      \"tool\": \"external_site\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_004\",\n      \"notes\": \"Patrick Flynn age 15 in household of Thomas Flynn, Schuylkill Co. Consistent with 1850 placement.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-02T09:00:00Z\",\n      \"plan_item_id\": \"pli_004\",\n      \"query\": {\n        \"birth_place\": \"Pennsylvania\",\n        \"birth_year\": 1845,\n        \"collection\": \"1860 Census\",\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 5,\n      \"tool\": \"record_search\"\n    },\n    {\n      \"external_site\": null,\n      \"id\": \"log_005\",\n      \"notes\": \"Death certificate found. Names Thomas Flynn as father. Informant was son-in-law James Brown.\",\n      \"outcome\": \"positive\",\n      \"performed\": \"2026-05-03T10:00:00Z\",\n      \"plan_item_id\": \"pli_005\",\n      \"query\": {\n        \"death_place\": \"Schuylkill County, Pennsylvania\",\n        \"death_year\": 1908,\n        \"given\": \"Patrick\",\n        \"surname\": \"Flynn\"\n      },\n      \"results_examined\": 2,\n      \"tool\": \"record_search\"\n    }\n  ],\n  \"person_evidence\": [\n    {\n      \"assertion_id\": \"a_001\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_001\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Name matches (Patrick Flynn), age consistent with ~1845 birth, located in Schuylkill County where subject is known to have lived. Only Patrick Flynn of this age in the county in 1850.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_002\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Same record as pe_001, same person. Household position and shared surname with head Thomas Flynn suggest parent-child relationship, but 1850 census does not state relationships explicitly.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_004\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_006\",\n      \"match_score\": null,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Same assertion as pe_002 but linked to Thomas Flynn (I2). The relationship assertion ('position consistent with child') equally bears on the head of household. Thomas Flynn is the other party in the implied parent-child relationship.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_005\",\n      \"confidence\": \"probable\",\n      \"created\": \"2026-05-01\",\n      \"id\": \"pe_003\",\n      \"match_score\": 0.82,\n      \"person_id\": \"I2\",\n      \"rationale\": \"Thomas Flynn, head of household where Patrick was found. Age (~32 in 1850, born ~1818) is consistent with being Patrick's father. Name matches candidate father.\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_010\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-02\",\n      \"id\": \"pe_004\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Patrick Flynn age 15 in Thomas Flynn household, 1860 census. Same county, age consistent with 1850 enumeration. Relationship inferred from household position and shared surname (1860 census does not state relationships explicitly).\",\n      \"superseded_by\": null\n    },\n    {\n      \"assertion_id\": \"a_013\",\n      \"confidence\": \"confident\",\n      \"created\": \"2026-05-03\",\n      \"id\": \"pe_005\",\n      \"match_score\": null,\n      \"person_id\": \"I1\",\n      \"rationale\": \"Death certificate for Patrick Flynn, d. 1908, Schuylkill County. Names match, death location matches known residence. Names Thomas Flynn as father.\",\n      \"superseded_by\": null\n    }\n  ],\n  \"plans\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"id\": \"pl_001\",\n      \"items\": [\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_001\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"1850 census fully indexed on FamilySearch. Free access, start here.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_002\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Ancestry has independent indexing; cross-check for transcription errors.\",\n          \"record_type\": \"census\",\n          \"repository\": \"Ancestry\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1850\",\n          \"fallback_for\": null,\n          \"id\": \"pli_003\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Third independent index for coverage confirmation.\",\n          \"record_type\": \"census\",\n          \"repository\": \"MyHeritage\",\n          \"sequence\": 3,\n          \"status\": \"completed\"\n        }\n      ],\n      \"question_id\": \"q_002\",\n      \"status\": \"completed\"\n    },\n    {\n      \"created\": \"2026-05-02\",\n      \"id\": \"pl_002\",\n      \"items\": [\n        {\n          \"date_range\": \"1860\",\n          \"fallback_for\": null,\n          \"id\": \"pli_004\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Confirm Patrick still in Thomas Flynn household in 1860. Strengthens parent-child identification.\",\n          \"record_type\": \"census\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 1,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1908\",\n          \"fallback_for\": null,\n          \"id\": \"pli_005\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Death certificate may name parents directly.\",\n          \"record_type\": \"vital_record\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 2,\n          \"status\": \"completed\"\n        },\n        {\n          \"date_range\": \"1870-1890\",\n          \"fallback_for\": null,\n          \"id\": \"pli_006\",\n          \"jurisdiction\": \"Schuylkill County, Pennsylvania\",\n          \"rationale\": \"Thomas Flynn probate/will may name Patrick as son.\",\n          \"record_type\": \"probate\",\n          \"repository\": \"FamilySearch\",\n          \"sequence\": 3,\n          \"status\": \"in_progress\"\n        }\n      ],\n      \"question_id\": \"q_001\",\n      \"status\": \"active\"\n    }\n  ],\n  \"project\": {\n    \"created\": \"2026-05-01\",\n    \"id\": \"rp_001\",\n    \"objective\": \"Identify the parents of Patrick Flynn, born ca. 1845 in Pennsylvania, died 1908 in Schuylkill County, PA\",\n    \"status\": \"active\",\n    \"subject_person_ids\": [\n      \"I1\"\n    ],\n    \"updated\": \"2026-05-04\"\n  },\n  \"proof_summaries\": [\n    {\n      \"exhaustive_search_summary\": \"Searched 1850 census (FamilySearch, Ancestry, MyHeritage \u2014 log_001, log_002, log_003), 1860 census (FamilySearch \u2014 log_004), and death certificate (FamilySearch \u2014 log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.\",\n      \"id\": \"ps_001\",\n      \"narrative_markdown\": \"## Parentage of Patrick Flynn (ca. 1845\u20131908)\\n\\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\\n\\n### Evidence Summary\\n\\nThree independent lines of evidence support this conclusion:\\n\\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\\n\\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\\n\\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \\\"Thomas Flynn\\\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact \u2014 he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\\n\\n### Conflict Resolution\\n\\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\\n\\n### Assessment\\n\\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated \u2014 the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive \u2014 the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\\n\\n### Citations\\n\\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"question_id\": \"q_001\",\n      \"resolved_conflict_ids\": [\n        \"c_001\"\n      ],\n      \"supporting_assertion_ids\": [\n        \"a_004\",\n        \"a_010\",\n        \"a_013\"\n      ],\n      \"tier\": \"probable\",\n      \"vehicle\": \"summary\"\n    }\n  ],\n  \"questions\": [\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": false,\n        \"justification\": null,\n        \"log_entry_ids\": [],\n        \"stop_criteria\": null\n      },\n      \"id\": \"q_001\",\n      \"priority\": \"high\",\n      \"question\": \"Who were the parents of Patrick Flynn (b. ~1845, PA, d. 1908)?\",\n      \"rationale\": \"This is the primary research objective.\",\n      \"resolution_assertion_ids\": [],\n      \"resolved\": null,\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"in_progress\",\n      \"unblocks\": []\n    },\n    {\n      \"created\": \"2026-05-01\",\n      \"depends_on\": [],\n      \"exhaustive_declaration\": {\n        \"declared\": true,\n        \"justification\": \"Searched 1850 census for Schuylkill County on FamilySearch (indexed and browse), Ancestry (indexed), and MyHeritage (indexed). All three returned the same household. No other Patrick Flynn of matching age found in the county.\",\n        \"log_entry_ids\": [\n          \"log_001\",\n          \"log_002\",\n          \"log_003\"\n        ],\n        \"stop_criteria\": {\n          \"conflict_resolution\": \"No conflicts on the 1850 census placement question.\",\n          \"evidence_class\": \"Yes \u2014 FamilySearch provides original census image with indeterminate-quality information.\",\n          \"goal_alignment\": \"Yes \u2014 Patrick Flynn located in a specific 1850 household, answering the question.\",\n          \"independent_verification\": \"FamilySearch (original) and Ancestry (derivative) both return the same household. Two access paths, one underlying original.\",\n          \"original_substitution\": \"FamilySearch provides the original census image; Ancestry index is derivative but confirmed consistent.\",\n          \"overturn_risk\": \"Low \u2014 all three repositories agree, and no competing Patrick Flynn of matching age exists in the county.\",\n          \"repository_breadth\": \"Three major repositories searched (FamilySearch, Ancestry, MyHeritage). No additional known indexes of the 1850 Schuylkill County census exist.\"\n        }\n      },\n      \"id\": \"q_002\",\n      \"priority\": \"high\",\n      \"question\": \"Where was Patrick Flynn in the 1850 census?\",\n      \"rationale\": \"The 1850 census is the earliest enumeration where Patrick would appear by name (age ~5). Locating him in a household identifies candidate parents.\",\n      \"resolution_assertion_ids\": [\n        \"a_001\",\n        \"a_002\",\n        \"a_003\"\n      ],\n      \"resolved\": \"2026-05-02\",\n      \"selection_basis\": \"objective_decomposition\",\n      \"status\": \"resolved\",\n      \"unblocks\": [\n        \"q_001\"\n      ]\n    }\n  ],\n  \"sources\": [\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"FamilySearch.org (NARA microfilm M432, roll 810)\",\n        \"where_within\": \"Schuylkill County, dwelling 84, family 91\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_001\",\n      \"log_entry_id\": \"log_001\",\n      \"notes\": \"Image quality good. Enumerator handwriting clear.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MXYZ\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-01\",\n      \"citation\": \"1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, Thomas Flynn household; digital image, Ancestry.com, accessed 1 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1850 U.S. Federal Census, population schedule (Ancestry index)\",\n        \"when_accessed\": \"2026-05-01\",\n        \"when_created\": \"1850\",\n        \"where\": \"Ancestry.com\",\n        \"where_within\": \"Schuylkill County, dwelling 84\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S1\",\n      \"id\": \"src_002\",\n      \"log_entry_id\": \"log_002\",\n      \"notes\": \"Ancestry's index of the same original census. Transcription consistent with FamilySearch.\",\n      \"repository\": \"Ancestry\",\n      \"source_classification\": \"derivative\",\n      \"url\": null,\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-02\",\n      \"citation\": \"1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"1860 U.S. Federal Census, population schedule\",\n        \"when_accessed\": \"2026-05-02\",\n        \"when_created\": \"1860\",\n        \"where\": \"FamilySearch.org (NARA microfilm M653, roll 1141)\",\n        \"where_within\": \"Schuylkill County, dwelling 112, family 119\",\n        \"who\": \"U.S. Census Bureau\"\n      },\n      \"gedcomx_source_description_id\": \"S2\",\n      \"id\": \"src_003\",\n      \"log_entry_id\": \"log_004\",\n      \"notes\": null,\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MABC\",\n      \"url_archived\": null\n    },\n    {\n      \"access_date\": \"2026-05-03\",\n      \"citation\": \"Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026.\",\n      \"citation_detail\": {\n        \"what\": \"Death certificate no. 4521\",\n        \"when_accessed\": \"2026-05-03\",\n        \"when_created\": \"1908-03-14\",\n        \"where\": \"FamilySearch.org (Pennsylvania State Archives, Harrisburg)\",\n        \"where_within\": \"Certificate no. 4521\",\n        \"who\": \"Pennsylvania Department of Health; informant: James Brown (son-in-law)\"\n      },\n      \"gedcomx_source_description_id\": \"S3\",\n      \"id\": \"src_004\",\n      \"log_entry_id\": \"log_005\",\n      \"notes\": \"Informant is son-in-law James Brown. Primary for death facts, secondary for birth facts.\",\n      \"repository\": \"FamilySearch\",\n      \"source_classification\": \"original\",\n      \"url\": \"https://www.familysearch.org/ark:/61903/1:1:MDEF\",\n      \"url_archived\": null\n    }\n  ],\n  \"timelines\": [\n    {\n      \"events\": [\n        {\n          \"assertion_ids\": [\n            \"a_002\",\n            \"a_009\"\n          ],\n          \"date\": \"~1845\",\n          \"date_certainty\": \"estimated\",\n          \"description\": \"Born in Ireland, estimated from census ages\",\n          \"event_type\": \"birth\",\n          \"place\": \"Ireland\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_003\",\n            \"a_004\"\n          ],\n          \"date\": \"1850\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 5 in Thomas Flynn household, dwelling 84\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_008\",\n            \"a_009\",\n            \"a_010\"\n          ],\n          \"date\": \"1860\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Enumerated age 15 in Thomas Flynn household, dwelling 112\",\n          \"event_type\": \"census\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        },\n        {\n          \"assertion_ids\": [\n            \"a_011\",\n            \"a_013\"\n          ],\n          \"date\": \"1908-03-12\",\n          \"date_certainty\": \"exact\",\n          \"description\": \"Died, death certificate names Thomas Flynn as father\",\n          \"event_type\": \"death\",\n          \"place\": \"Schuylkill County, Pennsylvania\"\n        }\n      ],\n      \"gaps\": [\n        {\n          \"end\": \"1908-03-12\",\n          \"expected_events\": [\n            \"marriage\",\n            \"1870_census\",\n            \"1880_census\",\n            \"1900_census\",\n            \"residence\",\n            \"occupation\"\n          ],\n          \"severity\": \"high\",\n          \"start\": \"1860-01-01\"\n        }\n      ],\n      \"generated\": \"2026-05-03T12:00:00Z\",\n      \"hypothesis_id\": \"h_001\",\n      \"id\": \"t_001\",\n      \"impossibilities\": [],\n      \"label\": \"Patrick Flynn \u2014 assuming Thomas Flynn parentage\",\n      \"person_ids\": [\n        \"I1\"\n      ]\n    }\n  ]\n}\n",
+    "eval/fixtures/scenarios/mid-research-flynn-typo/tree.gedcomx.json": "{\n  \"persons\": [\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1845\",\n          \"id\": \"F1\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"sources\": [\n            {\n              \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n              \"ref\": \"S1\"\n            }\n          ],\n          \"type\": \"Birth\"\n        },\n        {\n          \"date\": \"1908-03-21\",\n          \"id\": \"F2\",\n          \"place\": \"Schuylkill County, Pennsylvania\",\n          \"sources\": [\n            {\n              \"page\": \"Death cert. no. 4521\",\n              \"ref\": \"S3\"\n            }\n          ],\n          \"type\": \"Death\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I1\",\n      \"names\": [\n        {\n          \"given\": \"Patrick\",\n          \"id\": \"N1\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    },\n    {\n      \"facts\": [\n        {\n          \"date\": \"~1818\",\n          \"id\": \"F3\",\n          \"place\": \"Ireland\",\n          \"primary\": true,\n          \"type\": \"Birth\"\n        }\n      ],\n      \"gender\": \"Male\",\n      \"id\": \"I2\",\n      \"names\": [\n        {\n          \"given\": \"Thomas\",\n          \"id\": \"N2\",\n          \"preferred\": true,\n          \"surname\": \"Flynn\",\n          \"type\": \"BirthName\"\n        }\n      ]\n    }\n  ],\n  \"relationships\": [\n    {\n      \"child\": \"I1\",\n      \"id\": \"R1\",\n      \"parent\": \"I2\",\n      \"sources\": [\n        {\n          \"page\": \"1850 Census, Schuylkill Co., dwelling 84\",\n          \"quality\": 2,\n          \"ref\": \"S1\"\n        },\n        {\n          \"page\": \"1860 Census, Schuylkill Co., dwelling 112\",\n          \"quality\": 2,\n          \"ref\": \"S2\"\n        },\n        {\n          \"page\": \"Death cert. no. 4521\",\n          \"quality\": 2,\n          \"ref\": \"S3\"\n        }\n      ],\n      \"type\": \"ParentChild\"\n    }\n  ],\n  \"sources\": [\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S1\",\n      \"title\": \"1850 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"U.S. Census Bureau\",\n      \"id\": \"S2\",\n      \"title\": \"1860 U.S. Federal Census\"\n    },\n    {\n      \"author\": \"Pennsylvania Dept. of Health\",\n      \"id\": \"S3\",\n      \"title\": \"Pennsylvania Death Certificates\"\n    },\n    {\n      \"author\": \"Schuylkill County Register of Wills\",\n      \"id\": \"S4\",\n      \"title\": \"Schuylkill County Probate Records\"\n    }\n  ]\n}\n",
+    "eval/fixtures/mcp/person-person-matches-flynn.json": "{\n  \"args\": {\n    \"id\": \"LZNY-BRF\"\n  },\n  \"description\": \"Possible-duplicate tree-person matches for Patrick Flynn (LZNY-BRF): 1 pending candidate\",\n  \"response\": {\n    \"matches\": [\n      {\n        \"ark\": \"https://familysearch.org/ark:/61903/4:1:LZNY-QRS\",\n        \"arkType\": \"4:1:\",\n        \"collection\": \"https://familysearch.org/platform/collections/records\",\n        \"confidence\": 3,\n        \"pid\": \"LZNY-QRS\",\n        \"published\": \"2024-01-10T08:00:00.000Z\",\n        \"score\": 0.71,\n        \"status\": \"pending\",\n        \"title\": \"Patrick Flynn (1845\u20131908)\"\n      }\n    ],\n    \"queryArk\": \"ark:/61903/4:1:LZNY-BRF\",\n    \"resultCount\": 1,\n    \"returned\": 1,\n    \"title\": \"Possible duplicates for ark:/61903/4:1:LZNY-BRF\",\n    \"updated\": \"2026-05-01T10:00:00.000Z\"\n  },\n  \"tool\": \"person_person_matches\"\n}\n",
+    "eval/fixtures/mcp/person-record-matches-flynn.json": "{\n  \"args\": {\n    \"id\": \"LZNY-BRF\"\n  },\n  \"description\": \"Record matches for Patrick Flynn tree person (LZNY-BRF): 1 accepted, 2 pending\",\n  \"response\": {\n    \"matches\": [\n      {\n        \"ark\": \"https://familysearch.org/ark:/61903/1:1:MXYZ\",\n        \"arkType\": \"1:1:\",\n        \"collection\": \"https://familysearch.org/platform/collections/records\",\n        \"confidence\": 5,\n        \"pid\": \"MXYZ\",\n        \"published\": \"2024-03-15T12:00:00.000Z\",\n        \"score\": 0.97,\n        \"status\": \"accepted\",\n        \"title\": \"1850 United States Federal Census\"\n      },\n      {\n        \"ark\": \"https://familysearch.org/ark:/61903/1:1:MABC\",\n        \"arkType\": \"1:1:\",\n        \"collection\": \"https://familysearch.org/platform/collections/records\",\n        \"confidence\": 3,\n        \"pid\": \"MABC\",\n        \"published\": \"2024-03-15T12:00:00.000Z\",\n        \"score\": 0.72,\n        \"status\": \"pending\",\n        \"title\": \"1860 United States Federal Census\"\n      },\n      {\n        \"ark\": \"https://familysearch.org/ark:/61903/1:1:MDEF\",\n        \"arkType\": \"1:1:\",\n        \"collection\": \"https://familysearch.org/platform/collections/records\",\n        \"confidence\": 2,\n        \"pid\": \"MDEF\",\n        \"published\": \"2024-03-15T12:00:00.000Z\",\n        \"score\": 0.58,\n        \"status\": \"pending\",\n        \"title\": \"Pennsylvania Death Certificates, 1906-1967\"\n      }\n    ],\n    \"queryArk\": \"ark:/61903/4:1:LZNY-BRF\",\n    \"resultCount\": 3,\n    \"returned\": 3,\n    \"title\": \"Matches for ark:/61903/4:1:LZNY-BRF\",\n    \"updated\": \"2026-05-01T10:00:00.000Z\"\n  },\n  \"tool\": \"person_record_matches\"\n}\n",
+    "eval/fixtures/mcp/person-record-matches-flynn-person-id.json": "{\n  \"args\": {\n    \"person_id\": \"LZNY-BRF\"\n  },\n  \"description\": \"Record matches for Patrick Flynn tree person (LZNY-BRF): 1 accepted, 2 pending \u2014 snake_case person_id variant\",\n  \"response\": {\n    \"matches\": [\n      {\n        \"ark\": \"https://familysearch.org/ark:/61903/1:1:MXYZ\",\n        \"arkType\": \"1:1:\",\n        \"collection\": \"https://familysearch.org/platform/collections/records\",\n        \"confidence\": 5,\n        \"pid\": \"MXYZ\",\n        \"published\": \"2024-03-15T12:00:00.000Z\",\n        \"score\": 0.97,\n        \"status\": \"accepted\",\n        \"title\": \"1850 United States Federal Census\"\n      },\n      {\n        \"ark\": \"https://familysearch.org/ark:/61903/1:1:MABC\",\n        \"arkType\": \"1:1:\",\n        \"collection\": \"https://familysearch.org/platform/collections/records\",\n        \"confidence\": 3,\n        \"pid\": \"MABC\",\n        \"published\": \"2024-03-15T12:00:00.000Z\",\n        \"score\": 0.72,\n        \"status\": \"pending\",\n        \"title\": \"1860 United States Federal Census\"\n      },\n      {\n        \"ark\": \"https://familysearch.org/ark:/61903/1:1:MDEF\",\n        \"arkType\": \"1:1:\",\n        \"collection\": \"https://familysearch.org/platform/collections/records\",\n        \"confidence\": 2,\n        \"pid\": \"MDEF\",\n        \"published\": \"2024-03-15T12:00:00.000Z\",\n        \"score\": 0.58,\n        \"status\": \"pending\",\n        \"title\": \"Pennsylvania Death Certificates, 1906-1967\"\n      }\n    ],\n    \"queryArk\": \"ark:/61903/4:1:LZNY-BRF\",\n    \"resultCount\": 3,\n    \"returned\": 3,\n    \"title\": \"Matches for ark:/61903/4:1:LZNY-BRF\",\n    \"updated\": \"2026-05-01T10:00:00.000Z\"\n  },\n  \"tool\": \"person_record_matches\"\n}\n",
+    "eval/fixtures/mcp/person-record-matches-flynn-personid.json": "{\n  \"args\": {\n    \"personId\": \"LZNY-BRF\"\n  },\n  \"description\": \"Record matches for Patrick Flynn tree person (LZNY-BRF): 1 accepted, 2 pending \u2014 camelCase personId variant\",\n  \"response\": {\n    \"matches\": [\n      {\n        \"ark\": \"https://familysearch.org/ark:/61903/1:1:MXYZ\",\n        \"arkType\": \"1:1:\",\n        \"collection\": \"https://familysearch.org/platform/collections/records\",\n        \"confidence\": 5,\n        \"pid\": \"MXYZ\",\n        \"published\": \"2024-03-15T12:00:00.000Z\",\n        \"score\": 0.97,\n        \"status\": \"accepted\",\n        \"title\": \"1850 United States Federal Census\"\n      },\n      {\n        \"ark\": \"https://familysearch.org/ark:/61903/1:1:MABC\",\n        \"arkType\": \"1:1:\",\n        \"collection\": \"https://familysearch.org/platform/collections/records\",\n        \"confidence\": 3,\n        \"pid\": \"MABC\",\n        \"published\": \"2024-03-15T12:00:00.000Z\",\n        \"score\": 0.72,\n        \"status\": \"pending\",\n        \"title\": \"1860 United States Federal Census\"\n      },\n      {\n        \"ark\": \"https://familysearch.org/ark:/61903/1:1:MDEF\",\n        \"arkType\": \"1:1:\",\n        \"collection\": \"https://familysearch.org/platform/collections/records\",\n        \"confidence\": 2,\n        \"pid\": \"MDEF\",\n        \"published\": \"2024-03-15T12:00:00.000Z\",\n        \"score\": 0.58,\n        \"status\": \"pending\",\n        \"title\": \"Pennsylvania Death Certificates, 1906-1967\"\n      }\n    ],\n    \"queryArk\": \"ark:/61903/4:1:LZNY-BRF\",\n    \"resultCount\": 3,\n    \"returned\": 3,\n    \"title\": \"Matches for ark:/61903/4:1:LZNY-BRF\",\n    \"updated\": \"2026-05-01T10:00:00.000Z\"\n  },\n  \"tool\": \"person_record_matches\"\n}\n",
+    "eval/fixtures/mcp/place-search-ireland.json": "{\n  \"args\": {\n    \"placeName\": \"~Ireland\"\n  },\n  \"description\": \"FamilySearch place data for Ireland\",\n  \"response\": {\n    \"results\": [\n      {\n        \"dateRange\": \"+1801/\",\n        \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Ireland&focusedId=10\",\n        \"latitude\": 53.0,\n        \"longitude\": -8.0,\n        \"standardPlace\": \"Ireland\",\n        \"type\": \"Country\"\n      }\n    ]\n  },\n  \"tool\": \"place_search\"\n}\n",
+    "eval/fixtures/mcp/place-search-schuylkill-county.json": "{\n  \"args\": {\n    \"placeName\": \"~Schuylkill\"\n  },\n  \"description\": \"FamilySearch place data for Schuylkill County, Pennsylvania\",\n  \"response\": {\n    \"results\": [\n      {\n        \"dateRange\": \"+1811/\",\n        \"familysearchUrl\": \"https://www.familysearch.org/en/research/places/?text=Schuylkill&focusedId=7042\",\n        \"latitude\": 40.7,\n        \"longitude\": -76.2,\n        \"standardPlace\": \"Schuylkill, Pennsylvania, United States\",\n        \"type\": \"County\"\n      }\n    ]\n  },\n  \"tool\": \"place_search\"\n}\n"
+  },
+  "tests": [
+    {
+      "test_id": "ut_tree_edit_001",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly confirmed that F1 already shows place='Ireland' and date='~1845', matching the resolved conflict c_001. The response accurately cites the tree state and correctly identifies that no edit is needed. All claims are supported by the input state."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request: it checked the tree, confirmed F1's current values, verified alignment with c_001, and explicitly told the user no edit was needed. The user's requirement to know whether an edit was triggered was met by the clear statement 'No edit needed.'"
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill performed a verification-only task that required reading the provided input state rather than querying tools. N/A."
+          },
+          {
+            "source": "rubric",
+            "name": "Data preservation",
+            "score": 3,
+            "rationale": "This is a verification task, not an edit or merge. No data was modified, so all existing facts and sources remain intact. The dimension applies only to edit/merge operations; a no-op verification passes this dimension."
+          },
+          {
+            "source": "rubric",
+            "name": "Edit minimality",
+            "score": 3,
+            "rationale": "No edit was performed. The skill correctly identified that the tree already matched the user's expectation and declined to modify anything. Edit minimality is satisfied by making zero unneeded changes."
+          },
+          {
+            "source": "rubric",
+            "name": "Merge correctness",
+            "score": 3,
+            "rationale": "This is not a merge operation. The skill performed a verification check only. Per the rubric, when the test is not a merge, this dimension has nothing to grade and scores pass."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence grounding",
+            "score": 3,
+            "rationale": "This is a verification task, not an edit operation. The skill confirmed that F1 already carries a source reference (S1) and reflects a concluded value backed by resolved conflict c_001. No new edit was proposed, so grounding of new edits does not apply. For non-edit operations, this dimension scores pass."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 24128.816583019216,
+        "duration_api_ms": 23261.0,
+        "judge_duration_ms": 6760.5276250396855,
+        "wall_clock_ms": 30953.41396331787,
+        "num_turns": 5,
+        "input_tokens": 7,
+        "cached_input_tokens": 34478,
+        "output_tokens": 1069,
+        "judge_input_tokens": 3070,
+        "judge_cached_input_tokens": 5015,
+        "judge_output_tokens": 649,
+        "skill_cost_usd": 0.1156334,
+        "judge_cost_usd": 0.0018015000000000001,
+        "total_cost_usd": 0.1174349
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_tree_edit_001_2026-07-30_18-18-04_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 24128.816583019216,
+          "duration_api_ms": 23261.0,
+          "num_turns": 5,
+          "skill_attempts": 1,
+          "input_tokens": 7,
+          "cached_input_tokens": 34478,
+          "output_tokens": 1069,
+          "skill_cost_usd": 0.1156334,
+          "output": {
+            "text_response": "**No edit needed \u2014 F1 already reflects this correctly.**\n\nHere's what the tree shows for Patrick Flynn (I1), fact F1:\n\n| Field | Current value |\n|---|---|\n| `type` | Birth |\n| `date` | `~1845` |\n| `place` | Ireland |\n| `primary` | true |\n| `sources` | S1 \u2014 1850 Census, Schuylkill Co., dwelling 84 |\n\nThat matches the resolved conflict **c_001** exactly: the 1850 and 1860 census assertions (`a_002`, `a_009`) put Patrick's birthplace as Ireland, and c_001 accepted Ireland as the concluded value, rejecting the death certificate's \"Pennsylvania\" as a son-in-law informant error. F1's `date` of `~1845` likewise aligns with assertion `a_002`'s `~1845` estimated year, sourced back to the preferred contemporary census record (S1).\n\nNothing in the tree needs to change. The concluded, `primary`-flagged birth fact already carries the right date, the right place, and the right source reference.",
+            "activated": true,
+            "skills_invoked": [
+              "tree-edit"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_cross_file_person_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_edit_noop",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly confirmed that F1 already shows place='Ireland' and date='~1845', matching the resolved conflict c_001. The response accurately cites the tree state and correctly identifies that no edit is needed. All claims are supported by the input state."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request: it checked the tree, confirmed F1's current values, verified alignment with c_001, and explicitly told the user no edit was needed. The user's requirement to know whether an edit was triggered was met by the clear statement 'No edit needed.'"
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill performed a verification-only task that required reading the provided input state rather than querying tools. N/A."
+              },
+              {
+                "source": "rubric",
+                "name": "Data preservation",
+                "score": 3,
+                "rationale": "This is a verification task, not an edit or merge. No data was modified, so all existing facts and sources remain intact. The dimension applies only to edit/merge operations; a no-op verification passes this dimension."
+              },
+              {
+                "source": "rubric",
+                "name": "Edit minimality",
+                "score": 3,
+                "rationale": "No edit was performed. The skill correctly identified that the tree already matched the user's expectation and declined to modify anything. Edit minimality is satisfied by making zero unneeded changes."
+              },
+              {
+                "source": "rubric",
+                "name": "Merge correctness",
+                "score": 3,
+                "rationale": "This is not a merge operation. The skill performed a verification check only. Per the rubric, when the test is not a merge, this dimension has nothing to grade and scores pass."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence grounding",
+                "score": 3,
+                "rationale": "This is a verification task, not an edit operation. The skill confirmed that F1 already carries a source reference (S1) and reflects a concluded value backed by resolved conflict c_001. No new edit was proposed, so grounding of new edits does not apply. For non-edit operations, this dimension scores pass."
+              }
+            ],
+            "judge_cost_usd": 0.0018015000000000001,
+            "duration_ms": 6760.5276250396855,
+            "error": null,
+            "input_tokens": 3070,
+            "cached_input_tokens": 5015,
+            "output_tokens": 649
+          },
+          "started_at": 1785435537.784568,
+          "ended_at": 1785435568.737982
+        }
+      ]
+    },
+    {
+      "test_id": "ut_tree_edit_009",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "place-search-schuylkill-county"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly added an Occupation fact to person I1 (Patrick Flynn) with all required fields: type 'Occupation', date '1860', place 'Schuylkill County, Pennsylvania', standard_place 'Schuylkill, Pennsylvania, United States' (from place_search result), value 'Coal miner', and source reference to S2 with page 'dwelling 112'. The fact was assigned ID F4 (next available). No fabrication or unsupported claims; all values grounded in the source material and test requirements."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all requirements: called place_search for 'Schuylkill County, Pennsylvania', copied the standardPlace result verbatim into the new fact, added the Occupation fact with all required fields (type, date, place, standard_place, value, sources), and reused existing source S2 without creating a duplicate. No silent omissions."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Both tool calls passed correct arguments. place_search received placeName 'Schuylkill County' with contextName 'Pennsylvania', matching the expected ~Schuylkill pattern. tree_edit received correct operation 'add_fact', personId 'I1', and a fact object with all required fields (type, date, place, standard_place, value, sources array with ref 'S2' and page 'dwelling 112'). No fixture_not_found errors; both calls matched successfully."
+          },
+          {
+            "source": "rubric",
+            "name": "Data preservation",
+            "score": 3,
+            "rationale": "The edit added a single new Occupation fact (F4) to person I1 without modifying or dropping any existing facts. The file changes summary confirms only 1 person modified with 0 added/deleted persons. No existing facts on I1 (F1 Birth, F2 Death) were altered; no other persons, relationships, or sources were touched. All prior data survives intact."
+          },
+          {
+            "source": "rubric",
+            "name": "Edit minimality",
+            "score": 3,
+            "rationale": "The skill made only the requested change: adding a new Occupation fact to I1. No unrelated fields were modified. The test context explicitly required that F1 Birth and F2 Death stay byte-identical and no other person/relationship/source be touched. The file changes summary confirms only 1 person modified (I1) with no collateral edits. The edit is surgical and minimal."
+          },
+          {
+            "source": "rubric",
+            "name": "Merge correctness",
+            "score": 3,
+            "rationale": "This test is not a person merge \u2014 it is an add_fact operation on an existing person (I1). Per the rubric, when the test is NOT a merge, this dimension has nothing to grade and scores pass. No merge mechanics apply here."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence grounding",
+            "score": 3,
+            "rationale": "The new Occupation fact is grounded as sourced evidence: it carries a source-ref (S2, page 'dwelling 112') and materializes a fact extracted from an already-cited source (the 1860 census). The source S2 was already on file before this skill ran (per before-state summary). The fact does not require a proof_summary to materialize \u2014 only to be marked primary or merged. The skill correctly did not mark it primary (only one Occupation fact exists, so the primary rule does not apply). Grounding is sound."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 57726.996916986536,
+        "duration_api_ms": 56740.0,
+        "judge_duration_ms": 13087.336042022798,
+        "wall_clock_ms": 71173.49290847778,
+        "num_turns": 8,
+        "input_tokens": 12,
+        "cached_input_tokens": 82091,
+        "output_tokens": 1622,
+        "judge_input_tokens": 3913,
+        "judge_cached_input_tokens": 5015,
+        "judge_output_tokens": 970,
+        "skill_cost_usd": 0.12598454999999997,
+        "judge_cost_usd": 0.0042495,
+        "total_cost_usd": 0.13023404999999996
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_tree_edit_009_2026-07-30_18-18-04_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 57726.996916986536,
+          "duration_api_ms": 56740.0,
+          "num_turns": 8,
+          "skill_attempts": 1,
+          "input_tokens": 12,
+          "cached_input_tokens": 82091,
+          "output_tokens": 1622,
+          "skill_cost_usd": 0.12598454999999997,
+          "output": {
+            "text_response": "I'll load the project context and resolve the place at the same time.I have the standard place. Now let me read the tree to verify I1 and S2 exist before writing.I1 (Patrick Flynn) and S2 (1860 U.S. Federal Census) are both confirmed. No existing Occupation fact \u2014 safe to add. Standard place resolves to **Schuylkill, Pennsylvania, United States**. Calling `tree_edit` now.Done. Here's what was written:\n\n| Field | Value |\n|---|---|\n| **Person** | I1 \u2014 Patrick Flynn |\n| **Fact id** | F4 (assigned by tool) |\n| **Type** | Occupation |\n| **Value** | Coal miner |\n| **Date** | 1860 |\n| **Place** | Schuylkill County, Pennsylvania |\n| **Standard place** | Schuylkill, Pennsylvania, United States |\n| **Source** | S2 (1860 U.S. Federal Census), page: *dwelling 112* |\n\nValidation passed with no warnings. The tree was written successfully.",
+            "activated": true,
+            "skills_invoked": [
+              "tree-edit"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__place_search",
+                "args": {
+                  "placeName": "Schuylkill County",
+                  "contextName": "Pennsylvania"
+                },
+                "expected_args": {
+                  "placeName": "~Schuylkill"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "place-search-schuylkill-county"
+              },
+              {
+                "tool": "mcp__genealogy__tree_edit",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_009-0-0-2woetize",
+                  "operation": "add_fact",
+                  "personId": "I1",
+                  "fact": {
+                    "type": "Occupation",
+                    "date": "1860",
+                    "place": "Schuylkill County, Pennsylvania",
+                    "standard_place": "Schuylkill, Pennsylvania, United States",
+                    "value": "Coal miner",
+                    "sources": [
+                      {
+                        "ref": "S2",
+                        "page": "dwelling 112"
+                      }
+                    ]
+                  },
+                  "resolveStandardPlace": false
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:tree_edit"
+              }
+            ],
+            "files_created": [
+              "tree.gedcomx.json.bak"
+            ],
+            "file_changes": {
+              "tree.gedcomx.json": {
+                "sections_modified": [
+                  "persons"
+                ],
+                "diff": {
+                  "persons": {
+                    "added": [],
+                    "modified": [
+                      {
+                        "id": "I1",
+                        "changed_fields": {
+                          "facts": {
+                            "before": [
+                              {
+                                "id": "F1",
+                                "type": "Birth",
+                                "primary": true,
+                                "date": "~1845",
+                                "place": "Ireland",
+                                "sources": [
+                                  {
+                                    "ref": "S1",
+                                    "page": "1850 Census, Schuylkill Co., dwelling 84"
+                                  }
+                                ]
+                              },
+                              {
+                                "id": "F2",
+                                "type": "Death",
+                                "date": "1908-03-12",
+                                "place": "Schuylkill County, Pennsylvania",
+                                "sources": [
+                                  {
+                                    "ref": "S3",
+                                    "page": "Death cert. no. 4521"
+                                  }
+                                ]
+                              }
+                            ],
+                            "after": [
+                              {
+                                "id": "F1",
+                                "type": "Birth",
+                                "primary": true,
+                                "date": "~1845",
+                                "place": "Ireland",
+                                "sources": [
+                                  {
+                                    "ref": "S1",
+                                    "page": "1850 Census, Schuylkill Co., dwelling 84"
+                                  }
+                                ]
+                              },
+                              {
+                                "id": "F2",
+                                "type": "Death",
+                                "date": "1908-03-12",
+                                "place": "Schuylkill County, Pennsylvania",
+                                "sources": [
+                                  {
+                                    "ref": "S3",
+                                    "page": "Death cert. no. 4521"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "Occupation",
+                                "date": "1860",
+                                "place": "Schuylkill County, Pennsylvania",
+                                "standard_place": "Schuylkill, Pennsylvania, United States",
+                                "value": "Coal miner",
+                                "sources": [
+                                  {
+                                    "ref": "S2",
+                                    "page": "dwelling 112"
+                                  }
+                                ],
+                                "id": "F4"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              },
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 3 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__project_context",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_009-0-0-2woetize"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__place_search",
+                    "args": {
+                      "placeName": "Schuylkill County",
+                      "contextName": "Pennsylvania"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__tree_edit",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_009-0-0-2woetize",
+                      "operation": "add_fact",
+                      "personId": "I1",
+                      "fact": {
+                        "type": "Occupation",
+                        "date": "1860",
+                        "place": "Schuylkill County, Pennsylvania",
+                        "standard_place": "Schuylkill, Pennsylvania, United States",
+                        "value": "Coal miner",
+                        "sources": [
+                          {
+                            "ref": "S2",
+                            "page": "dwelling 112"
+                          }
+                        ]
+                      },
+                      "resolveStandardPlace": false
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_cross_file_person_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_edit_noop",
+                "passed": true,
+                "error": "skipped: not a tree-edit-noop scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly added an Occupation fact to person I1 (Patrick Flynn) with all required fields: type 'Occupation', date '1860', place 'Schuylkill County, Pennsylvania', standard_place 'Schuylkill, Pennsylvania, United States' (from place_search result), value 'Coal miner', and source reference to S2 with page 'dwelling 112'. The fact was assigned ID F4 (next available). No fabrication or unsupported claims; all values grounded in the source material and test requirements."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all requirements: called place_search for 'Schuylkill County, Pennsylvania', copied the standardPlace result verbatim into the new fact, added the Occupation fact with all required fields (type, date, place, standard_place, value, sources), and reused existing source S2 without creating a duplicate. No silent omissions."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Both tool calls passed correct arguments. place_search received placeName 'Schuylkill County' with contextName 'Pennsylvania', matching the expected ~Schuylkill pattern. tree_edit received correct operation 'add_fact', personId 'I1', and a fact object with all required fields (type, date, place, standard_place, value, sources array with ref 'S2' and page 'dwelling 112'). No fixture_not_found errors; both calls matched successfully."
+              },
+              {
+                "source": "rubric",
+                "name": "Data preservation",
+                "score": 3,
+                "rationale": "The edit added a single new Occupation fact (F4) to person I1 without modifying or dropping any existing facts. The file changes summary confirms only 1 person modified with 0 added/deleted persons. No existing facts on I1 (F1 Birth, F2 Death) were altered; no other persons, relationships, or sources were touched. All prior data survives intact."
+              },
+              {
+                "source": "rubric",
+                "name": "Edit minimality",
+                "score": 3,
+                "rationale": "The skill made only the requested change: adding a new Occupation fact to I1. No unrelated fields were modified. The test context explicitly required that F1 Birth and F2 Death stay byte-identical and no other person/relationship/source be touched. The file changes summary confirms only 1 person modified (I1) with no collateral edits. The edit is surgical and minimal."
+              },
+              {
+                "source": "rubric",
+                "name": "Merge correctness",
+                "score": 3,
+                "rationale": "This test is not a person merge \u2014 it is an add_fact operation on an existing person (I1). Per the rubric, when the test is NOT a merge, this dimension has nothing to grade and scores pass. No merge mechanics apply here."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence grounding",
+                "score": 3,
+                "rationale": "The new Occupation fact is grounded as sourced evidence: it carries a source-ref (S2, page 'dwelling 112') and materializes a fact extracted from an already-cited source (the 1860 census). The source S2 was already on file before this skill ran (per before-state summary). The fact does not require a proof_summary to materialize \u2014 only to be marked primary or merged. The skill correctly did not mark it primary (only one Occupation fact exists, so the primary rule does not apply). Grounding is sound."
+              }
+            ],
+            "judge_cost_usd": 0.0042495,
+            "duration_ms": 13087.336042022798,
+            "error": null,
+            "input_tokens": 3913,
+            "cached_input_tokens": 5015,
+            "output_tokens": 970
+          },
+          "started_at": 1785435485.006974,
+          "ended_at": 1785435556.180467
+        }
+      ]
+    },
+    {
+      "test_id": "ut_tree_edit_002",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly verified that R1 (Thomas I2 \u2192 Patrick I1, ParentChild) exists in the tree and is properly sourced with S1, S2, and S3. The reported relationship fields and source references match the ground truth. The skill appropriately made no edit, recognizing that the relationship was already correctly materialized and sourced. No fabricated claims or unsupported assertions."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to verify whether the tree reflects ps_001 at probable tier and whether R1 needs editing. It confirmed R1 exists with the correct type, parent/child direction, and all three source references (S1, S2, S3), and correctly concluded no edit was needed. All required verification steps were completed."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill correctly determined that verification could be performed against the provided ground truth without requiring tool invocation, and appropriately declined to call tree_edit or tree_correct when no changes were warranted. N/A."
+          },
+          {
+            "source": "rubric",
+            "name": "Data preservation",
+            "score": 3,
+            "rationale": "This is a verify-only operation with no edit. The skill made no modifications to the tree, so all existing facts, names, and source references on R1 and both persons remain intact. No data loss occurred."
+          },
+          {
+            "source": "rubric",
+            "name": "Edit minimality",
+            "score": 3,
+            "rationale": "The skill made zero edits, which is the correct minimal behavior. It recognized that R1 was already in the correct state and appropriately refrained from making any changes to the tree or related fields. This is surgical precision\u2014no unnecessary modifications."
+          },
+          {
+            "source": "rubric",
+            "name": "Merge correctness",
+            "score": 3,
+            "rationale": "This test is not a merge operation. The skill performed a verification task only, with no person merging involved. Per the rubric, when the test is not a merge, this dimension has nothing to grade and scores pass."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence grounding",
+            "score": 3,
+            "rationale": "This is a verification operation, not an edit operation. The skill correctly confirmed that R1 was already grounded through sourced evidence\u2014the three source-refs (S1, S2, S3) on the relationship edge were materialized at identity-link time and carry proper provenance. No new edits were made, so no grounding threshold needed to be evaluated. The skill appropriately recognized the relationship was already in the correct sourced state."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 30431.22566700913,
+        "duration_api_ms": 29306.0,
+        "judge_duration_ms": 8079.321250028443,
+        "wall_clock_ms": 38573.793172836304,
+        "num_turns": 7,
+        "input_tokens": 11,
+        "cached_input_tokens": 70996,
+        "output_tokens": 1424,
+        "judge_input_tokens": 3489,
+        "judge_cached_input_tokens": 5015,
+        "judge_output_tokens": 759,
+        "skill_cost_usd": 0.1443208,
+        "judge_cost_usd": 0.0027705000000000004,
+        "total_cost_usd": 0.1470913
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_tree_edit_002_2026-07-30_18-18-04_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 30431.22566700913,
+          "duration_api_ms": 29306.0,
+          "num_turns": 7,
+          "skill_attempts": 1,
+          "input_tokens": 11,
+          "cached_input_tokens": 70996,
+          "output_tokens": 1424,
+          "skill_cost_usd": 0.1443208,
+          "output": {
+            "text_response": "**No edit needed.** R1 already reflects exactly what ps_001 concludes.\n\nHere's what the tree already shows:\n\n| Field | Value |\n|---|---|\n| Relationship id | R1 |\n| Type | `ParentChild` |\n| Parent | I2 \u2014 Thomas Flynn |\n| Child | I1 \u2014 Patrick Flynn |\n| Sources | S1 (1850 Census, dwelling 84), S2 (1860 Census, dwelling 112), S3 (Death cert. no. 4521) |\n\nThose three source refs on R1 map directly to the three supporting assertions in ps_001 \u2014 a_004 (S1/1850 census co-enumeration), a_010 (S2/1860 census co-enumeration), and a_013 (S3/death certificate naming Thomas as father). The relationship type, direction (I2 parent \u2192 I1 child), and source backing are all consistent with the `probable` tier conclusion.\n\nThe tree is already in the correct state. No `tree_edit` or `tree_correct` call is warranted.",
+            "activated": true,
+            "skills_invoked": [
+              "tree-edit"
+            ],
+            "tool_calls": [],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 1 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__project_context",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_002-0-0-io1ipiwh"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_cross_file_person_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_edit_noop",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly verified that R1 (Thomas I2 \u2192 Patrick I1, ParentChild) exists in the tree and is properly sourced with S1, S2, and S3. The reported relationship fields and source references match the ground truth. The skill appropriately made no edit, recognizing that the relationship was already correctly materialized and sourced. No fabricated claims or unsupported assertions."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to verify whether the tree reflects ps_001 at probable tier and whether R1 needs editing. It confirmed R1 exists with the correct type, parent/child direction, and all three source references (S1, S2, S3), and correctly concluded no edit was needed. All required verification steps were completed."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill correctly determined that verification could be performed against the provided ground truth without requiring tool invocation, and appropriately declined to call tree_edit or tree_correct when no changes were warranted. N/A."
+              },
+              {
+                "source": "rubric",
+                "name": "Data preservation",
+                "score": 3,
+                "rationale": "This is a verify-only operation with no edit. The skill made no modifications to the tree, so all existing facts, names, and source references on R1 and both persons remain intact. No data loss occurred."
+              },
+              {
+                "source": "rubric",
+                "name": "Edit minimality",
+                "score": 3,
+                "rationale": "The skill made zero edits, which is the correct minimal behavior. It recognized that R1 was already in the correct state and appropriately refrained from making any changes to the tree or related fields. This is surgical precision\u2014no unnecessary modifications."
+              },
+              {
+                "source": "rubric",
+                "name": "Merge correctness",
+                "score": 3,
+                "rationale": "This test is not a merge operation. The skill performed a verification task only, with no person merging involved. Per the rubric, when the test is not a merge, this dimension has nothing to grade and scores pass."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence grounding",
+                "score": 3,
+                "rationale": "This is a verification operation, not an edit operation. The skill correctly confirmed that R1 was already grounded through sourced evidence\u2014the three source-refs (S1, S2, S3) on the relationship edge were materialized at identity-link time and carry proper provenance. No new edits were made, so no grounding threshold needed to be evaluated. The skill appropriately recognized the relationship was already in the correct sourced state."
+              }
+            ],
+            "judge_cost_usd": 0.0027705000000000004,
+            "duration_ms": 8079.321250028443,
+            "error": null,
+            "input_tokens": 3489,
+            "cached_input_tokens": 5015,
+            "output_tokens": 759
+          },
+          "started_at": 1785435504.9519129,
+          "ended_at": 1785435543.525706
+        }
+      ]
+    },
+    {
+      "test_id": "ut_tree_edit_008",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn-typo",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified the typo in F2.date (1908-03-21 vs. the correct 1908-03-12 from S3), executed the targeted correction via tree_correct with the right personId (I1), factId (F2), and new date value. The response accurately reports the change and confirms validation passed. No fabricated claims or unsupported assertions."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The user requested a single, specific correction: change F2.date from 1908-03-21 to 1908-03-12 and leave everything else alone. The skill completed this request fully, confirmed the correction was made, and verified validation passed. No required work was omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The tree_correct call passed correct arguments: projectPath is valid, operation is 'update_fact', personId 'I1' and factId 'F2' are correct identifiers for Patrick Flynn's death fact, and the fact object contains only the date field with the corrected value '1908-03-12'. The call matched live and succeeded with ok: true."
+          },
+          {
+            "source": "rubric",
+            "name": "Data preservation",
+            "score": 3,
+            "rationale": "The edit preserved all existing data. Only F2.date was modified (from 1908-03-21 to 1908-03-12); all other fields on F2 (type, place, source references) remain unchanged. No other facts (F1, F3), persons (I2), relationships (R1), or research.json entries were touched. The response explicitly confirms 'All other fields \u2014 type, place, source ref, and page \u2014 are untouched.'"
+          },
+          {
+            "source": "rubric",
+            "name": "Edit minimality",
+            "score": 3,
+            "rationale": "The skill made only the requested change: F2.date on person I1. The tool call passed only the date field in the fact object, leaving type, place, and source references byte-identical. No opportunistic normalization of adjacent fields occurred. The response confirms 'All other fields...are untouched' and validation passed with no warnings, indicating no collateral edits."
+          },
+          {
+            "source": "rubric",
+            "name": "Merge correctness",
+            "score": 3,
+            "rationale": "This test is not a person merge; it is a value correction on an existing fact. The merge-correctness dimension has nothing to grade and scores pass per the rubric instruction: 'When the test is NOT a merge...this dimension has nothing to grade and scores pass.'"
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence grounding",
+            "score": 3,
+            "rationale": "The correction is grounded as an objective-error correction verifiable against an already-cited source. The user explicitly cited S3 (Pennsylvania Death Certificate no. 4521) which records 12 March 1908, and the tree showed 1908-03-21 \u2014 a clear transcription typo. The skill's response references S3 and cert. no. 4521, confirming the correction is tied to the cited source. This meets the 'corrects an objective error verifiable against an already-cited source' threshold without requiring a proof_summary."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 43590.910999977496,
+        "duration_api_ms": 40407.0,
+        "judge_duration_ms": 8822.757249989081,
+        "wall_clock_ms": 52759.23299789429,
+        "num_turns": 9,
+        "input_tokens": 13,
+        "cached_input_tokens": 97314,
+        "output_tokens": 1323,
+        "judge_input_tokens": 3136,
+        "judge_cached_input_tokens": 5015,
+        "judge_output_tokens": 905,
+        "skill_cost_usd": 0.12148945,
+        "judge_cost_usd": 0.0031475,
+        "total_cost_usd": 0.12463695
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_tree_edit_008_2026-07-30_18-18-04_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 43590.910999977496,
+          "duration_api_ms": 40407.0,
+          "num_turns": 9,
+          "skill_attempts": 1,
+          "input_tokens": 13,
+          "cached_input_tokens": 97314,
+          "output_tokens": 1323,
+          "skill_cost_usd": 0.12148945,
+          "output": {
+            "text_response": "F2 is confirmed on I1 (Patrick Flynn) with `\"date\": \"1908-03-21\"` \u2014 the day-swap typo is clear. Correcting it now.Done. F2's date on Patrick Flynn (I1) has been corrected from `1908-03-21` to `1908-03-12`, matching death certificate S3 (cert. no. 4521). All other fields \u2014 type, place, source ref, and page \u2014 are untouched. Validation passed with no warnings.",
+            "activated": true,
+            "skills_invoked": [
+              "tree-edit"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__tree_correct",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_008-0-0-ushlokz1",
+                  "operation": "update_fact",
+                  "personId": "I1",
+                  "factId": "F2",
+                  "fact": {
+                    "date": "1908-03-12"
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:tree_correct"
+              }
+            ],
+            "files_created": [
+              "tree.gedcomx.json.bak"
+            ],
+            "file_changes": {
+              "tree.gedcomx.json": {
+                "sections_modified": [
+                  "persons"
+                ],
+                "diff": {
+                  "persons": {
+                    "added": [],
+                    "modified": [
+                      {
+                        "id": "I1",
+                        "changed_fields": {
+                          "facts": {
+                            "before": [
+                              {
+                                "id": "F1",
+                                "type": "Birth",
+                                "primary": true,
+                                "date": "~1845",
+                                "place": "Ireland",
+                                "sources": [
+                                  {
+                                    "ref": "S1",
+                                    "page": "1850 Census, Schuylkill Co., dwelling 84"
+                                  }
+                                ]
+                              },
+                              {
+                                "id": "F2",
+                                "type": "Death",
+                                "date": "1908-03-21",
+                                "place": "Schuylkill County, Pennsylvania",
+                                "sources": [
+                                  {
+                                    "ref": "S3",
+                                    "page": "Death cert. no. 4521"
+                                  }
+                                ]
+                              }
+                            ],
+                            "after": [
+                              {
+                                "id": "F1",
+                                "type": "Birth",
+                                "primary": true,
+                                "date": "~1845",
+                                "place": "Ireland",
+                                "sources": [
+                                  {
+                                    "ref": "S1",
+                                    "page": "1850 Census, Schuylkill Co., dwelling 84"
+                                  }
+                                ]
+                              },
+                              {
+                                "id": "F2",
+                                "type": "Death",
+                                "date": "1908-03-12",
+                                "place": "Schuylkill County, Pennsylvania",
+                                "sources": [
+                                  {
+                                    "ref": "S3",
+                                    "page": "Death cert. no. 4521"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              },
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 2 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__project_context",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_008-0-0-ushlokz1"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__tree_correct",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_008-0-0-ushlokz1",
+                      "operation": "update_fact",
+                      "personId": "I1",
+                      "factId": "F2",
+                      "fact": {
+                        "date": "1908-03-12"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_cross_file_person_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_edit_noop",
+                "passed": true,
+                "error": "skipped: not a tree-edit-noop scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified the typo in F2.date (1908-03-21 vs. the correct 1908-03-12 from S3), executed the targeted correction via tree_correct with the right personId (I1), factId (F2), and new date value. The response accurately reports the change and confirms validation passed. No fabricated claims or unsupported assertions."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The user requested a single, specific correction: change F2.date from 1908-03-21 to 1908-03-12 and leave everything else alone. The skill completed this request fully, confirmed the correction was made, and verified validation passed. No required work was omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The tree_correct call passed correct arguments: projectPath is valid, operation is 'update_fact', personId 'I1' and factId 'F2' are correct identifiers for Patrick Flynn's death fact, and the fact object contains only the date field with the corrected value '1908-03-12'. The call matched live and succeeded with ok: true."
+              },
+              {
+                "source": "rubric",
+                "name": "Data preservation",
+                "score": 3,
+                "rationale": "The edit preserved all existing data. Only F2.date was modified (from 1908-03-21 to 1908-03-12); all other fields on F2 (type, place, source references) remain unchanged. No other facts (F1, F3), persons (I2), relationships (R1), or research.json entries were touched. The response explicitly confirms 'All other fields \u2014 type, place, source ref, and page \u2014 are untouched.'"
+              },
+              {
+                "source": "rubric",
+                "name": "Edit minimality",
+                "score": 3,
+                "rationale": "The skill made only the requested change: F2.date on person I1. The tool call passed only the date field in the fact object, leaving type, place, and source references byte-identical. No opportunistic normalization of adjacent fields occurred. The response confirms 'All other fields...are untouched' and validation passed with no warnings, indicating no collateral edits."
+              },
+              {
+                "source": "rubric",
+                "name": "Merge correctness",
+                "score": 3,
+                "rationale": "This test is not a person merge; it is a value correction on an existing fact. The merge-correctness dimension has nothing to grade and scores pass per the rubric instruction: 'When the test is NOT a merge...this dimension has nothing to grade and scores pass.'"
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence grounding",
+                "score": 3,
+                "rationale": "The correction is grounded as an objective-error correction verifiable against an already-cited source. The user explicitly cited S3 (Pennsylvania Death Certificate no. 4521) which records 12 March 1908, and the tree showed 1908-03-21 \u2014 a clear transcription typo. The skill's response references S3 and cert. no. 4521, confirming the correction is tied to the cited source. This meets the 'corrects an objective error verifiable against an already-cited source' threshold without requiring a proof_summary."
+              }
+            ],
+            "judge_cost_usd": 0.0031475,
+            "duration_ms": 8822.757249989081,
+            "error": null,
+            "input_tokens": 3136,
+            "cached_input_tokens": 5015,
+            "output_tokens": 905
+          },
+          "started_at": 1785435485.006523,
+          "ended_at": 1785435537.765756
+        }
+      ]
+    },
+    {
+      "test_id": "ut_tree_edit_013",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "flynn-couple-marriage",
+      "mcp_fixtures": [],
+      "outcome": "partial",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "partial"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly created a Couple relationship (R1) between I2 and I3 with the Marriage fact properly placed on the relationship (not on a person), dated '12 May 1843', located at 'St. Patrick's Church, Schuylkill County, Pennsylvania', and sourced to S5. The marriage fact is GedcomX-parseable. The skill recovered cleanly from the first validation error (wrong assertion type) and corrected it by supplying sources directly on the relationship and fact. No fabricated material; all claims supported by the input state and tool responses."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill completed the requested marriage write: created the Couple relationship with the Marriage fact correctly placed and sourced. The user message asked to 'record this marriage in the tree,' and the skill did so. The skill attempted a post-edit check-warnings call (person_warnings) which was unavailable in the harness; per the completeness grading note, this does not lower the score since the requested marriage write itself was completed correctly."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 2,
+            "rationale": "The first call failed validation (not fixture_not_found) with a clear error: sourceAssertionId 'a_005' is a 'marriage' assertion, not a 'relationship' assertion. The skill recovered by removing sourceAssertionId and supplying sources directly on the relationship and fact objects in the second call, which succeeded. The recovery was clean and the final persisted args are correct. However, the initial misunderstanding of the assertion-type requirement (attempting to use a marriage assertion as a relationship-establishing assertion) represents a conceptual gap that warranted the first rejection. Per the retry policy, a single clean recovery scores full credit, but the initial incorrect reasoning (not understanding that the edge's provenance must come from a relationship-establishing assertion) is a minor defect in tool-usage understanding."
+          },
+          {
+            "source": "rubric",
+            "name": "Data preservation",
+            "score": 3,
+            "rationale": "The edit created a new Couple relationship without modifying or dropping any existing facts or sources. The two existing ParentChild relationships (RT1, RT2) and all person-level facts on I2 and I3 remain unchanged. No data was lost during the operation. The marriage fact and its source reference (S5) were added as new data, not by removing or replacing existing entries."
+          },
+          {
+            "source": "rubric",
+            "name": "Edit minimality",
+            "score": 3,
+            "rationale": "The skill made only the requested change: adding a single Couple relationship (R1) with the Marriage fact. No unrelated fields were touched. The existing ParentChild relationships, person facts, or other tree entries were not modified. The edit is surgical and confined to the specific relationship creation requested."
+          },
+          {
+            "source": "rubric",
+            "name": "Merge correctness",
+            "score": 3,
+            "rationale": "This test is not a merge operation; it is a fresh creation of a Couple relationship. Per the rubric, when the test is not a merge, this dimension has nothing to grade and scores pass. The skill correctly created a new relationship rather than attempting to merge or update existing persons."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence grounding",
+            "score": 3,
+            "rationale": "The marriage fact is evidence-grounded: assertion a_005 / source src_005 (tree source S5) documents it as direct primary evidence. The skill correctly attached source S5 to both the Couple relationship edge and the Marriage fact itself, materializing the sourced evidence at link time. No proof conclusion was required for this sourced-evidence layer operation. The skill did not refuse or defer; it proceeded with the correct source references in place, meeting the grounding requirement for newly-authored facts with source-refs."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 74183.80204198183,
+        "duration_api_ms": 70560.0,
+        "judge_duration_ms": 12192.006708995905,
+        "wall_clock_ms": 86740.61584472656,
+        "num_turns": 11,
+        "input_tokens": 18,
+        "cached_input_tokens": 158263,
+        "output_tokens": 3818,
+        "judge_input_tokens": 4145,
+        "judge_cached_input_tokens": 5015,
+        "judge_output_tokens": 1019,
+        "skill_cost_usd": 0.2235609,
+        "judge_cost_usd": 0.0047265,
+        "total_cost_usd": 0.2282874
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_tree_edit_013_2026-07-30_18-18-04_0",
+          "outcome": "partial",
+          "aborted_reason": null,
+          "duration_ms": 74183.80204198183,
+          "duration_api_ms": 70560.0,
+          "num_turns": 11,
+          "skill_attempts": 1,
+          "input_tokens": 18,
+          "cached_input_tokens": 158263,
+          "output_tokens": 3818,
+          "skill_cost_usd": 0.2235609,
+          "output": {
+            "text_response": "I can see:\n- Thomas Flynn is **I2**, Mary Flynn is **I3**; source **S5** is already in the tree.\n- There is currently no `Couple` relationship between I2 and I3 \u2014 only two `ParentChild` edges.\n- The marriage fact belongs on the `Couple` relationship, not on a person.\n\nLet me resolve the place first, then add the relationship.Both tools are loaded. The tree already has S5 and both persons (I2, I3). I'll now add the Couple relationship with the Marriage fact inline, sourced via assertion a_005 (which chains to src_005 \u2192 S5). The tool will auto-resolve the standard place.The tool requires a `relationship`-type assertion for `sourceAssertionId`. Since a_005 is a `marriage`-type assertion, I'll supply the source reference directly on the relationship edge (S5) instead.Done. Here's what was written to `tree.gedcomx.json`:\n\n| Assigned id | What was added |\n|---|---|\n| **R1** | Couple relationship \u2014 Thomas Flynn (I2) \u00d7 Mary Flynn (I3), sourced to S5 |\n| **F3** | Marriage fact on R1 \u2014 12 May 1843, St. Patrick's Church, Schuylkill County, Pennsylvania, sourced to S5 |\n\nValidation passed with no warnings. The marriage fact sits on the Couple relationship (R1) as required \u2014 not duplicated onto either spouse's person record. Source S5 (the St. Patrick's Church marriage register) is the backing citation on both the edge and the event fact, consistent with assertion a_005.",
+            "activated": true,
+            "skills_invoked": [
+              "tree-edit"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__tree_edit",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_013-0-0-r6itvuog",
+                  "operation": "add_relationship",
+                  "relationship": {
+                    "type": "Couple",
+                    "person1": "I2",
+                    "person2": "I3",
+                    "facts": [
+                      {
+                        "type": "Marriage",
+                        "date": "12 May 1843",
+                        "place": "St. Patrick's Church, Schuylkill County, Pennsylvania"
+                      }
+                    ]
+                  },
+                  "sourceAssertionId": "a_005"
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:tree_edit"
+              },
+              {
+                "tool": "mcp__genealogy__tree_edit",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_013-0-0-r6itvuog",
+                  "operation": "add_relationship",
+                  "relationship": {
+                    "type": "Couple",
+                    "person1": "I2",
+                    "person2": "I3",
+                    "sources": [
+                      {
+                        "ref": "S5"
+                      }
+                    ],
+                    "facts": [
+                      {
+                        "type": "Marriage",
+                        "date": "12 May 1843",
+                        "place": "St. Patrick's Church, Schuylkill County, Pennsylvania",
+                        "sources": [
+                          {
+                            "ref": "S5"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:tree_edit"
+              }
+            ],
+            "files_created": [
+              "tree.gedcomx.json.bak"
+            ],
+            "file_changes": {
+              "tree.gedcomx.json": {
+                "sections_modified": [
+                  "relationships"
+                ],
+                "diff": {
+                  "relationships": {
+                    "added": [
+                      {
+                        "type": "Couple",
+                        "person1": "I2",
+                        "person2": "I3",
+                        "sources": [
+                          {
+                            "ref": "S5"
+                          }
+                        ],
+                        "facts": [
+                          {
+                            "type": "Marriage",
+                            "date": "12 May 1843",
+                            "place": "St. Patrick's Church, Schuylkill County, Pennsylvania",
+                            "sources": [
+                              {
+                                "ref": "S5"
+                              }
+                            ],
+                            "id": "F3",
+                            "standard_place": "Saint Patrick Catholic Church, McAdoo, Schuylkill, Pennsylvania, United States"
+                          }
+                        ],
+                        "id": "R1"
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_cross_file_person_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_edit_noop",
+                "passed": true,
+                "error": "skipped: not a tree-edit-noop scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly created a Couple relationship (R1) between I2 and I3 with the Marriage fact properly placed on the relationship (not on a person), dated '12 May 1843', located at 'St. Patrick's Church, Schuylkill County, Pennsylvania', and sourced to S5. The marriage fact is GedcomX-parseable. The skill recovered cleanly from the first validation error (wrong assertion type) and corrected it by supplying sources directly on the relationship and fact. No fabricated material; all claims supported by the input state and tool responses."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill completed the requested marriage write: created the Couple relationship with the Marriage fact correctly placed and sourced. The user message asked to 'record this marriage in the tree,' and the skill did so. The skill attempted a post-edit check-warnings call (person_warnings) which was unavailable in the harness; per the completeness grading note, this does not lower the score since the requested marriage write itself was completed correctly."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 2,
+                "rationale": "The first call failed validation (not fixture_not_found) with a clear error: sourceAssertionId 'a_005' is a 'marriage' assertion, not a 'relationship' assertion. The skill recovered by removing sourceAssertionId and supplying sources directly on the relationship and fact objects in the second call, which succeeded. The recovery was clean and the final persisted args are correct. However, the initial misunderstanding of the assertion-type requirement (attempting to use a marriage assertion as a relationship-establishing assertion) represents a conceptual gap that warranted the first rejection. Per the retry policy, a single clean recovery scores full credit, but the initial incorrect reasoning (not understanding that the edge's provenance must come from a relationship-establishing assertion) is a minor defect in tool-usage understanding."
+              },
+              {
+                "source": "rubric",
+                "name": "Data preservation",
+                "score": 3,
+                "rationale": "The edit created a new Couple relationship without modifying or dropping any existing facts or sources. The two existing ParentChild relationships (RT1, RT2) and all person-level facts on I2 and I3 remain unchanged. No data was lost during the operation. The marriage fact and its source reference (S5) were added as new data, not by removing or replacing existing entries."
+              },
+              {
+                "source": "rubric",
+                "name": "Edit minimality",
+                "score": 3,
+                "rationale": "The skill made only the requested change: adding a single Couple relationship (R1) with the Marriage fact. No unrelated fields were touched. The existing ParentChild relationships, person facts, or other tree entries were not modified. The edit is surgical and confined to the specific relationship creation requested."
+              },
+              {
+                "source": "rubric",
+                "name": "Merge correctness",
+                "score": 3,
+                "rationale": "This test is not a merge operation; it is a fresh creation of a Couple relationship. Per the rubric, when the test is not a merge, this dimension has nothing to grade and scores pass. The skill correctly created a new relationship rather than attempting to merge or update existing persons."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence grounding",
+                "score": 3,
+                "rationale": "The marriage fact is evidence-grounded: assertion a_005 / source src_005 (tree source S5) documents it as direct primary evidence. The skill correctly attached source S5 to both the Couple relationship edge and the Marriage fact itself, materializing the sourced evidence at link time. No proof conclusion was required for this sourced-evidence layer operation. The skill did not refuse or defer; it proceeded with the correct source references in place, meeting the grounding requirement for newly-authored facts with source-refs."
+              }
+            ],
+            "judge_cost_usd": 0.0047265,
+            "duration_ms": 12192.006708995905,
+            "error": null,
+            "input_tokens": 4145,
+            "cached_input_tokens": 5015,
+            "output_tokens": 1019
+          },
+          "started_at": 1785435485.006536,
+          "ended_at": 1785435571.7471519
+        }
+      ]
+    },
+    {
+      "test_id": "ut_tree_edit_010",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn-merge-pending",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly created person I5 (Mary Flynn) with gender Female and a single preferred BirthName (N6) with given 'Mary' and surname 'Flynn'. The ParentChild relationship R2 was correctly added with parent I2 (Thomas), child I5 (Mary), and source S1 with page reference 'dwelling 84, family 91'. No facts were added to Mary's person record, as instructed. The tool response confirms both operations succeeded with correct ID assignments and validation passed."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all requirements from the user message: created Mary as a new person with the next available I-prefix id (I5), assigned the next N-prefix id for her name (N6), set gender to Female, made the name preferred, created the ParentChild relationship with the next available R-prefix id (R2), referenced the correct parent (I2), and included the source reference with the specified page detail. No facts were added to Mary's record, as explicitly requested."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The MCP tool call to mcp__genealogy__tree_edit passed correct arguments: projectPath was valid, the ops array contained two operations (add_person and add_relationship) with all required fields properly structured. The add_person operation specified gender 'Female', a single BirthName with preferred: true, given 'Mary', and surname 'Flynn'. The add_relationship operation specified type 'ParentChild', parent 'I2', child 'I5', and sources array with ref 'S1' and page 'dwelling 84, family 91'. All arguments matched the expected structure and the tool returned a successful response with correct ID assignments."
+          },
+          {
+            "source": "rubric",
+            "name": "Data preservation",
+            "score": 3,
+            "rationale": "This is a create operation (add_person + add_relationship), not a merge or edit of existing records. No existing facts, names, sources, or relationships were modified. The skill created only the new person I5 and new relationship R2 without touching any pre-existing data. The scenario notes confirm that I3, I4, and the merge-pending state remain intact, and the file changes summary shows only +1 person and +1 relationship added with no modifications or deletions to existing entries."
+          },
+          {
+            "source": "rubric",
+            "name": "Edit minimality",
+            "score": 3,
+            "rationale": "The skill made only the requested changes: created person I5 with the specified attributes and created relationship R2 with the specified parent, child, and source reference. No unrelated fields were modified, no existing persons or relationships were touched, and no opportunistic normalization or collateral edits occurred. The operation was surgical and limited to exactly what was requested."
+          },
+          {
+            "source": "rubric",
+            "name": "Merge correctness",
+            "score": 3,
+            "rationale": "This test is not a merge operation\u2014it is a create-person and add-relationship operation. Per the rubric guidance, when the test is NOT a merge, this dimension has nothing to grade and scores pass. The skill correctly did not attempt any merge mechanics; it only created the new person and relationship as instructed."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence grounding",
+            "score": 3,
+            "rationale": "The edit is grounded per the sourced-evidence layer. The ParentChild relationship edge carries a source-ref (S1 with page 'dwelling 84, family 91'), satisfying the mandatory-ref guard for newly-authored relationship edges. The skill correctly did not add any facts to Mary's person record\u2014facts will be materialized by person-evidence's materialize_facts when the time comes. The user message explicitly authorized this operation via ps_003 (probable tier), and the skill referenced this proof authorization in the response. The relationship-accuracy.md threshold is met via the probable-tier proof summary."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 56880.69154199911,
+        "duration_api_ms": 54052.0,
+        "judge_duration_ms": 10822.588750044815,
+        "wall_clock_ms": 68073.63700866699,
+        "num_turns": 8,
+        "input_tokens": 13,
+        "cached_input_tokens": 99293,
+        "output_tokens": 2281,
+        "judge_input_tokens": 4245,
+        "judge_cached_input_tokens": 5015,
+        "judge_output_tokens": 1047,
+        "skill_cost_usd": 0.14269540000000003,
+        "judge_cost_usd": 0.0049665,
+        "total_cost_usd": 0.14766190000000004
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_tree_edit_010_2026-07-30_18-18-04_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 56880.69154199911,
+          "duration_api_ms": 54052.0,
+          "num_turns": 8,
+          "skill_attempts": 1,
+          "input_tokens": 13,
+          "cached_input_tokens": 99293,
+          "output_tokens": 2281,
+          "skill_cost_usd": 0.14269540000000003,
+          "output": {
+            "text_response": "The tree currently has persons I1\u2013I4 (highest is I4), so Mary will become **I5**. I'll batch both operations \u2014 `add_person` then `add_relationship` \u2014 in one validate-once/write-once call.Done. Both writes succeeded in a single validated commit:\n\n| What | Id assigned |\n|---|---|\n| Mary Flynn (Female, preferred BirthName) | **I5** / N6 |\n| ParentChild relationship \u2014 Thomas (I2) \u2192 Mary (I5), source S1 page \"dwelling 84, family 91\" | **R2** |\n\nNo facts were added to Mary's record \u2014 the stub is clean, ready for `person-evidence / materialize_facts` to project sourced assertions onto her when the time comes.",
+            "activated": true,
+            "skills_invoked": [
+              "tree-edit"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__tree_edit",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_010-0-0-5ryoyred",
+                  "ops": [
+                    {
+                      "operation": "add_person",
+                      "person": {
+                        "gender": "Female",
+                        "names": [
+                          {
+                            "preferred": true,
+                            "given": "Mary",
+                            "surname": "Flynn",
+                            "type": "BirthName"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "operation": "add_relationship",
+                      "relationship": {
+                        "type": "ParentChild",
+                        "parent": "I2",
+                        "child": "I5",
+                        "sources": [
+                          {
+                            "ref": "S1",
+                            "page": "dwelling 84, family 91"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:tree_edit"
+              }
+            ],
+            "files_created": [
+              "tree.gedcomx.json.bak"
+            ],
+            "file_changes": {
+              "tree.gedcomx.json": {
+                "sections_modified": [
+                  "persons",
+                  "relationships"
+                ],
+                "diff": {
+                  "persons": {
+                    "added": [
+                      {
+                        "gender": "Female",
+                        "names": [
+                          {
+                            "preferred": true,
+                            "given": "Mary",
+                            "surname": "Flynn",
+                            "type": "BirthName",
+                            "id": "N6"
+                          }
+                        ],
+                        "id": "I5"
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  },
+                  "relationships": {
+                    "added": [
+                      {
+                        "type": "ParentChild",
+                        "parent": "I2",
+                        "child": "I5",
+                        "sources": [
+                          {
+                            "ref": "S1",
+                            "page": "dwelling 84, family 91"
+                          }
+                        ],
+                        "id": "R2"
+                      }
+                    ],
+                    "modified": [],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              },
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 2 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__project_context",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_010-0-0-5ryoyred"
+                    }
+                  },
+                  {
+                    "tool": "mcp__genealogy__tree_edit",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_010-0-0-5ryoyred",
+                      "ops": [
+                        {
+                          "operation": "add_person",
+                          "person": {
+                            "gender": "Female",
+                            "names": [
+                              {
+                                "preferred": true,
+                                "given": "Mary",
+                                "surname": "Flynn",
+                                "type": "BirthName"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "operation": "add_relationship",
+                          "relationship": {
+                            "type": "ParentChild",
+                            "parent": "I2",
+                            "child": "I5",
+                            "sources": [
+                              {
+                                "ref": "S1",
+                                "page": "dwelling 84, family 91"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_cross_file_person_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_edit_noop",
+                "passed": true,
+                "error": "skipped: not a tree-edit-noop scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly created person I5 (Mary Flynn) with gender Female and a single preferred BirthName (N6) with given 'Mary' and surname 'Flynn'. The ParentChild relationship R2 was correctly added with parent I2 (Thomas), child I5 (Mary), and source S1 with page reference 'dwelling 84, family 91'. No facts were added to Mary's person record, as instructed. The tool response confirms both operations succeeded with correct ID assignments and validation passed."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all requirements from the user message: created Mary as a new person with the next available I-prefix id (I5), assigned the next N-prefix id for her name (N6), set gender to Female, made the name preferred, created the ParentChild relationship with the next available R-prefix id (R2), referenced the correct parent (I2), and included the source reference with the specified page detail. No facts were added to Mary's record, as explicitly requested."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The MCP tool call to mcp__genealogy__tree_edit passed correct arguments: projectPath was valid, the ops array contained two operations (add_person and add_relationship) with all required fields properly structured. The add_person operation specified gender 'Female', a single BirthName with preferred: true, given 'Mary', and surname 'Flynn'. The add_relationship operation specified type 'ParentChild', parent 'I2', child 'I5', and sources array with ref 'S1' and page 'dwelling 84, family 91'. All arguments matched the expected structure and the tool returned a successful response with correct ID assignments."
+              },
+              {
+                "source": "rubric",
+                "name": "Data preservation",
+                "score": 3,
+                "rationale": "This is a create operation (add_person + add_relationship), not a merge or edit of existing records. No existing facts, names, sources, or relationships were modified. The skill created only the new person I5 and new relationship R2 without touching any pre-existing data. The scenario notes confirm that I3, I4, and the merge-pending state remain intact, and the file changes summary shows only +1 person and +1 relationship added with no modifications or deletions to existing entries."
+              },
+              {
+                "source": "rubric",
+                "name": "Edit minimality",
+                "score": 3,
+                "rationale": "The skill made only the requested changes: created person I5 with the specified attributes and created relationship R2 with the specified parent, child, and source reference. No unrelated fields were modified, no existing persons or relationships were touched, and no opportunistic normalization or collateral edits occurred. The operation was surgical and limited to exactly what was requested."
+              },
+              {
+                "source": "rubric",
+                "name": "Merge correctness",
+                "score": 3,
+                "rationale": "This test is not a merge operation\u2014it is a create-person and add-relationship operation. Per the rubric guidance, when the test is NOT a merge, this dimension has nothing to grade and scores pass. The skill correctly did not attempt any merge mechanics; it only created the new person and relationship as instructed."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence grounding",
+                "score": 3,
+                "rationale": "The edit is grounded per the sourced-evidence layer. The ParentChild relationship edge carries a source-ref (S1 with page 'dwelling 84, family 91'), satisfying the mandatory-ref guard for newly-authored relationship edges. The skill correctly did not add any facts to Mary's person record\u2014facts will be materialized by person-evidence's materialize_facts when the time comes. The user message explicitly authorized this operation via ps_003 (probable tier), and the skill referenced this proof authorization in the response. The relationship-accuracy.md threshold is met via the probable-tier proof summary."
+              }
+            ],
+            "judge_cost_usd": 0.0049665,
+            "duration_ms": 10822.588750044815,
+            "error": null,
+            "input_tokens": 4245,
+            "cached_input_tokens": 5015,
+            "output_tokens": 1047
+          },
+          "started_at": 1785435485.006274,
+          "ended_at": 1785435553.079911
+        }
+      ]
+    },
+    {
+      "test_id": "ut_tree_edit_012",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "This is a negative test where tree-edit should decline and route to person-evidence. The skill correctly declined to perform tree-edit's task (no edits to tree.gedcomx.json were made) and routed the user to person-evidence, which is the correct skill for creating person_evidence links in research.json. The routing decision is accurate and appropriate."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the test requirement: it correctly identified that the user's request (creating a person_evidence link) falls outside tree-edit's scope and properly declined to perform the task. The routing to person-evidence was the complete and correct response expected for this negative test scenario."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill appropriately declined to invoke tools and instead routed the request to person-evidence. N/A \u2014 zero tool calls."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 6331.07579202624,
+        "duration_api_ms": 0.0,
+        "judge_duration_ms": 3490.6046660034917,
+        "wall_clock_ms": 9870.508193969727,
+        "num_turns": 0,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "judge_input_tokens": 6225,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 321,
+        "skill_cost_usd": 0.0,
+        "judge_cost_usd": 0.00783,
+        "total_cost_usd": 0.00783
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_tree_edit_012_2026-07-30_18-18-04_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 6331.07579202624,
+          "duration_api_ms": 0.0,
+          "num_turns": 0,
+          "skill_attempts": 1,
+          "input_tokens": 0,
+          "cached_input_tokens": 0,
+          "output_tokens": 0,
+          "skill_cost_usd": 0.0,
+          "output": {
+            "text_response": "",
+            "activated": false,
+            "skills_invoked": [
+              "person-evidence"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_cross_file_person_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_edit_noop",
+                "passed": true,
+                "error": "skipped: not a tree-edit-noop scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "This is a negative test where tree-edit should decline and route to person-evidence. The skill correctly declined to perform tree-edit's task (no edits to tree.gedcomx.json were made) and routed the user to person-evidence, which is the correct skill for creating person_evidence links in research.json. The routing decision is accurate and appropriate."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the test requirement: it correctly identified that the user's request (creating a person_evidence link) falls outside tree-edit's scope and properly declined to perform the task. The routing to person-evidence was the complete and correct response expected for this negative test scenario."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill appropriately declined to invoke tools and instead routed the request to person-evidence. N/A \u2014 zero tool calls."
+              }
+            ],
+            "judge_cost_usd": 0.00783,
+            "duration_ms": 3490.6046660034917,
+            "error": null,
+            "input_tokens": 6225,
+            "cached_input_tokens": 0,
+            "output_tokens": 321
+          },
+          "started_at": 1785435543.5398998,
+          "ended_at": 1785435553.410408
+        }
+      ]
+    },
+    {
+      "test_id": "ut_tree_edit_011",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "This is a negative test where tree-edit should decline and route to proof-conclusion. Claude correctly declined to perform tree-edit's task (person merge) and routed to proof-conclusion, which is the correct behavior. The skill did not fabricate material or contradict the input state; it correctly recognized that writing a conclusion precedes executing a merge."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed what was required for a negative test: declining the tree-edit task and routing to proof-conclusion. The user's request was for a conclusion to be written before merging, and the skill correctly identified that proof-conclusion is the appropriate next step, not tree-edit. No required action was omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill declined to perform tree-edit's task and routed to proof-conclusion instead, which is the correct behavior for this negative test. N/A \u2014 zero tool calls."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 4690.559291979298,
+        "duration_api_ms": 0.0,
+        "judge_duration_ms": 3276.4082080102526,
+        "wall_clock_ms": 8015.276193618774,
+        "num_turns": 0,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "judge_input_tokens": 6228,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 335,
+        "skill_cost_usd": 0.0,
+        "judge_cost_usd": 0.007903,
+        "total_cost_usd": 0.007903
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_tree_edit_011_2026-07-30_18-18-04_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 4690.559291979298,
+          "duration_api_ms": 0.0,
+          "num_turns": 0,
+          "skill_attempts": 1,
+          "input_tokens": 0,
+          "cached_input_tokens": 0,
+          "output_tokens": 0,
+          "skill_cost_usd": 0.0,
+          "output": {
+            "text_response": "",
+            "activated": false,
+            "skills_invoked": [
+              "proof-conclusion"
+            ],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_cross_file_person_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_edit_noop",
+                "passed": true,
+                "error": "skipped: not a tree-edit-noop scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "This is a negative test where tree-edit should decline and route to proof-conclusion. Claude correctly declined to perform tree-edit's task (person merge) and routed to proof-conclusion, which is the correct behavior. The skill did not fabricate material or contradict the input state; it correctly recognized that writing a conclusion precedes executing a merge."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed what was required for a negative test: declining the tree-edit task and routing to proof-conclusion. The user's request was for a conclusion to be written before merging, and the skill correctly identified that proof-conclusion is the appropriate next step, not tree-edit. No required action was omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill declined to perform tree-edit's task and routed to proof-conclusion instead, which is the correct behavior for this negative test. N/A \u2014 zero tool calls."
+              }
+            ],
+            "judge_cost_usd": 0.007903,
+            "duration_ms": 3276.4082080102526,
+            "error": null,
+            "input_tokens": 6228,
+            "cached_input_tokens": 0,
+            "output_tokens": 335
+          },
+          "started_at": 1785435542.5017338,
+          "ended_at": 1785435550.51701
+        }
+      ]
+    },
+    {
+      "test_id": "ut_tree_edit_003",
+      "test_type": "negative",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly declined to perform tree-edit's task (writing census facts directly to tree.gedcomx.json). Instead, it appropriately asked the user to provide the raw record content, which is the correct routing behavior for this negative test. The response does not fabricate any facts or contradict the input state."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the requirement of this negative test: it did not activate tree-edit and did not write to tree.gedcomx.json. It correctly identified that record-extraction should handle this task and requested the necessary record details (FamilySearch ARK, image scan, or transcribed content) before proceeding, which is the appropriate handoff behavior."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill correctly declined to invoke any tools and instead asked the user for record details. N/A \u2014 zero tool calls."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 15702.17608299572,
+        "duration_api_ms": 12516.0,
+        "judge_duration_ms": 3699.9419170315377,
+        "wall_clock_ms": 19917.261838912964,
+        "num_turns": 1,
+        "input_tokens": 3,
+        "cached_input_tokens": 0,
+        "output_tokens": 470,
+        "judge_input_tokens": 6415,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 325,
+        "skill_cost_usd": 0.053388750000000006,
+        "judge_cost_usd": 0.00804,
+        "total_cost_usd": 0.061428750000000004
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_tree_edit_003_2026-07-30_18-18-04_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 15702.17608299572,
+          "duration_api_ms": 12516.0,
+          "num_turns": 1,
+          "skill_attempts": 1,
+          "input_tokens": 3,
+          "cached_input_tokens": 0,
+          "output_tokens": 470,
+          "skill_cost_usd": 0.053388750000000006,
+          "output": {
+            "text_response": "I'd be happy to extract the facts from that 1880 census record and add them to the tree! To get started, could you share the record details? I'll need one of the following:\n\n- **FamilySearch ARK** (the record URL or ID, e.g. `ark:/61903/1:1:XXXX`)\n- **Image scan** (a photo or upload of the census page)\n- **The record content** (what the record says \u2014 name, age, birthplace, household members, etc.)\n\nPlease share whichever you have and I'll take it from there.",
+            "activated": false,
+            "skills_invoked": [],
+            "tool_calls": [],
+            "files_created": []
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": "skipped: allowlist is not checked on negative tests \u2014 tool calls belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": "skipped: ownership is not checked on negative tests \u2014 writes belong to the routed-to skill, not the skill under test"
+              },
+              {
+                "name": "test_cross_file_person_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_edit_noop",
+                "passed": true,
+                "error": null
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly declined to perform tree-edit's task (writing census facts directly to tree.gedcomx.json). Instead, it appropriately asked the user to provide the raw record content, which is the correct routing behavior for this negative test. The response does not fabricate any facts or contradict the input state."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the requirement of this negative test: it did not activate tree-edit and did not write to tree.gedcomx.json. It correctly identified that record-extraction should handle this task and requested the necessary record details (FamilySearch ARK, image scan, or transcribed content) before proceeding, which is the appropriate handoff behavior."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill correctly declined to invoke any tools and instead asked the user for record details. N/A \u2014 zero tool calls."
+              }
+            ],
+            "judge_cost_usd": 0.00804,
+            "duration_ms": 3699.9419170315377,
+            "error": null,
+            "input_tokens": 6415,
+            "cached_input_tokens": 0,
+            "output_tokens": 325
+          },
+          "started_at": 1785435485.0078661,
+          "ended_at": 1785435504.925128
+        }
+      ]
+    },
+    {
+      "test_id": "ut_tree_edit_006",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn-merge-pending",
+      "mcp_fixtures": [
+        "place-search-ireland",
+        "place-search-schuylkill-county"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that I3's 'James Flynn' name was already present on I4 as an AKA, avoiding a duplicate. It properly added the conflicting birth fact (~1849, Ireland, S5) as non-primary to I4, preserving both conflicting dates as required. The skill accurately mapped all cross-references in research.json (subject_person_ids, person_evidence pe_007, timelines t_002) and correctly identified that tree-edit does not own those sections. No fabricated claims; all assertions are grounded in the provided state."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all required elements: (1) consolidated data on I4 by adding the non-primary birth fact, (2) verified the name was already present and avoided duplication, (3) checked relationships (found none to repoint), (4) explicitly presented a coordination plan naming the three owning skills (person-evidence, research-plan/research-append, timeline), (5) explained why I3 must remain in tree.gedcomx.json pending those rewrites, and (6) outlined the sequencing for final merge. Nothing the input state required was omitted."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "Two tool calls made: first call correctly passed all required args (projectPath, operation='add_fact', personId='I4', fact with type/date/place/sources) but included 'primary: false' which the tool rejected with clear guidance. Second call immediately corrected by omitting the 'primary' field entirely, matching the tool's validation requirement. The retry was clean and successful. All critical args (personId, fact structure, source ref) were correct in both attempts."
+          },
+          {
+            "source": "rubric",
+            "name": "Data preservation",
+            "score": 3,
+            "rationale": "All existing facts and sources survived the edit. I4's original birth fact (F5, ~1848, baptismal) was left untouched. The new non-primary birth fact (F6, ~1849, census) was added without dropping either conflicting date. I3's name 'James Flynn' was recognized as already present on I4 (N5, AKA) and no duplicate was created. No data was silently dropped during the partial merge."
+          },
+          {
+            "source": "rubric",
+            "name": "Edit minimality",
+            "score": 3,
+            "rationale": "Only the requested change was made: adding the conflicting birth fact to I4. No unrelated fields were touched. The skill did not modify I3, did not alter relationships, did not rewrite names unnecessarily, and did not make opportunistic corrections to other fields. The edit was surgical and confined to the single fact addition."
+          },
+          {
+            "source": "rubric",
+            "name": "Merge correctness",
+            "score": 3,
+            "rationale": "Per the test context, the correct behavior is to consolidate data on I4 + present a plan for coordinated rewrites + do NOT delete I3 yet. The skill did exactly this: (1) consolidated the conflicting birth fact onto I4 without dropping either date, (2) left I3 in place in tree.gedcomx.json, (3) explicitly named the three owning skills (person-evidence, research-plan/research-append, timeline) responsible for the research.json rewrites, and (4) outlined the sequencing for final merge. The skill correctly recognized that tree-edit lacks ownership of research.json sections per the OWNERSHIP_TABLE and presented a clear coordination plan. This is the intended behavior for a partial merge pending cross-file coordination."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence grounding",
+            "score": 3,
+            "rationale": "The edit is grounded in sourced evidence. The new birth fact (~1849, Ireland) carries a source-ref (S5, the 1880 census) and materializes as a non-primary fact without requiring a proof conclusion\u2014this is correct per the sourced-evidence layer. The skill did not mark either birth fact as primary (the primary F5 was already set; F6 is non-primary), so no conclusion-level gate was crossed. The skill correctly deferred the proof-conclusion decision (which date to mark primary) to the proof-conclusion skill, noting that ps_002 authorizes the identity merge but not the birth-date resolution."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 158114.54141698778,
+        "duration_api_ms": 154124.0,
+        "judge_duration_ms": 13551.612332987133,
+        "wall_clock_ms": 172030.26294708252,
+        "num_turns": 11,
+        "input_tokens": 16,
+        "cached_input_tokens": 202487,
+        "output_tokens": 7649,
+        "judge_input_tokens": 5549,
+        "judge_cached_input_tokens": 5015,
+        "judge_output_tokens": 1141,
+        "skill_cost_usd": 0.33810935000000003,
+        "judge_cost_usd": 0.0067405,
+        "total_cost_usd": 0.34484985
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_tree_edit_006_2026-07-30_18-18-04_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 158114.54141698778,
+          "duration_api_ms": 154124.0,
+          "num_turns": 11,
+          "skill_attempts": 1,
+          "input_tokens": 16,
+          "cached_input_tokens": 202487,
+          "output_tokens": 7649,
+          "skill_cost_usd": 0.33810935000000003,
+          "output": {
+            "text_response": "Good. I have both the tree and research files clearly in view. Let me map out exactly what needs to transfer before touching anything.\n\n---\n\n**I3 \u2192 I4 transfer analysis**\n\n| Element | I3 has | I4 already has | Action |\n|---|---|---|---|\n| Name \"James Flynn\" (BirthName) | N3, preferred | N5, AlsoKnownAs | Already present \u2014 no addition needed |\n| Birth ~1849, Ireland, S5 (1880 census) | F4, primary | \u2014 | **Must add** (non-primary; conflicts with F5) |\n| Birth ~1848, Branch Twp, S6 (baptism) | \u2014 | F5, primary | Already on I4 \u2014 no change |\n| Relationships | None (R1 is I2\u2192I1 only) | \u2014 | Nothing to repoint in tree |\n\nOne write needed: add the census-derived birth (~1849, Ireland, S5) onto I4 as a non-primary fact so both dates coexist pending proof-conclusion. The name \"James Flynn\" is already on I4 as N5 \u2014 no duplicate needed.\n\nProceeding with the add:Good \u2014 the tool enforces that `primary` is omitted for non-primary facts rather than set to false. Retrying without the flag:`ok: true` \u2014 F6 written to I4. Let me verify the result:I4 looks exactly right. Now let me present the full picture.\n\n---\n\n## What was done\n\n**F6 added to I4** (James Patrick Flynn / KWCJ-JAM7):\n\n| | |\n|---|---|\n| Type | Birth (non-primary) |\n| Date | ~1849 |\n| Place | Ireland |\n| Source | S5 \u2014 1880 U.S. Census, Schuylkill Co., dwelling 142 *(Patrick Flynn household, brother 'James' age 31, b. Ireland)* |\n\nI4 now carries **both conflicting birth assertions** side by side:\n- **F5** (primary): ~1848 \u00b7 Branch Township, Schuylkill County, PA \u2014 from the baptismal register (S6), the more authoritative source\n- **F6** (non-primary): ~1849 \u00b7 Ireland \u2014 from the 1880 census age back-calculation (S5)\n\nNeither is dropped. proof-conclusion owns the resolution.\n\n**Names \u2014 no addition needed.** I3's stub name \"James Flynn\" (BirthName) was already represented on I4 as N5 (AlsoKnownAs). No duplicate written.\n\n**Relationships \u2014 nothing to repoint.** I3 had no tree relationships (R1 is I2 \u2192 I1 only).\n\n---\n\n## What tree-edit deliberately did NOT do\n\nI3 remains in `tree.gedcomx.json` unchanged. Three live cross-references in `research.json` anchor it there \u2014 removing I3 now would produce dangling ids:\n\n| Location | Current value | Must change to | Owning skill |\n|---|---|---|---|\n| `project.subject_person_ids` | `[\"I1\", \"I3\"]` | `[\"I1\"]` | **research-plan** (or a direct `research_append` call) |\n| `person_evidence pe_007 \u2192 person_id` | `\"I3\"` | `\"I4\"` | **person-evidence** |\n| `timelines t_002 \u2192 person_ids` | `[\"I3\"]` | `[\"I4\"]` \u2014 or retire the timeline | **timeline** (or **research-append**) |\n\n---\n\n## Completing the merge \u2014 sequencing\n\nOnce those three rewrites land, the merge can finalize with a single `merge_tree_persons` call that collapses I3 into I4 and removes the now-orphaned stub from the tree. Suggested order:\n\n1. **person-evidence** \u2014 repoint `pe_007.person_id` \u2192 `\"I4\"`. This is the most important link; pe_007 is active evidence that must travel with the person.\n2. **research-plan / research-append** \u2014 drop `\"I3\"` from `project.subject_person_ids`. I3 was added as a subject while identity was open; ps_002 closes that question.\n3. **timeline** \u2014 update `t_002.person_ids` to `[\"I4\"]` (or mark the timeline superseded if you prefer to regenerate it from I4's fuller event set once the merge finalises).\n4. **tree-edit (final pass)** \u2014 with `research.json` clean, call `merge_tree_persons` to delete I3 from the tree. At that point no dangling references remain.\n\nThe tree write is done and validates clean. The three `research.json` rewrites above are all that stands between here and the final stub deletion.",
+            "activated": true,
+            "skills_invoked": [
+              "tree-edit"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__tree_edit",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_006-0-0-98q66q9y",
+                  "operation": "add_fact",
+                  "personId": "I4",
+                  "fact": {
+                    "type": "Birth",
+                    "primary": false,
+                    "date": "~1849",
+                    "place": "Ireland",
+                    "sources": [
+                      {
+                        "ref": "S5",
+                        "page": "1880 U.S. Census, Schuylkill Co., dwelling 142 (Patrick Flynn household, brother 'James' age 31, b. Ireland)"
+                      }
+                    ]
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:tree_edit"
+              },
+              {
+                "tool": "mcp__genealogy__tree_edit",
+                "args": {
+                  "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_006-0-0-98q66q9y",
+                  "operation": "add_fact",
+                  "personId": "I4",
+                  "fact": {
+                    "type": "Birth",
+                    "date": "~1849",
+                    "place": "Ireland",
+                    "sources": [
+                      {
+                        "ref": "S5",
+                        "page": "1880 U.S. Census, Schuylkill Co., dwelling 142 (Patrick Flynn household, brother 'James' age 31, b. Ireland)"
+                      }
+                    ]
+                  }
+                },
+                "expected_args": null,
+                "matched": {
+                  "kind": "live",
+                  "index": null
+                },
+                "response_fixture": "live:tree_edit"
+              }
+            ],
+            "files_created": [
+              "tree.gedcomx.json.bak"
+            ],
+            "file_changes": {
+              "tree.gedcomx.json": {
+                "sections_modified": [
+                  "persons"
+                ],
+                "diff": {
+                  "persons": {
+                    "added": [],
+                    "modified": [
+                      {
+                        "id": "I4",
+                        "changed_fields": {
+                          "facts": {
+                            "before": [
+                              {
+                                "id": "F5",
+                                "type": "Birth",
+                                "primary": true,
+                                "date": "~1848",
+                                "place": "Branch Township, Schuylkill County, Pennsylvania",
+                                "sources": [
+                                  {
+                                    "ref": "S6",
+                                    "page": "St. Patrick's RC Church baptismal register, 22 Mar 1848, entry 47"
+                                  }
+                                ]
+                              }
+                            ],
+                            "after": [
+                              {
+                                "id": "F5",
+                                "type": "Birth",
+                                "primary": true,
+                                "date": "~1848",
+                                "place": "Branch Township, Schuylkill County, Pennsylvania",
+                                "sources": [
+                                  {
+                                    "ref": "S6",
+                                    "page": "St. Patrick's RC Church baptismal register, 22 Mar 1848, entry 47"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "Birth",
+                                "date": "~1849",
+                                "place": "Ireland",
+                                "sources": [
+                                  {
+                                    "ref": "S5",
+                                    "page": "1880 U.S. Census, Schuylkill Co., dwelling 142 (Patrick Flynn household, brother 'James' age 31, b. Ireland)"
+                                  }
+                                ],
+                                "id": "F6",
+                                "standard_place": "Ireland"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "deleted": []
+                  }
+                }
+              }
+            },
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_cross_file_person_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_edit_noop",
+                "passed": true,
+                "error": "skipped: not a tree-edit-noop scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that I3's 'James Flynn' name was already present on I4 as an AKA, avoiding a duplicate. It properly added the conflicting birth fact (~1849, Ireland, S5) as non-primary to I4, preserving both conflicting dates as required. The skill accurately mapped all cross-references in research.json (subject_person_ids, person_evidence pe_007, timelines t_002) and correctly identified that tree-edit does not own those sections. No fabricated claims; all assertions are grounded in the provided state."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all required elements: (1) consolidated data on I4 by adding the non-primary birth fact, (2) verified the name was already present and avoided duplication, (3) checked relationships (found none to repoint), (4) explicitly presented a coordination plan naming the three owning skills (person-evidence, research-plan/research-append, timeline), (5) explained why I3 must remain in tree.gedcomx.json pending those rewrites, and (6) outlined the sequencing for final merge. Nothing the input state required was omitted."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "Two tool calls made: first call correctly passed all required args (projectPath, operation='add_fact', personId='I4', fact with type/date/place/sources) but included 'primary: false' which the tool rejected with clear guidance. Second call immediately corrected by omitting the 'primary' field entirely, matching the tool's validation requirement. The retry was clean and successful. All critical args (personId, fact structure, source ref) were correct in both attempts."
+              },
+              {
+                "source": "rubric",
+                "name": "Data preservation",
+                "score": 3,
+                "rationale": "All existing facts and sources survived the edit. I4's original birth fact (F5, ~1848, baptismal) was left untouched. The new non-primary birth fact (F6, ~1849, census) was added without dropping either conflicting date. I3's name 'James Flynn' was recognized as already present on I4 (N5, AKA) and no duplicate was created. No data was silently dropped during the partial merge."
+              },
+              {
+                "source": "rubric",
+                "name": "Edit minimality",
+                "score": 3,
+                "rationale": "Only the requested change was made: adding the conflicting birth fact to I4. No unrelated fields were touched. The skill did not modify I3, did not alter relationships, did not rewrite names unnecessarily, and did not make opportunistic corrections to other fields. The edit was surgical and confined to the single fact addition."
+              },
+              {
+                "source": "rubric",
+                "name": "Merge correctness",
+                "score": 3,
+                "rationale": "Per the test context, the correct behavior is to consolidate data on I4 + present a plan for coordinated rewrites + do NOT delete I3 yet. The skill did exactly this: (1) consolidated the conflicting birth fact onto I4 without dropping either date, (2) left I3 in place in tree.gedcomx.json, (3) explicitly named the three owning skills (person-evidence, research-plan/research-append, timeline) responsible for the research.json rewrites, and (4) outlined the sequencing for final merge. The skill correctly recognized that tree-edit lacks ownership of research.json sections per the OWNERSHIP_TABLE and presented a clear coordination plan. This is the intended behavior for a partial merge pending cross-file coordination."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence grounding",
+                "score": 3,
+                "rationale": "The edit is grounded in sourced evidence. The new birth fact (~1849, Ireland) carries a source-ref (S5, the 1880 census) and materializes as a non-primary fact without requiring a proof conclusion\u2014this is correct per the sourced-evidence layer. The skill did not mark either birth fact as primary (the primary F5 was already set; F6 is non-primary), so no conclusion-level gate was crossed. The skill correctly deferred the proof-conclusion decision (which date to mark primary) to the proof-conclusion skill, noting that ps_002 authorizes the identity merge but not the birth-date resolution."
+              }
+            ],
+            "judge_cost_usd": 0.0067405,
+            "duration_ms": 13551.612332987133,
+            "error": null,
+            "input_tokens": 5549,
+            "cached_input_tokens": 5015,
+            "output_tokens": 1141
+          },
+          "started_at": 1785435485.005845,
+          "ended_at": 1785435657.036108
+        }
+      ]
+    },
+    {
+      "test_id": "ut_tree_edit_005",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "person-person-matches-flynn"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly called person_person_matches with the expected ID (LZNY-BRF), accurately reported the single pending duplicate candidate (LZNY-QRS with confidence 3 and score 0.71), and properly advised the user to confirm identity via proof-conclusion before merging. No fabricated material or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill addressed all requirements: called the correct tool, reported the one pending duplicate candidate with all relevant details (name, ID, confidence, score, status), and provided clear guidance on next steps including the requirement for proof-conclusion before merge. No omissions."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The person_person_matches call passed the correct ID argument (LZNY-BRF) matching expected_args. The includeSummary parameter was added but is reasonable and non-critical. The call matched successfully (matched.kind == 'predicate') with no fixture_not_found errors."
+          },
+          {
+            "source": "rubric",
+            "name": "Data preservation",
+            "score": 3,
+            "rationale": "This is a read-only duplicate check with no edits to tree.gedcomx.json or research.json. No data preservation concerns apply since no modifications were made. All existing facts and sources remain untouched."
+          },
+          {
+            "source": "rubric",
+            "name": "Edit minimality",
+            "score": 3,
+            "rationale": "This is a read-only duplicate check operation. No edits were made to any files, so edit minimality is not applicable. The skill correctly performed only the requested duplicate check without modifying any data."
+          },
+          {
+            "source": "rubric",
+            "name": "Merge correctness",
+            "score": 3,
+            "rationale": "This is not a merge operation\u2014it is a read-only duplicate candidate check. The skill correctly refused to execute a merge and instead advised the user to confirm identity via proof-conclusion first. No merge mechanics were required or attempted, so this dimension has nothing to grade per the rubric guidance for non-merge tests."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence grounding",
+            "score": 3,
+            "rationale": "This is a read-only duplicate check, not an edit operation. The skill correctly declined to merge without proof-conclusion and explicitly advised the user that a probable-tier proof conclusion is required before merging. No edit grounding issues apply since no edits were made."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 23730.934291961603,
+        "duration_api_ms": 20571.0,
+        "judge_duration_ms": 7093.901708023623,
+        "wall_clock_ms": 31186.506986618042,
+        "num_turns": 5,
+        "input_tokens": 10,
+        "cached_input_tokens": 42745,
+        "output_tokens": 1006,
+        "judge_input_tokens": 3548,
+        "judge_cached_input_tokens": 0,
+        "judge_output_tokens": 714,
+        "skill_cost_usd": 0.08795275,
+        "judge_cost_usd": 0.007117999999999999,
+        "total_cost_usd": 0.09507075
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_tree_edit_005_2026-07-30_18-18-04_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 23730.934291961603,
+          "duration_api_ms": 20571.0,
+          "num_turns": 5,
+          "skill_attempts": 1,
+          "input_tokens": 10,
+          "cached_input_tokens": 42745,
+          "output_tokens": 1006,
+          "skill_cost_usd": 0.08795275,
+          "output": {
+            "text_response": "Here's what FamilySearch found for Patrick Flynn (**LZNY-BRF**):\n\n---\n\n## \ud83d\udd0d Possible Duplicate \u2014 1 Candidate Found\n\n| Field | Details |\n|---|---|\n| **Name** | Patrick Flynn (1845\u20131908) |\n| **FamilySearch ID** | LZNY-QRS |\n| **Confidence** | 3 / 5 |\n| **Score** | 0.71 |\n| **Status** | Pending (unreviewed) |\n\n---\n\n### What this means\n\nFamilySearch has flagged **LZNY-QRS** as a possible duplicate of your Patrick Flynn (LZNY-BRF), with a **moderate confidence of 3/5** and a score of 0.71. The life span (1845\u20131908) lines up with the same individual.\n\n### Next steps\n\nThis is a **candidate only** \u2014 a merge cannot proceed without proof. Here's the recommended path:\n\n1. **Review the evidence** \u2014 compare the records attached to both LZNY-BRF and LZNY-QRS to see whether they describe the same individual.\n2. **Run proof-conclusion** \u2014 if the evidence supports identity, use `/proof-conclusion` to write a formal conclusion at `probable` or higher confidence.\n3. **Return here to merge** \u2014 once proof-conclusion confirms identity, I can execute the merge (LZNY-QRS collapsed into LZNY-BRF, since LZNY-BRF is already your subject person).\n\nWould you like me to pull up the records attached to LZNY-QRS so you can start comparing, or would you like to kick off a proof-conclusion for this question?",
+            "activated": true,
+            "skills_invoked": [
+              "tree-edit"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_person_matches",
+                "args": {
+                  "id": "LZNY-BRF",
+                  "includeSummary": true
+                },
+                "expected_args": {
+                  "id": "LZNY-BRF"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-person-matches-flynn"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_cross_file_person_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_edit_noop",
+                "passed": true,
+                "error": "skipped: not a tree-edit-noop scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly called person_person_matches with the expected ID (LZNY-BRF), accurately reported the single pending duplicate candidate (LZNY-QRS with confidence 3 and score 0.71), and properly advised the user to confirm identity via proof-conclusion before merging. No fabricated material or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill addressed all requirements: called the correct tool, reported the one pending duplicate candidate with all relevant details (name, ID, confidence, score, status), and provided clear guidance on next steps including the requirement for proof-conclusion before merge. No omissions."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The person_person_matches call passed the correct ID argument (LZNY-BRF) matching expected_args. The includeSummary parameter was added but is reasonable and non-critical. The call matched successfully (matched.kind == 'predicate') with no fixture_not_found errors."
+              },
+              {
+                "source": "rubric",
+                "name": "Data preservation",
+                "score": 3,
+                "rationale": "This is a read-only duplicate check with no edits to tree.gedcomx.json or research.json. No data preservation concerns apply since no modifications were made. All existing facts and sources remain untouched."
+              },
+              {
+                "source": "rubric",
+                "name": "Edit minimality",
+                "score": 3,
+                "rationale": "This is a read-only duplicate check operation. No edits were made to any files, so edit minimality is not applicable. The skill correctly performed only the requested duplicate check without modifying any data."
+              },
+              {
+                "source": "rubric",
+                "name": "Merge correctness",
+                "score": 3,
+                "rationale": "This is not a merge operation\u2014it is a read-only duplicate candidate check. The skill correctly refused to execute a merge and instead advised the user to confirm identity via proof-conclusion first. No merge mechanics were required or attempted, so this dimension has nothing to grade per the rubric guidance for non-merge tests."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence grounding",
+                "score": 3,
+                "rationale": "This is a read-only duplicate check, not an edit operation. The skill correctly declined to merge without proof-conclusion and explicitly advised the user that a probable-tier proof conclusion is required before merging. No edit grounding issues apply since no edits were made."
+              }
+            ],
+            "judge_cost_usd": 0.007117999999999999,
+            "duration_ms": 7093.901708023623,
+            "error": null,
+            "input_tokens": 3548,
+            "cached_input_tokens": 0,
+            "output_tokens": 714
+          },
+          "started_at": 1785435485.007377,
+          "ended_at": 1785435516.193884
+        }
+      ]
+    },
+    {
+      "test_id": "ut_tree_edit_004",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [
+        "person-record-matches-flynn",
+        "person-record-matches-flynn-person-id",
+        "person-record-matches-flynn-personid"
+      ],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly called person_record_matches with the specified ID (LZNY-BRF) and accurately reported the three matches returned by the tool. The accepted match (1850 census, confidence 5, score 0.97) and the two pending matches (1860 census confidence 3, Pennsylvania Death Certificates confidence 2) are all correctly identified and distinguished. No fabricated material or unsupported claims."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request to check what records are attached to Patrick Flynn and to distinguish accepted matches from pending hints. All three matches returned by the tool are presented with clear status labels, confidence levels, and scores. The skill also appropriately offered follow-up options (extract assertions or review in more detail)."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": 3,
+            "rationale": "The skill called person_record_matches with the correct ID argument (LZNY-BRF) as specified in the test context. The tool matched successfully (matched.kind == 'predicate'). The additional status parameter filtering for 'accepted', 'pending', and 'rejected' was a reasonable addition that helped retrieve all relevant matches without error."
+          },
+          {
+            "source": "rubric",
+            "name": "Data preservation",
+            "score": 3,
+            "rationale": "This is a read-only query operation with no edits to tree.gedcomx.json or research.json. No data preservation concerns apply. The skill correctly did not modify any existing facts, sources, or relationships."
+          },
+          {
+            "source": "rubric",
+            "name": "Edit minimality",
+            "score": 3,
+            "rationale": "This is a read-only query operation with no edits requested or performed. The skill made zero modifications to any files, which is the correct behavior for a match-checking operation. Edit minimality is not applicable but the skill correctly avoided any collateral changes."
+          },
+          {
+            "source": "rubric",
+            "name": "Merge correctness",
+            "score": 3,
+            "rationale": "This is not a merge operation. The test explicitly states 'Should NOT make any edits to tree.gedcomx.json or research.json \u2014 this is a read-only query, not an edit request.' No merge mechanics apply; this dimension has nothing to grade and scores pass per the rubric guidance for non-merge tests."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence grounding",
+            "score": 3,
+            "rationale": "This is a read-only query operation that retrieves and reports existing FamilySearch matches. No new facts, relationships, or conclusions are being authored or edited. No evidence grounding is required for a match-checking operation. The skill correctly did not attempt to materialize or conclude any evidence."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 22898.158000025433,
+        "duration_api_ms": 21587.0,
+        "judge_duration_ms": 7933.732709032483,
+        "wall_clock_ms": 30887.62903213501,
+        "num_turns": 5,
+        "input_tokens": 10,
+        "cached_input_tokens": 50110,
+        "output_tokens": 920,
+        "judge_input_tokens": 3846,
+        "judge_cached_input_tokens": 5015,
+        "judge_output_tokens": 776,
+        "skill_cost_usd": 0.06303775,
+        "judge_cost_usd": 0.0032125,
+        "total_cost_usd": 0.06625025000000001
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_tree_edit_004_2026-07-30_18-18-04_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 22898.158000025433,
+          "duration_api_ms": 21587.0,
+          "num_turns": 5,
+          "skill_attempts": 1,
+          "input_tokens": 10,
+          "cached_input_tokens": 50110,
+          "output_tokens": 920,
+          "skill_cost_usd": 0.06303775,
+          "output": {
+            "text_response": "Here's a summary of what FamilySearch has for **Patrick Flynn (LZNY-BRF)**:\n\n---\n\n### \u2705 Accepted Match (1)\n\n| Record | ARK | Confidence | Score |\n|---|---|---|---|\n| **1850 U.S. Federal Census** | `1:1:MXYZ` | \u2b50\u2b50\u2b50\u2b50\u2b50 (5/5) | 0.97 |\n\nThis is the one record that has been **accepted** and attached to Patrick's profile \u2014 a high-confidence (0.97 score) hit in the 1850 census.\n\n---\n\n### \u23f3 Pending Matches (2)\n\n| Record | ARK | Confidence | Score |\n|---|---|---|---|\n| **1860 U.S. Federal Census** | `1:1:MABC` | \u2b50\u2b50\u2b50 (3/5) | 0.72 |\n| **Pennsylvania Death Certificates, 1906\u20131967** | `1:1:MDEF` | \u2b50\u2b50 (2/5) | 0.58 |\n\nThese two hints are **awaiting review**:\n- The **1860 census** is a moderate-confidence match (0.72) \u2014 worth investigating.\n- The **Pennsylvania Death Certificate** is a lower-confidence hit (0.58) but could still be relevant, especially if Patrick lived into the early 20th century.\n\n---\n\n**No rejected matches** on file for this person.\n\nWould you like me to extract assertions from either of the pending records, or accept/review them in more detail?",
+            "activated": true,
+            "skills_invoked": [
+              "tree-edit"
+            ],
+            "tool_calls": [
+              {
+                "tool": "mcp__genealogy__person_record_matches",
+                "args": {
+                  "id": "LZNY-BRF",
+                  "status": [
+                    "accepted",
+                    "pending",
+                    "rejected"
+                  ]
+                },
+                "expected_args": {
+                  "id": "LZNY-BRF"
+                },
+                "matched": {
+                  "kind": "predicate",
+                  "index": 0
+                },
+                "response_fixture": "person-record-matches-flynn"
+              }
+            ],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "missing_tool_usage_dimension",
+                "advisory": "Skill called MCP tools but the rubric has no dimension name suggesting tool-usage coverage (matched against keywords: ['tool usage', 'tool use', 'tool work', 'tool call', 'argument quality', 'argument-quality', 'response interpretation', 'tool selection', 'mcp tool', 'fixture']). The judge will grade other dimensions but won't score tool work explicitly. Consider adding a tool-usage dimension or renaming an existing one."
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_cross_file_person_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_edit_noop",
+                "passed": true,
+                "error": "skipped: not a tree-edit-noop scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly called person_record_matches with the specified ID (LZNY-BRF) and accurately reported the three matches returned by the tool. The accepted match (1850 census, confidence 5, score 0.97) and the two pending matches (1860 census confidence 3, Pennsylvania Death Certificates confidence 2) are all correctly identified and distinguished. No fabricated material or unsupported claims."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request to check what records are attached to Patrick Flynn and to distinguish accepted matches from pending hints. All three matches returned by the tool are presented with clear status labels, confidence levels, and scores. The skill also appropriately offered follow-up options (extract assertions or review in more detail)."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": 3,
+                "rationale": "The skill called person_record_matches with the correct ID argument (LZNY-BRF) as specified in the test context. The tool matched successfully (matched.kind == 'predicate'). The additional status parameter filtering for 'accepted', 'pending', and 'rejected' was a reasonable addition that helped retrieve all relevant matches without error."
+              },
+              {
+                "source": "rubric",
+                "name": "Data preservation",
+                "score": 3,
+                "rationale": "This is a read-only query operation with no edits to tree.gedcomx.json or research.json. No data preservation concerns apply. The skill correctly did not modify any existing facts, sources, or relationships."
+              },
+              {
+                "source": "rubric",
+                "name": "Edit minimality",
+                "score": 3,
+                "rationale": "This is a read-only query operation with no edits requested or performed. The skill made zero modifications to any files, which is the correct behavior for a match-checking operation. Edit minimality is not applicable but the skill correctly avoided any collateral changes."
+              },
+              {
+                "source": "rubric",
+                "name": "Merge correctness",
+                "score": 3,
+                "rationale": "This is not a merge operation. The test explicitly states 'Should NOT make any edits to tree.gedcomx.json or research.json \u2014 this is a read-only query, not an edit request.' No merge mechanics apply; this dimension has nothing to grade and scores pass per the rubric guidance for non-merge tests."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence grounding",
+                "score": 3,
+                "rationale": "This is a read-only query operation that retrieves and reports existing FamilySearch matches. No new facts, relationships, or conclusions are being authored or edited. No evidence grounding is required for a match-checking operation. The skill correctly did not attempt to materialize or conclude any evidence."
+              }
+            ],
+            "judge_cost_usd": 0.0032125,
+            "duration_ms": 7933.732709032483,
+            "error": null,
+            "input_tokens": 3846,
+            "cached_input_tokens": 5015,
+            "output_tokens": 776
+          },
+          "started_at": 1785435516.206866,
+          "ended_at": 1785435547.094495
+        }
+      ]
+    },
+    {
+      "test_id": "ut_tree_edit_007",
+      "test_type": "positive",
+      "expected_outcome": "pass",
+      "scenario": "mid-research-flynn",
+      "mcp_fixtures": [],
+      "outcome": "pass",
+      "flaky": false,
+      "outcome_summary": {
+        "per_run_outcomes": [
+          "pass"
+        ],
+        "aggregated_dimensions": [
+          {
+            "source": "base",
+            "name": "Correctness",
+            "score": 3,
+            "rationale": "The skill correctly identified that I1 and I2 are father and son, not the same person. All factual claims are supported: R1 exists and records ParentChild (Thomas\u2192Patrick), ps_001 is rated Probable and confirms parentage, birth years differ by ~27 years, and the three sources (1850/1860 census, death cert) all document the relationship. No fabricated material."
+          },
+          {
+            "source": "base",
+            "name": "Completeness",
+            "score": 3,
+            "rationale": "The skill fully addressed the user's request by refusing the merge and explaining why. It identified the key evidence (R1, ps_001, h_001, source citations), clarified the misunderstanding (co-occurrence as evidence of relationship, not identity), and offered constructive next steps. All required context from the input state was covered."
+          },
+          {
+            "source": "base",
+            "name": "Tool Arguments",
+            "score": null,
+            "rationale": "No MCP tool calls were made. The skill correctly declined to execute the merge without invoking any tools, which is the appropriate behavior when refusing an unsafe operation."
+          },
+          {
+            "source": "rubric",
+            "name": "Data preservation",
+            "score": 3,
+            "rationale": "This is a negative test (refusal case). No edits were made to tree.gedcomx.json or research.json, so all existing facts, names, and source references remain intact. The skill correctly preserved the entire state by declining the merge."
+          },
+          {
+            "source": "rubric",
+            "name": "Edit minimality",
+            "score": 3,
+            "rationale": "This is a negative test (refusal case). No edits were made at all, so there are no collateral modifications. The skill made zero changes, which is the correct minimal response to a refused merge request."
+          },
+          {
+            "source": "rubric",
+            "name": "Merge correctness",
+            "score": 3,
+            "rationale": "This is a negative test (refusal case). The skill correctly refused to execute the merge, so the merge-correctness dimension has nothing to grade. No references were rewritten, no persons were deleted, and no cross-file corruption occurred because the merge never happened."
+          },
+          {
+            "source": "rubric",
+            "name": "Evidence grounding",
+            "score": 3,
+            "rationale": "This is a negative test (refusal case). The skill correctly refused an ungrounded merge request. Per SKILL.md, merges require a proof_summary at probable+ tier confirming identity. ps_001 exists and is probable, but it confirms *parentage* (Thomas is Patrick's father), not *identity* (they are the same person). The skill correctly identified this distinction and refused to merge without an identity proof-conclusion. The skill also correctly noted that R1 (the existing ParentChild relationship) is evidence they are NOT the same person."
+          }
+        ]
+      },
+      "totals": {
+        "duration_ms": 49278.30087498296,
+        "duration_api_ms": 46169.0,
+        "judge_duration_ms": 7842.080749978777,
+        "wall_clock_ms": 57474.66230392456,
+        "num_turns": 7,
+        "input_tokens": 12,
+        "cached_input_tokens": 75988,
+        "output_tokens": 2026,
+        "judge_input_tokens": 3462,
+        "judge_cached_input_tokens": 5015,
+        "judge_output_tokens": 776,
+        "skill_cost_usd": 0.17182389999999997,
+        "judge_cost_usd": 0.0028285000000000003,
+        "total_cost_usd": 0.17465239999999999
+      },
+      "runs": [
+        {
+          "run_index": 0,
+          "run_id": "run_ut_tree_edit_007_2026-07-30_18-18-04_0",
+          "outcome": "pass",
+          "aborted_reason": null,
+          "duration_ms": 49278.30087498296,
+          "duration_api_ms": 46169.0,
+          "num_turns": 7,
+          "skill_attempts": 1,
+          "input_tokens": 12,
+          "cached_input_tokens": 75988,
+          "output_tokens": 2026,
+          "skill_cost_usd": 0.17182389999999997,
+          "output": {
+            "text_response": "I need to stop before executing this merge \u2014 the data shows these are **not** the same person, and proceeding would be a destructive mistake.\n\n---\n\n## \u26d4 Merge Blocked \u2014 These Are Two Different People\n\nHere's what the tree and research files actually show:\n\n| | **I1 \u2013 Patrick Flynn** | **I2 \u2013 Thomas Flynn** |\n|---|---|---|\n| Birth | ca. 1845, Ireland | ca. 1818, Ireland |\n| Death | 12 March 1908, Schuylkill Co., PA | \u2014 |\n| Role in project | **Subject** (whose parents are being researched) | **Candidate father** |\n\n**Their birth years differ by ~27 years.** Thomas is old enough to be Patrick's father \u2014 because he *is* Patrick's father, according to everything in this project:\n\n- **R1** already records a **ParentChild** relationship \u2014 Thomas (I2) \u2192 Patrick (I1) \u2014 supported by three sources (1850 census S1, 1860 census S2, death cert S3).\n- **ps_001** is a completed proof summary rated **Probable** concluding: *\"Patrick Flynn is probably the son of Thomas Flynn.\"*\n- **h_001** is a supported hypothesis for exactly this parentage claim.\n\n---\n\n## Why They Keep Appearing Together\n\nThey show up together in the same records precisely *because* they're father and son:\n\n- **1850 census** (dwelling 84): Thomas as head of household, Patrick age 5 as child\n- **1860 census** (dwelling 112): Thomas as head of household, Patrick age 15\n- **1908 death certificate**: names \"Thomas Flynn\" as Patrick's father\n\nThat co-occurrence is the *evidence of their relationship*, not evidence of shared identity.\n\n---\n\n## What to Do Instead\n\nThe research is on the right track \u2014 the parent-child relationship is already in the tree and backed by a probable proof. If you'd like, I can:\n\n1. **Continue the research** \u2014 run the probate search (pli_006, Thomas Flynn's will) that's still in progress, which could upgrade this to **Proved**\n2. **Search the 1870/1880/1900 censuses** to fill the large gap in Patrick's timeline\n3. **Write a fuller proof argument** once exhaustive research is complete\n\nWould you like to pick up on any of those next steps?",
+            "activated": true,
+            "skills_invoked": [
+              "tree-edit"
+            ],
+            "tool_calls": [],
+            "files_created": [],
+            "warnings": [
+              {
+                "kind": "uncovered_tool_call",
+                "advisory": "1 of 1 MCP tool call(s) matched no fixture predicate \u2014 the skill ran against a fixture_not_found or denied/unknown-tool error. Add or fix an mcp_fixture whose args match the call.",
+                "attempted": [
+                  {
+                    "tool": "mcp__genealogy__project_context",
+                    "args": {
+                      "projectPath": "/private/var/folders/tv/yzyl0n517xj5v54fgn0c0j3h0000gn/T/eval-ut_tree_edit_007-0-0-1pxp716d"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "validators": {
+            "passed": true,
+            "results": [
+              {
+                "name": "test_id_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_log_append_only",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_entries_deleted",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_no_main_thread_subagent_only_calls",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_project_file_changes_route_through_writer_tools",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_research_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tool_allowlist",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_gedcomx_json_validates_schema",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_ownership_table",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_cross_file_person_references_resolve",
+                "passed": true,
+                "error": null
+              },
+              {
+                "name": "test_tree_edit_noop",
+                "passed": true,
+                "error": "skipped: not a tree-edit-noop scenario"
+              }
+            ]
+          },
+          "judge": {
+            "skipped": false,
+            "dimensions": [
+              {
+                "source": "base",
+                "name": "Correctness",
+                "score": 3,
+                "rationale": "The skill correctly identified that I1 and I2 are father and son, not the same person. All factual claims are supported: R1 exists and records ParentChild (Thomas\u2192Patrick), ps_001 is rated Probable and confirms parentage, birth years differ by ~27 years, and the three sources (1850/1860 census, death cert) all document the relationship. No fabricated material."
+              },
+              {
+                "source": "base",
+                "name": "Completeness",
+                "score": 3,
+                "rationale": "The skill fully addressed the user's request by refusing the merge and explaining why. It identified the key evidence (R1, ps_001, h_001, source citations), clarified the misunderstanding (co-occurrence as evidence of relationship, not identity), and offered constructive next steps. All required context from the input state was covered."
+              },
+              {
+                "source": "base",
+                "name": "Tool Arguments",
+                "score": null,
+                "rationale": "No MCP tool calls were made. The skill correctly declined to execute the merge without invoking any tools, which is the appropriate behavior when refusing an unsafe operation."
+              },
+              {
+                "source": "rubric",
+                "name": "Data preservation",
+                "score": 3,
+                "rationale": "This is a negative test (refusal case). No edits were made to tree.gedcomx.json or research.json, so all existing facts, names, and source references remain intact. The skill correctly preserved the entire state by declining the merge."
+              },
+              {
+                "source": "rubric",
+                "name": "Edit minimality",
+                "score": 3,
+                "rationale": "This is a negative test (refusal case). No edits were made at all, so there are no collateral modifications. The skill made zero changes, which is the correct minimal response to a refused merge request."
+              },
+              {
+                "source": "rubric",
+                "name": "Merge correctness",
+                "score": 3,
+                "rationale": "This is a negative test (refusal case). The skill correctly refused to execute the merge, so the merge-correctness dimension has nothing to grade. No references were rewritten, no persons were deleted, and no cross-file corruption occurred because the merge never happened."
+              },
+              {
+                "source": "rubric",
+                "name": "Evidence grounding",
+                "score": 3,
+                "rationale": "This is a negative test (refusal case). The skill correctly refused an ungrounded merge request. Per SKILL.md, merges require a proof_summary at probable+ tier confirming identity. ps_001 exists and is probable, but it confirms *parentage* (Thomas is Patrick's father), not *identity* (they are the same person). The skill correctly identified this distinction and refused to merge without an identity proof-conclusion. The skill also correctly noted that R1 (the existing ParentChild relationship) is evidence they are NOT the same person."
+              }
+            ],
+            "judge_cost_usd": 0.0028285000000000003,
+            "duration_ms": 7842.080749978777,
+            "error": null,
+            "input_tokens": 3462,
+            "cached_input_tokens": 5015,
+            "output_tokens": 776
+          },
+          "started_at": 1785435485.0040908,
+          "ended_at": 1785435542.478753
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "duration_ms": 567688.1895019324,
+    "duration_api_ms": 529293.0,
+    "judge_duration_ms": 106652.81991718803,
+    "num_turns": 77,
+    "input_tokens": 125,
+    "cached_input_tokens": 913765,
+    "output_tokens": 23608,
+    "judge_input_tokens": 57271,
+    "judge_cached_input_tokens": 45135,
+    "judge_output_tokens": 9737,
+    "skill_cost_usd": 1.5879969999999999,
+    "judge_cost_usd": 0.0653345,
+    "total_cost_usd": 1.6533315,
+    "wall_clock_ms": 172032.01723098755
+  }
+}

--- a/eval/tests/unit/tree-edit/add-occupation-fact-with-place.json
+++ b/eval/tests/unit/tree-edit/add-occupation-fact-with-place.json
@@ -5,19 +5,27 @@
     "name": "Add a new Occupation fact with place_search-resolved standard_place",
     "type": "positive",
     "description": "Patrick Flynn's 1860 census entry (source S2) records his occupation as 'Coal miner'. The mid-research-flynn scenario has S2 cited but no Occupation fact on I1. Tests adding a genuinely new fact (not a no-op verify). Per SKILL.md §'Adding a fact to a person': the skill must generate the next F-prefix ID, call place_search to resolve standard_place, and include a source reference back to S2. Per places-guidance.md, the standard_place must be the place_search result's `standardPlace` field verbatim.",
-    "tags": ["tree-edit", "add-fact", "occupation", "place_search", "standard_place"]
+    "tags": [
+      "tree-edit",
+      "add-fact",
+      "occupation",
+      "place_search",
+      "standard_place"
+    ]
   },
   "input": {
     "user_message": "tree-edit: add occupation — the 1860 census (source S2, already cited on R1) records Patrick Flynn's occupation as 'Coal miner' at Schuylkill County, Pennsylvania. Add an Occupation fact to Patrick (I1) with date 1860, the place from the source, and a source reference back to S2 with page 'dwelling 112'.",
     "scenario": "mid-research-flynn"
   },
-  "mcp_fixtures": ["place-search-schuylkill-county"],
+  "mcp_fixtures": [
+    "place-search-schuylkill-county"
+  ],
   "judge_context": [
     "Should call place_search with placeName 'Schuylkill County, Pennsylvania' and copy the first result's standardPlace verbatim into the new fact's standard_place field (per places-guidance.md)",
     "Should add a new Occupation fact to person I1 with: a fresh F-prefix id (next available — e.g., F4), type 'Occupation', date '1860', place 'Schuylkill County, Pennsylvania', standard_place matching place_search result, sources [{ ref: 'S2', page: 'dwelling 112' }]",
     "Should NOT mark the new fact `primary: true` unless it's the primary Occupation (and only Occupation) for this person — the SKILL.md primary rule only applies when there are competing facts of the same type",
     "Edit-minimality: no other facts on I1 are changed (F1 Birth and F2 Death stay byte-identical); no other person, relationship, or source is touched; research.json is not modified",
-    "Should call validate_research_schema after the edit to confirm both files remain valid",
+    "Should NOT need a separate validate_research_schema call — tree_edit, tree_correct, and merge_tree_persons all validate-before-persist (SKILL.md § Validation), and the tool is not in this skill's allowed-tools. Do not score down for omitting it; do not reward calling it.",
     "Should reuse S2 (1860 census already in tree.sources) — must NOT create a duplicate S-prefix source entry"
   ],
   "execution": {

--- a/eval/tests/unit/tree-edit/correct-typo-death-date.json
+++ b/eval/tests/unit/tree-edit/correct-typo-death-date.json
@@ -5,14 +5,20 @@
     "name": "Correct a transcription typo in a Birth fact's date — real mutation with minimality",
     "type": "positive",
     "description": "The mid-research-flynn-typo scenario seeds tree.gedcomx.json with a day-swap typo: Patrick Flynn's F2.date reads `1908-03-21`, but the cited source S3 (Pennsylvania Death Certificate no. 4521) records 12 March 1908. This is the canonical 'ad-hoc edit' case from SKILL.md §'Correcting a value': edit is verifiable against an already-cited source, so the threshold is met. Tests the edit-minimality dimension under a REAL mutation (the other no-op tests ut_001/002 never exercise mutation paths). Only F2.date must change — every other byte of both project files must be unchanged.",
-    "tags": ["tree-edit", "value-correction", "typo-fix", "edit-minimality", "real-mutation"]
+    "tags": [
+      "tree-edit",
+      "value-correction",
+      "typo-fix",
+      "edit-minimality",
+      "real-mutation"
+    ]
   },
   "input": {
     "user_message": "tree-edit: change birth year — actually, fix this date. Patrick Flynn's death fact F2 currently shows `1908-03-21` in the tree, but the death certificate (S3, cert. no. 4521) records 12 March 1908. The tree has a day-swap typo. Correct F2.date to `1908-03-12` and leave everything else alone.",
     "scenario": "mid-research-flynn-typo"
   },
   "judge_context": [
-    "Should call validate_research_schema AFTER the edit — SKILL.md §Validation requires post-edit validation (a pre-edit call is optional and not required by the SKILL.md). Judges must NOT score down for skipping a pre-edit validation call",
+    "Should NOT need a separate validate_research_schema call — tree_edit, tree_correct, and merge_tree_persons all validate-before-persist (SKILL.md § Validation), and the tool is not in this skill's allowed-tools. Do not score down for omitting it; do not reward calling it.",
     "Should change ONLY F2.date in tree.gedcomx.json from `1908-03-21` to `1908-03-12`",
     "Edit-minimality REQUIRED: no other field on F2 may change (place, sources, type, primary all stay byte-identical); no other fact (F1, F3) is touched; no other person (I2) is touched; no relationship (R1) is touched; research.json is not touched at all",
     "Should NOT 'normalize' adjacent fields opportunistically (e.g., re-resolving F2.place via place_search when only the date was wrong)",

--- a/eval/tests/unit/tree-edit/create-sibling-with-parentchild.json
+++ b/eval/tests/unit/tree-edit/create-sibling-with-parentchild.json
@@ -5,7 +5,13 @@
     "name": "Create a new person and a ParentChild relationship authorized by a probable-tier proof",
     "type": "positive",
     "description": "Per SKILL.md §'Adding a person' and §'Adding a relationship', combined with relationship-accuracy.md threshold. The merge-pending scenario has ps_003 at `probable` tier authorizing Mary Flynn as Thomas Flynn's daughter (1850 census household evidence, a_016). Mary is NOT yet in tree.gedcomx.json — this test creates her with a fresh I-prefix id, a name, and a ParentChild relationship from Thomas (I2) to her, with S1 (the 1850 census source already in tree.sources) as the relationship source.",
-    "tags": ["tree-edit", "add-person", "parentchild-relationship", "proof-authorized", "synthetic-id"]
+    "tags": [
+      "tree-edit",
+      "add-person",
+      "parentchild-relationship",
+      "proof-authorized",
+      "synthetic-id"
+    ]
   },
   "input": {
     "user_message": "tree-edit: add a relationship. Per ps_003 (probable tier), Mary Flynn is Thomas's daughter. Create Mary in the tree with the next synthetic I-prefix id (gender Female, name 'Mary Flynn' as the preferred BirthName) and add a ParentChild relationship from Thomas (I2) to Mary with S1 as the source (page 'dwelling 84, family 91'). Do NOT add any facts to Mary's person record (no Birth fact, no Residence, nothing) — sourced facts are materialized onto the tree person by person-evidence's materialize_facts (record-extraction is assertion-only), not invented here. This call creates only the person stub + the ParentChild relationship.",
@@ -18,7 +24,7 @@
     "Should NOT add a Birth fact to Mary directly from raw census data — materializing sourced facts onto a tree person is person-evidence's materialize_facts (record-extraction is assertion-only), not this ad-hoc tree-edit call. tree-edit creates the person stub + the sourced relationship edge; assertions in research.json remain the source of truth for facts",
     "Edit-minimality: no existing person, relationship, fact, or source is modified. I3, I4, and the merge-pending state stay intact (this test does not perform the pending merge)",
     "Should reference ps_003 as the proof authorization in the response — relationship-accuracy.md requires the threshold to be met before writing a relationship",
-    "Should call validate_research_schema after the edit to confirm both files remain valid"
+    "Should NOT need a separate validate_research_schema call — tree_edit, tree_correct, and merge_tree_persons all validate-before-persist (SKILL.md § Validation), and the tool is not in this skill's allowed-tools. Do not score down for omitting it; do not reward calling it."
   ],
   "execution": {
     "max_wall_clock_seconds": 600,

--- a/eval/tests/unit/tree-edit/person-merge-stub-into-fs-person.json
+++ b/eval/tests/unit/tree-edit/person-merge-stub-into-fs-person.json
@@ -5,20 +5,29 @@
     "name": "Person merge — synthetic stub into FamilySearch tree person with conflicting facts",
     "type": "positive",
     "description": "Per the SKILL.md merge protocol, ps_002 confirms I3 (\"James Flynn\" stub from 1880 census) is the same individual as I4 (FamilySearch \"James Patrick Flynn\", ark ending KWCJ-JAM7). Tests the skill's tree-side merge: combine names + facts on I4 without dropping data, then delete I3 from persons[]. I3 has Birth ~1849 Ireland; I4 has Birth ~1848 Branch Township — conflicting birth dates with no proof-specified value, so per SKILL.md §'Conflicting facts during merge' the skill must KEEP BOTH facts on I4 rather than silently discarding either. (NOTE: the research.json cross-file reference rewrite that SKILL.md Step 3 prescribes — project.subject_person_ids / person_evidence.person_id / timelines.person_ids — is owned by other skills per the harness ownership table, so tree-edit must present a plan for that side and route to person-evidence / proof-conclusion / timeline rather than mutate those sections directly.)",
-    "tags": ["tree-edit", "person-merge", "tree-side-merge", "conflict-handling", "ownership-aware"]
+    "tags": [
+      "tree-edit",
+      "person-merge",
+      "tree-side-merge",
+      "conflict-handling",
+      "ownership-aware"
+    ]
   },
   "input": {
     "user_message": "tree-edit: merge data from I3 into I4 — but only as far as tree-edit can safely go. Per proof_summary ps_002, the synthetic stub I3 (\"James Flynn\") is the same individual as the FamilySearch tree person I4 (\"James Patrick Flynn\", ark .../KWCJ-JAM7). Consolidate names + facts onto I4 (keep both conflicting birth dates — no proof specifies which to drop). Do NOT delete I3 yet — research.json still references I3 in project.subject_person_ids, person_evidence pe_007, and timelines t_002, and those sections aren't owned by tree-edit. Present the I3-deletion plan + the cross-file rewrites as work the user needs to coordinate via the owning skills before the merge can finalize.",
     "scenario": "mid-research-flynn-merge-pending"
   },
-  "mcp_fixtures": ["place-search-ireland", "place-search-schuylkill-county"],
+  "mcp_fixtures": [
+    "place-search-ireland",
+    "place-search-schuylkill-county"
+  ],
   "judge_context": [
     "Per SKILL.md merge protocol: I4 is the keep person (has the FamilySearch ark); I3 is the deprecated person",
     "Step 1 (merge person data): combine names — I3's 'James Flynn' is a subset of I4's 'James Patrick Flynn' (do not add a duplicate). Birth-fact conflict (~1849 vs ~1848) has no proof-specified value, so BOTH birth facts must survive on I4 — do NOT silently discard either",
     "Should NOT delete I3 from tree.gedcomx.json persons[] in this call — research.json still references I3 in project.subject_person_ids, person_evidence pe_007, and timelines t_002. Deleting I3 would create dangling cross-file references that the test_cross_file_person_references_resolve validator catches. Tree-edit doesn't own those research.json sections per the harness OWNERSHIP_TABLE",
     "Should explicitly present a coordination plan: which research.json sections need rewriting and which skills own them (project → init-project / proof-conclusion; person_evidence → person-evidence; timelines → timeline). The actual I3 deletion happens only after those rewrites are coordinated",
     "MERGE-CORRECTNESS GRADING NOTE for the judge: the standard rubric clause 'every reference is rewritten' does NOT apply here because tree-edit lacks ownership of the research.json sections involved (per the harness OWNERSHIP_TABLE: project belongs to init-project / proof-conclusion, person_evidence to person-evidence, timelines to timeline). The CORRECT behavior in this test is consolidate-data-on-I4 + present-plan-for-coordinated-rewrites + do-not-delete-I3-yet. Judges MUST score Merge correctness as `pass` when the skill (a) consolidates data on I4 without dropping conflicting facts, (b) leaves I3 in place pending coordination, and (c) explicitly names the owning skills that need to do the research.json rewrites. Do NOT mark partial because the rewrites weren't done — that's the entire point of the test",
-    "Should call validate_research_schema after the consolidation step and confirm both files remain valid",
+    "Should NOT need a separate validate_research_schema call — tree_edit, tree_correct, and merge_tree_persons all validate-before-persist (SKILL.md § Validation), and the tool is not in this skill's allowed-tools. Do not score down for omitting it; do not reward calling it.",
     "Should present the merge plan to the user before executing — SKILL.md 'Important rules' requires confirmation since merges are irreversible in practice"
   ],
   "execution": {

--- a/eval/tests/unit/tree-edit/rubric.md
+++ b/eval/tests/unit/tree-edit/rubric.md
@@ -20,7 +20,7 @@ Did the skill make only the requested change without modifying unrelated data? E
 
 ## Merge correctness
 
-For person merges, did the skill rewrite ALL references to the deprecated person across BOTH project files, and remove the deprecated person from `tree.gedcomx.json` `persons[]`? A missed reference creates a broken foreign key that propagates silently until `validate_research_schema` (or downstream readers) catches it.
+For person merges, did the skill rewrite ALL references to the deprecated person across BOTH project files, and remove the deprecated person from `tree.gedcomx.json` `persons[]`? A missed reference creates a broken foreign key that propagates silently until a downstream reader trips over it.
 
 The full rewrite scope is enumerated in SKILL.md §"Person merging" Step 3:
 
@@ -31,13 +31,13 @@ The full rewrite scope is enumerated in SKILL.md §"Person merging" Step 3:
 | `research.json` | `person_evidence[].person_id` |
 | `research.json` | `timelines[].person_ids` |
 
-After the rewrite, the deprecated person must be deleted from `tree.gedcomx.json` `persons[]`, and `validate_research_schema` must pass.
+After the rewrite, the deprecated person must be deleted from `tree.gedcomx.json` `persons[]`, and both project files must be left structurally valid. `merge_tree_persons` validates before persisting, so a separate `validate_research_schema` call is neither required nor available to this skill (SKILL.md § Validation).
 
 **When the test is NOT a merge** (no-op verify, value correction, add fact, create person, refuse-merge, negative routing, match-checking), this dimension has nothing to grade and scores `pass`. Judges must NOT score partial on a non-merge test for the absence of merge mechanics.
 
-- **pass:** Either (a) the test is not a merge and this dimension has nothing to grade, OR (b) every reference enumerated above is rewritten from the deprecated ID to the keep ID, the deprecated person is removed from `persons[]`, and post-merge `validate_research_schema` is clean.
+- **pass:** Either (a) the test is not a merge and this dimension has nothing to grade, OR (b) every reference enumerated above is rewritten from the deprecated ID to the keep ID, the deprecated person is removed from `persons[]`, and no unresolved cross-file reference is left behind.
 - **partial:** Most references rewritten, but one location is missed (e.g., a relationship updated and `subject_person_ids` updated but a `timelines.person_ids` entry still references the deprecated ID).
-- **fail:** Multiple references unrewritten, OR the deprecated person remains in `persons[]` after the merge, OR `validate_research_schema` surfaces an unresolved cross-file reference and the skill does not fix it.
+- **fail:** Multiple references unrewritten, OR the deprecated person remains in `persons[]` after the merge, OR an unresolved cross-file reference to the deprecated ID is left behind.
 
 ## Evidence grounding
 


### PR DESCRIPTION
Found by `check_rubric_tool_drift.py` (#915) on its first corpus run — the lint's first real catch.

## The contradiction

Three sources, two disagreeing with the skill's own contract:

| Source | Says |
|---|---|
| `tree-edit/SKILL.md:94` § Validation | *"`tree_edit`, `tree_correct`, and `merge_tree_persons` all validate-before-persist; **no separate `validate_research_schema` call is needed**"* |
| `tree-edit/SKILL.md` frontmatter | `allowed-tools` does not list `validate_research_schema` |
| 4 × `judge_context` + `rubric.md` | *"Should call `validate_research_schema` after the edit"*, and a merge-dimension pass/fail condition |

## What it actually cost — narrower than first reported

The pre-merge review of #925 characterised this as *"the judge is failing runs for not calling a tool the skill is denied."* Checking the last committed run log (`v1_2026-07-28_13-02-56`) does not support that: on `ut_tree_edit_009` the skill **made** the call and the judge **credited** it — *"called `validate_research_schema`. No required steps were omitted."*

So the live cost is a **wasted turn per edit** plus a corpus teaching against the skill body — not a hard mis-grade. Still worth fixing; the urgency is lower than the review implied, and this PR says so rather than repeating the stronger claim.

## Changes

- **4 `judge_context` lines** (`add-occupation-fact-with-place`, `person-merge-stub-into-fs-person`, `create-sibling-with-parentchild`, `correct-typo-death-date`) now state the contract and tell the judge not to score either way on it.
- **`rubric.md`** merge dimension grades the observable state — no unresolved cross-file reference to the deprecated ID — rather than a validator call. The descriptive line 23 mention is reworded too, so the lint clears rather than leaving a hit that trains people to skim.

## Before merge

**Needs a fresh tree-edit run + annotation.** Touching `rubric.md` and four test files flips the committed run log inactive (`check_runlogs.py` Rule 2). This is not eligible for `eval-cosmetic-skip` — it changes how the judge grades.

```
uv run python eval/harness/run_tests.py --skill tree-edit
```

Then annotate the new run log in the CRUD UI.

## Related

`research-exhaustiveness` and `init-project` rubrics carry the same defect (both name `validate_research_schema` without holding it). Not fixed here — each costs its own run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)