### PR TITLE
ci: label TypeScript as `developer`, and accept PRs from forks

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,11 +4,21 @@
 # Keep this list short. A label here only earns its place if someone
 # actually filters or routes on it.
 
-# Python is the developer-facing half of this repo — the eval harness
-# (eval/harness, eval/triggering) and the FastAPI control plane
-# (apps/server). Nothing a genealogist reviews is written in Python, so
-# "touches a .py file" is a reliable proxy for "needs a developer's eyes".
+# Source code is the developer-facing half of this repo. Python is the eval
+# harness (eval/harness, eval/triggering) and the FastAPI control plane
+# (apps/server); TypeScript is the MCP server (packages/engine/mcp-server),
+# the shared web packages (packages/schema, packages/viewer-ui) and the apps
+# that consume them (apps/web, apps/electron, eval/app).
+#
+# What a genealogist actually reviews — skill and agent prose, eval fixtures
+# and run logs, docs — is .md and .json, never .py/.ts/.tsx. So "touches a
+# source file" stays a reliable proxy for "needs a developer's eyes".
+#
+# .tsx is listed alongside .ts because the React half of the web and Electron
+# clients lives in .tsx; omitting it would leave every UI-only PR unlabelled.
 developer:
   - changed-files:
       - any-glob-to-any-file:
           - '**/*.py'
+          - '**/*.ts'
+          - '**/*.tsx'

--- a/.github/workflows/genealogist-queue.yml
+++ b/.github/workflows/genealogist-queue.yml
@@ -60,8 +60,29 @@ name: genealogist-queue
 # is what makes the queue eventually correct. If you ever remove the schedule,
 # something else must answer "what re-checks a PR after CI finishes?"
 
+# TRIGGER CHOICE: `pull_request_target`, switched from `pull_request` on
+# 2026-07-31 when we started taking PRs from developers who have no write
+# access to this repo and therefore contribute from forks. Under
+# `pull_request` a fork PR gets a read-only GITHUB_TOKEN, so `addLabels` would
+# 403 — which is why the job carried an `if:` guard skipping cross-repository
+# PRs outright. That guard is removed with this switch: `github.event_name` is
+# no longer `pull_request`, so its first clause would always pass and it would
+# be dead code that reads as protection.
+#
+# What the guard cost, for the record: fork PRs lost the low-latency path
+# entirely. They were still labelled — `pull_request_review` already runs in
+# base context with a writable token, and the sweep below catches everything —
+# but a fork PR that opened green and pre-approved waited up to 30 minutes for
+# its label instead of seconds.
+#
+# Safe here for the same two reasons as labeler.yml: the job is a single inline
+# `actions/github-script` step with no `actions/checkout` and no `run:`, so
+# nothing fork-authored ever executes; and the script is read from the base
+# branch, so a fork cannot edit the readiness rules in its own PR. Adding a
+# checkout of PR content here would turn this into a pwn-request vector.
+
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
   pull_request_review:
     types: [submitted, dismissed]
@@ -120,10 +141,6 @@ jobs:
   promote:
     name: genealogist-queue
     runs-on: ubuntu-latest
-    # Fork PRs get a read-only token; the label write would 403.
-    if: >-
-      github.event_name != 'pull_request'
-      || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/github-script@v8
         env:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,25 +1,35 @@
 name: labeler
 
 # Applies path-based labels to PRs from .github/labeler.yml.
-# Today that is one rule: any PR touching a *.py file gets `developer`.
+# Today that is one rule: any PR touching a *.py, *.ts, or *.tsx file gets
+# `developer`.
 #
 # `sync-labels: true` means the label tracks the diff rather than the PR's
-# history — push a commit that drops the last .py change and the label comes
-# off. That also means a human cannot hand-apply `developer` to a PR with no
-# Python in it: the next push will strip it. If you want a label that sticks,
+# history — push a commit that drops the last source-file change and the label
+# comes off. That also means a human cannot hand-apply `developer` to a PR with
+# no code in it: the next push will strip it. If you want a label that sticks,
 # it does not belong in labeler.yml.
 #
-# TRIGGER CHOICE: `pull_request`, not `pull_request_target`. The labeler docs
-# suggest the latter because it is the only way to get a writable token on a
-# PR from a fork. This repo has never taken a fork PR (0 of the last 30 were
-# cross-repository) — every branch lives here. If that changes, a fork PR will
-# fail this job red with a 403 on the label write, which is the loud failure
-# we want; switch to `pull_request_target` at that point, and only then. It is
-# safe for this action specifically (labeler v5 checks out no PR code), but it
-# runs with repo secrets in scope, so it is not a default worth carrying.
+# TRIGGER CHOICE: `pull_request_target`, switched from `pull_request` on
+# 2026-07-31 when we decided to start accepting PRs from forks. A fork PR gets
+# a read-only GITHUB_TOKEN under `pull_request`, so the label write would 403
+# and fail this job red on every outside contribution.
+#
+# `pull_request_target` runs with a writable token and repo secrets in scope,
+# which is why it is not a default worth carrying — but it is safe for this
+# action specifically, on two counts that must both stay true:
+#   1. labeler v5 checks out no PR code, and there is no `actions/checkout`
+#      step below. Nothing fork-authored ever executes in this job.
+#   2. The event context is the BASE branch, so `.github/labeler.yml` is read
+#      from main — a fork cannot rewrite the label rules in its own PR.
+# If you ever add a checkout or a `run:` step that touches PR content here,
+# this trigger becomes a pwn-request vector: split the job instead.
+#
+# Fork PRs from first-time contributors still wait on the repo's
+# "require approval to run workflows" setting before any of this fires.
 
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: read

