### PR TITLE
fix: schema-mirror drift, test-all typecheck gap, inverted ToolSearch comments, dead dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,13 +247,19 @@ typecheck: $(JS_DEPS) ## Typecheck the whole JS workspace (turbo)
 	pnpm typecheck
 
 .PHONY: test-all
-test-all: ## Run EVERY test suite (JS workspace + server + engine + eval harness + CRUD UI)
+test-all: ## Run EVERY check: typecheck + every test suite (JS workspace + server + engine + eval harness + CRUD UI)
+	# `typecheck` first, and it is NOT redundant with test-js: turbo.json defines
+	# `test` and `typecheck` as separate tasks, so `pnpm test` never runs tsc. A
+	# viewer-side type break used to pass `make test-all` clean and surface only
+	# in CI (.github/workflows/js-tests.yml, which runs both). It costs seconds
+	# and fails fast, so it goes before the suites rather than after.
+	$(MAKE) typecheck
 	$(MAKE) test-js
 	$(MAKE) server-test
 	$(MAKE) engine-test
 	$(MAKE) harness-test
 	$(MAKE) eval-ui-test
-	@echo "✓ all test suites passed"
+	@echo "✓ typecheck + all test suites passed"
 
 .PHONY: test
 test: ## Quick loop: JS workspace + server tests (a subset of test-all)

