### PR TITLE
docs: ADRs — template, convention, first six decisions, staleness lint

### DIFF
--- a/docs/adrs/ADR-0001-run-network-code-on-the-host.md
+++ b/docs/adrs/ADR-0001-run-network-code-on-the-host.md
@@ -1,0 +1,120 @@
+# ADR-0001: Run all network code on the host and ship only offline code into the VM
+
+> **Read before you:** add a feature that calls an external API · write a script
+> that ships inside a skill or hook · wonder why a tool lives on the server
+> instead of in a skill · debug a call that returns nothing with no error.
+
+- **Status:** Accepted
+- **Decided:** pre-2026-05 (reconstructed — this predates the specs directory)
+- **Recorded:** 2026-08-02
+- **Deciders:** Dallan Quass
+- **Supersedes:** —
+- **Superseded by:** —
+- **Applies to:** `packages/engine/mcp-server`, `packages/engine/plugin`
+- **Related:** `docs/architecture.md` §2, `CLAUDE.md` § "Architecture you must understand"
+
+## Context
+
+Cowork runs Claude inside a sandboxed Linux VM whose egress allowlist does not
+work for arbitrary domains. Code running in that VM cannot reliably reach the
+network, and — this is the part that matters — **it does not fail loudly when it
+tries.** The egress proxy blocks the call; the script sees a timeout or an empty
+result, and the model narrates around it.
+
+This product is almost entirely network work. It queries FamilySearch's search,
+records, persons, places, and full-text APIs; a hosted wiki sidecar; a
+population-statistics service; and an OpenRouter VLM for OCR. If the VM cannot
+make those calls, the VM cannot be where that code lives.
+
+The constraint is not ours to negotiate. It is a property of the platform we
+ship into.
+
+> **Sourcing gap, named honestly.** This is the load-bearing premise of the whole
+> system, and **no dated observation of it exists in the repo** — no runlog, no
+> probe, no verification note. It is asserted in `CLAUDE.md` and has been since
+> the first architecture notes. Everything downstream is built on it and it has
+> never been contradicted in practice, but "blocked calls fail silently" is a
+> claim a reader cannot currently reproduce. If anyone re-observes it, date it
+> here.
+
+## Decision
+
+**Every piece of code that touches the network runs on the host, inside the MCP
+server. Everything shipped into the VM — skills, agents, hooks, and any bundled
+Python — must work with no network at all.** The two halves share no files at
+runtime and communicate only through MCP tool calls: structured JSON in,
+structured JSON out.
+
+Concretely this produces two artifacts from one repo: a TypeScript MCP server
+packaged as a `.mcpb` desktop extension that runs on the user's machine, and a
+Cowork plugin folder packaged as a `.zip` that runs in the VM. They are
+developed together and versioned together because they are two halves of one
+contract.
+
+The operational test for any new feature is one question: **does this need the
+network?** If yes, it is an MCP tool. If no — data processing, formatting,
+templating, judgment — it can live in the VM.
+
+## Alternatives considered
+
+| Option | Why rejected | Evidence |
+|---|---|---|
+| **Run everything in the VM**, calling APIs from skill scripts | The egress allowlist does not work for arbitrary domains, and blocked calls fail silently rather than erroring — the worst possible failure mode for an agent that will narrate a plausible result anyway | Platform constraint; `CLAUDE.md` has carried the warning since the repo's first architecture notes |
+| **Proxy VM traffic through a host-side relay**, keeping logic in the VM | Moves the network boundary without removing it, and buys a second protocol to version alongside MCP. MCP already *is* the host↔VM channel — a relay would be a parallel one doing the same job worse | Argued, not measured |
+| **Run everything on the host**, including the judgment work | The judgment work needs the session's own context — the conversation, the project state, the user's prior answers. A host-side process has none of that, and shipping it across the boundary on every call is the "hand the LLM a large document" anti-pattern this system spent two tool families removing | See ADR-0002 and `project-context-tool-spec.md` |
+| **Ship a bundled HTTP client into the VM** with a pinned allowlist | The allowlist mechanism is the thing that does not work. A client cannot fix a proxy | Platform constraint |
+
+## Consequences
+
+**Gains.** Network failures surface at a tool boundary that validates and
+returns structured errors, so the model gets an actionable message instead of
+silence. Credentials — the FamilySearch OAuth tokens, the OpenRouter key — stay
+on the host in `~/.familysearch-mcp/` and never enter the **Cowork** VM. And the
+split forces every host capability through a declared, schema'd tool, which is
+what makes the capability-binding layer (ADR-0004, ADR-0006) possible at all.
+
+> **The hosted web workbench is the exception, and it matters.** There the MCP
+> server runs *inside* the E2B sandbox, and the control plane deliberately
+> injects credentials into it — `apps/server/app/fs_oauth.py` writes both
+> `tokens.json` and `config["openRouterApiKey"]` under the sandbox HOME. So the
+> "credentials never cross" property is a property of the **Cowork** topology,
+> not of this decision. Do not carry it over when reasoning about the hosted
+> path.
+
+**Costs, knowingly accepted.** Three real ones:
+
+1. **No runtime code sharing between the halves.** A structure needed on both
+   sides is duplicated, not imported. `CLAUDE.md` names this explicitly as a
+   thing not to try.
+2. **Two artifacts, two install paths, one contract.** A change that spans the
+   boundary needs both rebuilt, and the ways to do that differ per environment
+   — the single most common way to spend an hour testing a fix that was never
+   loaded.
+3. **Skill scripts are stdlib-only Python.** No dependency the VM might lack, no
+   pip install slowing every invocation. Today this costs nothing, because no
+   skill ships a `scripts/` folder — the plugin's only Python is the guard hook.
+
+**Risks.** The silent-failure mode still exists for anyone who forgets the rule:
+a skill script that calls out gets blocked with no error. Nothing in CI detects
+network code in a skill script; the only guard is review and the
+`cowork-skill-builder` subagent, which refuses to write one.
+
+## Enforcement
+
+**Partial — the architectural rule is convention; only its packaging is tested.**
+
+> `packages/engine/mcp-server/tests/packaging/plugin-hooks.test.ts` — asserts the
+> hooks directory ships and runs the real guard script.
+> `packages/engine/mcp-server/tests/packaging/manifest.test.ts` — asserts the
+> advertised tool list matches the registry.
+
+Neither catches the actual failure: **no test detects a network call in a skill
+or hook script.** It would be a cheap lint (grep the plugin tree for `urllib`,
+`requests`, `http.client`, `socket`, `fetch`) and does not exist.
+
+## Revisit when
+
+Cowork's egress allowlist becomes reliable for arbitrary domains — at which
+point the question is not whether to move code into the VM (the credential
+argument and ADR-0006's capability boundary still favour the host) but whether
+the two-artifact build is still worth its cost.

--- a/docs/adrs/ADR-0002-decompose-into-tools-skills-and-agents.md
+++ b/docs/adrs/ADR-0002-decompose-into-tools-skills-and-agents.md
@@ -1,0 +1,119 @@
+# ADR-0002: Decompose into MCP tools, skills, and plugin agents by what each needs
+
+> **Read before you:** add any new capability and wonder where it goes · decide
+> between a skill and a subagent · consider adding a tool for something the model
+> could just do · review a PR that puts judgment in a tool or an invariant in
+> prose.
+
+- **Status:** Accepted
+- **Decided:** 2026-07-12 (the three-way split reached its current shape with the `record-extractor` agent, #650)
+- **Recorded:** 2026-08-02
+- **Deciders:** Dallan Quass
+- **Supersedes:** —
+- **Superseded by:** —
+- **Applies to:** `packages/engine/mcp-server/src/tools`, `packages/engine/plugin/skills`, `packages/engine/plugin/agents`
+- **Related:** ADR-0001, ADR-0003, ADR-0006, `docs/architecture.md` §3
+
+## Context
+
+ADR-0001 splits the system by *where code can run*. That leaves a second
+question it does not answer: within the VM half, what belongs in a skill body
+and what belongs somewhere else?
+
+Three pressures push in different directions.
+
+**Context is the scarce resource.** Every skill `description` is resident in the
+orchestrator's context on every turn. Every tool schema costs tokens. Plugin
+markdown is already 912 KB, of which skill bodies are 7,730 lines. Anything that
+grows without bound eventually evicts something that matters — and when a skill
+body is evicted by compaction, the rules in it stop being followed (ADR-0003).
+
+**Some work must not inherit the session's state.** Record extraction reads an
+unfamiliar document and classifies it. Doing that in the main thread means the
+extraction sees — and can be steered by — everything the session has already
+concluded, which is exactly how a researcher talks themselves into a match.
+
+**Some rules must not be arguable.** A boundary enforced by prose can be
+prompted past. This was observed, not theorised: a delegation message pushed the
+extractor outside its stated lane and it fabricated a match score.
+
+## Decision
+
+**Three kinds of component, each chosen by what the work needs:**
+
+| Component | Where | Chosen when the work needs… |
+|---|---|---|
+| **MCP tool** | host | the network, or an invariant that must hold against any caller |
+| **Skill** | VM, session context | judgment that depends on what the session already knows |
+| **Plugin agent** | VM, **fresh context** | isolation from session state, a narrowed capability set, or a different model |
+
+Today that is 47 tools, 27 skills, and 4 agents.
+
+The dividing line between a skill and an agent is **not** size — it is whether
+inheriting the conversation helps or hurts. `record-extractor` runs one agent per
+record specifically so no record's extraction can see another's conclusions.
+`gps-mentor` critiques a proof in fresh context so it cannot be persuaded by the
+reasoning that produced it.
+
+## Alternatives considered
+
+| Option | Why rejected | Evidence |
+|---|---|---|
+| **Two kinds only — tools and skills** (no agents) | Loses all three things agents provide: fresh context, a narrowable capability set, and per-step model routing. Model routing especially: skill `model:` pins are read only by the unit harness, so an agent is the *only* place a per-step model choice binds in production | `docs/architecture.md` §3.5; all 26 skill pins are dead lines (26 of the 27 skills carry one — `forget-and-rederive` never had one) |
+| **One tool per provider/endpoint** (`familysearch_search`, `wiki_search`, …) | Tool count is context budget in every session. The generic-tool-with-a-provider-parameter shape keeps the catalog small; at 47 tools Cowork already defers the schemas past a size threshold | `CLAUDE.md` § "MCP server tools". ToolSearch measured ~11% of all tool calls — but that was measured while `ENABLE_TOOL_SEARCH` was set under an inverted reading of its polarity (#1110), so treat it as a snapshot pending re-measurement, not a stable property |
+| **Put the GPS doctrine in tools** — make the tools enforce good research | Most of it is genuinely judgment. Of the orchestrator's 17 routing rows, only **6 are mechanically computable**, and those six were never the ones failing. The other 11 need an LLM | `docs/agentic-system-critique.md` §3 P2, row-by-row analysis |
+| **Put the invariants in prose** — trust the skill bodies | Measured to decay. See ADR-0003 | 77% → 3% compliance after compaction |
+| **Split agents further**, one per record type (a probate agent, a census agent) | Every agent body is a full prompt; N agents is N prompts to keep consistent. The per-type material is a table inside one body instead — and the attempt to externalise those tables failed measurably | Issue #702; `CLAUDE.md` § "No playbook/reference files for agents" and `docs/architecture.md` §3.4 (no ADR yet) |
+
+## Consequences
+
+**Gains.** Each layer can be reasoned about on its own terms: a tool has a
+contract and a spec, a skill has a rubric and an eval suite, an agent has a
+frontmatter capability list that CI lints. The seams are also where enforcement
+lives — because a tool boundary is un-arguable, invariants that must hold across
+hours can be moved there (ADR-0003), and because an agent's tool list is exact-
+matched at spawn, capability can be narrowed per delegate (ADR-0006).
+
+**Costs, knowingly accepted.**
+
+1. **Three places to look, and the boundaries are not self-evident.** "Should
+   this be a skill or an agent?" is a real question a newcomer will get wrong,
+   and the answer (does inheriting session state help or hurt?) is not visible
+   from the file tree.
+2. **Delegation is not free.** An agent spawns with no session state, so
+   everything it needs must be in its prompt or fetched through a tool. That is
+   the point — but be careful attributing costs to it. `gps-mentor` read
+   `research.json` front-to-back for 112 of 178 reads across 24 runs, and that
+   was **not** an intrinsic cost of delegation: its `tools:` list, correct by
+   every lint we have, simply lacked the projection tools (#1084/#1085, granted
+   in #1082). The real cost of delegation is that a wrong capability grant is
+   invisible until someone reads the runlogs.
+3. **The orchestrator is a skill, so routing is prose**, and prose is the thing
+   ADR-0003 says decays. This is a known tension, not a solved one — 11 of the 17
+   rows genuinely cannot move.
+
+**Risks.** The decomposition's weakest seam is that nothing verifies an agent's
+declared tools actually bind at runtime — the lints stop at spelling. An agent
+can be correctly declared, pass every check, and run without the capability.
+
+## Enforcement
+
+**Structural, not semantic — the layers are enforced; the placement judgement is not.**
+
+> `packages/engine/mcp-server/tests/packaging/manifest.test.ts` — the advertised
+> tool list matches `allToolSchemas`.
+> `packages/engine/mcp-server/tests/packaging/agent-tool-names.test.ts` — agent
+> capability declarations resolve in every environment.
+> `packages/engine/mcp-server/tests/packaging/skill-description-length.test.ts` —
+> the description budget that keeps skill count affordable.
+
+**Nothing checks that a capability was put in the right layer.** A judgment rule
+written into a tool, or an invariant left in prose, passes CI. Review is the only
+guard.
+
+## Revisit when
+
+The skill count grows past the point where all 27 descriptions can sit in the
+orchestrator's context alongside real work — at which point the routing layer
+needs a different shape, and the "most utterances land on `research`" assumption
+should be re-measured rather than re-asserted.

--- a/docs/adrs/ADR-0003-anchor-cross-turn-rules-structurally.md
+++ b/docs/adrs/ADR-0003-anchor-cross-turn-rules-structurally.md
@@ -1,0 +1,131 @@
+# ADR-0003: Anchor cross-turn rules structurally rather than in prose
+
+> **Read before you:** write a new rule into any `SKILL.md` or agent body · fix a
+> compliance failure by "making the instruction clearer" · argue that a
+> guardrail belongs in prose because a tool check would be too strict · reinforce
+> a rule that keeps getting violated.
+
+- **Status:** Accepted
+- **Decided:** 2026-07-27 (on the §5.3 rule audit)
+- **Recorded:** 2026-08-02
+- **Deciders:** Dallan Quass
+- **Supersedes:** —
+- **Superseded by:** —
+- **Applies to:** `packages/engine/plugin/skills`, `packages/engine/plugin/agents`, `packages/engine/mcp-server/src/tools/research-append.ts`
+- **Related:** ADR-0005, ADR-0006, `docs/plan/research-performance-2026-07-27.md` §5.3, `docs/specs/guardrail-enforcement-spec.md` §2
+
+## Context
+
+Skill bodies are long — 7,730 lines across 27 skills, the largest at 50 KB — and
+they are the system's main vehicle for doctrine. A research session runs for
+hours. Somewhere in those hours, context is compacted and a skill body is
+evicted.
+
+The question is what happens to the rules in it. That was measured rather than
+guessed, over 309 turns of one real session
+(`docs/plan/research-performance-2026-07-27.md` §5.3):
+
+| Rule | Anchored? | Compliance |
+|---|---|---|
+| every rule with a structural anchor | yes | **100%** |
+| "always call `rank_search_matches`" | no | 77% → **3%** |
+| `count: 50` | no | 100% → 45% |
+| keep `givenName`, no surname-only | no | 54% → 94% (*rose*) |
+
+The operational figure usually quoted alongside it — **prose survives roughly
+three compactions** — is the source's own *extrapolation*, not a counted
+quantity: §5.3 reports early/late segments, not compaction counts. Treat it as a
+rule of thumb, and treat the compliance percentages as the measurement.
+
+Two things about that table matter as much as the headline. First, the third
+unanchored rule *improved* — so the law runs one direction only: an anchor
+guarantees survival, its absence merely permits decay. "It is unanchored and it
+is fine" is not a counterexample. Second, the audit covers **one skill**
+(`search-records`, resident for 228 of the 309 turns) and says explicitly that
+the per-skill result should not be assumed elsewhere. It also exempts plugin
+agents, which get fresh context per invocation and cannot decay this way.
+
+`docs/agentic-system-critique.md` §1.1 reports a public precedent for the general
+effect (arXiv 2606.22528, "Governance Decay," June 2026 — constraint violations
+rising 0% → 30–59% after compaction). **That citation carries no DOI, authors, or
+URL anywhere in this repo and nothing here can establish the paper exists**; it
+is repeated as attribution, not as evidence. This decision rests on the §5.3
+audit alone, which is reproducible.
+
+## Decision
+
+**A rule that must hold across turns gets a structural anchor. Prose is for
+rules that only have to hold within one invocation.**
+
+A rule is structurally anchored if any of these holds:
+
+1. **The tool rejects the violation.**
+2. **The output feeds a step that cannot proceed without it.**
+3. **It leaves a durable trace the agent re-reads.** (A trace nothing re-reads is
+   not an anchor.)
+
+So the question when writing a new rule is *where it goes*:
+
+| Must hold… | Goes in |
+|---|---|
+| across hours, past compaction | a tool contract — validate and reject |
+| for the main thread, which no allow-list can narrow | a `PreToolUse` hook (ADR-0005) |
+| for one delegated agent | that agent's `tools:`/`disallowedTools:`, or a narrowed tool (ADR-0006) |
+| within a single invocation | skill prose — this is what prose is *for* |
+
+## Alternatives considered
+
+| Option | Why rejected | Evidence |
+|---|---|---|
+| **Reinforce the prose** — repeat the rule, bold it, add a "hard rules" section | This is what the 3% rule already had. Restating a rule does not survive the eviction of the text doing the restating | §5.3 audit; the ranking doctrine was already emphatic |
+| **Shorten skill bodies** so less gets evicted | Attacks the wrong variable, and the unit suite cannot gate it — the suite grades a single invocation in fresh context and will happily bless a cut that removes something only a multi-hour session needs. Worth doing for cost reasons (critique §6 lever 4), but it is not a correctness mechanism | `docs/agentic-system-critique.md` §6 |
+| **Split the rule into a dedicated per-skill write tool** so the tool name carries the doctrine | Rejected earlier and independently, for a reason that generalises: *"a split tool is exactly as callable by the router as a section branch is."* Splitting names does not constrain a caller | `docs/specs/guardrail-enforcement-spec.md` §9 |
+| **A read-only advisory tool** the model calls each turn to be told the next step | "Call the advisory every turn" is itself unanchored prose. Our own data disconfirms it: `project_context`, built for exactly this, is called ~3 times per run against `Read`'s ~19. It also adds a serial tool call — a turn — per routing decision | critique §3 P2 |
+| **Post-run detection** — let it happen, catch it in grading | Catches it after the user has the wrong answer, and the detectors themselves currently have three open defects and an unquantified false-positive rate | #998, #999, #1006 |
+
+## Consequences
+
+**Gains.** Two rules were converted on the strength of this — the `count: 50`
+default and the ranking fold, both now in `record-search.ts`. (The critique
+reports the fold "verified 7/7"; the *conversions* are verifiable in the code,
+the 7/7 result is not recorded in any test or runlog here.) Every invariant moved
+into `research_append` holds regardless of context
+state, model, or how long the session has run — and holds identically in Cowork,
+the hosted path, and both harnesses, which prose never does.
+
+**Costs, knowingly accepted.**
+
+1. **A tool check can false-deny, and that is the worse failure.** A structural
+   anchor refuses work; when the check is wrong, it refuses *legitimate* work.
+   `guardrail-enforcement-spec.md` is explicit that false-deny is the asymmetric
+   risk, which is why the `Bash` route stays open (ADR-0005) and why new gates
+   are scoped conservatively.
+2. **Not everything can move.** 11 of the orchestrator's 17 routing rows need
+   judgment. Those stay prose and stay subject to decay — a known, unfixed
+   exposure, not a solved problem.
+3. **Anchoring is more work than editing prose**, so there is standing pressure
+   to skip it under deadline. That is exactly when the rule matters.
+
+**Risks.** The law was measured on one skill. Applying it as universal is a
+generalisation the source does not license, and no compaction-segment audit of
+any other body has been done — `research/SKILL.md`, the longest-resident body in
+the system, has never been audited.
+
+## Enforcement
+
+**None — convention only.** No lint detects a cross-turn invariant written as
+prose. The check is review, and the honest signal is this: two gates identified
+as needing anchors — the **tree-encoding gate** and the **mentor gate** — are
+still prose today, and both are computable from files `research_append` already
+loads.
+
+The one instrument that measures the *effect* is the post-run compliance
+detector, and it is uncalibrated (#998, #999, #1006), so its 8-of-25 violation
+rate is a floor with an unquantified false-positive rate and should not be
+trended.
+
+## Revisit when
+
+A compaction-segment audit of a second skill body contradicts the §5.3 result —
+or the platform's context handling changes such that skill bodies are no longer
+evicted mid-session, which would make the whole question moot.

--- a/docs/adrs/ADR-0004-dual-spell-mcp-tool-names-in-agent-frontmatter.md
+++ b/docs/adrs/ADR-0004-dual-spell-mcp-tool-names-in-agent-frontmatter.md
@@ -1,0 +1,149 @@
+# ADR-0004: Dual-spell every MCP tool name in agent frontmatter
+
+> **Read before you:** grant a tool to a plugin agent · deny a tool to a plugin
+> agent · write a `ToolSearch` query in a skill or agent body · rename the
+> desktop extension · wonder why every tool appears twice in a `tools:` list.
+
+- **Status:** Accepted
+- **Decided:** 2026-07-18 (#742, repairing #650/#698)
+- **Recorded:** 2026-08-02
+- **Deciders:** Dallan Quass
+- **Supersedes:** —
+- **Superseded by:** —
+- **Applies to:** `packages/engine/plugin/agents`, `packages/engine/mcp-server/manifest.json`
+- **Related:** ADR-0002, ADR-0006, `docs/architecture.md` §5.2, issues #650, #698, #695, #939
+
+## Context
+
+An MCP server's name is chosen by **whoever registers it**, not by the server.
+The plugin ships into the VM and cannot control that choice. In practice the same
+47 tools appear under two different prefixes:
+
+| Registrar | Prefix |
+|---|---|
+| `.mcp.json`, both eval harnesses, the hosted control plane | `mcp__genealogy__<tool>` |
+| Cowork, reaching the host `.mcpb` through its remote-device bridge | `mcp__remote-devices__Genealogy_Research__<tool>` |
+
+Cowork's bridge derives its segment from `manifest.json`'s `display_name`
+("Genealogy Research" → `Genealogy_Research`), which is a *product* string —
+chosen for the install dialog, not for us.
+
+Agent frontmatter entries are matched **exactly**: no prefix fallback, no
+inherit-on-miss. And the failure when every entry misses is not a degraded agent
+— the runtime refuses to spawn it at all ("would be spawned with zero tools —
+refusing").
+
+That is not hypothetical, and the history is worth reading precisely — the usual
+"#650/#698" shorthand compresses a there-and-back:
+
+| | |
+|---|---|
+| **#650** (07-12) | the three then-existing agents ship qualified against the eval harness's `genealogy` key |
+| **#657** (07-15) | moved to **bare** names, on the reasoning that "the `mcp__genealogy__` prefix breaks in Cowork" |
+| **#698** (07-17) | moved back to qualified — bare leaves the subagent toolless in the SDK path |
+| **#742** (07-18) | **both spellings**, which is the only state that works everywhere |
+
+Two full reversals before the answer stuck, and **every test passed at every
+step**. That is the argument for the lint, not the anecdote.
+
+*Precision about "broken in Cowork":* the strongest documented observation
+(`research-append-tool-spec.md` §11.1) is narrower than "all three dead" — it
+records `image-reader` failing to resolve a tool, and a later live check in which
+an agent with one of two entries unresolvable **spawned normally**. So the
+zero-tools refusal above is the documented runtime rule, but the blast radius of
+#650 specifically rests on a small number of live sessions rather than a
+systematic sweep.
+
+The deny side is sharper still. `disallowedTools:` binds **even under
+`bypassPermissions`**, which is the hosted path's mode (#695), making it the last
+line keeping `record-extractor` off the broad `research_append`. A deny naming
+one spelling binds *nothing* wherever the server carries the other name — and
+unlike a missing grant, a missing deny fails open and silently.
+
+## Decision
+
+**Every MCP tool in an agent's `tools:` — and in `disallowedTools:` — is listed
+twice, once under each server spelling:**
+
+```yaml
+- mcp__genealogy__record_read
+- mcp__remote-devices__Genealogy_Research__record_read
+```
+
+This is safe because unrecognized entries are ignored so long as at least one
+resolves.
+
+Three corollaries:
+
+- **Never grant a server-level prefix** (`mcp__remote-devices`). That namespace
+  also carries `device_bash`, `device_commit_files`, and `project_memory_write` —
+  it would hand a read-only agent shell access to the host.
+- **Never hardcode a qualified name in a `ToolSearch` query.** Search by bare
+  name (`query: "+research_append"`), which matches whatever prefix the session
+  exposes. Cowork defers tool schemas past a size threshold and offers no control
+  over it, so `ToolSearch` is the real load path there — and
+  `select:mcp__genealogy__…` resolves to nothing behind the bridge.
+- **Built-in tools (`Read`) stay bare**, and skill `allowed-tools` stays bare
+  everywhere — it is not an exact-match spawn filter.
+
+## Alternatives considered
+
+| Option | Why rejected | Evidence |
+|---|---|---|
+| **One qualified name** (whichever prefix the author happens to know) | The exact failure of #650/#698. Whichever one you pick is wrong in some environment, and CI — which registers under `genealogy` — cannot see it | #650/#698; all three agents broken in Cowork, CI green |
+| **Bare names only** | Leaves the subagent toolless in the SDK path used by the unit harness. Bare works for skills' `allowed-tools` but not for the agent spawn filter | `CLAUDE.md` § "Dual-spelled tool names" |
+| **Grant the server-level prefix** `mcp__remote-devices` and let everything through | That namespace carries `device_bash`, `device_commit_files`, `project_memory_write`. A read-only critique agent would get host shell access | `agent-tool-names.test.ts` header comment |
+| **Make Cowork register the server under `genealogy`** | Not ours to set. The bridge namespaces by `display_name`, which is a user-facing product string | Platform behaviour |
+| **Rename the extension** so both spellings collapse | `display_name` is what users see in the install dialog; optimising it for a namespacing artifact is the wrong trade. The lint instead *derives* the expected prefix from it, so a rename fails loudly in CI | `agent-tool-names.test.ts` |
+| **Generate frontmatter at plugin-build time** from a single declaration | Splits the reviewed artifact from the executed one — the same objection that killed build-time assembly of agent bodies. An agent's capability list is security-relevant; a reviewer must see what actually ships | Issue #702 precedent |
+
+## Consequences
+
+**Gains.** Agents bind correctly in all four environments from one declaration,
+and the rename hazard is caught by CI rather than in production. The underlying
+namespacing hazard is documented across several frameworks including Anthropic's
+own surfaces (claude-code#18763); what this adds is treating allow/deny binding
+across spellings as a **CI-linted invariant**, which matters most on the deny
+side where a miss is silent. (An earlier draft claimed no public precedent for
+that. Dropped: a negative literature claim is unfalsifiable, an ADR is the wrong
+place for one, and the decision is fully justified by #650/#698 without it —
+critique §9 retracted a neighbouring novelty claim for the same reason.)
+
+**Costs, knowingly accepted.**
+
+1. **Every capability list is twice as long**, and the duplication looks like a
+   mistake to anyone who has not read this ADR. `record-extractor`'s frontmatter
+   is visibly repetitive.
+2. **Adding a tool means remembering both lines.** The lint catches a missing
+   second spelling; nothing catches a *pair* of correct entries for a tool the
+   agent's body never uses — `record-extractor` has carried `place_search` and
+   `place_search_all` under both spellings since 2026-07-18 while its body tells
+   it to omit `standard_place`.
+3. **A third registrar would need a third spelling**, and the failure mode would
+   again be silent in whichever environment we did not think of.
+
+**Risks.** The lint verifies *spelling*, not *binding*. An agent can be perfectly
+declared under both names, pass every check, and still not hold the tool at
+runtime — the SDK init handshake exposes only name, description, and model per
+agent, so there is nothing to assert against (#1084/#1085). The sibling hazard is
+agent *resolution*: a bare-name delegation silently falling back to a
+general-purpose stand-in that binds none of the deny list (#939).
+
+## Enforcement
+
+> `packages/engine/mcp-server/tests/packaging/agent-tool-names.test.ts` —
+> asserts both spellings are present for every MCP tool in `tools:` and
+> `disallowedTools:`; **derives** the bridge prefix from `manifest.json`'s
+> `display_name`, so renaming the extension fails in CI; asserts all five
+> registration sites still agree on the `genealogy` key; and fails any
+> `select:mcp__…` in a plugin body.
+
+What it does **not** catch: whether a granted tool actually binds at runtime
+(#1084/#1085); whether the agent's body ever tells it to call the tool; and a
+third prefix nobody has registered yet.
+
+## Revisit when
+
+The runtime gains prefix-insensitive matching or an inherit-on-miss default — or
+a check appears that can verify binding rather than spelling, at which point the
+dual-spelling lint becomes a subset of a stronger one.

--- a/docs/adrs/ADR-0005-ship-the-write-lockdown-as-a-plugin-hook.md
+++ b/docs/adrs/ADR-0005-ship-the-write-lockdown-as-a-plugin-hook.md
@@ -1,0 +1,140 @@
+# ADR-0005: Ship the write lockdown as a plugin `PreToolUse` hook
+
+> **Read before you:** add a guardrail · restrain the main thread · try to stop
+> the agent doing something with an allow-list · wonder why the `Bash` route is
+> left open · change `PROTECTED_PROJECT_FILES`.
+
+- **Status:** Accepted
+- **Decided:** 2026-07-30 (#989; Windows path fix #984)
+- **Recorded:** 2026-08-02
+- **Deciders:** Dallan Quass
+- **Supersedes:** —
+- **Superseded by:** —
+- **Applies to:** `packages/engine/plugin/hooks`, `apps/server/app/agent/real_agent.py`, `eval/harness/e2e/orchestrator.py`
+- **Related:** ADR-0003, ADR-0006, `docs/specs/guardrail-enforcement-spec.md` §6, issues #941, #984, #989, #911, #1160
+
+## Context
+
+`research.json` and `tree.gedcomx.json` are the durable product of a research
+session. Both are written through validating writer tools that check the whole
+project in memory and write nothing on failure. A raw `Write` or `Edit` to either
+file bypasses every invariant those tools enforce.
+
+This is not a theoretical bypass. Across three `william-ferber-origins` e2e runs
+on 2026-07-29, the agent wrote `research.json` raw **33 times** (12 / 13 / 8 —
+32 `Edit` plus 1 `Write`), all successful. All three runs made **zero MCP tool
+calls** — the genealogy server never connected (#941) — and
+`eval/runlogs/e2e/william-ferber-origins/run-2026-07-29_17-05-11.json` carries
+the agent's own diagnosis verbatim: `BLOCKER: mcp__genealogy__research_append
+tool not found`. Having no writer tool, it fell back to editing the file
+directly.
+
+The obvious fix is an allow-list. It cannot work, for a structural reason:
+**allow-lists are subtractive.** A per-agent `tools:` list can only *narrow* what
+a subagent inherits from the session, and the session's tool set is always a
+superset. There is no allow-list that denies the **main thread** a tool, and the
+main thread is what did the writing.
+
+The second constraint is environmental. `hooks=` is an SDK argument. The hosted
+control plane can set it; **Cowork cannot be made to** — session options there
+are not ours. And Cowork is the product.
+
+## Decision
+
+**The lockdown ships as a `PreToolUse` hook inside the plugin**
+(`packages/engine/plugin/hooks/hooks.json` + `guard_project_files.py`), denying
+raw `Write` / `Edit` / `NotebookEdit` on `research.json` and `tree.gedcomx.json`,
+matched on basename with both path separators handled.
+
+A plugin-shipped hook binds in **both** environments that matter: Cowork loads it
+as part of the plugin, and the hosted path gets it alongside its own `hooks=`.
+Verified live in Cowork on 2026-07-30 — the hook loads, fires under either
+matcher form, and its deny is honored with the script's own reason text
+surfacing. (That probe used a **broader matcher** than the shipped one and so
+also fired for `Bash`; the shipped `hooks.json` matcher is
+`Write|Edit|NotebookEdit`, and the `Bash` route is deliberately open — see the
+costs below.) Cowork runs `permission_mode: "default"`, the hosted path runs
+`bypassPermissions`; a hook binds under both.
+
+Three deliberate properties of the script:
+
+1. **It never raises.** Every failure path — unparseable stdin, missing fields —
+   falls through to **allowing** the call. An exception here would fail a tool
+   call the user was entitled to make.
+2. **The deny names the sanctioned writer tools, and sets no `stopReason`.** A
+   denied write is a recoverable mistake, not a stop; the turn continues.
+3. **The `Bash` route is deliberately left open.**
+
+## Alternatives considered
+
+| Option | Why rejected | Evidence |
+|---|---|---|
+| **A per-agent `tools:` allow-list** | Subtractive — cannot restrain the main thread, which is what performed all 33 raw writes | `CLAUDE.md` § "Allow-lists are subtractive"; the ferber runs |
+| **The `hooks=` SDK argument only** (no plugin hook) | The hosted path can set it; Cowork cannot be made to — and Cowork is the product. This is why the shipped hook lives in the plugin *and* the hosted path keeps its own | Verified live in Cowork 2026-07-30 |
+| **Prose in the skill bodies** — "never write these files directly" | The rule must hold for hours, so ADR-0003 applies: unanchored prose decays. The agent that wrote raw 33 times had that instruction | §5.3 audit; #941 runs |
+| **Also match `Bash`** by pattern-matching command text | Would false-deny a legitimate `python script.py research.json > out` while still missing a variable-built path. False-deny is the asymmetric risk here | `real_agent.py`; `guardrail-enforcement-spec.md` §10 |
+| **Revoke `Write`/`Edit` entirely** from the session | Skills legitimately write other files — reports, notes, templates. And no MCP tool reads `tree.gedcomx.json` as a query surface, so `Read` and its siblings are still needed | `guardrail-enforcement-spec.md` §6 "Deliberate gaps" |
+| **Raise on malformed input** so failures are visible | Inverts the risk: a bug in the guard would then fail tool calls the user was entitled to make. Fail-open is correct for a guard that sits in front of every call | Script design, `guard_project_files.py` |
+
+## Consequences
+
+**Gains.** The one route no allow-list can close is closed, in the one
+environment we cannot configure. Since it shipped, a repeat of the ferber
+scenario flails against denied writes rather than producing an unvalidated file
+— the degradation path is closed even though the underlying cause is not.
+
+**Costs, knowingly accepted.**
+
+1. **The `Bash` route is open, on purpose.** `cat >`, `sed -i`, and `python -c`
+   all get through, because the guard matches on `file_path`. The stated
+   rationale — "skills run their stdlib-only scripts through `Bash`, so it cannot
+   be revoked" — is currently *hypothetical*: no skill ships a `scripts/` folder
+   today. **The decision stands on the false-deny argument alone**, which is the
+   honest version. The rationale lives in `docs/specs/guardrail-enforcement-spec.md`
+   §6 ("`Bash` is not covered"), to be revisited only if a bypass ever actually
+   uses the shell.
+2. **Three sibling implementations exist** — the plugin hook, the hosted SDK
+   hook, and the e2e harness's own — and no test asserts they agree. They are
+   behaviourally identical today but are not textual copies, so a same-behavior
+   test has to be vector-driven rather than a string diff.
+3. **The guard is silent about *why* the writer tool was missing.** It denies the
+   symptom. Nothing treats "the writer tools are absent" as a halt condition, so
+   a run in the ferber situation now burns its full budget producing nothing at
+   all, rather than producing something wrong (#941).
+
+**Risks.** The unit tier has **no write-lockdown in any form** — its harness hook
+handles `Skill` tracking, the `image_read` context policy, and call limits, but
+carries no protected-file rule, and the unit baseline grants `Write`/`Edit` to
+every skill. So the raw-write class is entirely ungated at call time in unit runs
+and is caught only at grading time.
+
+A POSIX-only path split made the **e2e harness's** copy of this rule a complete
+no-op on Windows — the platform the genealogist team runs — between #914 (07-27)
+and #984 (07-30). The plugin hook shipped *after* that fix (#989, eleven minutes
+later the same day) and never carried the bug. But it shipped as a **copy of a
+rule that had**, which is exactly why cost 2 above matters: the divergence risk
+is not hypothetical, it has already produced one silent no-op.
+
+## Enforcement
+
+> `packages/engine/mcp-server/tests/packaging/plugin-hooks.test.ts` — asserts
+> `scripts/package-plugin.mjs`'s `INCLUDE` carries `"hooks"` (without it the
+> directory never ships, which looks identical to the runtime refusing to load
+> it) and **runs the real guard script** against vectors.
+
+What it does **not** catch: that the hook **binds as a runtime hook** — only the
+script's decisions are exercised (#1160); that the three implementations agree
+(tracked only as critique §3 P3 — no issue number of its own);
+or the `Bash` route, which is out of scope by design.
+
+`docs/specs/guardrail-enforcement-spec.md` **§6** is the authority on this
+guardrail; **§4** is the table of every guardrail's instrument, binding
+environment, and enforcing-vs-shadow status.
+
+## Revisit when
+
+A bypass is observed using the shell route — at which point the false-deny
+calculus changes and `Bash` matching becomes worth its cost. Or a skill ships a
+`scripts/` folder, which would finally make the hypothetical half of the
+rationale real. Or the per-context policy is ported to production (#911), which
+would give the hook layer a caller dimension it does not have today.

--- a/docs/adrs/ADR-0006-restrict-capability-by-tool-identity.md
+++ b/docs/adrs/ADR-0006-restrict-capability-by-tool-identity.md
@@ -1,0 +1,134 @@
+# ADR-0006: Restrict capability by tool identity, not by prompt or parameter
+
+> **Read before you:** need a delegated agent to do *part* of what a tool can do
+> · find yourself writing "you must only use this for X" in an agent body · add a
+> `mode` or `section` parameter to a writer tool to scope it · design a boundary
+> that must hold against a caller who wants to cross it.
+
+- **Status:** Accepted
+- **Decided:** 2026-07-18 (#695/#736, after the birkeland lane breach — the agent itself shipped 2026-07-12 in #650 carrying the *prose* lane this replaced)
+- **Recorded:** 2026-08-02
+- **Deciders:** Dallan Quass
+- **Supersedes:** —
+- **Superseded by:** —
+- **Applies to:** `packages/engine/mcp-server/src/tools/extraction-append.ts`, `packages/engine/mcp-server/src/tools/research-append.ts`, `packages/engine/plugin/agents/record-extractor.md`
+- **Related:** ADR-0003, ADR-0004, ADR-0005, `docs/specs/research-append-tool-spec.md` §11
+
+## Context
+
+`record-extractor` is delegated one record at a time and owns exactly two
+sections of `research.json`: `sources` and `assertions`. It must not write
+identity links, conflicts, proof summaries, or anything else — those belong to
+`person-evidence`, `conflict-resolution`, and `proof-conclusion`, and the whole
+point of extracting in fresh context is that the extractor has not seen, and
+cannot be steered by, the session's prior conclusions.
+
+The boundary was originally prose in the agent body. It did not hold. In the
+birkeland re-run, a delegation message prompted the extractor past its stated
+lane and **it fabricated a `match_score`** (0.92) — a number that belongs to the
+identity decision it is specifically not supposed to make.
+
+> *Sourcing note:* this incident survives only as a quotation. It is recorded in
+> `src/tools/extraction-append.ts` and `research-append-tool-spec.md` §11, but
+> the primary write-up it cites is not in the repo, so the run cannot be re-read.
+
+That failure is instructive about *why*, not just *that*. The caller composes the
+delegation message. A boundary written in the callee's prompt is being enforced
+by the same text the caller is arguing with, and the caller wins often enough to
+matter.
+
+The obvious next idea — put the restriction in the tool's input — fails for a
+sibling reason: **the caller supplies the input.** A `sections: ["sources"]`
+parameter is a request, not a constraint.
+
+## Decision
+
+**Where a boundary must hold against a misdirected caller, narrow the tool, not
+the prompt.**
+
+`extraction_append` is `research_append` restricted to `sources` and
+`assertions`. It is the *same implementation*, gated by a **second function
+parameter**:
+
+```ts
+researchAppend(input, { allowedSections, toolName })
+```
+
+A tool caller structurally cannot reach that second argument, because dispatch
+builds only the first one from tool input. The restriction is not in the payload,
+so there is nothing for the model to set.
+
+The agent then holds `extraction_append` and **not** `research_append` — omitted
+from `tools:` and additionally named in `disallowedTools:` under both spellings
+(ADR-0004), because a deny binds even under `bypassPermissions`.
+
+The general form:
+
+| Lane | Holds? | Why |
+|---|---|---|
+| Prose in the agent body | **No** | the caller can prompt past it |
+| A parameter on the tool input | **No** | the caller supplies the input |
+| **Tool identity** | **Yes** | the capability is absent from the agent's world |
+
+## Alternatives considered
+
+| Option | Why rejected | Evidence |
+|---|---|---|
+| **Prose in the agent body** — "only write sources and assertions" | This is what was there. A delegation message prompted past it and the agent fabricated a `match_score` | The birkeland re-run; `research-append-tool-spec.md` §11 |
+| **A `sections:` parameter** on `research_append` | The caller supplies the input; a parameter is a request. Same class of failure as prose, one layer down | `research-append-tool-spec.md` §11.2 |
+| **A separate per-skill write tool for every lane** (`person_evidence_append`, `conflict_append`, …) | Rejected earlier and independently: *"a split tool is exactly as callable by the router as a section branch is."* Splitting names does not constrain a caller who holds all of them — the constraint comes from *not holding* the broad one, which is what `disallowedTools:` provides | `docs/specs/guardrail-enforcement-spec.md` §9 |
+| **A `PreToolUse` hook** discriminating by caller | A design exists, but it is less portable than it looks. `eval/harness/harness/context_policy.py` denies `image_read` on **three** conditions — the tool is guarded, `agent_id` is absent, **and** the calling skill did not declare it in its own `allowed-tools` (`search-images` declares it and legitimately calls it on the main thread). The discriminator is therefore the skill's declaration, which the production path has no equivalent of, and the module says the e2e orchestrator cannot use it either. Unported and gated on calibrating the shadow window first (#911). Tool identity needed no new machinery | #911; `context_policy.py` ("Membership here is necessary but NOT sufficient") |
+| **Duplicate the implementation** into a genuinely separate `extraction_append` | Two copies of the validation logic drift. Same implementation, different entry point, keeps one contract | Code-reuse convention, `CLAUDE.md` |
+| **Trust the eval suite to catch lane violations** | Grades after the fact and only on cases the corpus covers. `research-append-tool-spec.md` is explicit that for `match_score` specifically *"the lever there is eval/rubric, not tooling"* — which is precisely the gap this pattern closes for sections | `research-append-tool-spec.md` |
+
+## Consequences
+
+**Gains.** The boundary is unforgeable from the callee's side: there is no
+argument, no parameter, and no prompt that lets `record-extractor` write a proof
+summary, because the capability is not in its world. It composes with ADR-0004 —
+the deny binds even under `bypassPermissions`, which is the hosted path's mode —
+and it needed no new enforcement machinery. This is textbook least-privilege by
+2025 standards (OWASP Excessive Agency); what is worth keeping is the specific
+mechanism, the second function parameter that dispatch cannot populate.
+
+**Costs, knowingly accepted.**
+
+1. **Every narrowed lane is another tool in the catalog**, and tool count is
+   context budget in every session (ADR-0002). This does not scale to a lane per
+   skill — it is reserved for boundaries that have actually been crossed.
+2. **The pattern only covers what a *tool* can express.** It scopes *which
+   sections* the extractor writes. It does **not** stop it writing a wrong value
+   into a section it legitimately owns — `match_score` remains caller-fabricable,
+   and the spec says so plainly.
+3. **Two places must agree.** The tool must be narrowed *and* the agent's
+   frontmatter must omit-and-deny the broad one. Getting only the first gives an
+   agent that can still call `research_append` directly.
+
+**Risks.** Nothing verifies the deny actually binds at runtime — the lint checks
+spelling only (#1084/#1085, ADR-0004). And the same reasoning is wanted for
+identity scoring (`same_person`), where it has **not** been made to work: three
+candidate discriminators have now failed adversarial review, and the next
+deliverable there is a gate spec with five named design constraints, not a code
+change. **Do not assume this pattern generalises to that problem** — read
+`docs/agentic-system-critique.md` §3 P0 and §9 before proposing a fourth.
+
+## Enforcement
+
+> `packages/engine/mcp-server/tests/packaging/agent-tool-names.test.ts` —
+> asserts `disallowedTools:` entries carry both spellings, so the deny binds
+> wherever the server is registered.
+
+The structural half needs no test: dispatch builds only the first argument, so
+the second is unreachable from tool input by construction. That is the point of
+choosing this mechanism over a parameter.
+
+What is **not** covered: that the deny binds at runtime; that a *value* written
+into an owned section is correct.
+
+## Revisit when
+
+A second lane needs narrowing — at which point the question is whether a
+per-context `PreToolUse` policy (#911) has become the cheaper general mechanism,
+since it discriminates by caller without adding a tool per lane. Or when the
+`same_person` gate spec lands, which may establish a different pattern for
+boundaries that depend on *values* rather than sections.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,91 @@
+# Architecture Decision Records
+
+One decision per file. **What each one owes you: why it is this way, what else
+was tried, and what it would take to change it.**
+
+These exist so a developer — working with Claude, at the moment of work — can
+act on a decision without having to re-derive it or re-litigate it. That is a
+different job from the two neighbouring docs:
+
+| Doc | Answers |
+|---|---|
+| [`CLAUDE.md`](../../CLAUDE.md) | *What rule must I follow?* — auto-loaded every session |
+| [`docs/architecture.md`](../architecture.md) | *Where does my change land?* — the map |
+| **`docs/adrs/`** | *Why is it this way, and what would change it?* |
+
+## When something is an ADR
+
+**An ADR is a decision with a rejected alternative.** If nothing was rejected,
+it is not a decision — it is architecture-guide prose. Write it there instead.
+
+Two more tests:
+
+- **Would a competent developer plausibly do it the other way?** If not, it is a
+  fact, not a decision.
+- **Has someone already argued for the other way?** Then the ADR is overdue —
+  that argument is the most valuable thing in it.
+
+## The rules
+
+**1. Numbered, zero-padded, never reused.** `ADR-0007-short-slug.md`. A deleted
+ADR's number stays retired.
+
+**2. Titled as an action.** "Dual-spell every MCP tool name in agent
+frontmatter," not "Tool naming." A reader scanning the index should see what was
+decided, not what it was about.
+
+**3. Immutable where it is history; live where it is a pointer.**
+
+| Section | Rule |
+|---|---|
+| Context, Decision, Alternatives considered, Consequences | **Frozen.** History does not rot. To change a decision, write a new ADR and mark this one `Superseded by`. Never edit these to reflect new reality. |
+| Applies to, Enforcement, Related | **Live.** These are pointers into a moving codebase. Fix them in the PR that moves the code. |
+
+That split is deliberate. Classic ADR practice freezes the whole file, which is
+right for an archive and wrong for us — a developer reads these *while working*,
+so a stale path is not a curiosity, it is a wrong answer they will act on.
+
+**4. Every path is linted.** `tests/packaging/adr-links.test.ts` asserts that
+every repo path cited in `Applies to` or `Enforcement` resolves. Move the code,
+and CI fails until the ADR is updated or superseded. This is the only thing
+keeping the set trustworthy past a few months — do not weaken it.
+
+**5. `Read before you:` is the routing line.** It is the field that decides
+whether the ADR is ever opened, so write it like a skill `description`: the
+concrete tasks that should send someone here, in their words. Under-trigger and
+the ADR is invisible; over-trigger and it dilutes the index.
+
+**6. Say what it costs.** The `Costs, knowingly accepted` paragraph is not
+optional and is not a formality. If the answer is "nothing," the decision was
+not a tradeoff and probably does not need an ADR.
+
+**7. Evidence, not assertion.** This repo rejects things by measurement — the
+`record-extractor` playbook A/B, the compaction-decay audit, the model
+downgrade. When that evidence exists, cite it with a number. When it does not,
+say "argued, not measured." Both are fine; pretending is not.
+
+## Superseding
+
+Add `**Superseded by:** ADR-00NN` to the old file's header and nothing else —
+leave its body untouched. Add `**Supersedes:** ADR-00MM` to the new one. A
+superseded ADR stays in the directory: the record of a decision that was
+reversed is often worth more than the decision that replaced it.
+
+## Writing a new one
+
+Copy [`_template.md`](_template.md). Fill every field — an empty section means
+"we did not think about this," so write that if it is true.
+
+Then add a row to the index in [`docs/architecture.md`](../architecture.md) §0,
+between the `ADR-INDEX-START` / `ADR-INDEX-END` markers. The index line carries
+the routing weight, because it is what a reader sees before deciding to open
+anything.
+
+## Related
+
+- [`docs/agentic-system-critique.md`](../agentic-system-critique.md) §9 —
+  "Refuted in review — do not re-derive." A running ledger of claims that were
+  argued and disproved. Several of these ADRs were mined from it, and new
+  entries there are candidate ADRs.
+- `docs/specs/guardrail-enforcement-spec.md` §9 — "Options set aside," the same
+  pattern scoped to guardrails.

--- a/docs/adrs/_template.md
+++ b/docs/adrs/_template.md
@@ -1,0 +1,67 @@
+# ADR-NNNN: <The decision, stated as an action>
+
+> **Read before you:** <the concrete tasks that should send someone here, in
+> their words — e.g. "add an MCP tool · change an agent's `tools:` frontmatter ·
+> grant a tool to a subagent">. This line is the routing surface; write it like
+> a skill `description`.
+
+- **Status:** Proposed | Accepted | Superseded
+- **Decided:** <when the decision was actually taken — or "pre-YYYY-MM (reconstructed)">
+- **Recorded:** <when this file was written>
+- **Deciders:** <names>
+- **Supersedes:** — <or ADR-00MM>
+- **Superseded by:** — <set when retired; never edit the body instead>
+- **Applies to:** `path/or/glob` — *linted; keep current*
+- **Related:** <issues, PRs, specs>
+
+## Context
+
+The **forces**, not the solution. What was true when this was decided, what
+constraint was non-negotiable, and what goes wrong if nothing is done.
+
+State facts that were *verified*, and say where. If a number appears here, a
+reader must be able to reproduce it.
+
+## Decision
+
+One sentence, active voice, present tense. Then at most a paragraph on what that
+concretely means at the code level.
+
+## Alternatives considered
+
+| Option | Why rejected | Evidence |
+|---|---|---|
+| <the obvious other way> | <the specific failure> | <file:line, a measurement, an incident — or "argued, not measured"> |
+
+Every row needs a **why** *and* an **evidence** cell. An alternative with no
+evidence is one nobody actually evaluated — write "argued, not measured" and be
+honest, rather than implying a test that never ran.
+
+Include the alternatives a newcomer will propose. An ADR that only lists exotic
+options will not stop the obvious suggestion from coming back.
+
+## Consequences
+
+**Gains.** What this buys, concretely.
+
+**Costs, knowingly accepted.** What it makes worse, and who pays. Not optional.
+If the answer is "nothing," this was not a tradeoff and may not need an ADR.
+
+**Risks.** What could bite later, and what we are not doing about it.
+
+## Enforcement
+
+How we would know this broke — a test, a CI job, a lint. Or the words
+**"None — convention only,"** which is a legitimate and useful answer.
+
+> `path/to/test` — what it asserts.
+> What it does **not** catch.
+
+*Linted: every path in this section must resolve.*
+
+## Revisit when
+
+The specific new fact that would reopen this. Not "if requirements change."
+
+> <e.g. "A bypass is observed using the shell route," or "a skill ships a
+> `scripts/` folder that needs `Bash`.">

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,7 +91,7 @@ Facts about this system live in one of three places:
 |---|---|---|
 | **`CLAUDE.md`** (repo root) | **The imperative.** "List both spellings." "Pass `encoding="utf-8"`." The rules you must follow to make a correct change. | Always — the only tier auto-loaded into every session. |
 | **This guide** | **The map.** What the pieces are, how they bind, where a change lands, what nothing checks. It restates an imperative only where you need it to size a blast radius, and names `CLAUDE.md` as that rule's owner. **On conflict, `CLAUDE.md` wins.** | Before a change whose blast radius you don't already know. |
-| **`docs/adrs/`** *(planned — not yet written)* | **The why.** One decision per file: forces, alternatives tried and rejected, consequences knowingly accepted. | Until it exists, the "why" is in the linked spec or in [`docs/agentic-system-critique.md`](agentic-system-critique.md). |
+| [**`docs/adrs/`**](adrs/) | **The why.** One decision per file: forces, alternatives tried and rejected, consequences knowingly accepted. Its Context/Decision/Alternatives are frozen history; its `Applies to`/`Enforcement` pointers are live and CI-linted. | A rule looks arbitrary, or you want to change it. Index below. |
 
 If this guide and a per-tool spec (`docs/specs/<tool>-tool-spec.md`) disagree,
 **the spec wins** — it is the contract `spec-review` checks against.
@@ -113,8 +113,23 @@ carries the instruction, not the reasoning.
 ### ADR index
 
 <!-- ADR-INDEX-START -->
-*`docs/adrs/` is being written. Until it lands, the "why" behind each decision
-below lives in the linked spec, in `CLAUDE.md`, or in the critique.*
+One decision per file, in [`docs/adrs/`](adrs/). Read one when a rule looks
+arbitrary, or when you want to change it. The **"read before you"** column is the
+routing surface — find your task, then open that ADR.
+
+| ADR | Decision | Read before you… |
+|---|---|---|
+| [0001](adrs/ADR-0001-run-network-code-on-the-host.md) | Run all network code on the host; ship only offline code into the VM | add a feature that calls an external API · write a script that ships in a skill or hook · debug a call that returns nothing with no error |
+| [0002](adrs/ADR-0002-decompose-into-tools-skills-and-agents.md) | Decompose into MCP tools, skills, and plugin agents by what each needs | add any capability and wonder where it goes · choose between a skill and a subagent · add a tool for something the model could just do |
+| [0003](adrs/ADR-0003-anchor-cross-turn-rules-structurally.md) | Anchor cross-turn rules structurally rather than in prose | write a new rule into a `SKILL.md` or agent body · fix a compliance failure by making an instruction clearer · reinforce a rule that keeps being violated |
+| [0004](adrs/ADR-0004-dual-spell-mcp-tool-names-in-agent-frontmatter.md) | Dual-spell every MCP tool name in agent frontmatter | grant or deny a tool to a plugin agent · write a `ToolSearch` query · rename the desktop extension |
+| [0005](adrs/ADR-0005-ship-the-write-lockdown-as-a-plugin-hook.md) | Ship the write lockdown as a plugin `PreToolUse` hook | add a guardrail · restrain the main thread · try to stop the agent doing something with an allow-list · change `PROTECTED_PROJECT_FILES` |
+| [0006](adrs/ADR-0006-restrict-capability-by-tool-identity.md) | Restrict capability by tool identity, not by prompt or parameter | need a delegated agent to do *part* of what a tool can do · write "you must only use this for X" in an agent body · add a `mode` parameter to scope a writer tool |
+
+Conventions, and how to add one: [`docs/adrs/README.md`](adrs/README.md).
+Not yet written: state and the writer/projection tools, self-contained agent
+bodies, duplicated `references/`, the casing seam, model routing,
+descriptions-as-triggering.
 <!-- ADR-INDEX-END -->
 
 ---
@@ -791,8 +806,9 @@ that produced it** — `record_search`, `fulltext_search`, and
 `external_links_search` write their payload into `results/.staging/` and return a
 handle plus a **reduced** inline copy, which `research_log_append` later
 finalizes. The reduction differs by tool: `record_search` drops `gedcomx`,
-`collectionUrl`, and empty `treeMatches` and hoists `collectionTitle` into a
-response-level map; `fulltext_search` drops `textDocument`; both leave
+`collectionUrl`, and empty `treeMatches`, hoists `collectionTitle` into a
+response-level map, and de-duplicates `events`; `fulltext_search` drops
+`textDocument`; both leave
 name/date/place stubs for triage. `external_links_search` reduces differently —
 it caps the *number* of inline rows and leaves each row intact, because its
 payload is curated third-party URLs with nothing to triage on. **The full payload travels
@@ -1087,7 +1103,7 @@ skips silently**, which looks identical to passing.
 | `make server-test` | `apps/server` (FastAPI, pytest) | the in-sandbox path on real E2B |
 | **`make agent-smoke`** | that the hosted path resolves plugin agents under bare names | whether a granted tool actually **binds**; skips silently with no API key |
 | `make eval-skill SKILL=<name>` | one skill's unit suite against mocked MCP fixtures | multi-turn decay — it grades a single invocation in fresh context |
-| `make e2e-run TEST=<fixture>` | one fixture against **live FamilySearch**. Across all 111 committed costed runs: ~$7 median, range $3–25, 20–180 min | everything outside that fixture. A capped or timed-out run is the expensive tail, not an exception — and timed-out runs record *no* cost, so the mean is a floor. (`Makefile` says "~20-60 min, $3-10" over a narrower window.) |
+| `make e2e-run TEST=<fixture>` | one fixture against **live FamilySearch**. Across all 111 committed costed runs: ~$7 median, $3–25 typical, 20–180 min (two outliers below $3, floor $0.06 — those are runs that died early) | everything outside that fixture. A capped or timed-out run is the expensive tail, not an exception — and most timed-out runs record *no* cost, so the mean is a floor. (`Makefile` says "~20-60 min, $3-10" over a narrower window.) |
 
 ### 9.2 The lint layer
 
@@ -1219,7 +1235,7 @@ Things that are genuinely unsettled, as distinct from §9.4's missing guards.
 | What rule must I follow to make a correct change? | [`CLAUDE.md`](../CLAUDE.md) — the operating manual, auto-loaded every session |
 | What does tool X do? | `docs/specs/<tool>-tool-spec.md` — **wins over this guide on conflict** |
 | What tools / skills / agents exist, for a user? | [`README.md`](../README.md) |
-| Why is it built this way? | [`docs/agentic-system-critique.md`](agentic-system-critique.md) for the measured why; the linked spec for the rest. (`docs/adrs/` is planned, not written.) |
+| Why is it built this way? | [`docs/adrs/`](adrs/) — one decision per file, with the alternatives that were tried and rejected. Index in §0. For decisions with no ADR yet, the linked spec or [`docs/agentic-system-critique.md`](agentic-system-critique.md). |
 | What is wrong with it, and what's next? | [`docs/agentic-system-critique.md`](agentic-system-critique.md) |
 | Every guardrail, its instrument, its status | [`guardrail-enforcement-spec.md`](specs/guardrail-enforcement-spec.md) |
 | The write boundary and the `extraction_append` lane | [`research-append-tool-spec.md`](specs/research-append-tool-spec.md) §11 |

--- a/packages/engine/mcp-server/tests/packaging/adr-links.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/adr-links.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * ADR staleness lint.
+ *
+ * ADRs are read *at the moment of work* by developers (and by Claude) who
+ * treat them as authoritative. Classic ADR practice freezes the whole file,
+ * which is right for an archive and wrong for us: a stale path is not a
+ * curiosity, it is a wrong answer someone will act on.
+ *
+ * So `docs/adrs/README.md` splits each ADR in two — Context / Decision /
+ * Alternatives / Consequences are frozen history, while **Applies to** and
+ * **Enforcement** are live pointers into a moving codebase. This test is what
+ * makes the live half true: every repo path cited in those two places must
+ * resolve. Move the code and CI fails until the ADR is updated or superseded.
+ *
+ * Without this the set is trustworthy for about two months.
+ *
+ * Scope note: a path is any backticked token containing "/" that starts with a
+ * known top-level directory. That deliberately excludes bare filenames
+ * (`research.json`), tool names (`mcp__genealogy__record_read`), and prose, so
+ * the lint has no false positives to train people to ignore.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const engineRoot = join(here, "..", "..", ".."); // packages/engine/
+const projectRoot = join(engineRoot, "..", ".."); // repo root
+const adrDir = join(projectRoot, "docs", "adrs");
+
+/** Top-level dirs a cited path may start with. */
+const REPO_ROOTS = [
+  "docs/",
+  "packages/",
+  "apps/",
+  "eval/",
+  "scripts/",
+  ".github/",
+  ".claude/",
+];
+
+/** Sections whose paths must resolve. The rest of an ADR is frozen history. */
+const LIVE_SECTIONS = ["Applies to", "Enforcement"];
+
+const ADR_FILE = /^ADR-(\d{4})-[a-z0-9-]+\.md$/;
+
+function adrFiles(): string[] {
+  if (!existsSync(adrDir)) return [];
+  return readdirSync(adrDir)
+    .filter((f) => f.endsWith(".md") && f !== "README.md" && f !== "_template.md")
+    .sort();
+}
+
+/**
+ * Pull the text of the live sections: the `**Applies to:**` header line, and
+ * the `## Enforcement` section up to the next `## `.
+ */
+function liveSectionText(body: string): string {
+  const parts: string[] = [];
+
+  const appliesTo = body.match(/^\s*-\s*\*\*Applies to:\*\*(.*)$/m);
+  if (appliesTo) parts.push(appliesTo[1]);
+
+  const enforcement = body.match(/^## Enforcement\s*$([\s\S]*?)(?=^## |\Z)/m);
+  if (enforcement) parts.push(enforcement[1]);
+
+  return parts.join("\n");
+}
+
+/** Backticked tokens that look like repo paths. */
+function citedPaths(text: string): string[] {
+  const found = new Set<string>();
+  for (const m of text.matchAll(/`([^`\n]+)`/g)) {
+    const token = m[1].trim();
+    if (!token.includes("/")) continue;
+    if (!REPO_ROOTS.some((r) => token.startsWith(r))) continue;
+    // Strip a trailing line/anchor reference: path.ts:123 or path.md#section
+    found.add(token.replace(/[:#].*$/, ""));
+  }
+  return [...found];
+}
+
+describe("ADR hygiene", () => {
+  const files = adrFiles();
+
+  it("has a template and a README explaining the convention", () => {
+    expect(existsSync(join(adrDir, "_template.md"))).toBe(true);
+    expect(existsSync(join(adrDir, "README.md"))).toBe(true);
+  });
+
+  it("names every ADR ADR-NNNN-slug.md with a unique, zero-padded number", () => {
+    const seen = new Map<string, string>();
+    for (const f of files) {
+      expect(f, `${f} must match ADR-NNNN-slug.md`).toMatch(ADR_FILE);
+      const num = f.match(ADR_FILE)![1];
+      expect(
+        seen.has(num),
+        `ADR number ${num} is used by both ${seen.get(num)} and ${f} — numbers are never reused`,
+      ).toBe(false);
+      seen.set(num, f);
+    }
+  });
+
+  it.each(files)("%s carries every required field", (file) => {
+    const body = readFileSync(join(adrDir, file), "utf8");
+
+    for (const field of [
+      "Read before you:",
+      "**Status:**",
+      "**Decided:**",
+      "**Recorded:**",
+      "**Applies to:**",
+    ]) {
+      expect(body, `${file} is missing "${field}"`).toContain(field);
+    }
+
+    for (const heading of [
+      "## Context",
+      "## Decision",
+      "## Alternatives considered",
+      "## Consequences",
+      "## Enforcement",
+      "## Revisit when",
+    ]) {
+      expect(body, `${file} is missing "${heading}"`).toContain(heading);
+    }
+
+    // An ADR is a decision with a rejected alternative. Require at least one
+    // real table row rather than an empty section.
+    const alts = body.match(/^## Alternatives considered\s*$([\s\S]*?)(?=^## )/m);
+    const rows = (alts?.[1] ?? "")
+      .split("\n")
+      .filter((l) => l.trim().startsWith("|") && !/^\|[\s|:-]+\|$/.test(l.trim()));
+    expect(
+      rows.length,
+      `${file} lists no rejected alternative. If nothing was rejected it is not a decision — put it in docs/architecture.md instead.`,
+    ).toBeGreaterThanOrEqual(2); // header row + at least one option
+
+    // Costs are not optional; an ADR with no cost was not a tradeoff.
+    expect(
+      body,
+      `${file} must state "Costs, knowingly accepted" — if nothing was given up, reconsider whether this is an ADR`,
+    ).toContain("Costs, knowingly accepted");
+  });
+
+  it.each(files)("%s cites only paths that still exist", (file) => {
+    const body = readFileSync(join(adrDir, file), "utf8");
+    const missing = citedPaths(liveSectionText(body)).filter(
+      (p) => !existsSync(join(projectRoot, p)),
+    );
+
+    expect(
+      missing,
+      `${file} cites paths that no longer exist: ${missing.join(", ")}\n` +
+        `Fix the "Applies to" / "Enforcement" pointers in the same PR that moved the code, ` +
+        `or supersede the ADR. Do not edit its Context/Decision/Alternatives — those are frozen history.`,
+    ).toEqual([]);
+  });
+
+  it("is indexed in docs/architecture.md", () => {
+    const guide = join(projectRoot, "docs", "architecture.md");
+    if (!existsSync(guide)) return; // guide lands on its own branch
+    const text = readFileSync(guide, "utf8");
+    const index = text.match(
+      /<!-- ADR-INDEX-START -->([\s\S]*?)<!-- ADR-INDEX-END -->/,
+    );
+    expect(index, "docs/architecture.md has lost its ADR-INDEX markers").not.toBeNull();
+
+    const missing = files.filter((f) => !index![1].includes(f));
+    expect(
+      missing,
+      `these ADRs are not in the docs/architecture.md index, so nobody will find them: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
> **Stacked on #1169.** Review that first; this diffs against it.

## Summary

Adds `docs/adrs/` so a developer working with Claude can act on a decision without re-deriving or re-litigating it — the third tier alongside `CLAUDE.md` (the rule) and `docs/architecture.md` (the map).

| ADR | Decision |
|---|---|
| 0001 | Run all network code on the host; ship only offline code into the VM |
| 0002 | Decompose into MCP tools, skills, and plugin agents by what each needs |
| 0003 | Anchor cross-turn rules structurally rather than in prose |
| 0004 | Dual-spell every MCP tool name in agent frontmatter |
| 0005 | Ship the write lockdown as a plugin `PreToolUse` hook |
| 0006 | Restrict capability by tool identity, not by prompt or parameter |

The arc is deliberate: constraint → decomposition → the rule-placement law → the three capability decisions that follow. Batch 2 (state, self-contained agent bodies, duplicated references, the casing seam, model routing, descriptions-as-triggering) is listed in the guide's index as not-yet-written.

## Two departures from classic ADR practice

Both because these get read **at the moment of work**, not as an archive:

1. **Split by tense.** Context / Decision / Alternatives / Consequences are frozen history — to change a decision you write a new ADR and supersede. But **`Applies to` and `Enforcement` are live pointers**, fixed in the PR that moves the code. A stale path in a doc someone consults while working isn't a curiosity, it's a wrong answer they'll act on.

2. **`tests/packaging/adr-links.test.ts` enforces that.** Every repo path an ADR cites in those two sections must resolve — move the code and CI fails until the ADR is updated or superseded. It also requires at least one rejected alternative (*"if nothing was rejected it is not a decision — put it in the architecture guide"*), a `Costs, knowingly accepted` paragraph, unique zero-padded numbering, and presence in the guide's index. **Verified to fail, not just to pass** — I injected a bogus path and confirmed the error message is actionable.

Each ADR opens with a **`Read before you:`** trigger line written like a skill `description`. An ADR nobody opens is worse than none.

## Sourcing caveats — deliberate, and worth a look

Where a claim can't be reproduced from the repo, the ADR says so rather than asserting it:

- **ADR-0001's founding premise** — "blocked calls fail silently in the VM" — has **no dated observation anywhere in the repo.** It's in `CLAUDE.md` and has never been contradicted, but a reader can't reproduce it. Named as a gap, with a request to date it if anyone re-observes.
- **ADR-0003's arXiv citation** carries no DOI, authors, or URL. Repeated as attribution, not evidence; the decision rests on the reproducible §5.3 audit alone.
- **The birkeland incident** survives only as a quotation — the primary write-up isn't in the repo.

The reasoning: separating reproducible from attested means a bad citation costs one sentence instead of the whole decision. Six of the eight errors an adversarial review found in the first draft were inherited from confidently-worded prose upstream.

## Verification

One adversarial pass found **8 factual errors, 4 cross-document contradictions, and 8 unverifiable claims** — including a `Decided` date that was the date of the thing the ADR *replaced*, a Windows bug attributed to a guard that didn't exist yet, and a reasoning error where I used a capability-grant bug as evidence for a design tradeoff. All fixed.

`npx vitest run tests/packaging/` — 161/161 (146 + 15 new).

## Test plan

- [x] Packaging suite passes, including the new lint
- [x] Lint verified to **fail** on an injected bad path
- [x] Every ADR index link resolves; trigger lines match each ADR's own

🤖 Generated with [Claude Code](https://claude.com/claude-code)