### PR TITLE
deps: close 19 of 24 Dependabot alerts (1 critical, 13 of 16 high) + add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,140 @@
+# Dependabot configuration.
+#
+# Until this file existed, GitHub raised security *alerts* from the dependency
+# graph but nothing opened routine version-update PRs — which is how 24 open
+# alerts accumulated by 2026-07-31 (see docs/dependency-security-advisories.md).
+# Most of them turned out to be a plain lockfile refresh that no upstream
+# constraint was blocking; they were open only because nobody ran the refresh.
+#
+# Everything is grouped and weekly. A separate PR per dependency across five
+# manifests is how a config like this gets muted, so minor/patch updates land as
+# one grouped PR per ecosystem and only majors arrive individually — a major is
+# the one that deserves to be read.
+#
+# ── Pins that must NOT be floated ─────────────────────────────────────────────
+# Two upper bounds in eval/harness/pyproject.toml are load-bearing and have
+# explicit `ignore` rules below. They are correctness pins, not staleness:
+#
+#   mcp>=1.29,<2          mcp 2.0.0 removed/renamed Server.list_tools, which
+#                         claude_agent_sdk.create_sdk_mcp_server calls. It broke
+#                         CI the day it shipped (PR #932). Delete the ignore only
+#                         when claude-agent-sdk itself supports mcp 2.x.
+#   claude-agent-sdk<0.2  workspace.py depends on behavior present since 0.1.x.
+#                         For a 0.x package Dependabot classifies 0.1 -> 0.2 as
+#                         semver-MINOR, so the ignore must cover minor as well as
+#                         major or the bound gets raised anyway.
+#
+# Both ignores are scoped to `version-update:*` update-types, so they suppress
+# only routine version bumps — a genuine *security* advisory on either package
+# still opens a PR.
+#
+# ── Engine lockfile caveat ────────────────────────────────────────────────────
+# packages/engine/mcp-server pins `npm@11.12.1` via its packageManager field, and
+# .github/workflows/check-engine-lockfile.yml fails any PR whose lockfile would be
+# rewritten by that exact npm. Dependabot resolves with its own npm build, so an
+# engine PR from Dependabot can trip that gate through no fault of the bump. The
+# fix is mechanical, not a reason to distrust the PR: check the branch out, run
+# `npm install` under npm 11.12.1, and commit the re-normalized lockfile.
+
+version: 2
+
+updates:
+  # ── JavaScript / TypeScript ─────────────────────────────────────────────────
+  # Three separate trees by design (see CLAUDE.md): the root pnpm workspace for
+  # the web/electron side, and two npm-managed trees — the engine, kept out of
+  # the workspace so the .mcpb release pipeline is untouched, and the Eval CRUD
+  # UI. Dependabot reads pnpm-lock.yaml and package-lock.json alike.
+  - package-ecosystem: npm
+    directories:
+      - "/"
+      - "/packages/engine/mcp-server"
+      - "/eval/app"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - javascript
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # ── GitHub Actions ──────────────────────────────────────────────────────────
+  # Action majors (actions/checkout@v5, setup-node@v4, …) drift silently and are
+  # a supply-chain surface; group them so the bump is one reviewable PR.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # ── Python: hosted control plane (apps/server) ──────────────────────────────
+  - package-ecosystem: uv
+    directory: "/apps/server"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python:uv
+      - developer
+    commit-message:
+      prefix: "deps(server)"
+    groups:
+      uv-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # ── Python: eval harness ────────────────────────────────────────────────────
+  # CI runs `uv sync --frozen` / `uv run --frozen` (PR #932), so the committed
+  # uv.lock is authoritative and never re-resolved on CI. That makes a Dependabot
+  # PR the deliberate, reviewable way this lock moves — which is the point.
+  - package-ecosystem: uv
+    directory: "/eval/harness"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python:uv
+      - developer
+    commit-message:
+      prefix: "deps(eval)"
+    ignore:
+      # See "Pins that must NOT be floated" above. Security updates still fire.
+      - dependency-name: mcp
+        update-types:
+          - version-update:semver-major
+      - dependency-name: claude-agent-sdk
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+    groups:
+      uv-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,6 +85,34 @@ updates:
         patterns:
           - "*"
 
