### PR TITLE
docs: drop the person-evidence epistemic gate entry — it is issue #738

### DIFF
--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -278,11 +278,6 @@ Deferred at wrap; see
   scenarios; judges penalize the thin tree). Needs an ownership spec:
   `merge_record_into_tree` grows this, or person-evidence does.
 
-- [ ] **person-evidence epistemic gate** — identity over-reach: pe links
-  written at `confident` from one uncorroborated record with `[?]` readings
-  (clark-parents). The extractor agent got a tentative-cap line; person-evidence
-  needs the equivalent gate + mandatory conflicts entry.
-
 - [ ] **Recover the classification-quality drop from the sonnet-4-6 pin.** The
   extractor was re-pinned sonnet-5 → `claude-sonnet-4-6` (2026-07-18) because sonnet-5
   hangs at Cowork/e2e `effortLevel: high` (adaptive-thinking runaway); the 8k


### PR DESCRIPTION
Applies the rule #982 just added: **an entry leaves `TODOs.md` when it becomes an issue**, not when the work ships. This is the first entry to hit that exit event since the rule landed.

## Why this one is safe to delete

The entry named two things person-evidence needed. Both are accounted for — I checked rather than assuming:

| Half | Status |
|---|---|
| the **gate** | **Shipped.** `personEvidenceInvariants` is wired for the `person_evidence` section in `research-append.ts` (on append, and on any update raising confidence to `confident`), and refuses `confident` when the linked assertion carries a `[?]` reading with no corroborating record. |
| **mandatory conflicts entry** | **Issue #738**, carded in Backlog and assigned. |

Nothing is lost: the shipped half is enforced in code with an explanatory comment at the site it constrains, and the open half is tracked where the team actually picks work up. #738's body already carries the rationale for why it was split rather than shipped with the cap — no precedent exists for requiring a companion write to another section, so it needs cross-op batch inspection plus a decision on the lone-append case.

`52 → 51` entries, `549 → 547` lines.

## Context

Found while reconciling the project board: #738 was simultaneously a `TODOs.md` entry and a Backlog card, which is exactly the double-tracking #982 set out to end. Companion to #979/#983, which made board membership automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)