### PR TITLE
fix(electron): set executableName for the Linux target

### DIFF
--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -44,6 +44,12 @@ nsis:
   artifactName: research-viewer-${version}-setup.${ext}
 
 linux:
+  # Required, not cosmetic. Without it electron-builder derives the executable
+  # name from package.json's `name` — "@genealogy/electron" — and refuses to
+  # build: `executableName contains characters that cannot be safely used in
+  # file paths: @genealogyelectron`. `win` already sets this; `mac` is unaffected
+  # because a .app bundle is named from productName instead.
+  executableName: research-viewer
   target:
     - target: AppImage
       arch: [x64]


### PR DESCRIPTION
**The AppImage build has never succeeded.** `electron-release.yml` had never run at all until it was dispatched today while verifying #1040 — the entire run history was one entry. Its Linux leg fails:

```
⨯ failed to build AppImage error=executableName contains characters that
  cannot be safely used in file paths: @genealogyelectron.
  Please use only letters, digits, hyphens, underscores, dots, and spaces.
```

## Cause

electron-builder derives the Linux executable name from `package.json`'s `name` — `@genealogy/electron` — when the platform block doesn't override it. `win:` already sets `executableName: research-viewer`; `linux:` didn't. `mac:` is unaffected, because a `.app` bundle is named from `productName` instead.

## Verified by local A/B

Same branch, same electron-builder 26.15.0, only the config line differing:

**Without the fix:**
```
• building        target=AppImage arch=x64 file=dist/research-viewer-1.0.0.AppImage
⨯ failed to build AppImage  error=executableName contains characters that
  cannot be safely used in file paths: @genealogyelectron.
```

**With the fix:**
```
• building        target=AppImage arch=x64 file=dist/research-viewer-1.0.0.AppImage
-rwxr-xr-x  116457297  dist/research-viewer-1.0.0.AppImage
```

Scoped to the `linux` block rather than hoisted to top level, so the mac and win naming paths are untouched.

## Worth knowing

Nothing has shipped broken — no `electron-v*` tag exists, so this would have failed the first time someone cut a real release. It was found only because the workflow got dispatched by hand.

The other leg that failed in that same dispatch, mac, hit `hdiutil: create failed - Device not configured` — the classic macOS-runner DMG flake, not a real bug. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)