### PR TITLE
docs: correct the guardrail-bypass status claims (#940 closed, #1054 filed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,10 @@ superset — so no allow-list can deny the *main thread* a tool one of its
 subagents needs. Discriminating by caller is a `PreToolUse` hook's job, and the
 hook layer always could do it: `eval/harness/harness/context_policy.py` denies
 `image_read` when `agent_id` is absent. Don't re-derive a per-context policy
-design; it exists. What is missing is a production port (issue #940).
+design; it exists. What is missing is a production port — issue #911, which
+gates it on calibrating the shadow window first (#940, which used to carry this,
+is closed: its raw-write half shipped in #984/#989 and its detector half moved
+to #1054).
 
 Do **not** reach for a server-level prefix grant (`mcp__remote-devices`):
 that namespace also carries `device_bash`, `device_commit_files`, and

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -173,13 +173,19 @@ create. Google is gone. Follow-ups (`docs/plan/familysearch-login-plan.md`):
 
 ## Guardrail enforcement in production
 Plan: `docs/plan/research-guardrail-bypass-plan.md`. The eval-side mechanisms
-have proven out. Only §4.3 reaches production — everywhere, via the plugin hook;
-§4.1's caller-id gate and §4.4's detectors are still harness-only.
+have proven out. **§4.2 and §4.3 reach production**: §4.2 as
+`proofSummaryInvariants` in `research-append.ts` — caller-agnostic, so it has
+bound in Cowork and hosted since #914 — and §4.3 everywhere via the plugin hook.
+§4.1's caller-id gate and §4.4's detectors are still harness-only; the §4.4 port
+is deferred behind #1054 (nothing retains hosted tool calls, so a production
+detector would have nothing to read).
 
 - [ ] **§4.3's lockdown covers `Write`/`Edit`/`NotebookEdit`, not `Bash`.**
-  `real_agent._pretool_hook` matches on `file_path`, so the shell route around it
-  stays open: `cat > research.json`, `sed -i`, `python -c`. Deliberate — the
-  reasoning is the comment on `_FILE_WRITE_TOOLS` in
+  Both copies of the rule — `real_agent._pretool_hook` and the plugin's
+  `hooks/guard_project_files.py`, which is the one that reaches Cowork — match on
+  `file_path`, so the shell route around them stays open: `cat > research.json`,
+  `sed -i`, `python -c`. Deliberate — the reasoning is the comment on
+  `_FILE_WRITE_TOOLS` in
   `apps/server/app/agent/real_agent.py` (skills run their scripts through `Bash`
   so it can't be revoked; matching command text would deny a legitimate
   `python script.py research.json > out` while still missing a variable-built
@@ -195,7 +201,10 @@ have proven out. Only §4.3 reaches production — everywhere, via the plugin ho
   #939 disproved for agents. Confirm with one hosted run (write to
   `research.json` via `Write` with the SDK hook removed) before deleting the
   Python copy. Until then both fire, which is harmless: they deny the same thing
-  with the same reason.
+  with the same reason. Note there is a **third** copy in
+  `eval/harness/e2e/orchestrator.py`, and no test asserts the three agree — each
+  is tested alone, so the day `PROTECTED_PROJECT_FILES` gains a file, two of them
+  can silently lag.
 
 - [ ] **`SessionStart` plugin hooks do not fire in Cowork.** Measured 2026-07-30
   in the same probe that confirmed `PreToolUse` works: no invocation, and the

--- a/docs/plan/research-guardrail-bypass-plan.md
+++ b/docs/plan/research-guardrail-bypass-plan.md
@@ -1,8 +1,17 @@
 # Research Guardrail Bypass — Plan
 
 **Project:** Cowork Genealogy — `/research` orchestration
-**Status:** DRAFT, for review (engineering) — adversarially reviewed once;
-findings incorporated, see §8.
+**Status:** PARTLY SHIPPED — not a pending plan in full. §4.2 and §4.3 are in
+production: §4.2 as `proofSummaryInvariants` in
+`packages/engine/mcp-server/src/tools/research-append.ts` (#914, caller-agnostic,
+so it binds in Cowork and hosted alike), §4.3 as the plugin-shipped `PreToolUse`
+hook `packages/engine/plugin/hooks/` plus the SDK hook in
+`apps/server/app/agent/real_agent.py` (#984, #989 — issue #940, now closed).
+§4.1 is shipped **shadow-mode only** and §4.4's detectors are harness-only;
+graduating §4.1 to hard-deny is #911, and porting §4.4 to production is deferred
+behind #1054 (nothing retains hosted tool calls today, so there is nothing to
+detect against). §9 and §10 are the post-ship record, not proposals.
+Adversarially reviewed once before landing; findings incorporated, see §8.
 **Goal:** Close the structural gap that lets autonomous `/research` silently
 bypass `research-exhaustiveness`, `proof-conclusion`, `person-evidence`, and
 `conflict-resolution` — the four sub-skills that own GPS tier/exhaustiveness/


### PR DESCRIPTION
Fallout from reviewing issue #940, which is now closed. Docs only — no behavior change.

Three stale claims, all of the kind this repo's conventions treat as load-bearing:

| File | Claimed | Actually |
|---|---|---|
| `docs/plan/research-guardrail-bypass-plan.md:4` | `**Status:** DRAFT, for review (engineering)` | §4.2 and §4.3 shipped to production in #914 / #984 / #989, and the file had already grown post-ship §9 and §10 sections |
| `docs/TODOs.md:176` | "Only §4.3 reaches production" | §4.2 is `proofSummaryInvariants` in `research-append.ts` — caller-agnostic, so it has bound in Cowork and hosted since it landed |
| `CLAUDE.md:255` | per-context policy's production port is "(issue #940)" | #940 is closed; #911 owns it, gated on calibrating the shadow window first |

The plan's Status line now says what shipped, what is shadow-mode only, and which issue owns each remainder (#911 for graduating §4.1, #1054 for the §4.4 production detector). CLAUDE.md's own guidance names this exact failure — "two files here spent weeks claiming 'not yet implemented' for things that had shipped" — so this is that rule applied to a third.

Two precision fixes in the same `TODOs.md` section while I was there:

- The `Bash` gap is in **both** copies of the §4.3 rule, not just `real_agent._pretool_hook`; the plugin's `guard_project_files.py` has the same hole and is the one that reaches Cowork.
- There is a **third** copy in `eval/harness/e2e/orchestrator.py`, and no test asserts the three agree — each is tested alone, so a future addition to `PROTECTED_PROJECT_FILES` can silently lag in two of them.

## Related

- #940 — closed; asks #1/#2 shipped in #984/#989
- #1054 — successor, carries #940's asks #3/#4 (retain the hosted tool-call ledger first)
- #911, #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)