### PR TITLE
docs: correct the realtime status guide's login flow and wiki-tools gap

### DIFF
--- a/docs/realtime-rearch-status.md
+++ b/docs/realtime-rearch-status.md
@@ -43,19 +43,29 @@ of the streaming path (affinity-free).
 
 ## Morning run — client + server + E2B
 Prereqs in `apps/server/.env`: `E2B_API_KEY`, `E2B_ACCESS_TOKEN`,
-`ANTHROPIC_API_KEY`, `GOOGLE_CLIENT_ID`/`SECRET`, a stable `SESSION_SECRET`. The
+`ANTHROPIC_API_KEY`, `FAMILYSEARCH_WEB_ENABLED=true`, a stable `SESSION_SECRET`,
+and — for anything but local dev — a real `WS_SIGNING_KEY`. The
 `genealogy-agent` image built (C2).
 
 1. **Terminal A:** `make server-e2b`  (control plane on `127.0.0.1:1837`,
    `SANDBOX_PROVIDER=e2b`, `AGENT_MODE=real`).
-2. **Terminal B:** `make web-oauth`  (Vite proxied at `:1837`).
-3. Open **http://127.0.0.1:5173** → Sign in with Google → create a research
-   session. That provisions an E2B sandbox from `genealogy-agent`, boots its WS
-   server; the browser connects **directly** to the sandbox's `wss://…e2b.app`
-   for chat + the live viewer.
-4. **FamilySearch (optional):** "Connect FamilySearch" (popup) or dev-connect —
-   writes the token into the E2B sandbox. Needed only for FS tools; basic agent
-   turns work without it.
+2. **Terminal B:** `make web`  (Vite proxied at `:1837`).
+3. Open **http://127.0.0.1:5173** → **Sign in with FamilySearch** → create a
+   research session. That provisions an E2B sandbox from `genealogy-agent`, boots
+   its WS server; the browser connects **directly** to the sandbox's
+   `wss://…e2b.app` for chat + the live viewer.
+
+> **Login changed after this was written, verified 2026-08-02.** FamilySearch is
+> now the **single front door** (`apps/server/app/auth.py`): one OAuth round-trip
+> both gates app access via the email allowlist *and* persists the data token
+> every sandbox-create injects. There is **no Google sign-in** and **no
+> per-session "Connect FamilySearch" step** — both are gone, along with
+> `GOOGLE_CLIENT_ID`/`SECRET`. There is also no `make web-oauth` target; the
+> FamilySearch path is `make web` (`:1837`). With `FAMILYSEARCH_WEB_ENABLED` off,
+> a **dev-login** (allowlisted email, no round-trip) stands in and the agent runs
+> in mock mode — pair that with `make server-dev` / `make server-mock` on `:8000`
+> and `make web-dev`. Full target matrix: `DEVELOPMENT.md` → "Running the hosted
+> web workbench locally".
 
 ### How a turn flows
 `/connect` (E2B branch, `sessions.py`) → `provider.resume(sandbox)` +
@@ -70,9 +80,11 @@ sidecar, feedback) — never the stream.
   the C5 cleanup removed every import. Dead weight in the image, not a behavior
   gap.
 - **FamilySearch token** is not auto-injected into E2B — dev/real connect writes it.
-- **Wiki tools** (`wiki_read`/`wiki_place_page`) need the pre-crawled markdown
-  corpus baked into the image (`wikiMarkdownDir`) — not baked, so those two tools
-  error; everything else (incl. `wiki_search` over the network) works.
+- ~~**Wiki tools** need the pre-crawled markdown corpus baked into the image
+  (`wikiMarkdownDir`).~~ **Obsolete, not pending (verified 2026-08-02).**
+  `wiki_read` and `wiki_place_page` are now HTTP clients against the hosted
+  `wiki-query-api`, the same as `wiki_search` — there is no corpus to bake and no
+  `wikiMarkdownDir`. All three work in the sandbox wherever the API is reachable.
 - **1h Hobby cap:** a continuously-active session force-pauses at ~1h (resumes in
   ~1s; a mid-turn pause breaks that turn). Proactive between-turn pause deferred.
 - **Delete-janitor** (abandoned-sandbox GC) deferred — use the explicit DELETE.


### PR DESCRIPTION
> **Stacked on #1170.** Review that first; this diffs against it.

## Summary

Two stale claims in `docs/realtime-rearch-status.md`'s morning-run guide. Both surfaced from the spec audit in #1172, which flagged them as contradictions between that spec and this doc. Both verified against the code before changing.

**1. The login flow described doesn't exist.**

The guide said "Sign in with **Google**", listed `GOOGLE_CLIENT_ID`/`SECRET` as `.env` prerequisites, and told you to run `make web-oauth`.

- There is no Google sign-in. `apps/server/app/auth.py` opens: *"FamilySearch is the **single front door**… There is no separate Google sign-in and no per-session 'Connect FamilySearch' step."* No Google client id, no OIDC dependency, no `google_sub` anywhere.
- There is no `make web-oauth` target — only `web` (`:1837`) and `web-dev` (`:8000`).
- Step 4's "Connect FamilySearch (optional)" is gone too; the single OAuth round-trip at login both gates access via the allowlist *and* persists the data token every sandbox-create injects.

Corrected the prerequisites and steps, and added a note explaining what replaced it — including the `FAMILYSEARCH_WEB_ENABLED=false` dev-login fallback and which server target it pairs with, since that's the part a newcomer gets wrong.

**2. The wiki-tools "known gap" is obsolete, not pending.**

Listed as *"`wiki_read`/`wiki_place_page` need the pre-crawled markdown corpus baked into the image (`wikiMarkdownDir`) — not baked, so those two tools error."*

They became HTTP clients against the hosted `wiki-query-api`, same as `wiki_search`. There is no corpus to bake and no `wikiMarkdownDir`. Struck through with the correction rather than deleted, so anyone who remembers the old constraint sees it resolved.

## Note on the base

This is stacked on #1170 rather than `main` because that PR already fixed this file's `**Branch:**` line and C5 status. Basing on `main` would have re-fixed them and conflicted.

## Test plan

- [x] `npx vitest run tests/packaging/` — 146/146
- [x] Every claim checked at source (`auth.py`, `config.py`, `Makefile`, the wiki tool implementations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)