+  # ── Container base images ───────────────────────────────────────────────────
+  # /deploy is the production Fly path (`fly deploy --dockerfile deploy/Dockerfile`,
+  # see the Makefile); /apps/server/sandbox is the E2B sandbox image.
+  #
+  # Scope this honestly: both files pin *floating* tags (node:22-bookworm-slim,
+  # python:3.12-slim-bookworm, ubuntu:24.04), not digests, so Dependabot will
+  # propose tag moves — python 3.12 -> 3.13, ubuntu 24.04 -> 26.04 — and nothing
+  # else. Patch-level base-image CVEs land via upstream rebuilding the same tag,
+  # which a rebuild picks up and Dependabot never sees. This entry is cheap and
+  # worth having; it is NOT a base-image security net. Pin by digest if that is
+  # ever wanted, and Dependabot will track digests instead.
+  - package-ecosystem: docker
+    directories:
+      - "/deploy"
+      - "/apps/server/sandbox"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "ci(docker)"
+    groups:
+      docker-base-images:
+        patterns:
+          - "*"
+
   # ── Python: hosted control plane (apps/server) ──────────────────────────────
   - package-ecosystem: uv
     directory: "/apps/server"

--- a/docs/dependency-security-advisories.md
+++ b/docs/dependency-security-advisories.md
@@ -131,9 +131,24 @@ shipped artifact. Weigh fix churn against that before treating a HIGH as urgent.
 Until then GitHub raised security *alerts* from the dependency graph but nothing
 opened routine version-update PRs — which is how 24 open alerts accumulated, most
 of them a plain lockfile refresh that no upstream constraint was blocking. The
