### PR TITLE
ci(labeler): label PRs that touch Python as `developer`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,14 @@
+# Path-based PR labels, applied by .github/workflows/labeler.yml
+# (actions/labeler v5 config format).
+#
+# Keep this list short. A label here only earns its place if someone
+# actually filters or routes on it.
+
+# Python is the developer-facing half of this repo — the eval harness
+# (eval/harness, eval/triggering) and the FastAPI control plane
+# (apps/server). Nothing a genealogist reviews is written in Python, so
+# "touches a .py file" is a reliable proxy for "needs a developer's eyes".
+developer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.py'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,34 @@
+name: labeler
+
+# Applies path-based labels to PRs from .github/labeler.yml.
+# Today that is one rule: any PR touching a *.py file gets `developer`.
+#
+# `sync-labels: true` means the label tracks the diff rather than the PR's
+# history — push a commit that drops the last .py change and the label comes
+# off. That also means a human cannot hand-apply `developer` to a PR with no
+# Python in it: the next push will strip it. If you want a label that sticks,
+# it does not belong in labeler.yml.
+#
+# TRIGGER CHOICE: `pull_request`, not `pull_request_target`. The labeler docs
+# suggest the latter because it is the only way to get a writable token on a
+# PR from a fork. This repo has never taken a fork PR (0 of the last 30 were
+# cross-repository) — every branch lives here. If that changes, a fork PR will
+# fail this job red with a 403 on the label write, which is the loud failure
+# we want; switch to `pull_request_target` at that point, and only then. It is
+# safe for this action specifically (labeler v5 checks out no PR code), but it
+# runs with repo secrets in scope, so it is not a default worth carrying.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/labeler.yml` + `.github/labeler.yml`, which put a
  `developer` label on any PR whose diff includes a `**/*.py` file.
- Python here is entirely developer-facing — the eval harness
  (`eval/harness`, `eval/triggering`) and the FastAPI control plane
  (`apps/server`). Nothing a genealogist reviews is written in it, so
  "touches a .py file" is a usable proxy for "needs a developer's eyes."
- The `developer` label was created on the repo out-of-band
  (`gh label create developer --color 0052CC`), so the API doesn't
  auto-create a random-colored one on first use.

Two choices worth a reviewer's attention, both documented inline:

- **`pull_request`, not `pull_request_target`.** The labeler docs suggest the
  latter, but its only purpose is a writable token on fork PRs — 0 of the last
  30 PRs here were cross-repository, and it runs with repo secrets in scope.
  A fork PR will fail this job red on a 403, which is the signal to switch.
- **`sync-labels: true`.** The label tracks the current diff, so it comes off
  when the last `.py` change does. Side effect: `developer` cannot be
  hand-applied to a Python-free PR — the next push strips it.

Scope is `**/*.py` only. Widening to `pyproject.toml` / `uv.lock` /
`requirements*.txt` is a three-line change to `labeler.yml` if wanted.

## Test plan

- [ ] ~~`scripts/test.sh`~~ — n/a, no application code changed; this is CI
      config only, and no suite covers workflow YAML.
- [ ] ~~`RunTests.bat <skill>`~~ — n/a, no skill files touched.
- [x] Both YAML files parse (`yaml.safe_load`).
- [x] Negative case verified by this PR itself: it touches no `.py` files, so
      the `labeler` job should run green and leave it **unlabeled**.
- [ ] Positive case lands with the next PR that touches Python — check that
      `developer` appears on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)