--- a/apps/server/app/agent/real_agent.py
+++ b/apps/server/app/agent/real_agent.py
@@ -244,11 +244,22 @@ def build_options(project_dir: Path, resume: str | None = None, api_key: str | N
         # minutes. The deltas are also what keeps the socket's data frames flowing
         # through the sandbox's edge proxy during that stretch.
         include_partial_messages=True,
-        # ENABLE_TOOL_SEARCH=true eager-loads the genealogy MCP tool schemas
-        # instead of deferring them above the bundled CLI's token threshold
-        # (the ~38-tool server trips it), which otherwise forces repeated
-        # ToolSearch re-discovery mid-session. See speedup plan §3a — kept in
-        # sync with the e2e orchestrator so hosted-web users get the same win.
+        # ENABLE_TOOL_SEARCH turns tool search ON, not off — the polarity is the
+        # opposite of what this comment claimed until issue #1110. Read off the
+        # installed CLI (v2.1.220): a truthy value (`true|1|yes|on`) selects
+        # deferred/tool-search mode, `auto`/`auto:N` is the adaptive variant, and
+        # only a FALSY value (`false|0|no|off`) selects "standard" mode, where
+        # every schema is loaded up front. Unset also lands on tool-search mode,
+        # so deleting the variable eager-loads nothing. (Additionally forced off
+        # on a non-first-party ANTHROPIC_BASE_URL, on Vertex, and under
+        # CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS.)
+        #
+        # So "true" below means hosted sessions run WITH tool search: the
+        # ~38-tool genealogy server's schemas are deferred and re-discovered via
+        # ToolSearch mid-session. Speedup plan §3a wanted the opposite; flipping
+        # to "false" is a separate, tracked decision that requires re-measuring
+        # the tool mix, so the value is left as it has been running — and kept in
+        # sync with the e2e orchestrator either way.
         env={
             "ANTHROPIC_API_KEY": current_api_key() if api_key is None else api_key,
             "ENABLE_TOOL_SEARCH": "true",

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "python-multipart>=0.0.12",
     "pydantic-settings>=2.14.2",
     "claude-agent-sdk>=0.2.128",
-    "ably>=3.1.2",
     "e2b>=2.35.0",
     # Postgres driver (Neon on Fly); SQLite remains the local default. The
     # [binary] extra bundles libpq → no Dockerfile/apt change on python:3.12-slim.

--- a/apps/server/uv.lock
+++ b/apps/server/uv.lock
@@ -9,22 +9,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "ably"
-version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "h2" },
-    { name = "httpx" },
-    { name = "msgpack" },
-    { name = "pyee" },
-    { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/35/dfa754f987629c103d17078cd5f6c2af389e4e89f23f8f8ed903e36e7b4b/ably-3.1.2.tar.gz", hash = "sha256:d760bc7ac07b37be51f0122da2630bd6c525ea9b9faba71ed5a1307b4210ef3f", size = 1098509, upload-time = "2026-03-27T15:38:24.49Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/a0/5869023a50a7671f84832cc46ca6c72f08949ab7296f01662cca3aea1ed3/ably-3.1.2-py3-none-any.whl", hash = "sha256:1b7c4147229f73460de637235c1812dbb7055eb7df23f4a77af221134ec18d9f", size = 191263, upload-time = "2026-03-27T15:38:22.967Z" },
-]
-
-[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -297,7 +281,6 @@ name = "genealogy-workbench-server"
 version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "ably" },
     { name = "claude-agent-sdk" },
     { name = "e2b" },
     { name = "fastapi" },
@@ -320,7 +303,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ably", specifier = ">=3.1.2" },
     { name = "claude-agent-sdk", specifier = ">=0.2.128" },
     { name = "e2b", specifier = ">=2.35.0" },
     { name = "fastapi", specifier = ">=0.140.13" },
@@ -610,58 +592,6 @@ wheels = [
 ]
 
 [[package]]
-name = "msgpack"
-version = "1.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
-    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
-    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
-    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
-    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
-    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
-    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
-    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
-    { url = "https://files.pythonhosted.org/packages/77/58/cce442852c6b9e1639c7c8ac8fd9143121cb32dab0f308df4d1426a8eb9c/msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d", size = 83610, upload-time = "2026-06-18T16:13:25.724Z" },
-    { url = "https://files.pythonhosted.org/packages/60/5c/15b4c7a0182f75ffa90751958ba36a9c01cafee367d49a3edc10ed140b01/msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7", size = 83138, upload-time = "2026-06-18T16:13:26.781Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a6/99e58722feaffc5f2fbcc0c8c0d1451ab9f84097f7af87291b46af2390f4/msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889", size = 406090, upload-time = "2026-06-18T16:13:28.072Z" },
-    { url = "https://files.pythonhosted.org/packages/19/03/8c63e8cf52958534ef688625965ab04c269a6cadd8caef16758b380a821a/msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720", size = 412106, upload-time = "2026-06-18T16:13:29.427Z" },
-    { url = "https://files.pythonhosted.org/packages/63/d2/155d9e71b40e41fd934bc0c48b9b2770f22263e1ac20aad8e29fdca7be3f/msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190", size = 374851, upload-time = "2026-06-18T16:13:30.631Z" },
-    { url = "https://files.pythonhosted.org/packages/98/48/deaf2326262a8d5ea3295ce9649912ecd3f551ba7ec8e33c665d2ba583f3/msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d", size = 396168, upload-time = "2026-06-18T16:13:31.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/2a/b4410f906c2ec0008f1608d3ab5143afc3ad3f4e6da0fed3ea2231d0bef4/msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24", size = 371959, upload-time = "2026-06-18T16:13:33.282Z" },
-    { url = "https://files.pythonhosted.org/packages/59/86/1edc67270099a528fa2093ea60fe191233cd238e4bd30cfacf7db79fc959/msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7", size = 408457, upload-time = "2026-06-18T16:13:34.567Z" },
-    { url = "https://files.pythonhosted.org/packages/82/90/8b630fef07d8c5ab457b71ff2c217910c83d333c7a68472c186e87cc504a/msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb", size = 65942, upload-time = "2026-06-18T16:13:36.056Z" },
-    { url = "https://files.pythonhosted.org/packages/16/f1/467b81e98b24dd3885d7b1857728797b4ffc76a7a7483af4fb321a07de3c/msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b", size = 72627, upload-time = "2026-06-18T16:13:37.079Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/1d/5d8c4c89985feb6acefb82a09e501c60392261856d2408d20bfe4f0360b1/msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7", size = 66908, upload-time = "2026-06-18T16:13:38.23Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/02/ad2afb678b4de94496cd432b581759b756a92c1192d8c767edd6b132efdc/msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273", size = 86000, upload-time = "2026-06-18T16:13:39.44Z" },
-    { url = "https://files.pythonhosted.org/packages/54/74/0b797484013128837f3b1cbb6cea019277c4de4e377dc512b4d9a0f92940/msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1", size = 86544, upload-time = "2026-06-18T16:13:40.447Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/b4/b774d7eb95561739907fec675582f83203cf41c597a418c2589b4bfb8e9d/msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc", size = 427661, upload-time = "2026-06-18T16:13:41.574Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/f9/3243191dc9937e00756c8bc1b0272fed8f23758e43df2a3b46f533e5090f/msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde", size = 426375, upload-time = "2026-06-18T16:13:42.936Z" },
-    { url = "https://files.pythonhosted.org/packages/23/c7/1693111db9944ba4ad4b67a1e788400d78a0b6af7a6523dc7e4e58f8274b/msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4", size = 380495, upload-time = "2026-06-18T16:13:44.306Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/2b/92f86956a0c13e8662f7e2ad630c4eb4db07497b967589bd5245e018b2c1/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d", size = 410897, upload-time = "2026-06-18T16:13:45.629Z" },
-    { url = "https://files.pythonhosted.org/packages/da/ea/1479f72d200313a76fc2f823a79d1e07ed052ab7b8a0280640aa7b95de42/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355", size = 378519, upload-time = "2026-06-18T16:13:46.998Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/4d/fa006060ffa1011d32bfae826fe766fe73e02982183601633b7121058ab3/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c", size = 419815, upload-time = "2026-06-18T16:13:48.205Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
-    { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
-]
-
-[[package]]
 name = "opentelemetry-api"
 version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
@@ -907,18 +837,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
-name = "pyee"
-version = "13.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]

--- a/eval/harness/e2e/orchestrator.py
+++ b/eval/harness/e2e/orchestrator.py
@@ -805,13 +805,26 @@ async def _run_agent(
         # hook, not the allowlist, so it can deny per-call with arguments.
         allowed_tools=BASELINE_ALLOWED_TOOLS + ["mcp__genealogy"],
         permission_mode="dontAsk",
-        # Idea 3a (speedup plan §3a): eager-load the genealogy MCP tool schemas.
-        # The bundled CLI defers MCP tool schemas above a token threshold (the
-        # ~38-tool genealogy server trips it), forcing repeated ToolSearch
-        # re-discovery (17x in the spriggs run). Forcing tool search off loads
-        # them once at session start. `env` MERGES onto the inherited environment
-        # (claude_agent_sdk subprocess_cli merges os.environ, then options.env),
-        # so this adds the var without dropping PATH.
+        # ENABLE_TOOL_SEARCH turns tool search ON, not off. This comment used to
+        # say "forcing tool search off" while setting "true"; the polarity is
+        # inverted (issue #1110). Read off the installed CLI (v2.1.220): a truthy
+        # value (`true|1|yes|on`) selects deferred/tool-search mode, `auto`/
+        # `auto:N` is the adaptive variant, and only a FALSY value
+        # (`false|0|no|off`) selects "standard" mode, where every schema is
+        # loaded up front. Unset also lands on tool-search mode, so deleting the
+        # variable eager-loads nothing. (Additionally forced off on a
+        # non-first-party ANTHROPIC_BASE_URL, on Vertex, and under
+        # CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS.)
+        #
+        # So "true" below means e2e runs WITH tool search: the ~38-tool
+        # genealogy server's schemas are deferred and re-discovered via
+        # ToolSearch mid-session (the 17x in the spriggs run, ~11% of all tool
+        # calls across recent runs). Idea 3a of the speedup plan wanted the
+        # opposite; flipping to "false" is a separate, tracked decision that
+        # requires re-measuring the tool mix, so the value is left as it has been
+        # running. `env` MERGES onto the inherited environment (claude_agent_sdk
+        # subprocess_cli merges os.environ, then options.env), so this adds the
+        # var without dropping PATH.
         #
         # env_for_sdk(resolve_auth()) routes the agent run to the operator's
         # subscription when one is available (suppressing the ANTHROPIC_API_KEY

--- a/eval/harness/harness/auth.py
+++ b/eval/harness/harness/auth.py
@@ -130,12 +130,22 @@ def env_for_sdk(auth: AuthConfig) -> dict[str, str]:
     OAuth session). Without this a key in the operator's shell would silently
     win over the subscription.
 
-    `ENABLE_TOOL_SEARCH=true` eager-loads the genealogy MCP tool schemas at
-    agent start (matches the e2e orchestrator + hosted-web agent). Without
-    this flag the unit-test harness occasionally hits the deferred-tool
-    registry path, where the agent doesn't find `research_append` / `tree_edit`
-    via ToolSearch and falls back to "write JSON directly" — failing the test
-    on Completeness/Tool-Arguments rather than the skill's actual logic.
+    `ENABLE_TOOL_SEARCH` turns tool search ON, not off — the polarity is the
+    opposite of what this comment claimed until issue #1110. Read off the
+    installed CLI (v2.1.220): a truthy value (`true|1|yes|on`) selects
+    deferred/tool-search mode, `auto`/`auto:N` is the adaptive variant, and
+    only a FALSY value (`false|0|no|off`) selects "standard" mode, where every
+    schema is loaded up front. Leaving it unset also lands on tool-search mode,
+    so deleting the variable eager-loads nothing. (It is additionally forced
+    off on a non-first-party `ANTHROPIC_BASE_URL`, on Vertex, and under
+    `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS`.)
+
+    So the `"true"` below means the harness runs WITH tool search — schemas
+    deferred, discovered via ToolSearch. That matches the e2e orchestrator and
+    the hosted-web agent, and matches the measured tool mix (~11% of all tool
+    calls are ToolSearch). Whether to flip it to `"false"` is a separate,
+    tracked decision that requires re-measuring the mix; the value is left as
+    it has been running.
     """
     env = {"ENABLE_TOOL_SEARCH": "true"}
     if auth.skill_runner_mode == "api_key" and auth.api_key:

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -214,6 +214,8 @@ export interface Assertion {
   date: string | null
   date_certainty: DateCertainty | null
   place: string | null
+  /** Standardized place-name sidecar of `place`, resolved via place_search. */
+  standard_place?: string | null
   information_quality: InformationQuality
   informant: string
   informant_proximity: InformantProximity
@@ -267,6 +269,8 @@ export interface TimelineEvent {
   date_certainty: string
   event_type: string
   place: string | null
+  /** Standardized place-name sidecar of `place`, resolved via place_search. */
+  standard_place?: string | null
   place_id?: string | null
   description: string
   assertion_ids: string[]


### PR DESCRIPTION
> Independent of the doc stack (#1169–#1172). Lands on `main` on its own.

## Summary

Four small, independent fixes, one commit each so any can be reverted alone.

## 1. Two schema-mirror drifts — `standard_place` missing from TS (`d5de4025`)

Both `research.schema.json` copies carry `standard_place` on the assertion object; the hand-maintained TypeScript mirror in `packages/schema/src/index.ts` did not. Added to **`Assertion`** and — found in a full audit of all 22 `$defs` against all 22 interfaces — **`TimelineEvent`** too.

**Not fixed, deliberately, because both need a decision:**

- `TimelineEvent.place_id` exists in TS, in **neither** JSON Schema. Three live fixtures still emit it, so removing it breaks typecheck until they migrate to `standard_place`.
- 25 fields across 11 interfaces are optional in schema but required in TS. All 25 are `T | null` — key required, value nullable, zero exceptions — which reads as deliberate house style rather than drift. Flipping them is behavior-visible to every consumer.

Tracked in #1165.

## 2. `make test-all` didn't typecheck (`d55695c0`)

`turbo.json` defines `test` and `typecheck` as separate tasks, so `pnpm test` never typechecks. CI ran both; **locally you didn't.** A viewer-side type break passed `make test-all` and was caught only in CI.

`test-all` now typechecks first (3s, fails fast). `make test` — the quick loop — is untouched.

## 3. Three comments describe `ENABLE_TOOL_SEARCH` backwards (`187ede25`)

Confirmed against the installed CLI v2.1.220. The mode selector maps a **truthy** value to tool-search-on (deferred mode), a **falsy** value to off, and **unset also means on**. All three sites claimed `true` "eager-loads the schemas," and one says *"Forcing tool search off"* while setting `"true"`.

**Only the comments changed. No flag values touched** — flipping the flag is separate work requiring a re-measurement of the tool mix (the critique's P1 lever #2).

Two more sites carry the same inverted claim and are left for that PR: `CLAUDE.md:273` and `tests/packaging/agent-tool-names.test.ts:241`.

## 4. Dead `ably` dependency (`d4fe2a45`)

All Ably code is gone from `apps/server/app`; only historical comments remain. Removed `ably>=3.1.2` and relocked — clean removal of `ably`, `msgpack`, `pyee`, no other resolution change. The repo installs with `uv sync --frozen` in CI and the Dockerfile, so the lock had to stay in sync.

## Test plan

- [x] `make typecheck` — 5/5
- [x] **`make test-all` — exit 0** (typecheck + all five suites)
- [x] `make engine-test` — 1793 passed
- [x] `make server-test` — 134 passed, 1 skipped
- [x] `make harness-test` — 1381 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)