-config covers five manifests across three ecosystems (`npm` × 3 directories,
-`github-actions`, `uv` × 2), weekly, with minor/patch grouped into one PR per
-ecosystem so majors are the ones that arrive individually.
+config covers seven manifests across five ecosystems (`npm` × 3 directories,
+`github-actions`, `docker` × 2, `uv` × 2), weekly, with minor/patch grouped into
+one PR per ecosystem so majors are the ones that arrive individually.
+
+That grouping *is* the safety mechanism, and it is worth stating why. Dependabot
+has no semantic knowledge of this codebase — it reads version ranges, so it will
+propose a major that typechecks and still breaks behavior (`mcp` 2.0.0 removing
+`Server.list_tools` is exactly that shape). Grouping minor/patch means every
+**major arrives as its own individual PR**, never buried in a batch. Read those,
+especially for the engine's production dependencies, which ship inside the
+`.mcpb`, and hardest of all for `@modelcontextprotocol/sdk` — same failure class
+as the mcp break, and it ships. Note also that no CI job exercises the Cowork
+plugin path; run `make agent-smoke` before merging an Agent-SDK-chain major.
+
+The `docker` entry is deliberately narrow. Both Dockerfiles pin *floating* tags,
+not digests, so it catches tag moves (`python:3.12` → `3.13`) and nothing else —
+patch-level base-image CVEs land when upstream rebuilds the same tag, which a
+rebuild picks up and Dependabot never sees. Pin by digest if that ever matters.
 
 Two `ignore` rules protect load-bearing upper bounds in
 `eval/harness/pyproject.toml` — `mcp>=1.29,<2` (PR #932; mcp 2.0.0 removed

--- a/docs/dependency-security-advisories.md
+++ b/docs/dependency-security-advisories.md
@@ -4,9 +4,62 @@ Tracking note for `pnpm audit` / `npm audit` findings across the repo's three JS
 dependency trees (root pnpm workspace, `packages/engine/mcp-server` npm,
 `eval/app` npm). Re-run the audits after any dependency bump and update this file.
 
-Last reviewed: **2026-07-07**.
+Last reviewed: **2026-07-31**.
+
+**Reachability, once, up front.** Every finding below except `fast-uri` lives in a
+**devDependency** — dev tooling (eslint, vite/vitest, electron-builder,
+`@anthropic-ai/mcpb`) or the internal-only Eval CRUD UI. `pnpm why --prod` returns
+*nothing* for every vulnerable package in the workspace. The `.mcpb` is built with
+`npm ci --omit=dev` (`scripts/build-mcpb.mjs`), so dev-tree findings never reach a
+shipped artifact. Weigh fix churn against that before treating a HIGH as urgent.
 
 ## Fixed
+
+- **tar** (CRITICAL GHSA-23hp-3jrh-7fpw + HIGH GHSA-8x88-c5mf-7j5w + 3 MODERATE),
+  **postcss** (HIGH GHSA-r28c-9q8g-f849, source-map path traversal),
+  **js-yaml** (HIGH GHSA-52cp-r559-cp3m), **fast-uri** (HIGH GHSA-4c8g-83qw-93j6 +
+  GHSA-v2hh-gcrm-f6hx, host confusion), **brace-expansion** (HIGH
+  GHSA-3jxr-9vmj-r5cp) — root pnpm workspace, all dev-only (electron-builder,
+  eslint, vite/vitest). Fixed 2026-07-31 by a **targeted lockfile refresh**, no
+  manifest change: every parent range already permitted the patched version.
+
+      pnpm update -r --depth Infinity tar postcss js-yaml brace-expansion fast-uri
+
+  tar 7.5.16 → 7.5.22, postcss 8.5.15 → 8.5.25, js-yaml 4.2.0 → 4.3.0,
+  fast-uri 3.1.2 → 3.1.5, brace-expansion 1.1.15 → 1.1.18 / 2.1.1 → 2.1.4 /
+  5.0.6 → 5.0.9. Churn: 8 target packages plus `nanoid` (a postcss dep) and a
+  seventh `fs-extra` copy.
+
+- **fast-uri** (HIGH ×2, as above) and **postcss** (HIGH) —
+  `packages/engine/mcp-server`. Fixed 2026-07-31 by
+  `npm update --package-lock-only fast-uri postcss` (npm 11.12.1, the
+  `packageManager` pin). Four lockfile entries, no `package.json` change;
+  `check-engine-lockfile` verified idempotent. **`fast-uri` is the one finding in
+  this file that ships** — it is a prod dep via `@modelcontextprotocol/sdk` → `ajv`
+  and is bundled into the `.mcpb`. Exploitability is still low: `ajv` uses it only
+  to resolve `$id`/`$ref` in our own static tool schemas, never an attacker-supplied
+  URL.
+
+- **postcss** (HIGH GHSA-r28c-9q8g-f849 + HIGH GHSA-6g55-p6wh-862q + MODERATE
+  GHSA-qx2v-qp2m-jg93) and **sharp** (HIGH GHSA-f88m-g3jw-g9cj, inherited libvips
+  CVEs) — `eval/app`. Fixed 2026-07-31 by npm `overrides`. **This supersedes the
+  earlier deferral of the postcss finding**, whose stated cost no longer holds (see
+  below). `next` pins `postcss` at exactly `8.4.31` and `sharp` at `^0.34.3`, and
+  **upgrading `next` does not help** — `next@16.2.12` still pins postcss `8.4.31`
+  and sharp `^0.34.5`. An override is the only route:
+
+      "postcss": "$postcss",   // + the direct devDep raised to ^8.5.25
+      "sharp": "^0.35.3"
+
+  The `$postcss` form is required: npm rejects a literal override that conflicts
+  with a direct dependency (`EOVERRIDE`). Result: next's nested `postcss@8.4.31`
+  disappears entirely (dedupes to one 8.5.25) and sharp → 0.35.3. Churn was **31
+  lockfile entries, 28 of them sharp's platform binaries** — *not* the ~113
+  dev-toolchain packages the 2026-07-07 note predicted. That estimate was correct
+  when written and went stale: the lockfile has since been refreshed
+  independently, so the re-resolve no longer moves vitest/playwright/rollup/tsx.
+  Verified with `npm ci` + 134 tests + `tsc --noEmit` + a full `next build`.
+
 - **form-data** (HIGH, GHSA-hmw2-7cc7-3qxx, CRLF injection) — root pnpm
   workspace, pulled transitively by `electron-builder` → `electron-publish`
   (build/publish tooling in `apps/electron`; not in the running app or the MCP
@@ -16,32 +69,68 @@ Last reviewed: **2026-07-07**.
 
 ## Deferred / no clean fix
 
-- **postcss** (MODERATE, GHSA-qx2v-qp2m-jg93, XSS via unescaped `</style>` in CSS
-  stringify) — `eval/app` only, via `next`'s internally pinned `postcss@8.4.31`.
-  **Deferred.** `next` 15.5.18/.19/.20 all pin the vulnerable exact version, so a
-  safe patch bump doesn't help. An npm `overrides` entry *does* fix it (dedupes to
-  the already-present patched 8.5.16 → 0 vulnerabilities), but npm won't apply a
-  new override to an already-locked exact pin without a full re-resolve, which
-  drifts ~113 unrelated dev-toolchain packages (vitest, playwright, rollup,
-  typescript-eslint, tsx…) and rewrites platform-binary entries. Not worth that
-  churn for a moderate CSS-stringify XSS in an internal-only dev tool (the Eval
-  CRUD UI is never shipped or deployed).
-  **Revisit when** `eval/app` needs a routine lockfile refresh anyway, or on the
-  next `next` major bump (16+, which ships a patched postcss natively).
+- **brace-expansion** (HIGH, GHSA-mh99-v99m-4gvg, unbounded-expansion OOM DoS) —
+  root pnpm workspace, dev-only (eslint's `minimatch@3.1.5`, electron-builder's
+  `minimatch@9`). **Partially unfixable — read the range carefully.** Unlike the
+  sibling advisory GHSA-3jxr-9vmj-r5cp, which was backported to each release line
+  (1.1.16 / 2.1.2 / 5.0.7), this one publishes a **single** range `<= 5.0.7`
+  patched **only** at `5.0.8`. By plain semver that range swallows the entire 1.x
+  and 2.x lines, so `brace-expansion@1.1.18` and `@2.1.4` stay flagged forever and
+  the refresh above cannot clear the alert. Closing it would mean overriding
+  `minimatch@3.x`/`@9.x` consumers onto `brace-expansion@5` — three majors, a
+  changed `balanced-match` peer and a narrowed `engines` field — for a DoS in a
+  glob expander that only ever sees our own hardcoded patterns (EPSS 0.0034).
+  **Not worth it.**
+  **Revisit when** a 1.x/2.x backport is published, or when eslint/electron-builder
+  move to a minimatch that depends on `brace-expansion@^5`.
 
-- **tmp** (HIGH, GHSA-52f5-9888-hmc6 + GHSA-ph9p-34f9-6g65, symlink /
+- **tmp** (HIGH GHSA-ph9p-34f9-6g65 + LOW GHSA-52f5-9888-hmc6, symlink /
   path-traversal write) — `packages/engine/mcp-server` only, via
   `@anthropic-ai/mcpb` → `@inquirer/prompts` → `@inquirer/editor` →
-  `external-editor` → `tmp`. **No fix available.** We are already on the newest
-  `@anthropic-ai/mcpb` (2.1.2), whose `@inquirer` chain pins the old `tmp`; no
-  patched release exists. `@anthropic-ai/mcpb` is a devDependency used only to
-  build the `.mcpb` desktop extension — it is not shipped in the MCP server
-  runtime or any deployed artifact.
+  `external-editor` → `tmp@0.0.33`. **No clean fix available.** We are already on
+  the newest `@anthropic-ai/mcpb` (2.1.2), which pins `@inquirer/prompts@^6.0.1`;
+  `external-editor@3.1.0` in turn requires `tmp@^0.0.33`, hard-pinning the 0.0.x
+  line. Newer `@inquirer/editor` dropped `external-editor` for
+  `@inquirer/external-editor` (no `tmp` at all), but the `^6.0.1` pin cannot reach
+  it. An `overrides: {"tmp": "^0.2.7"}` would probably work — `fileSync` and
+  `setGracefulCleanup` both survive into 0.2.x — but it is an untested API gamble
+  across a package we only invoke to pack the extension.
+  `@anthropic-ai/mcpb` is a devDependency used only to build the `.mcpb` desktop
+  extension — `npm ci --omit=dev` means it is not shipped in the MCP server runtime
+  or any deployed artifact.
   **Revisit when** `@anthropic-ai/mcpb` publishes a release that bumps the
   `@inquirer`/`tmp` chain.
 
+- **@hono/node-server** (MODERATE, GHSA-frvp-7c67-39w9, `serve-static` path
+  traversal on Windows via encoded backslash) — `packages/engine/mcp-server`,
+  1.19.14, pulled by `@modelcontextprotocol/sdk`. **Deliberately deferred
+  2026-07-31.** The patch is 2.0.5, i.e. a **major** bump of a prod dep that ships
+  in the `.mcpb`. The SDK does permit it (`"@hono/node-server": "^1.19.9 ||
+  ^2.0.5"`), but the vulnerable code is unreachable here: `src/index.ts` uses
+  `StdioServerTransport`, so the SDK's HTTP/SSE transport — the only thing that
+  imports hono — is never loaded. The bump would buy no real security and add
+  major-version risk to the shipped artifact.
+  *Historical note:* PR #920 is titled "bump @hono/node-server … to 2.0.12" but
+  **did not** move it — the merged lockfile still reads 1.19.14. Dependabot bumped
+  only the SDK (1.29.0 → 1.30.0), which widened the *declared* range. Don't read
+  that PR title as evidence hono 2 was ever exercised here.
+  **Revisit when** the server grows an HTTP/SSE transport, or on the next SDK major.
+
 - **esbuild** (LOW, GHSA-g7r4-m6w7-qqqr, dev-server arbitrary file read,
   **Windows only**) — root pnpm workspace, bundled by `vite@7.3.5`. **Deferred.**
-  Affects only the running dev server on Windows; `vite` pins its esbuild, so an
-  override risks a vite/esbuild version mismatch for near-zero security gain.
-  **Revisit when** `vite` is upgraded to a release bundling esbuild ≥ 0.28.1.
+  Affects only the running dev server on Windows; `vite@7.3.5` pins
+  `esbuild@^0.27.0` and the patch is 0.28.1, out of range. Clearing it needs a
+  vite 7 → 8 migration across `apps/web`, `packages/viewer-ui` and
+  `apps/electron` (vite 8 drops the esbuild dependency for rolldown) — a real
+  migration, not a dep bump, for near-zero security gain.
+  **Revisit when** the workspace moves to vite 8 for unrelated reasons.
+
+## Not configured: automated dependency updates
+
+There is **no `.github/dependabot.yml`** in this repo. GitHub still raises security
+*alerts* from the dependency graph, but nothing opens routine version-update PRs,
+which is how 24 open alerts accumulated by 2026-07-31. Adding a config for the
+three JS manifests (plus `github-actions`, and `uv`/pip for `apps/server` and
+`eval/harness`) would keep this file short. Note that `eval/harness` deliberately
+pins `mcp>=1.29,<2` and runs `uv sync --frozen` (PR #932) — any Dependabot config
+must not be allowed to float that pin.

--- a/docs/dependency-security-advisories.md
+++ b/docs/dependency-security-advisories.md
@@ -131,8 +131,10 @@ shipped artifact. Weigh fix churn against that before treating a HIGH as urgent.
 Until then GitHub raised security *alerts* from the dependency graph but nothing
 opened routine version-update PRs — which is how 24 open alerts accumulated, most
 of them a plain lockfile refresh that no upstream constraint was blocking. The
-config covers seven manifests across five ecosystems (`npm` × 3 directories,
-`github-actions`, `docker` × 2, `uv` × 2), weekly, with minor/patch grouped into
+config covers **four ecosystems in five update blocks** — `npm` (the three
+package.json trees), `github-actions` (`.github/workflows`), `docker` (both
+Dockerfiles), and `uv` twice (`apps/server` and `eval/harness`, split so the
+harness can carry its own `ignore` rules). Weekly, with minor/patch grouped into
 one PR per ecosystem so majors are the ones that arrive individually.
 
 That grouping *is* the safety mechanism, and it is worth stating why. Dependabot

--- a/docs/dependency-security-advisories.md
+++ b/docs/dependency-security-advisories.md
@@ -125,12 +125,27 @@ shipped artifact. Weigh fix churn against that before treating a HIGH as urgent.
   migration, not a dep bump, for near-zero security gain.
   **Revisit when** the workspace moves to vite 8 for unrelated reasons.
 
-## Not configured: automated dependency updates
+## Automated dependency updates
 
-There is **no `.github/dependabot.yml`** in this repo. GitHub still raises security
-*alerts* from the dependency graph, but nothing opens routine version-update PRs,
-which is how 24 open alerts accumulated by 2026-07-31. Adding a config for the
-three JS manifests (plus `github-actions`, and `uv`/pip for `apps/server` and
-`eval/harness`) would keep this file short. Note that `eval/harness` deliberately
-pins `mcp>=1.29,<2` and runs `uv sync --frozen` (PR #932) — any Dependabot config
-must not be allowed to float that pin.
+`.github/dependabot.yml` was added 2026-07-31, in the same PR as the fixes above.
+Until then GitHub raised security *alerts* from the dependency graph but nothing
+opened routine version-update PRs — which is how 24 open alerts accumulated, most
+of them a plain lockfile refresh that no upstream constraint was blocking. The
+config covers five manifests across three ecosystems (`npm` × 3 directories,
+`github-actions`, `uv` × 2), weekly, with minor/patch grouped into one PR per
+ecosystem so majors are the ones that arrive individually.
+
+Two `ignore` rules protect load-bearing upper bounds in
+`eval/harness/pyproject.toml` — `mcp>=1.29,<2` (PR #932; mcp 2.0.0 removed
+`Server.list_tools`, which `claude_agent_sdk.create_sdk_mcp_server` calls) and
+`claude-agent-sdk<0.2`. Both are scoped to `version-update:*`, so a genuine
+security advisory on either package still opens a PR. Note that Dependabot
+classifies `0.1 → 0.2` as semver-**minor** for a 0.x package, so the
+`claude-agent-sdk` ignore must cover minor as well as major.
+
+One known rough edge: `packages/engine/mcp-server` pins `npm@11.12.1` and
+`check-engine-lockfile.yml` fails any PR whose lockfile that exact npm would
+rewrite. Dependabot resolves with its own npm, so an engine PR can trip the gate
+through no fault of the bump — check the branch out, run `npm install` under
+11.12.1, commit the re-normalized lockfile. See the header comment in
+`dependabot.yml`.

--- a/eval/app/package-lock.json
+++ b/eval/app/package-lock.json
@@ -30,7 +30,7 @@
         "eslint": "^9.17.0",
         "eslint-config-next": "16.2.11",
         "json-schema-to-zod": "2.6.1",
-        "postcss": "^8.4.49",
+        "postcss": "^8.5.25",
         "postcss-preset-mantine": "^1.17.0",
         "postcss-simple-vars": "^7.0.1",
         "tsx": "^4.19.2",
@@ -1153,9 +1153,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -1165,19 +1165,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -1187,19 +1187,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -1213,9 +1232,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -1229,9 +1248,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -1248,9 +1267,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -1267,9 +1286,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -1286,9 +1305,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -1305,9 +1324,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -1324,9 +1343,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -1343,9 +1362,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -1362,9 +1381,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -1381,9 +1400,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -1396,19 +1415,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -1421,19 +1440,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -1446,19 +1465,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1471,19 +1490,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -1496,19 +1515,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -1521,19 +1540,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -1546,19 +1565,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -1571,38 +1590,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -1612,16 +1647,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -1631,16 +1666,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -1650,7 +1685,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -6688,9 +6723,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -6778,34 +6813,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-exports-info": {
@@ -7164,10 +7171,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
-      "dev": true,
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7184,7 +7190,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7858,54 +7864,59 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "optional": true,
       "bin": {

--- a/eval/app/package.json
+++ b/eval/app/package.json
@@ -37,7 +37,7 @@
     "eslint": "^9.17.0",
     "eslint-config-next": "16.2.11",
     "json-schema-to-zod": "2.6.1",
-    "postcss": "^8.4.49",
+    "postcss": "^8.5.25",
     "postcss-preset-mantine": "^1.17.0",
     "postcss-simple-vars": "^7.0.1",
     "tsx": "^4.19.2",
@@ -45,6 +45,8 @@
     "vitest": "^4.1.9"
   },
   "overrides": {
-    "react-textarea-autosize": "8.5.9"
+    "react-textarea-autosize": "8.5.9",
+    "postcss": "$postcss",
+    "sharp": "^0.35.3"
   }
 }

--- a/packages/engine/mcp-server/package-lock.json
+++ b/packages/engine/mcp-server/package-lock.json
@@ -1683,9 +1683,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -2463,9 +2463,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2707,9 +2707,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -2727,7 +2727,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1393,15 +1393,15 @@ packages:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -1932,8 +1932,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
@@ -1994,6 +1994,10 @@ packages:
 
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.4.0:
+    resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
     engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
@@ -2381,8 +2385,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@27.4.0:
@@ -2727,8 +2731,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2902,8 +2906,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
@@ -3331,8 +3335,8 @@ packages:
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   temp-file@3.4.0:
@@ -3988,7 +3992,7 @@ snapshots:
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
       semver: 7.8.5
-      tar: 7.5.16
+      tar: 7.5.22
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
@@ -4009,7 +4013,7 @@ snapshots:
     dependencies:
       cross-dirname: 0.1.0
       debug: 4.4.3
-      fs-extra: 11.3.5
+      fs-extra: 11.4.0
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
     transitivePeerDependencies:
@@ -4203,7 +4207,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -4726,7 +4730,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4773,7 +4777,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -4782,7 +4786,7 @@ snapshots:
       proper-lockfile: 4.1.2
       resedit: 1.7.2
       semver: 7.7.4
-      tar: 7.5.16
+      tar: 7.5.22
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
       unzipper: 0.12.3
@@ -4904,16 +4908,16 @@ snapshots:
   boolean@3.2.0:
     optional: true
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4951,7 +4955,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -4976,7 +4980,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       p-map: 7.0.4
       ssri: 12.0.0
-      tar: 7.5.16
+      tar: 7.5.22
       unique-filename: 4.0.0
 
   cacheable-lookup@5.0.4: {}
@@ -5199,7 +5203,7 @@ snapshots:
       app-builder-lib: 26.15.0(dmg-builder@26.15.0)(electron-builder-squirrel-windows@26.15.0)
       builder-util: 26.15.0
       fs-extra: 10.1.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
@@ -5646,7 +5650,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.5: {}
 
   fd-slicer@1.1.0:
     dependencies:
@@ -5717,6 +5721,13 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
+
+  fs-extra@11.4.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+    optional: true
 
   fs-extra@7.0.1:
     dependencies:
@@ -6142,7 +6153,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -6658,19 +6669,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -6714,7 +6725,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -6744,7 +6755,7 @@ snapshots:
       nopt: 8.1.0
       proc-log: 5.0.0
       semver: 7.8.5
-      tar: 7.5.16
+      tar: 7.5.22
       tinyglobby: 0.2.17
       which: 5.0.0
     transitivePeerDependencies:
@@ -6907,9 +6918,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.15:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7447,7 +7458,7 @@ snapshots:
 
   tabbable@6.4.0: {}
 
-  tar@7.5.16:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -7692,7 +7703,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.25
       rollup: 4.61.1
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
Targeted dependency-security refresh across all three JS trees, plus the `dependabot.yml` that was missing. Closes the **1 critical** alert and **13 of 16 high**.

| Severity | Closed |
|---|---|
| Critical | **1/1** (#76 tar) |
| High | **13/16** |
| Moderate | 4/5 |
| Low | 0/2 |

Verified per-alert by evaluating each advisory's version range against the new lockfiles, not by assumption.

Two commits (squash-merging, so this is just for review order):
1. `deps:` — the three lockfiles + a 6-line `eval/app` manifest edit
2. `ci:` — `.github/dependabot.yml`

## Reachability, up front

Every finding here **except `fast-uri` is a devDependency**. `pnpm why --prod` returns nothing for all of them, and the `.mcpb` is built with `npm ci --omit=dev`, so dev-tree findings never reach a shipped artifact. `fast-uri` is the sole exception — it ships via `@modelcontextprotocol/sdk` → `ajv`, though `ajv` only uses it to resolve `$id`/`$ref` in our own static tool schemas, never an attacker-supplied URL.

## What changed

**pnpm workspace (13 alerts)** — lockfile refresh only; every parent range already permitted the patch:

```
pnpm update -r --depth Infinity tar postcss js-yaml brace-expansion fast-uri
```

tar 7.5.16 → 7.5.22 (closes **CRITICAL** GHSA-23hp-3jrh-7fpw), postcss 8.5.15 → 8.5.25, js-yaml 4.2.0 → 4.3.0, fast-uri 3.1.2 → 3.1.5, brace-expansion 1.1.15 → 1.1.18 / 2.1.1 → 2.1.4 / 5.0.6 → 5.0.9.

**mcp-server (4 alerts)** — `npm update --package-lock-only fast-uri postcss` under the pinned npm 11.12.1. Four lockfile entries, `package.json` untouched; `check-engine-lockfile` green.

**eval/app (4 alerts)** — npm `overrides`, because `next` pins postcss at exactly `8.4.31` and sharp at `^0.34.3`, and **upgrading `next` does not help** (`next@16.2.12` still pins postcss `8.4.31`, sharp `^0.34.5`). The `$postcss` form is required — a literal override conflicting with a direct dep is an `EOVERRIDE`. next's nested `postcss@8.4.31` now dedupes away entirely.

This supersedes the 2026-07-07 deferral of that postcss finding, whose "~113 packages of drift" cost no longer reproduces — actual churn is 31 entries, 28 of them sharp platform binaries. That estimate was right when written; the lockfile has since been refreshed independently.

## New: `.github/dependabot.yml`

Nothing opened routine version-update PRs before this — which is how 24 alerts accumulated, most of them a plain lockfile refresh no upstream constraint was blocking. **Four ecosystems in five update blocks** — `npm` (the three package.json trees), `github-actions`, `docker` (both Dockerfiles), and `uv` twice (`apps/server` + `eval/harness`, split so the harness carries its own `ignore` rules). Weekly, minor/patch grouped into one PR per ecosystem so **majors always arrive as their own individual PR** — that grouping is the safety mechanism, not a tidiness preference.

The `docker` entry is deliberately narrow: both Dockerfiles pin *floating* tags, not digests, so it catches tag moves (`python:3.12` → `3.13`, `ubuntu:24.04` → `26.04`) and nothing else. Patch-level base-image CVEs arrive when upstream rebuilds the same tag, which a rebuild picks up and Dependabot never sees. Cheap and worth having; not a base-image security net.

Two `ignore` rules protect load-bearing upper bounds in `eval/harness/pyproject.toml`:

- `mcp>=1.29,<2` — mcp 2.0.0 removed `Server.list_tools`, which `claude_agent_sdk.create_sdk_mcp_server` calls; broke CI the day it shipped (#932)
- `claude-agent-sdk<0.2` — `workspace.py` depends on `project_key_for_directory`

Both scoped to `version-update:*`, so a genuine **security** advisory on either still opens a PR. Note Dependabot classifies `0.1 → 0.2` as semver-**minor** for a 0.x package, so the `claude-agent-sdk` ignore covers minor too or the bound gets raised anyway.

⚠️ Known rough edge, documented in the file header: the engine pins `npm@11.12.1` and `check-engine-lockfile.yml` fails any PR whose lockfile that exact npm would rewrite. Dependabot resolves with its own npm, so an engine PR can trip the gate through no fault of the bump — check out the branch, `npm install` under 11.12.1, commit the re-normalized lockfile.

## `@hono/node-server` deliberately NOT bumped

Its patch is 2.0.5 — a **major** bump of a prod dep that ships in the `.mcpb` — and the vulnerable code is unreachable: `src/index.ts` uses `StdioServerTransport`, so the SDK's HTTP/SSE transport, the only importer of hono, never loads. Alert #68 (moderate) stays open by choice.

⚠️ Worth knowing: **PR #920 is titled "bump @hono/node-server to 2.0.12" but never moved it** — the merged lockfile still read 1.19.14. Dependabot bumped only the SDK (1.29.0 → 1.30.0), which widened the *declared* range. Don't read that title as evidence hono 2 was ever exercised here. Corrected on the record in https://github.com/PioneerAIAcademy/cowork-genealogy/pull/920#issuecomment-5145147321.

## Left open, with rationale in the doc

- **#85 brace-expansion (high) is unfixable as published.** Unlike its sibling GHSA-3jxr-9vmj-r5cp, which was backported per release line (1.1.16 / 2.1.2 / 5.0.7), GHSA-mh99-v99m-4gvg publishes a **single** range `<= 5.0.7` patched only at `5.0.8`. By plain semver that swallows the whole 1.x and 2.x lines, so `1.1.18` and `2.1.4` stay flagged no matter what we resolve to. Closing it means forcing eslint's `minimatch@3.x` across three majors of brace-expansion for an OOM DoS in a glob expander that only ever sees our own hardcoded patterns (EPSS 0.0034).
- **#31/#30 tmp** — `@anthropic-ai/mcpb` 2.1.2 (newest) pins `@inquirer/prompts@^6.0.1`, whose `external-editor@3.1.0` requires `tmp@^0.0.33`. Build-time only, never shipped.
- **#50 esbuild** — `vite@7.3.5` pins `esbuild@^0.27.0`, patch is 0.28.1. Needs a vite 7→8 migration, not a dep bump. Windows dev-server only.

## Verification

| Tree | Result |
|---|---|
| pnpm workspace | `install --frozen-lockfile` ✅ · typecheck 5/5 ✅ · **185 tests** ✅ · build 3/3 ✅ |
| engine (`.mcpb`) | `tsc` ✅ · **1693/1693 tests** ✅ · `check-engine-lockfile` green ✅ |
| eval/app | `npm ci` ✅ · **134/134 tests** ✅ · `tsc --noEmit` ✅ · full `next build` ✅ |

The engine suite ran against a real isolated install of the new lockfile (fast-uri 3.1.5), not a stale `node_modules`. `dependabot.yml` parses and every referenced directory has its manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


