### PR TITLE
build: keep worktree npm ci off the shared engine node_modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,22 @@ $(JS_DEPS): package.json pnpm-lock.yaml
 # builds can't dirty package-lock.json (some npm versions re-normalize the `libc`
 # tags on rolldown's optional binaries). It hard-fails if package.json and the
 # lockfile drift out of sync — run `npm install` in $(ENGINE_DIR) to re-sync.
+#
+# The symlink guard: in a linked worktree, node_modules is a symlink to the
+# primary checkout's copy (scripts/link-worktree.sh), and `npm ci` deletes the
+# existing install THROUGH that symlink before repopulating — gutting the
+# shared copy for every other worktree at once (verified 2026-08-02: an
+# interrupted run left the primary missing `open`, which disarmed the two
+# packaging guard suites while everything else stayed green). A fresh worktree
+# always trips this rule, too: checkout stamps package.json with the current
+# time, which is newer than the shared stamp. Dropping the symlink first keeps
+# the reinstall local — this worktree forks its own node_modules and the
+# primary is never touched.
 $(ENGINE_DEPS): $(ENGINE_DIR)/package.json $(ENGINE_DIR)/package-lock.json
+	@if [ -L $(ENGINE_DIR)/node_modules ]; then \
+	  echo "engine deps: node_modules is a symlink (linked worktree) — unlinking so npm ci installs locally instead of gutting the shared copy"; \
+	  rm $(ENGINE_DIR)/node_modules; \
+	fi
 	cd $(ENGINE_DIR) && npm ci
 	@touch $@
 

--- a/scripts/link-worktree.sh
+++ b/scripts/link-worktree.sh
@@ -59,8 +59,22 @@ for rel in $SHARED_PATHS; do
     continue
   fi
   if [ -e "$dst" ] && [ ! -L "$dst" ]; then   # real file/dir already here → keep
-    echo "link-worktree: keeping existing $rel (not a symlink)"
-    continue
+    # …unless it is a directory holding nothing but vite/vitest cache dirs.
+    # A bare `npx vitest` run before this script ever linked node_modules
+    # creates node_modules/.vite (and .vite-temp) in an otherwise-unpopulated
+    # directory — and treating that as "a real install this worktree owns"
+    # blocks the symlink on every future run, silently (broke two worktrees
+    # on 2026-08-02: their tests then resolved deps from the primary's hoisted
+    # ROOT node_modules, which lacks the engine's deps). `ls -A` deliberately,
+    # unlike the source-side guard above: here the dotfile entries are exactly
+    # what we need to see.
+    if [ -d "$dst" ] && ! ls -A "$dst" 2>/dev/null | grep -qv -e '^\.vite$' -e '^\.vite-temp$'; then
+      echo "link-worktree: replacing $rel — contains only .vite/.vite-temp caches"
+      rm -rf "$dst"
+    else
+      echo "link-worktree: keeping existing $rel (not a symlink)"
+      continue
+    fi
   fi
   mkdir -p "$(dirname "$dst")"
   ln -sfn "$src" "$dst"


### PR DESCRIPTION
## Problem

Worktrees share `packages/engine/mcp-server/node_modules` by symlink to the primary checkout (`scripts/link-worktree.sh`). Two failure modes around that link surfaced on 2026-08-02, when two sessions independently found the packaging suite under-running (108 → 146 tests in `tests/packaging/`):

1. **`npm ci` guts the shared copy.** `npm ci` deletes the existing install *through* the symlink before repopulating, then replaces the link with a local real dir. The Makefile's `$(ENGINE_DEPS)` stamp rule triggers exactly that `npm ci` on the first `make engine-test` / `make install` in any fresh worktree (checkout stamps `package.json` newer than the shared stamp). An interrupted run left the primary missing `open` — which disarms exactly `manifest.test.ts` and `agent-tool-names.test.ts`, the only test files importing `tool-schemas` (whose chain reaches `src/auth/login.ts`'s `import open`; the login tests escape via `vi.mock`), while the other 1755 tests stay green.

2. **A stale `.vite` cache blocks re-linking.** A bare vitest run before the link exists creates `node_modules/.vite` in an otherwise-empty directory, and the "keep existing real dir" rule then protects it forever — the worktree silently resolves engine deps from the primary's hoisted root `node_modules`, which lacks them.

## Fix

- `Makefile`: in the `$(ENGINE_DEPS)` recipe, drop the symlink before `npm ci` so the reinstall forks locally and the primary is never touched.
- `scripts/link-worktree.sh`: treat a destination `node_modules` holding only `.vite`/`.vite-temp` as replaceable; anything else is still kept.

## Verification

- Reproduced the broken state (install minus `open`) in a throwaway worktree: exactly the two packaging suites fail to load (`Cannot find package 'open'`), 1755 tests pass, vitest exits 1.
- With the guard: `make engine-test` in a fresh linked worktree prints the unlink notice, installs locally, and passes the full suite (75 files, 1793 tests = 1755 + the 38 previously disarmed). The primary's `node_modules` and stamp are byte-for-byte untouched afterwards.
- `link-worktree.sh`: `.vite`-only dir → replaced and linked; dir with any real entry → kept; syntax-checked with `sh -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)