--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -44,10 +44,21 @@ name: project-status-sync
 # when this shipped. The fix for that is `Closes #N` in the PR body, not a
 # looser matcher here.
 #
-# TRIGGER CHOICE: `pull_request`, not `pull_request_target` — same reasoning
-# as labeler.yml. Every branch lives in this repo (0 of the last 30 PRs were
-# cross-repository). A fork PR would fail this job red on the project write,
-# which is the loud failure we want; switch then, and only then.
+# TRIGGER CHOICE: `pull_request_target`, switched from `pull_request` on
+# 2026-07-31 when we started taking PRs from developers who have no write
+# access to this repo and therefore contribute from forks. GitHub passes NO
+# secrets to a fork PR under `pull_request`, so the App-token step below would
+# fail on an empty `PROJECT_APP_ID` before a single board read happened —
+# failing this job red on every outside contribution. Unlike
+# genealogist-queue.yml there is no cron sweep here, so the card would then
+# simply never move until someone ran the dispatch by hand.
+#
+# Safe here for the same two reasons as labeler.yml: no `actions/checkout` and
+# no `run:` step, just one inline `actions/github-script`, so nothing
+# fork-authored executes; and the script is read from the base branch. Adding a
+# checkout of PR content would turn this into a pwn-request vector, and the
+# blast radius here is worse than usual — the App token in scope is
+# org-scoped with Projects: Read and write.
 #
 # TWO TOKENS, ON PURPOSE. The App minted below (see add-to-project.yml for the
 # one-time setup) holds Organization > Projects: Read and write, which is the
@@ -59,7 +70,7 @@ name: project-status-sync
 # read, grant GITHUB_TOKEN the permission below — not the App.
 
 on:
-  pull_request:
+  pull_request_target:
     # `edited` is not noise: it is the event that fires when someone adds
     # "Closes #123" to an existing PR body, which is how most links here are
     # created. `converted_to_draft` walks a card back from Review.


### PR DESCRIPTION
## Summary

- Adds `**/*.ts` and `**/*.tsx` to the `developer` labeler rule. TypeScript is as developer-facing as Python here (MCP server, `packages/schema`, `packages/viewer-ui`, `apps/web`, `apps/electron`, `eval/app`). `.tsx` is included because the React half of the web and Electron clients lives there — 87 files — and omitting it would leave every UI-only PR unlabelled.
- Switches the three PR workflows that need a writable token or repo secrets to `pull_request_target`, so they work on PRs from a contributor who has no write access to this repo and therefore contributes from a fork.

## What each of the three was doing on a fork PR

| workflow | before | why |
|---|---|---|
| `labeler.yml` | fails red | fork token is read-only; the label write 403s |
| `genealogist-queue.yml` | silently skipped | an `if:` guard skipped cross-repository PRs outright, so they lost the low-latency path and waited up to 30 min for the sweep to apply `ready-for-senior` |
| `project-status-sync.yml` | fails red | GitHub passes no secrets to a fork PR, so the App-token step failed before any board read — and with no cron sweep here, the card never moved |

`genealogist-queue`'s guard is removed rather than left in place: under the new trigger `github.event_name` is no longer `pull_request`, so its first clause would always pass. It would be dead code that reads as protection.

## Why `pull_request_target` is safe in these three specifically

Both conditions hold in all three, and each file now says so inline:

1. No `actions/checkout` and no `run:` step — every one is a single inline `actions/github-script` (or `actions/labeler`, which checks out nothing). Nothing fork-authored ever executes.
2. The event context is the base branch, so the workflow and its config are read from `main`. A fork cannot rewrite the label rules or the readiness rules in its own PR.

Adding a checkout of PR content to any of them converts it into a pwn-request vector. That warning is in each file.

## What is deliberately not in this PR

`check-runlogs.yml` stays on `pull_request`. It checks out the PR and runs PR-authored Python, so `pull_request_target` is not available to it — the checkout would default to `main` and the discipline checks would pass vacuously on every PR. Its fork gap is that the `eval-cosmetic-skip` auto-strip needs a write token, fails silently behind `|| true`, and lets the rule-2 bypass outlive the commit a senior approved it for. Fixed separately, in a PR that wants the eval gate's owners as reviewers rather than this one's audience.

## Test plan

- [x] Both configs and all three workflows parse as YAML; triggers verified as `pull_request_target`.
- [x] No dead fork guards left anywhere in `.github/workflows/`.
- [x] Audited the other 8 workflows: `engine-tests`, `eval-harness-tests`, `check-coauthor`, `check-e2e-fixtures`, `check-engine-lockfile`, `payload-guard` are read-only with zero secrets and are already correct on forks; `add-to-project` and `electron-release` do not trigger on PRs.
- [ ] Real verification is the first fork PR — the label rule and all three triggers only exercise on one.

Repo settings to confirm alongside this (not code): Settings -> Actions -> require approval for fork PRs from first-time contributors, and "allow edits by maintainers" on incoming PRs if the team wants to push fixups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)