### PR TITLE
docs: add the task lifecycle + a plan-critic subagent

### DIFF
--- a/.claude/agents/plan-critic.md
+++ b/.claude/agents/plan-critic.md
@@ -1,0 +1,104 @@
+---
+name: plan-critic
+description: Use to adversarially review an implementation plan BEFORE any code is written. Trigger phrases include "review this plan", "critique my plan", "poke holes in this plan", "adversarial review before I implement", "is this plan going to work". Reads the plan plus the code it claims to touch and tries to make it fail — hallucinated call sites, missed edit sites, unfalsifiable acceptance checks, spec drift, a simpler approach not considered. Read-only — reports findings for a human to act on, never edits the plan or the code. Do NOT use to review a finished diff or PR (that is a code review), or to write the plan in the first place.
+tools: Read, Grep, Glob, Bash
+---
+
+# Plan Critic (read-only)
+
+A wrong plan costs an implementation. Your job is to make it fail **now**, on
+paper, while the fix is a paragraph instead of a branch.
+
+You **never edit** the plan or any code. You report findings; a human decides
+what to do with them.
+
+Your default posture is adversarial, not supportive. The author already
+believes the plan works — repeating that back is worth nothing. But adversarial
+does not mean padded: **a plan with no blocking findings must be reported as
+having no blocking findings**, plainly, with no manufactured concerns to look
+thorough. Inventing a fourth finding to round out a list of three is the
+failure mode that makes this agent worthless.
+
+## What you read
+
+1. **The plan** — as given to you (chat text, a PR body, or a file under
+   `docs/plan/`).
+2. **The task it claims to satisfy** — the issue, ticket, or request. Read it
+   yourself; do not trust the plan's paraphrase of it.
+3. **The code the plan names.** This is the highest-yield part of your job.
+   Open every file, function, field, and command the plan cites and confirm it
+   exists and does what the plan assumes.
+4. **`CLAUDE.md`** (project rules that override defaults), **`docs/architecture.md`**
+   (which sites a change touches — its "If you're asked to…" blocks), the
+   relevant **`docs/specs/`** file if the plan touches a specced tool, and
+   **`docs/adrs/`** if the plan reverses something already decided.
+
+## What to look for
+
+Ranked by how often it is the thing that actually sinks a plan.
+
+1. **Ungrounded references.** A named file, function, field, flag, make target,
+   or CLI command that does not exist, or does not behave as assumed. Verify
+   every one. This is the single most common defect in a plan written from an
+   issue body.
+2. **Missed edit sites.** The plan changes something whose real blast radius is
+   larger than it says. Check `CLAUDE.md` and `docs/architecture.md` for the
+   documented site list — several changes in this repo have a fixed, countable
+   set of files (schema fields, closed enums, tree-shape allow-lists, tool
+   registration, agent frontmatter). A plan naming fewer sites than the
+   documented list is incomplete; say which are missing.
+3. **No falsifiable acceptance check.** The plan must say how we will know it
+   worked, in terms someone else can run. "Tests pass" is not one unless a
+   *named* test fails today and passes after. If there is no such check, the
+   implementation has no stopping condition and will be declared done when the
+   model runs out of obvious work.
+4. **Scope drift.** Against the task as stated: is the plan quietly doing less
+   (a hard part deferred without saying so), or quietly doing more (a refactor
+   nobody asked for riding along)? Both are findings. Widened scope is the more
+   common one and the harder one to review later.
+5. **Contract drift.** The plan changes observable behavior of something with a
+   spec, a schema, an ADR, or a documented rule — and does not change that
+   document in the same breath. Name the document.
+6. **A simpler approach not considered.** Especially: the plan adds a second
+   mechanism where one already exists, builds a general solution for one
+   concrete caller, or adds configuration for a decision that could just be
+   made. Say what the simpler version is, concretely enough to choose.
+7. **What breaks.** Existing callers, fixtures, CI checks, in-flight branches.
+   Name the specific ones, found by grep, not the category.
+8. **Irreversibility.** Data migration, anything that writes user state,
+   anything user-facing or external. These deserve an explicit rollback story
+   in the plan; flag their absence.
+
+## What is not a finding
+
+Do not report: naming preferences, comment style, formatting, hypothetical
+future requirements the task did not ask for, or "consider adding tests" when
+the plan already has an acceptance check. Do not restate the plan back as
+"strengths." If you have nothing blocking, say so and stop.
+
+## Output
+
+Findings first, ordered most-severe first. For each:
+
+- **Severity** — one of:
+  - `BLOCKING` — the plan as written produces wrong, broken, or incomplete
+    work. Reserve this for defects you can name a concrete failure for.
+  - `SHOULD-FIX` — the plan works but will cost a review round or leave a
+    known gap.
+  - `NOTE` — worth a sentence in the plan; would not hold up implementation.
+- **What's wrong** — one or two sentences, citing `file:line` where you
+  verified it.
+- **The change** — the concrete edit to the plan. State the replacement, not
+  the problem: "add `packages/schema/src/index.ts` to step 2", not "the schema
+  mirror may need updating."
+
+End with one verdict line, exactly one of:
+
+- `VERDICT: blocking findings — N` (the plan needs revision before code)
+- `VERDICT: no blocking findings` (implementation can start; SHOULD-FIX and
+  NOTE items are the author's call)
+
+If the plan is too vague to review — no named files, no acceptance check, no
+sequence — say that instead of guessing at what it means. "This plan cannot be
+reviewed as written, here is what it is missing" is a legitimate and useful
+result.

--- a/.claude/agents/plan-critic.md
+++ b/.claude/agents/plan-critic.md
@@ -21,10 +21,14 @@ failure mode that makes this agent worthless.
 
 ## What you read
 
-1. **The plan** — as given to you (chat text, a PR body, or a file under
-   `docs/plan/`).
+1. **The plan** — always a *file*: `PLAN.md` at the repo root (the normal case)
+   or a file under `docs/plan/` (for larger, riskier work). If you were handed
+   a description of a plan rather than a path to one, say so and stop. A
+   paraphrase of the plan is not the plan, and a critique of a paraphrase is
+   indistinguishable from a real one once it reaches the author.
 2. **The task it claims to satisfy** — the issue, ticket, or request. Read it
-   yourself; do not trust the plan's paraphrase of it.
+   yourself; do not trust the plan's paraphrase of it. If the plan names an
+   issue, run `gh issue view <N>`. If it names none, that is itself a finding.
 3. **The code the plan names.** This is the highest-yield part of your job.
    Open every file, function, field, and command the plan cites and confirm it
    exists and does what the plan assumes.
@@ -32,6 +36,10 @@ failure mode that makes this agent worthless.
    (which sites a change touches — its "If you're asked to…" blocks), the
    relevant **`docs/specs/`** file if the plan touches a specced tool, and
    **`docs/adrs/`** if the plan reverses something already decided.
+5. **Which round this is**, if you were told. On round two, start by checking
+   whether round one's findings were actually addressed, and say which were
+   not. Do not open new lines of criticism that round one could have raised —
+   that is how a plan gets longer without getting better.
 
 ## What to look for
 

--- a/.claude/agents/plan-critic.md
+++ b/.claude/agents/plan-critic.md
@@ -6,8 +6,8 @@ tools: Read, Grep, Glob, Bash
 
 # Plan Critic (read-only)
 
-A wrong plan costs an implementation. Your job is to make it fail **now**, on
-paper, while the fix is a paragraph instead of a branch.
+Make the plan fail **now**, on paper, while the fix is a paragraph instead of a
+branch.
 
 You **never edit** the plan or any code. You report findings; a human decides
 what to do with them.

--- a/.claude/commands/critique-plan.md
+++ b/.claude/commands/critique-plan.md
@@ -24,13 +24,16 @@ Subagents start in fresh context and see **only** what the prompt hands them.
 A plan described rather than pasted arrives as your paraphrase — which is
 exactly the input the critic is told not to trust.
 
+- `$ARGUMENTS` names a path that exists → use it.
+- `$ARGUMENTS` names a path that does **not** exist → say so and stop. Do not
+  silently fall back to a search; the user named a file, and guessing at a
+  different one produces a critique of the wrong plan.
 - `$ARGUMENTS` empty → look for `PLAN.md` at the repo root, then any
   `docs/plan/*.md` modified on this branch (`git diff --name-only main...`).
-- Found exactly one → use it, and say which.
-- Found none → the plan exists only in this conversation. Write it to
+  Found exactly one → use it, and say which. Found several → ask which.
+- Nothing found → the plan exists only in this conversation. Write it to
   `PLAN.md` first (it is gitignored), then continue. Do not paste a summary
   into the agent prompt instead.
-- Found several → ask which.
 
 ## Step 2 — Find the task it claims to satisfy
 

--- a/.claude/commands/critique-plan.md
+++ b/.claude/commands/critique-plan.md
@@ -1,0 +1,79 @@
+---
+description: Adversarially review an implementation plan before any code is written. Dispatches to the read-only plan-critic agent; never edits the plan or the code.
+argument-hint: [path-to-plan] (defaults to PLAN.md)
+---
+
+Run the **`plan-critic`** agent against the plan named in `$ARGUMENTS`.
+
+Step 3 of [`docs/task-lifecycle.md`](../../docs/task-lifecycle.md).
+
+## Why this is a command and not a sentence
+
+The session you are in **wrote the plan**. Asking it in prose to "review this
+plan" relies on description matching, and a miss doesn't fail loudly — you get
+main-context Claude, which is anchored on its own reasoning and holds Edit and
+Write, grading its own work. It will agree with itself, and it may start
+implementing. Dispatching explicitly is what buys the fresh context that makes
+the review worth anything.
+
+So: dispatch, and do not do the review yourself.
+
+## Step 1 — Resolve the plan to a file
+
+Subagents start in fresh context and see **only** what the prompt hands them.
+A plan described rather than pasted arrives as your paraphrase — which is
+exactly the input the critic is told not to trust.
+
+- `$ARGUMENTS` empty → look for `PLAN.md` at the repo root, then any
+  `docs/plan/*.md` modified on this branch (`git diff --name-only main...`).
+- Found exactly one → use it, and say which.
+- Found none → the plan exists only in this conversation. Write it to
+  `PLAN.md` first (it is gitignored), then continue. Do not paste a summary
+  into the agent prompt instead.
+- Found several → ask which.
+
+## Step 2 — Find the task it claims to satisfy
+
+The critic checks the plan against the *task*, not against itself, and is told
+to read the task rather than trust the plan's paraphrase of it.
+
+Look for an issue number in the plan, the branch name, or the conversation. If
+you find one, pass it. If there is genuinely no issue, say so in the dispatch —
+"no issue; the task as stated by the user was: …" — so the critic knows the
+acceptance bar came from a person and not a ticket.
+
+## Step 3 — Say which round this is
+
+The lifecycle caps this at **two rounds**. Round one finds real problems; round
+two confirms the fixes and usually finds one more; round three yields style
+opinions and a longer plan.
+
+Check the conversation for an earlier critique of the same plan and tell the
+agent which round it is. If this would be round three, **stop and say so**: two
+rounds of unresolved blocking findings means the task is underspecified, not
+the plan, and it goes to the lead.
+
+## Step 4 — Dispatch
+
+Call the Agent tool with `subagent_type: "plan-critic"`, passing the plan's
+path, the task/issue, and the round number. Do not summarize the plan for it,
+and do not tell it what you think is weak — a pre-digest biases which parts it
+examines, and the parts you already doubt are not the ones that need finding.
+
+## Step 5 — Relay, and verify before acting
+
+Print the findings substantially intact, with severities and the verdict line.
+
+**Then check each one before acting on it.** Some will be wrong. Open the file,
+run the command, confirm the claim. This applies to the agent's *proposals* as
+much as its criticisms: a suggested command, flag, or file name relayed without
+checking reads like an established thing to whoever you hand it to, and this is
+how invented names enter a document. Deciding which findings are real is the
+part of the job that teaches you the codebase — do not skip it because the
+output is confident and well-formatted.
+
+Report what you rejected and why, alongside what you accepted. A review where
+everything was correct is a review that wasn't checked.
+
+**Do not apply the fixes yourself unless asked.** The findings go back to the
+plan's author, who revises and — if this was round one — dispatches once more.

--- a/.claude/commands/critique-plan.md
+++ b/.claude/commands/critique-plan.md
@@ -5,78 +5,62 @@ argument-hint: [path-to-plan] (defaults to PLAN.md)
 
 Run the **`plan-critic`** agent against the plan named in `$ARGUMENTS`.
 
-Step 3 of [`docs/task-lifecycle.md`](../../docs/task-lifecycle.md).
-
-## Why this is a command and not a sentence
-
-The session you are in **wrote the plan**. Asking it in prose to "review this
-plan" relies on description matching, and a miss doesn't fail loudly — you get
-main-context Claude, which is anchored on its own reasoning and holds Edit and
-Write, grading its own work. It will agree with itself, and it may start
-implementing. Dispatching explicitly is what buys the fresh context that makes
-the review worth anything.
-
-So: dispatch, and do not do the review yourself.
+Step 3 of [`docs/task-lifecycle.md`](../../docs/task-lifecycle.md). Dispatch —
+do not do the review yourself. Rationale:
+[ADR-0007](../../docs/adrs/ADR-0007-attack-the-plan-before-writing-code.md).
 
 ## Step 1 — Resolve the plan to a file
 
-Subagents start in fresh context and see **only** what the prompt hands them.
-A plan described rather than pasted arrives as your paraphrase — which is
-exactly the input the critic is told not to trust.
+Subagents start in fresh context and see **only** what the prompt hands them, so
+the critic must get a path. A plan you describe instead of pointing at arrives
+as your paraphrase, which is the one input it is told not to trust.
 
 - `$ARGUMENTS` names a path that exists → use it.
 - `$ARGUMENTS` names a path that does **not** exist → say so and stop. Do not
-  silently fall back to a search; the user named a file, and guessing at a
-  different one produces a critique of the wrong plan.
+  fall back to a search: the user named a file, and guessing at a different one
+  produces a critique of the wrong plan.
 - `$ARGUMENTS` empty → look for `PLAN.md` at the repo root, then any
   `docs/plan/*.md` modified on this branch (`git diff --name-only main...`).
-  Found exactly one → use it, and say which. Found several → ask which.
+  Exactly one → use it, and say which. Several → ask which.
 - Nothing found → the plan exists only in this conversation. Write it to
-  `PLAN.md` first (it is gitignored), then continue. Do not paste a summary
-  into the agent prompt instead.
+  `PLAN.md` (gitignored) first, then continue. Do not paste a summary into the
+  agent prompt instead.
 
 ## Step 2 — Find the task it claims to satisfy
 
-The critic checks the plan against the *task*, not against itself, and is told
-to read the task rather than trust the plan's paraphrase of it.
+The critic checks the plan against the *task*, and reads the task itself rather
+than trusting the plan's paraphrase of it.
 
-Look for an issue number in the plan, the branch name, or the conversation. If
-you find one, pass it. If there is genuinely no issue, say so in the dispatch —
+Look for an issue number in the plan, the branch name, or the conversation. Pass
+it if you find one. If there genuinely is no issue, say so in the dispatch —
 "no issue; the task as stated by the user was: …" — so the critic knows the
 acceptance bar came from a person and not a ticket.
 
 ## Step 3 — Say which round this is
 
-The lifecycle caps this at **two rounds**. Round one finds real problems; round
-two confirms the fixes and usually finds one more; round three yields style
-opinions and a longer plan.
-
 Check the conversation for an earlier critique of the same plan and tell the
-agent which round it is. If this would be round three, **stop and say so**: two
-rounds of unresolved blocking findings means the task is underspecified, not
-the plan, and it goes to the lead.
+agent the round number.
+
+If this would be **round three, stop and say so**. Two rounds of unresolved
+blocking findings means the task is underspecified, and it goes to the lead.
 
 ## Step 4 — Dispatch
 
 Call the Agent tool with `subagent_type: "plan-critic"`, passing the plan's
-path, the task/issue, and the round number. Do not summarize the plan for it,
-and do not tell it what you think is weak — a pre-digest biases which parts it
+path, the task/issue, and the round number. Do not summarize the plan for it and
+do not tell it what you think is weak — a pre-digest biases which parts it
 examines, and the parts you already doubt are not the ones that need finding.
 
 ## Step 5 — Relay, and verify before acting
 
 Print the findings substantially intact, with severities and the verdict line.
 
-**Then check each one before acting on it.** Some will be wrong. Open the file,
-run the command, confirm the claim. This applies to the agent's *proposals* as
-much as its criticisms: a suggested command, flag, or file name relayed without
-checking reads like an established thing to whoever you hand it to, and this is
-how invented names enter a document. Deciding which findings are real is the
-part of the job that teaches you the codebase — do not skip it because the
-output is confident and well-formatted.
+**Then check each one before acting on it.** Open the file, run the command,
+confirm the claim. This applies to the agent's *proposals* as much as its
+criticisms: a suggested command, flag, or file name relayed without checking
+reads like an established thing to whoever you hand it to.
 
-Report what you rejected and why, alongside what you accepted. A review where
-everything was correct is a review that wasn't checked.
+Report what you rejected and why, alongside what you accepted.
 
 **Do not apply the fixes yourself unless asked.** The findings go back to the
 plan's author, who revises and — if this was round one — dispatches once more.

--- a/.claude/skills/interpret-e2e-result/SKILL.md
+++ b/.claude/skills/interpret-e2e-result/SKILL.md
@@ -304,12 +304,12 @@ that produced a tree without its `.ann.json` (a treeless skip run is exempt).
 
 ## Example
 
-User: "Why did the smith-parents-1850 run fail?"
+User: "Why did the <slug> run fail?"
 
 You should:
-1. Read `eval/runlogs/e2e/smith-parents-1850/run-<latest>.json` (harness
+1. Read `eval/runlogs/e2e/<slug>/run-<latest>.json` (harness
    fields only — skip `judge_output`, `verdict`, and `outcome`).
-2. Read `eval/tests/e2e/smith-parents-1850/expected-findings.json` and the
+2. Read `eval/tests/e2e/<slug>/expected-findings.json` and the
    final tree; the tree contains **none** of the required findings.
 3. See `stop_reason: tool_cap`.
 4. Skim the last 30 tool calls in the transcript — agent is looping

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,13 @@
 ## Test plan
 
 - [ ] I ran `make test-all` (or `scripts/test.sh` — the same command) and it passed.
+      <!-- No Windows equivalent exists (issue #1185): `eval\RunTests.bat` is the
+           paid per-skill eval run, not this gate. On Windows, say so here and
+           lean on CI, which runs the same suites. -->
+      <!-- Note: this runs the harness's e2e-marked contract test, which makes a
+           real (billed) Anthropic call. It skips itself when no key is
+           reachable; CI never runs it. -->
+
 - [ ] For every skill whose **run-log snapshot** I changed (anything under its
       skill dir, an agent it delegates to, its `eval/tests/unit/<skill>/`, or a
       scenario/fixture it references), I ran `make eval-skill SKILL=<name>` —

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,25 @@
 ## Summary
 
-<!-- 1-3 bullets describing what changed and why. -->
+<!-- 1-3 bullets describing what changed and why. Name the tier
+     (Trivial / Normal / Risky) — docs/task-lifecycle.md. -->
+
+## Plan
+
+<!-- Normal tier: paste PLAN.md. Risky tier: paste it here and get the lead's
+     review before writing code. Trivial: delete this section. -->
 
 ## Test plan
 
-- [ ] I ran `scripts/test.sh` and it passed.
-- [ ] For every skill whose files I changed (SKILL.md, scenarios, fixtures,
-      tests, or supporting MCP/harness code), I ran `RunTests.bat <skill>`
-      and committed an all-pass runlog under `eval/runlogs/unit/<skill>/`.
+- [ ] I ran `make test-all` (or `scripts/test.sh` — the same command) and it passed.
+- [ ] For every skill whose **run-log snapshot** I changed (anything under its
+      skill dir, an agent it delegates to, its `eval/tests/unit/<skill>/`, or a
+      scenario/fixture it references), I ran `make eval-skill SKILL=<name>` —
+      Windows: `RunTests.bat` — and committed the run log **and its
+      `.ann.json`** under `eval/runlogs/unit/<skill>/`.
+      <!-- Behaviour-neutral skill edit (typo, rewording, comment)? Ask a senior
+           for the `eval-cosmetic-skip` label instead of burning a paid run.
+           Rules: eval/CLAUDE.md § "GitHub Action rules". -->
+
+## Follow-on issues
+
+<!-- Numbers filed for work you deferred. DEVELOPMENT.md § "Follow-on work". -->

--- a/.github/workflows/engine-tests.yml
+++ b/.github/workflows/engine-tests.yml
@@ -52,7 +52,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PATTERNS: '^packages/engine/mcp-server/|^packages/engine/plugin/|^packages/schema/schemas/|^docs/specs/schemas/|^eval/tests/unit/|^\.github/workflows/engine-tests\.yml$'
+          # `.claude/`, `docs/adrs/` and `docs/task-lifecycle.md` are here because
+          # adr-links.test.ts and doc-links.test.ts lint them. Without these three
+          # a PR touching only a skill body, an agent, or an ADR skips vitest and
+          # reports success — the lint would be dark for its entire domain.
+          PATTERNS: '^packages/engine/mcp-server/|^packages/engine/plugin/|^packages/schema/schemas/|^docs/specs/schemas/|^eval/tests/unit/|^\.claude/|^docs/adrs/|^docs/task-lifecycle\.md$|^\.github/workflows/engine-tests\.yml$'
         run: |
           set -euo pipefail
           files="$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \

--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,8 @@ packages/engine/mcp-server/.mcp.json
 # anchors this to the repo root so it does NOT match packages/engine/mcp-server.
 /mcp-server/
 
-# Normal-tier task plan (docs/task-lifecycle.md §2). A scratch artifact: it is
-# what you hand plan-critic and the fresh-session review, then paste into the
-# PR description. Root-anchored so a real PLAN.md nested in a package is still
-# tracked if one is ever wanted.
+# Per-task plan (docs/task-lifecycle.md step 2) — a scratch artifact that ends
+# up in the PR description. Root-anchored so a nested PLAN.md stays tracked.
 /PLAN.md
 
 releases/*

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@ packages/engine/mcp-server/.mcp.json
 # anchors this to the repo root so it does NOT match packages/engine/mcp-server.
 /mcp-server/
 
+# Normal-tier task plan (docs/task-lifecycle.md §2). A scratch artifact: it is
+# what you hand plan-critic and the fresh-session review, then paste into the
+# PR description. Root-anchored so a real PLAN.md nested in a package is still
+# tracked if one is ever wanted.
+/PLAN.md
+
 releases/*
 !releases/.gitkeep
 *.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -639,7 +639,7 @@ explicitly with the Agent tool.
   and rejects plans with no falsifiable acceptance check. Step 3 of
   [`docs/task-lifecycle.md`](./docs/task-lifecycle.md), which caps it at two
   rounds — a second round of blocking findings means the *task* is
-  underspecified, not the plan.
+  underspecified, not the plan. `/critique-plan [path]`.
 - **`rubric-critic`** — read-only. Audits a skill's eval rubric and judge
   quality from its run logs; flags non-discriminating, flaky, and unexercised
   dimensions. `/audit-rubric <skill>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,33 +134,25 @@ mocks (no E2B/Anthropic/OAuth needed).
     --title "…" --body "…"
   ```
 
-  The card lands in Backlog on its own — `.github/workflows/add-to-project.yml`
-  fires on `issues: opened` and adds it. **Creating the issue is the whole job:
-  do not call the Projects API yourself** (no `gh project` commands, no
-  `addProjectV2ItemById`). The workflow puts it on the board; `/fill-ready` moves
-  it from there. A `gh` token without the `project` scope — the default after
-  `gh auth login` — would fail a board write *while still creating the issue*,
-  which looks like success. Reference the number in the PR body.
-
   | Label | Use for |
   |---|---|
   | `developer` | Lints, CI, validators, harness/Python, MCP tools, refactors, tooling bugs — anything with a mechanical pass/fail |
   | `genealogist` | Fixture adjudication, run-log annotation, record research, doctrine prose |
   | `icebox` | Add alongside either one when the item is a candidate with **no decision behind it**, so triage skips it instead of re-ranking it every morning |
 
-  **Rationale does not go in the issue.** A body says what the work is and enough
-  of *why it is still open* to stop the next person re-opening a settled question
-  — issue bodies are read once at triage and essentially never again. A settled
-  tradeoff, a rejected alternative, or a measurement goes to the tool's spec or a
-  comment at the site it constrains, where the next person will actually be
-  standing. If there is no spec to write it into, the item is spec-shaped, not
-  queue-shaped. Git history keeps the prose either way.
+  **Creating the issue is the whole job: do not call the Projects API yourself**
+  (no `gh project` commands, no `addProjectV2ItemById`).
+  `.github/workflows/add-to-project.yml` fires on `issues: opened` and puts the
+  card in Backlog. A `gh` token without the `project` scope — the default after
+  `gh auth login` — fails a board write *while still creating the issue*, which
+  looks like success. Reference the number in the PR body.
 
-  This replaced `docs/TODOs.md` (retired 2026-08-02, issues #1117–#1157). That
-  file was a staging queue whose exit event — "an entry leaves when it becomes an
-  issue" — never fired on its own: it reached 932 lines, then 54 unassignable
-  items touched by 54 separate PRs, and became a merge-conflict hotspot across
-  concurrent worktrees. Do not reintroduce a queue file under any name.
+  **Do not reintroduce a queue file under any name.** This replaced
+  `docs/TODOs.md`, retired 2026-08-02.
+
+  The rest — how to pick the label, what belongs in a body and what doesn't, the
+  `TODOs.md` postmortem — is in [`DEVELOPMENT.md`](./DEVELOPMENT.md) §
+  "Follow-on work you find along the way", which owns these rules.
 - **Verification is automated, not a manual playbook.** New tools are
   verified by the eval harness (`eval/`, `make test`, `eval/tests/e2e/`)
   and by `packages/engine/mcp-server/dev/try-*.ts` smoke scripts — **not**
@@ -637,9 +629,8 @@ explicitly with the Agent tool.
   *before* any code exists: verifies every file/function/command the plan names
   actually exists, checks the plan against the documented multi-site edit lists,
   and rejects plans with no falsifiable acceptance check. Step 3 of
-  [`docs/task-lifecycle.md`](./docs/task-lifecycle.md), which caps it at two
-  rounds — a second round of blocking findings means the *task* is
-  underspecified, not the plan. `/critique-plan [path]`.
+  [`docs/task-lifecycle.md`](./docs/task-lifecycle.md), capped at two rounds
+  (ADR-0007). `/critique-plan [path]`.
 - **`rubric-critic`** — read-only. Audits a skill's eval rubric and judge
   quality from its run logs; flags non-discriminating, flaky, and unexercised
   dimensions. `/audit-rubric <skill>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -621,7 +621,7 @@ signal to consolidate; one isn't.
 
 ## Subagents
 
-Three project subagents live under `.claude/agents/`. Claude Code invokes them
+Project subagents live under `.claude/agents/`. Claude Code invokes them
 automatically when their description matches the request, or you can call them
 explicitly with the Agent tool.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -629,10 +629,17 @@ signal to consolidate; one isn't.
 
 ## Subagents
 
-Two project subagents live under `.claude/agents/`. Claude Code invokes them
+Three project subagents live under `.claude/agents/`. Claude Code invokes them
 automatically when their description matches the request, or you can call them
 explicitly with the Agent tool.
 
+- **`plan-critic`** — read-only. Adversarially reviews an implementation plan
+  *before* any code exists: verifies every file/function/command the plan names
+  actually exists, checks the plan against the documented multi-site edit lists,
+  and rejects plans with no falsifiable acceptance check. Step 3 of
+  [`docs/task-lifecycle.md`](./docs/task-lifecycle.md), which caps it at two
+  rounds — a second round of blocking findings means the *task* is
+  underspecified, not the plan.
 - **`rubric-critic`** — read-only. Audits a skill's eval rubric and judge
   quality from its run logs; flags non-discriminating, flaky, and unexercised
   dimensions. `/audit-rubric <skill>`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,12 @@
 # Development
 
 Developer guide for building, testing, and extending this repository.
+
+**New here? Start with [docs/task-lifecycle.md](./docs/task-lifecycle.md)** —
+the process a developer task goes through from issue to merge (plan,
+adversarial plan review, implement, verify, review). This file is the
+reference it sends you to for individual recipes.
+
 For how the pieces bind and what a change's blast radius is, see
 [docs/architecture.md](./docs/architecture.md). For architecture and
 conventions Claude needs when editing the code, see [CLAUDE.md](./CLAUDE.md).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,7 +17,7 @@ contribution criteria, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ```bash
 cd packages/engine/mcp-server && npm install && npm run build       # Build MCP server
-./scripts/test.sh                                    # Run ALL test suites (see below)
+make test-all                                        # Run EVERY check (== ./scripts/test.sh; see below)
 cd packages/engine/mcp-server && npm test                            # Run MCP server tests only (vitest)
 cd packages/engine/mcp-server && npx vitest run tests/tools/places.test.ts   # Run a single test file
 cd packages/engine/mcp-server && npx vitest run -t "test name"       # Run tests matching a name
@@ -154,16 +154,24 @@ gh issue create --label developer --title "…" --body "…"
   scope (the default from `gh auth login`) fails a board write *while still
   creating the issue*, which looks like it worked.
 - **Keep the body short and put the reasoning elsewhere.** Say what the work is
-  and why it's still open. A settled tradeoff, a rejected alternative, or a
-  measurement belongs in the tool's spec or in a comment at the line it
-  constrains — that's where the next person will be standing, and nobody
-  re-reads an issue body after triage.
+  and enough of why it's still open to stop the next person re-opening a settled
+  question. A settled tradeoff, a rejected alternative, or a measurement belongs
+  in the tool's spec or in a comment at the line it constrains — that's where the
+  next person will be standing, and nobody re-reads an issue body after triage.
+  If there's no spec to write it into, the item is spec-shaped, not queue-shaped.
+  Git history keeps the prose either way.
 - **Mention the number in your PR description** so the reviewer can see what you
   chose not to do.
 
-Do not park these in a to-do file. That was tried (`docs/TODOs.md`, retired
-2026-08-02): items that live only in a file never get assigned, and the file
-becomes a merge-conflict hotspot once several people work in parallel.
+**Do not park these in a to-do file, under any name.** That was tried:
+`docs/TODOs.md`, retired 2026-08-02 as issues #1117–#1157. Its exit event — "an
+entry leaves when it becomes an issue" — never fired on its own. It reached 932
+lines and then 54 unassignable items touched by 54 separate PRs, and became a
+merge-conflict hotspot across concurrent worktrees.
+
+This section is the owner of these rules. [`CLAUDE.md`](./CLAUDE.md) keeps only
+the two whose failure is silent (never write to the board yourself; never start
+a queue file), and points here for the rest.
 
 ## How to test a new tool end-to-end
 
@@ -574,21 +582,28 @@ A match means the new code is built; no match means the build is stale.
 
 ## Running all tests
 
-`scripts/test.sh` runs every test suite in the repo in one shot:
+**One command runs everything, and it is the one the PR template requires:**
 
 ```bash
-./scripts/test.sh
+make test-all        # `./scripts/test.sh` is the same command — the target delegates to it
 ```
 
-It runs three suites in order and exits non-zero if any fail:
+It runs every suite (never stopping at the first failure) and exits non-zero if
+any failed:
 
 | Suite | Directory | Runner | What it tests |
 |---|---|---|---|
-| MCP server | `packages/engine/mcp-server/` | vitest | Tool code correctness |
+| Typecheck | whole JS workspace | turbo/tsc | Types — turbo runs this as a task no test suite triggers |
+| JS workspace | `apps/web/`, `apps/electron/`, `packages/viewer-ui/`, `packages/schema/` | vitest | Web + viewer + schema mirror |
+| Control plane | `apps/server/` | pytest | FastAPI auth, sessions, `/v1` |
+| MCP server | `packages/engine/mcp-server/` | vitest | Tool code correctness + packaging lints |
 | Eval app | `eval/app/` | vitest | Next.js CRUD UI logic |
-| Eval harness | `eval/harness/` | pytest | Python test harness internals |
+| Eval harness | `eval/harness/` | pytest | Harness internals, **including** the `e2e`-marked contract test (a real billed Anthropic call; skips itself with no key) |
 
-To run a single suite, use the per-suite commands in the sections below.
+To run one suite, use `make engine-test` / `make harness-test` / `make test-js`
+/ `make server-test` / `make eval-ui-test` — see
+[`docs/architecture.md`](./docs/architecture.md) §9.1 for exactly what each
+covers and misses.
 
 ## Running the eval test suite
 

--- a/Makefile
+++ b/Makefile
@@ -262,19 +262,13 @@ typecheck: $(JS_DEPS) ## Typecheck the whole JS workspace (turbo)
 	pnpm typecheck
 
 .PHONY: test-all
-test-all: ## Run EVERY check: typecheck + every test suite (JS workspace + server + engine + eval harness + CRUD UI)
-	# `typecheck` first, and it is NOT redundant with test-js: turbo.json defines
-	# `test` and `typecheck` as separate tasks, so `pnpm test` never runs tsc. A
-	# viewer-side type break used to pass `make test-all` clean and surface only
-	# in CI (.github/workflows/js-tests.yml, which runs both). It costs seconds
-	# and fails fast, so it goes before the suites rather than after.
-	$(MAKE) typecheck
-	$(MAKE) test-js
-	$(MAKE) server-test
-	$(MAKE) engine-test
-	$(MAKE) harness-test
-	$(MAKE) eval-ui-test
-	@echo "✓ typecheck + all test suites passed"
+test-all: ## Run EVERY check before a PR: typecheck + JS + server + engine + CRUD UI + eval harness. Alias for scripts/test.sh
+	# One command, one contract. This used to inline the suite list and reach
+	# the harness via `harness-test` (`-m 'not e2e'`), so it and scripts/test.sh
+	# each covered something the other missed and both had to be run. They are
+	# the same command now; scripts/test.sh owns the implementation because it
+	# reports every failure instead of stopping at the first.
+	scripts/test.sh
 
 .PHONY: test
 test: ## Quick loop: JS workspace + server tests (a subset of test-all)

--- a/docs/adrs/ADR-0007-attack-the-plan-before-writing-code.md
+++ b/docs/adrs/ADR-0007-attack-the-plan-before-writing-code.md
@@ -1,0 +1,102 @@
+# ADR-0007: Attack the plan before writing code, with a read-only critic
+
+> **Read before you:** wonder why `/critique-plan` is a command instead of "ask
+> Claude to review this" · want to add a third critique round · want to skip
+> writing `PLAN.md` because the plan is already in the chat · want Risky-tier
+> plans filed under `docs/plan/` · want the critic to fix what it finds.
+
+- **Status:** Accepted
+- **Decided:** 2026-08-02 (#1177)
+- **Recorded:** 2026-08-02
+- **Deciders:** Dallan Quass
+- **Supersedes:** —
+- **Superseded by:** —
+- **Applies to:** `docs/task-lifecycle.md`, `.claude/agents/plan-critic.md`, `.claude/commands/critique-plan.md`
+- **Related:** ADR-0006, `docs/skill-lifecycle.md`
+
+## Context
+
+Working with Claude moves the expensive mistake. Writing code is no longer the
+slow part; deciding what code to write is — and a wrong decision now gets
+implemented fast and completely. A plan wrong in one sentence becomes a branch
+wrong in forty files.
+
+The cheapest place to kill a bad approach is a paragraph in a plan. The second
+cheapest is the author's own review of their own diff. Peer review is third and
+the lead's review is last and most expensive.
+
+Two properties of the collaborator shape the mechanism:
+
+1. **A session is anchored on its own reasoning.** The session that wrote the
+   plan will confirm the plan. The same holds for a diff: asked whether the
+   implementation matches the plan, the session that wrote both says yes.
+2. **A confident wrong answer is indistinguishable from a right one.** Critique
+   output is well-formatted whether or not it is correct. This branch's own
+   first commit cited a `/code-review` command that does not exist here — three
+   times, inside the document warning about exactly that.
+
+## Decision
+
+**The plan is a file, and a read-only subagent attacks it before any code is
+written.** Concretely:
+
+- The plan is written to `PLAN.md` (gitignored) before implementation.
+- `/critique-plan` dispatches the `plan-critic` subagent, whose frontmatter
+  grants `Read, Grep, Glob, Bash` and nothing else.
+- Two rounds maximum. A blocking finding surviving round two escalates to the
+  lead as a task problem, not a plan problem.
+- Findings are verified by the author before being acted on or relayed —
+  proposals included.
+- Risky-tier plans are reviewed by the lead **in the draft PR description**.
+
+## Alternatives considered
+
+| Option | Why rejected | Evidence |
+|---|---|---|
+| **Ask in prose** — "review this plan", no command, no subagent | Two mechanisms, both silent. Description matching can miss, and a miss hands the job to main-context Claude — which wrote the plan and holds `Edit`/`Write`, so it agrees with itself and may begin implementing. Prose also passes a *paraphrase*; a critique of a paraphrase is indistinguishable from a real one by the time it reaches the author | Argued, not measured. The anchoring half is the same effect `docs/task-lifecycle.md` step 6 exists for |
+| **A skill instead of a command** | Same defect — skills fire by description matching. A command is invoked by name and cannot silently no-op | The three deleted subagents (#1161) are the standing evidence that silent `.claude/` failure modes go unnoticed |
+| **A general-purpose subagent** | Buys the fresh context but not the tool restriction, which is the only part a prompt cannot buy | ADR-0006 is the general form: capability is restricted by tool identity, not by prompt |
+| **Three or more critique rounds** | Round one finds real problems; round two confirms fixes and usually finds one more; round three yields style opinions and a longer plan | Argued, not measured. This branch ran two adversarial passes and found seven real defects; the value was in rounds one and two |
+| **Let the critic apply its own findings** | Collapses the verification step the design rests on. Read-only forces someone to decide which findings are real — the part that teaches the codebase | This branch's own round: one finding was rejected as wrong, and one *proposal* was relayed as though it existed when it did not |
+| **Risky plans as files under `docs/plan/`** | That directory holds multi-week design docs reviewed with a designer and an engineer; a per-task plan is a different genre with a different lifespan. Filing one there means it lands on `main` and must be deleted when the work ships | `CLAUDE.md` § `docs/plan/`: "Two files here spent weeks claiming 'not yet implemented' and 'not yet branched' for things that had shipped" |
+
+## Consequences
+
+**Gains.** Bad approaches die in a paragraph instead of a branch. The author,
+not the reviewer, discovers implement-vs-plan drift. The lead's review is spent
+on whether the approach is right, because everything mechanical is settled.
+
+**Costs, knowingly accepted.**
+
+- A dispatch that finds nothing still costs a subagent run. The agent is
+  instructed to report "no blocking findings" plainly rather than manufacture a
+  fourth concern, so the floor is one cheap run.
+- Two rounds is a stopping rule, not a measurement. The escalation it forces
+  (round two still blocking → go to the lead) is the load-bearing part; the
+  number is the cheap way to trigger it.
+- The author owns verification. A finding acted on unverified is worse than no
+  finding — it arrives at whoever you hand it to looking established.
+
+**Risks.** `plan-critic` has no eval the way a shipped skill does, so its
+judgement can degrade silently if the prompt drifts. The lint below catches
+stale paths, not weak criticism. Nothing currently measures whether the
+critique step changes outcomes.
+
+## Enforcement
+
+> `packages/engine/mcp-server/tests/packaging/doc-links.test.ts` — every repo
+> path, markdown link, and `make` target cited in `.claude/agents/`,
+> `.claude/commands/`, `.claude/skills/`, and `docs/task-lifecycle.md`
+> resolves.
+> It does **not** check that the critic was run, that findings were verified,
+> or that a Risky plan reached the lead. Those are convention.
+
+`.github/pull_request_template.md` carries the tier and the plan; nothing
+blocks a PR that leaves them blank.
+
+## Revisit when
+
+A plan-stage critique demonstrably misses a defect that a third round would
+have caught, or when a Risky plan turns out to need review by someone who is
+not on the PR — at which point the `docs/plan/` question reopens with a
+concrete reader, rather than as a filing preference.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,10 +71,11 @@ uses freely: *assertion*, *source*, *proof summary*, *tier*, *exhaustiveness*,
 0. **Prerequisites on PATH:** `make`, `node` + `npm`, `pnpm`, and `uv`.
    (`scripts/test.sh`'s preflight names `make`, `npm`, and `uv`; a missing
    `pnpm` surfaces only when `make install` reaches `pnpm install`.)
-1. `make install`, then **`make test-all && make typecheck`** — confirm green
-   *before* you change anything, so a pre-existing failure isn't mistaken for
-   yours. (`make test-all` does **not** typecheck; turbo runs those as separate
-   tasks.)
+1. `make install`, then **`make test-all`** — confirm green *before* you change
+   anything, so a pre-existing failure isn't mistaken for yours. (It runs
+   `make typecheck` first, since #1173; turbo defines `test` and `typecheck` as
+   separate tasks, so `pnpm test` alone never typechecks. It still does not
+   cover the e2e-marked harness tests that `scripts/test.sh` runs — see §9.1.)
 2. Read [`docs/gps-research-flow.md`](gps-research-flow.md) (the domain).
 3. Read §§1–3 here (the shape).
 4. Open one skill (`packages/engine/plugin/skills/record-extraction/SKILL.md`),
@@ -1097,7 +1098,7 @@ skips silently**, which looks identical to passing.
 |---|---|---|
 | **`scripts/test.sh`** | engine + eval app + eval harness (harness **including** e2e-marked tests). **The PR template requires this one.** | the JS workspace, `apps/server`, and typecheck |
 | `make test` | JS workspace + server tests | **engine, packaging lints, harness** — an engine-only change gets *zero* coverage |
-| `make test-all` | JS, server, engine, eval harness, CRUD UI | **`make typecheck`** (turbo runs `test` and `typecheck` as separate tasks), and the eval suites |
+| `make test-all` | typecheck (since #1173 — it runs `make typecheck` first), JS, server, engine, eval harness, CRUD UI | the **e2e-marked harness tests** — it reaches the harness via `make harness-test`, which is `-m 'not e2e'`. `scripts/test.sh` is the only command that runs those. |
 | `make engine-test` | `packages/engine/mcp-server` (vitest) + all packaging lints | the `packages/schema` mirror; anything needing a live API |
 | `make harness-test` | `eval/harness` (pytest, excludes e2e) — **the sole gate on the `packages/schema` mirror** | engine unit tests, though it *does* execute the compiled `build/` — a broken engine fails here wearing the costume of a harness bug |
 | `make typecheck` | the whole JS workspace (turbo) — the only gate on viewer code | Python |
@@ -1236,6 +1237,7 @@ Things that are genuinely unsettled, as distinct from §9.4's missing guards.
 | Question | Read |
 |---|---|
 | What is genealogical research, and what are all these words? | [`docs/gps-research-flow.md`](gps-research-flow.md) — **read this first** |
+| How does a task get from issue to merge? | [`docs/task-lifecycle.md`](task-lifecycle.md) — the developer process (plan → attack → implement → verify → review). §0 "First day" above is the setup that precedes it. For skill-prose work, [`docs/skill-lifecycle.md`](skill-lifecycle.md) instead. |
 | How do I build / run / test / deploy? | [`DEVELOPMENT.md`](../DEVELOPMENT.md) |
 | What rule must I follow to make a correct change? | [`CLAUDE.md`](../CLAUDE.md) — the operating manual, auto-loaded every session |
 | What does tool X do? | `docs/specs/<tool>-tool-spec.md` — **wins over this guide on conflict** |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,14 +68,12 @@ uses freely: *assertion*, *source*, *proof summary*, *tier*, *exhaustiveness*,
 
 ### First day
 
-0. **Prerequisites on PATH:** `make`, `node` + `npm`, `pnpm`, and `uv`.
-   (`scripts/test.sh`'s preflight names `make`, `npm`, and `uv`; a missing
-   `pnpm` surfaces only when `make install` reaches `pnpm install`.)
+0. **Prerequisites on PATH:** `make`, `node` + `npm`, `pnpm`, and `uv` — all
+   four named by `scripts/test.sh`'s preflight.
 1. `make install`, then **`make test-all`** — confirm green *before* you change
-   anything, so a pre-existing failure isn't mistaken for yours. (It runs
-   `make typecheck` first, since #1173; turbo defines `test` and `typecheck` as
-   separate tasks, so `pnpm test` alone never typechecks. It still does not
-   cover the e2e-marked harness tests that `scripts/test.sh` runs — see §9.1.)
+   anything, so a pre-existing failure isn't mistaken for yours. It is the
+   whole gate (it delegates to `scripts/test.sh`, which the PR template names);
+   nothing else needs running before a PR. See §9.1 for the per-suite targets.
 2. Read [`docs/gps-research-flow.md`](gps-research-flow.md) (the domain).
 3. Read §§1–3 here (the shape).
 4. Open one skill (`packages/engine/plugin/skills/record-extraction/SKILL.md`),
@@ -126,6 +124,7 @@ routing surface — find your task, then open that ADR.
 | [0004](adrs/ADR-0004-dual-spell-mcp-tool-names-in-agent-frontmatter.md) | Dual-spell every MCP tool name in agent frontmatter | grant or deny a tool to a plugin agent · write a `ToolSearch` query · rename the desktop extension |
 | [0005](adrs/ADR-0005-ship-the-write-lockdown-as-a-plugin-hook.md) | Ship the write lockdown as a plugin `PreToolUse` hook | add a guardrail · restrain the main thread · try to stop the agent doing something with an allow-list · change `PROTECTED_PROJECT_FILES` |
 | [0006](adrs/ADR-0006-restrict-capability-by-tool-identity.md) | Restrict capability by tool identity, not by prompt or parameter | need a delegated agent to do *part* of what a tool can do · write "you must only use this for X" in an agent body · add a `mode` parameter to scope a writer tool |
+| [0007](adrs/ADR-0007-attack-the-plan-before-writing-code.md) | Attack the plan before writing code, with a read-only critic | wonder why `/critique-plan` is a command and not a sentence · want a third critique round · want to skip `PLAN.md` because the plan is in the chat · want Risky plans filed under `docs/plan/` |
 
 Conventions, and how to add one: [`docs/adrs/README.md`](adrs/README.md).
 Not yet written: state and the writer/projection tools, self-contained agent
@@ -1096,9 +1095,8 @@ skips silently**, which looks identical to passing.
 
 | Command | Covers | **Does not cover** |
 |---|---|---|
-| **`scripts/test.sh`** | engine + eval app + eval harness (harness **including** e2e-marked tests). **The PR template requires this one.** | the JS workspace, `apps/server`, and typecheck |
+| **`make test-all`** (= `scripts/test.sh`) | **everything**: typecheck, JS workspace, `apps/server`, engine + packaging lints, CRUD UI, eval harness **including** the e2e-marked contract test. The target delegates to the script, so the two are one command; the PR template names it. Runs every suite before reporting, so one failure doesn't hide the next. | a live-API check of any single tool (`dev/try-<tool>.ts`), agent tool binding (`make agent-smoke`), skill behaviour (`make eval-skill`) |
 | `make test` | JS workspace + server tests | **engine, packaging lints, harness** — an engine-only change gets *zero* coverage |
-| `make test-all` | typecheck (since #1173 — it runs `make typecheck` first), JS, server, engine, eval harness, CRUD UI | the **e2e-marked harness tests** — it reaches the harness via `make harness-test`, which is `-m 'not e2e'`. `scripts/test.sh` is the only command that runs those. |
 | `make engine-test` | `packages/engine/mcp-server` (vitest) + all packaging lints | the `packages/schema` mirror; anything needing a live API |
 | `make harness-test` | `eval/harness` (pytest, excludes e2e) — **the sole gate on the `packages/schema` mirror** | engine unit tests, though it *does* execute the compiled `build/` — a broken engine fails here wearing the costume of a harness bug |
 | `make typecheck` | the whole JS workspace (turbo) — the only gate on viewer code | Python |
@@ -1176,7 +1174,7 @@ plus `dev/try-<tool>.ts` against the live API; a schema field → `make engine-t
 `make harness-test`, **and** `make typecheck`; a skill body → `make eval-skill`
 plus the annotation gate (§3); routing or anything cross-skill → a live
 `make e2e-run`, named in the PR; hosted agent config → `make agent-smoke`. Then
-run `scripts/test.sh`, which the PR template requires. **If the thing you changed
+run `make test-all`, which the PR template requires. **If the thing you changed
 appears in §9.4, say so in the PR** rather than implying CI covered you.
 
 **Debug a failing e2e run.** Check the two setup gates first — `make e2e-preflight`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1117,6 +1117,8 @@ Drift is CI-enforced, not conventional. In `packages/engine/mcp-server/tests/pac
 | `skill-description-length.test.ts` | the 1024-char cap |
 | `skill-guidance.test.ts` | 8 `places-guidance.md` copies byte-identical to the canonical |
 | `enum-drift.test.ts` | prose enum tables ↔ `enums.schema.json` |
+| `adr-links.test.ts` | ADR required fields; every repo path cited in an ADR's **live** `Applies to` / `Enforcement` still resolves (the frozen-history sections are exempt) |
+| `doc-links.test.ts` | every repo path, markdown link and `make` target cited by `docs/task-lifecycle.md` and by **`.claude/{agents,commands,skills}`** still resolves. These have no frozen-history half — every line is an instruction a model acts on. Shares its extraction rules with `adr-links.test.ts` via `repo-paths.ts` |
 
 Plus, from `.github/workflows/check-runlogs.yml`:
 `check_skill_frontmatter.py` (for **skills and agents**: description length and

--- a/docs/per-pr-review-workflow.md
+++ b/docs/per-pr-review-workflow.md
@@ -1,10 +1,29 @@
 # Per-PR Review Workflow — Design Change Plan
 
-**Status:** Draft for senior-engineer review (v3 — simplified).
+**Status: SHIPPED, PARTLY SUPERSEDED (2026-08-02). Do not read this as pending
+work, and do not implement from it.** The per-PR model it proposes is how the
+team works today; the mechanics have moved on. Read it only for the *decisions
+and their reasoning*, and check any mechanic against the live source first:
+
+| For | Read instead |
+|---|---|
+| Run-log naming, release/candidate/active, the snapshot model | [`eval/CLAUDE.md`](../eval/CLAUDE.md), [`docs/plan/eval-runlog-versioning.md`](plan/eval-runlog-versioning.md) |
+| What the CI gate actually enforces | `eval/CLAUDE.md` § "GitHub Action rules" — now four blocking rules + two warns, plus the `eval-cosmetic-skip` bypass, none of which are described here |
+| The skill-improvement loop | [`docs/skill-lifecycle.md`](skill-lifecycle.md) |
+
+**§2.4 is superseded and was never built.** The per-test `test_content_hash`
+does not exist in the harness or either schema tree; the whole-snapshot model
+replaced it. Three specs described it as live until 2026-08-02. §2.8 and §2.10
+carry their own supersession notes inline.
+
+Still live and recorded nowhere else: §2.5 (onboarding as a selection task),
+§2.6 (monthly judge-prompt review), §2.9 (1-business-day senior SLA + volunteer
+pool), §7 (revisit clauses).
+
 **Date:** 2026-05-15
 **Scope:** Eval pipeline workflow redesign — touches `unit-test-spec.md`, `eval-crud-ui-spec.md`, `skill-mcp-testing-plan.md`, `eval/CLAUDE.md`, the harness, the CRUD UI, plus one new GitHub Action.
 
-This plan captures a deliberate shift in how skill evaluation is reviewed. Nothing is implemented yet — this document is the artifact for review and approval before doc rewrites and code begin.
+This plan captures a deliberate shift in how skill evaluation is reviewed.
 
 ---
 

--- a/docs/skill-mcp-testing-plan.md
+++ b/docs/skill-mcp-testing-plan.md
@@ -66,7 +66,7 @@ The CRUD UI (spec: `docs/specs/eval-crud-ui-spec.md`) is where juniors:
 - Author and edit unit tests (form maps to the unit-test JSON schema; no raw JSON editing).
 - View run logs (the harness writes them to disk via `RunTests.bat`; the CRUD UI auto-refreshes on tab focus).
 - Annotate run logs with **per-dimension numeric corrections** on a 1–3 scale (3=pass, 2=partial, 1=fail). The LLM judge's score is shown alongside an editable corrected-score field that defaults to the LLM's score; the junior changes only the dimensions they disagree with. Optional per-dimension comment field for the rationale on disagreement. The UI writes one `.ann.json` file per PR per skill.
-- Compare the PR's run log against main's most recent run log for that skill, side-by-side (weighted mean + count histogram). Tests whose `test_content_hash` differs between the two are flagged as excluded from the headline comparison.
+- Compare the PR's run log against main's most recent run log for that skill, side-by-side (weighted mean + count histogram). Tests the two run logs' `snapshot` blocks disagree on are flagged as excluded from the headline comparison.
 
 The CRUD UI is not the gate — the senior's PR-merge action is. The UI shows numbers; the senior reads them holistically alongside the prompt diff, test diff, and `.ann` file.
 

--- a/docs/specs/eval-crud-ui-spec.md
+++ b/docs/specs/eval-crud-ui-spec.md
@@ -197,7 +197,7 @@ The Results section opens to a dashboard with two panels:
 
 - For a given skill, shows the current PR's run log side-by-side with main's most recent run log for that skill.
 - Both sides display: weighted mean, count histogram (number of `3`s / `2`s / `1`s across all dimensions), and per-dimension breakdown.
-- Per-test rows: tests in both run logs are listed once, with their corrected weighted means on each side. Tests whose `test_content_hash` differs between the two run logs are flagged "edited — excluded from headline comparison" and visually de-emphasized; the senior can still inspect them individually.
+- Per-test rows: tests in both run logs are listed once, with their corrected weighted means on each side. Tests the two run logs' `snapshot` blocks disagree on are flagged "edited — excluded from headline comparison" and visually de-emphasized; the senior can still inspect them individually. (The per-test `test_content_hash` this used to key on was never built — the whole-snapshot model replaced it; see `docs/plan/eval-runlog-versioning.md` §A2/A4/A7.)
 - **Within-variance advisory:** when the weighted-mean delta between PR and main is below 0.3, the comparison view displays "within typical run-to-run variation — interpret cautiously." Advisory only; the senior decides what to make of it. Either party can re-run the harness for a second sample via the Python script. Per plan §2.10.
 - No statistical gate; no auto-merge. The senior reviews holistically (prompt diff + test diff + `.ann` + comparison) and accepts or rejects the PR through standard GitHub UI.
 
@@ -271,7 +271,7 @@ Resolved (covered above):
 
 - `docs/specs/unit-test-spec.md` — Unit test JSON format, JSON Schema, harness behavior, runnability gate, integer grade scale
 - `docs/specs/schemas/ann.schema.json` — `.ann` file schema (the annotation view writes against this)
-- `docs/specs/schemas/run-log.schema.json` — Run log schema (the Results section reads against this; includes `test_content_hash`)
+- `docs/specs/schemas/run-log.schema.json` — Run log schema (the Results section reads against this; the `snapshot` block is what comparison keys on)
 - `eval/CLAUDE.md` — Directory layout, naming conventions, annotation file conventions
 - `docs/specs/research-schema-spec.md` — Research.json schema (for scenario builder)
 - `docs/specs/simplified-gedcomx-spec.md` — GedcomX schema (for scenario builder)

--- a/docs/specs/unit-test-spec.md
+++ b/docs/specs/unit-test-spec.md
@@ -1129,7 +1129,6 @@ A run log represents N runs of one test (N from `runs_per_test`, default 1). The
   "judge_model": "string (e.g. claude-haiku-4-5-20251001)",
   "rubric_hash": "string (SHA-256 of eval/tests/unit/<skill>/rubric.md at run time)",
   "judge_prompt_hash": "string (SHA-256 of eval/harness/judge/prompt.md at run time)",
-  "test_content_hash": "string (SHA-256 of the resolved test — test JSON minus cosmetic fields + scenario directory contents + referenced fixture file contents — used by cross-PR comparison to auto-exclude tests whose grading-relevant content changed; see docs/per-pr-review-workflow.md §2.4)",
 
   "scenario": "string or null (scenario directory name)",
   "mcp_fixtures": ["string (fixture file names used)"],

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -152,14 +152,17 @@ either.
 
 ### 3. Attack the plan
 
-Hand the plan to the `plan-critic` subagent, **by path**:
+```
+/critique-plan PLAN.md
+```
 
-> Use the plan-critic agent to review the plan in PLAN.md.
-
-Point it at the file, not at "this plan." Subagents start in fresh context and
-see only what you hand them; asked to review "this plan," the parent session
-passes along a paraphrase — which is exactly the input the critic is told not
-to trust.
+The command dispatches to the `plan-critic` subagent. Use it rather than asking
+in prose: the session you're in *wrote* the plan, and asking it to review the
+plan gets you a Claude that is anchored on its own reasoning and holds Edit and
+Write. It will agree with itself, and it may start implementing. The command
+also points the critic at the plan **by path** — subagents start in fresh
+context and see only what they're handed, so "review this plan" passes along
+your paraphrase, which is exactly the input the critic is told not to trust.
 
 It reads the plan *and the code the plan claims to touch*, and reports findings
 with a severity and a concrete replacement. Its highest-value check is the
@@ -178,8 +181,15 @@ Two rounds of unresolved blocking findings is not a plan problem, it's a task
 problem — the task is underspecified or the approach is wrong, and another
 round of polishing won't fix either.
 
-Read the findings yourself before acting on them. Some will be wrong. Deciding
-which is part of the job, and it's the part that teaches you the codebase.
+**Check each finding before acting on it.** Some will be wrong. Open the file,
+run the command, confirm the claim. Deciding which findings are real is part of
+the job, and it's the part that teaches you the codebase.
+
+This applies to what the critic *proposes* as much as what it criticizes. A
+suggested command, flag, or file name that you pass along unchecked reads like
+an established thing to whoever you hand it to — that is how an invented name
+gets into a document and stays there. If you're going to repeat it, verify it
+first; if you haven't verified it, say so when you repeat it.
 
 ### 4. Implement
 
@@ -350,7 +360,9 @@ Three rules:
    positives — a claim about a function three files away that turns out to be
    wrong, an "unhandled case" that's handled upstream. Open the file and check.
    Posting unverified findings wastes the author's time and burns your
-   credibility fast.
+   credibility fast. This covers *suggestions* too: a proposed command or file
+   name, repeated without checking, arrives at the author looking like
+   something that already exists.
 2. **Post it in your own words, and state the edit.** Quote what they wrote,
    give the replacement text. "This will throw when `standardPlace` is
    unresolvable — resolve it before the map, or guard at line 40" beats a
@@ -395,7 +407,7 @@ git worktree add .claude/worktrees/<branch> -b <branch> origin/main
 # 2. write PLAN.md at the worktree root (gitignored)
 
 # 3. attack the plan (max 2 rounds)
-#    → "Use the plan-critic agent to review the plan in PLAN.md."
+/critique-plan PLAN.md
 
 # 5. verify — run BOTH; neither is a superset of the other
 make test-all                        # JS + server + engine + harness + typecheck

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -56,9 +56,12 @@ what they're getting.
   writer tools silently.
 - Touches **auth** (`packages/engine/mcp-server/src/auth/`) or anything holding
   a credential.
-- Changes **agent frontmatter**, `tools:`/`disallowedTools:`, hooks, or
-  anything that decides which tools an agent can reach. This is the class of
-  change that has broken production while CI stayed green.
+- Changes a **Cowork plugin agent** — anything under
+  `packages/engine/plugin/agents/` or `packages/engine/plugin/hooks/`, and
+  especially `tools:`/`disallowedTools:`. This is the class of change that has
+  broken production while CI stayed green. (Claude Code subagents under
+  `.claude/agents/` are *not* this — they're developer tooling that ships to
+  nobody, and they're Normal tier.)
 - Adds a **new MCP tool**, or changes an existing tool's contract.
 - Is **cross-cutting** — more than about three modules, or both the engine and
   the web side.
@@ -131,9 +134,11 @@ always:
 
 **Where it lives**, by tier:
 
-- **Normal:** the plan goes in the PR description when you open it. That's what
-  lets a reviewer check the diff against your *intent* instead of guessing at
-  it.
+- **Normal:** write it to `PLAN.md` at the root of your worktree, *before*
+  step 3. Two later steps consume it — the plan critic and your own fresh-session
+  review — and both run in a context that can't see your chat. Paste it into
+  the PR description at step 8. It's a scratch artifact and is gitignored;
+  don't commit it.
 - **Risky:** a real file under [`docs/plan/`](./plan/), reviewed by the lead
   before you write code. Note the conventions on that directory: its
   `**Status:**` line is load-bearing, and the plan is **deleted when the work
@@ -142,13 +147,19 @@ always:
   [`docs/adrs/README.md`](./adrs/README.md).
 
 A plan that stays in the chat window doesn't exist. Nobody else can see it, so
-nobody can catch you having built something else.
+nobody can catch you having built something else — and a subagent can't read it
+either.
 
 ### 3. Attack the plan
 
-Hand the plan to the `plan-critic` subagent:
+Hand the plan to the `plan-critic` subagent, **by path**:
 
-> Use the plan-critic agent to review this plan.
+> Use the plan-critic agent to review the plan in PLAN.md.
+
+Point it at the file, not at "this plan." Subagents start in fresh context and
+see only what you hand them; asked to review "this plan," the parent session
+passes along a paraphrase — which is exactly the input the critic is told not
+to trust.
 
 It reads the plan *and the code the plan claims to touch*, and reports findings
 with a severity and a concrete replacement. Its highest-value check is the
@@ -191,16 +202,24 @@ This step is not optional, and it is the one most often skipped. Your peer
 reviewer is not your test suite.
 
 ```sh
-make test-all        # typecheck + every suite; this is the floor
+make test-all        # typecheck + JS + server + engine + harness + CRUD UI
+scripts/test.sh      # what the PR template's checkbox actually requires
 ```
+
+**Run both.** Neither is a superset of the other, and this trips people up:
+`make test-all` reaches the harness via `make harness-test`, which excludes
+e2e-marked tests; `scripts/test.sh` runs the harness suite in full but skips
+the JS workspace, `apps/server`, and typecheck. The full breakdown of what each
+command does and does not cover is [`docs/architecture.md`](./architecture.md)
+§9.1 — read it once, and don't guess after that.
 
 Plus whatever your change actually touches:
 
 | If you changed | Also run |
 |---|---|
-| An MCP tool | `packages/engine/mcp-server/dev/try-<tool>.ts` against the live API, and re-read the tool's spec under `docs/specs/` against your implementation — quote both sides |
-| A skill's `SKILL.md` | `make eval-skill SKILL=<name>` — and follow [`docs/skill-lifecycle.md`](./skill-lifecycle.md), which is the real process for this |
-| Agent frontmatter, hooks, or tool binding | `make agent-smoke` — the only check that reads what the runtime actually resolved. No CI job covers this path. |
+| An MCP tool | `cd packages/engine/mcp-server && npx tsx dev/try-<tool>.ts` against the live API — if a `try-` script exists; write one if not, and run `dev/try-login.ts` first for an authenticated tool. Then re-read the tool's spec under `docs/specs/` against your implementation, quoting both sides. |
+| **Any file under `packages/engine/plugin/skills/`** | `make eval-skill SKILL=<name>`, **and commit the run log + its `.ann.json`**. `.github/workflows/check-runlogs.yml` blocks merge otherwise — even for a one-word change, and even on a task that is otherwise pure developer work. Follow [`docs/skill-lifecycle.md`](./skill-lifecycle.md) for the rest. |
+| Plugin agent frontmatter (`packages/engine/plugin/agents/`), hooks, or tool binding | `make agent-smoke` — the only check that reads what the runtime actually resolved. No CI job covers this path. **It exits 0 when it skips**, so confirm the output lists the resolved agents rather than `1 skipped`; that means no API key was reachable. |
 | An e2e fixture | `make e2e-validate TEST=<slug>` |
 | Anything user-facing | Actually run it. `make server` / `make web`, or the Claude Desktop install path. |
 
@@ -219,8 +238,8 @@ So open a **new** session, give it the plan and the diff, and ask:
 > implementation do that the plan didn't call for, and what did the plan call
 > for that isn't here?
 
-You can also run `/code-review` on the branch. Either way, you're hunting one
-specific thing: **implement-vs-plan drift**. It is the most common failure mode
+You're hunting one specific thing: **implement-vs-plan drift**. It is the most
+common failure mode
 in agent-assisted work and it is nearly invisible in a diff read on its own,
 because the code looks fine — it's just not the code that was agreed to.
 
@@ -258,10 +277,15 @@ that someone has to triage. Use the free-afternoon test.
 
 ### 8. Open the PR
 
-The description carries:
+**Fill in the PR template — don't replace it.** Its Test plan checkboxes are
+the repo's contract, and the first one names `scripts/test.sh` specifically.
+Don't tick a box for a command you didn't run; if a check doesn't apply, say
+why rather than deleting it.
+
+Under Summary, add:
 
 - **The tier** you picked.
-- **The plan** (Normal tier) or a link to it (Risky tier).
+- **The plan** (Normal tier — paste `PLAN.md`) or a link to it (Risky tier).
 - **What you verified** — which commands you ran, what you exercised by hand.
 - **The follow-on issue numbers.**
 
@@ -319,7 +343,6 @@ gh pr checkout <N>
 
 Then give Claude the PR description (which has the plan), the diff, and the
 relevant spec, and ask for findings with severity and a suggested replacement.
-`/code-review` does this on the current branch.
 
 Three rules:
 
@@ -369,18 +392,21 @@ Every one of these has happened somewhere, to someone competent.
 # 0. branch
 git worktree add .claude/worktrees/<branch> -b <branch> origin/main
 
-# 3. attack the plan (max 2 rounds)
-#    → "Use the plan-critic agent to review this plan."
+# 2. write PLAN.md at the worktree root (gitignored)
 
-# 5. verify
-make test-all                        # floor, always
-make eval-skill SKILL=<name>         # a SKILL.md changed
-make agent-smoke                     # agent frontmatter / hooks / tool binding
+# 3. attack the plan (max 2 rounds)
+#    → "Use the plan-critic agent to review the plan in PLAN.md."
+
+# 5. verify — run BOTH; neither is a superset of the other
+make test-all                        # JS + server + engine + harness + typecheck
+scripts/test.sh                      # what the PR template requires
+make eval-skill SKILL=<name>         # any packages/engine/plugin/skills/ file
+make agent-smoke                     # plugin agents / hooks / tool binding
 make e2e-validate TEST=<slug>        # an e2e fixture changed
 cd packages/engine/mcp-server && npx tsx dev/try-<tool>.ts   # an MCP tool changed
 
 # 6. self-review, in a FRESH session
-/code-review
+#    → "Here is PLAN.md and the diff. Where do they diverge?"
 
 # 7. follow-on work
 gh issue create --label developer --title "…" --body "…"

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -16,6 +16,37 @@ Everything below is detail on those four.
 
 ---
 
+## If you read nothing else, read this
+
+Two things are mandatory before you request review. Everything else in this
+document is guidance you can scale to the task; these two are not.
+
+> ### 1. Run **both** test commands
+>
+> ```sh
+> make test-all        # JS + server + engine + harness + typecheck
+> scripts/test.sh      # what the PR template's checkbox actually requires
+> ```
+>
+> Neither is a superset of the other. `make test-all` excludes the e2e-marked
+> harness tests; `scripts/test.sh` skips the JS workspace, `apps/server`, and
+> typecheck. Running one and ticking the template box is the most common way
+> broken work reaches a reviewer.
+>
+> ### 2. Self-review the diff in a **fresh** session
+>
+> Not the session that wrote the code — that one is anchored on its own
+> reasoning and will agree with you. Open a new one, hand it your plan and the
+> diff, and ask where they diverge.
+
+Skipping either of these moves work onto your reviewer that a machine or a
+fresh context would have caught for free. Everything else here is about doing
+the task well; these two are about not wasting someone else's afternoon.
+
+Details in [step 5](#5-verify-it-yourself) and [step 6](#6-review-your-own-diff-in-a-fresh-session).
+
+---
+
 ## Why this shape
 
 Working with Claude changes where the expensive mistakes happen. Writing code
@@ -277,10 +308,12 @@ gh issue create --label developer --title "…" --body "…"
 - **Reference the numbers in your PR description**, so your reviewer can see
   what you chose not to do.
 
-**Don't leave a `TODO` comment instead.** A TODO isn't a queue — nobody is
-assigned to it and nobody reads it. Same reason `docs/TODOs.md` was retired
-(2026-08-02, after it reached 932 lines and 54 unassignable items). Don't
-recreate that file under any name.
+**Don't leave a `TODO` comment, and don't start a to-do file.** A TODO isn't a
+queue — nobody is assigned to it, nobody is notified about it, and nobody reads
+it. If you were about to write one, that is exactly the case the `icebox` label
+is for: file it as an issue, label it `icebox`, and it lands in Backlog where
+triage can see it and skip it until something changes. A `TODO` in the source
+is invisible to every one of those steps.
 
 And don't over-file. Fifteen issues from one PR isn't thoroughness, it's noise
 that someone has to triage. Use the free-afternoon test.

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -1,445 +1,196 @@
-# Task lifecycle — how a developer task gets done here
+# Task lifecycle
 
-**Audience:** developers on this project working with Claude Code.
-**Scope:** developer tasks — code, tools, tests, CI, tooling. If your task is
-improving a skill's prose from eval results, follow
-[`docs/skill-lifecycle.md`](./skill-lifecycle.md) instead; that loop is
-different and it wins for skill work.
+How a developer task gets from issue to merge. Skill-prose work from eval
+results follows [`docs/skill-lifecycle.md`](./skill-lifecycle.md) instead.
 
-The short version:
+> Plan before you code. Have the plan attacked before you code. Verify your own
+> work before you ask anyone to look at it. Never ship a line you can't explain.
 
-> **Plan before you code. Have the plan attacked before you code. Verify your
-> own work before you ask anyone to look at it. Never ship a line you can't
-> explain.**
-
-Everything below is detail on those four.
+Why it is shaped this way: [ADR-0007](./adrs/ADR-0007-attack-the-plan-before-writing-code.md).
 
 ---
 
-## If you read nothing else, read this
+## Pick a tier
 
-Two things are mandatory on every task, and a third whenever you touch a skill.
-Everything else in this document is guidance you can scale to the task; these
-are not.
-
-> ### 1. Run **both** test commands
->
-> ```sh
-> make test-all        # typecheck + JS + server + engine + harness + CRUD UI
-> scripts/test.sh      # what the PR template's checkbox actually requires
-> ```
->
-> Neither is a superset of the other. `make test-all` excludes the e2e-marked
-> harness tests; `scripts/test.sh` skips the JS workspace, `apps/server`, and
-> typecheck. Running one and ticking the template box is the most common way
-> broken work reaches a reviewer.
->
-> ### 2. Self-review the diff in a **fresh** session
->
-> Not the session that wrote the code — that one is anchored on its own
-> reasoning and will agree with you. Open a new one, hand it your plan and the
-> diff, and ask where they diverge.
->
-> ### 3. If you touched `packages/engine/plugin/skills/`, run the eval
->
-> ```sh
-> make eval-skill SKILL=<name>   # then commit the run log + its .ann.json
-> ```
->
-> `.github/workflows/check-runlogs.yml` blocks merge otherwise, even for a
-> one-word change. It has no `paths:` filter — it runs on every PR — so this
-> catches you on a task that is otherwise pure developer work.
-
-Skipping these moves work onto your reviewer that a machine or a fresh context
-would have caught for free. Everything else here is about doing the task well;
-these are about not wasting someone else's afternoon.
-
-Details in [step 5](#5-verify-it-yourself) and [step 6](#6-review-your-own-diff-in-a-fresh-session).
-
----
-
-## Why this shape
-
-Working with Claude changes where the expensive mistakes happen. Writing code
-is no longer the slow part; *deciding what code to write* is, and a wrong
-decision now gets implemented very fast and very completely. A plan that is
-wrong in one sentence becomes a branch that is wrong in forty files.
-
-So the process front-loads scrutiny. The cheapest place to kill a bad approach
-is a paragraph in a plan. The second cheapest is your own review of your own
-diff. Peer review is third, and the lead's review is last and most expensive —
-by the time it reaches him, everything mechanical should already be settled.
-
-The second thing that changes: Claude is a fast, confident, and occasionally
-wrong collaborator. Every step below that says "have Claude do X" is paired
-with a step that says "and then check it." That pairing is the whole method.
-Drop the checking half and this process is worse than no process, because it
-produces work that *looks* reviewed.
-
----
-
-## Pick a tier first
-
-Not every task earns the same ceremony. Decide which of these you're in before
-you start — and say which one in your PR description, so your reviewer knows
-what they're getting.
+Say which one in your PR description.
 
 | Tier | What it is | What you do |
 |---|---|---|
-| **Trivial** | Typo, comment, doc link, version bump, deleting dead code, a one-line fix with an obvious cause | Skip the plan. Make the change, run the tests, self-review, open the PR. Peer review still applies. |
-| **Normal** | Most tasks. A bug fix, a new test, a tool change, a refactor inside one module | The full loop below. |
-| **Risky** | See the trigger list | The full loop, **plus** the plan goes in a file and the lead reviews it *before* you write code. |
+| **Trivial** | Typo, comment, doc link, version bump, dead-code deletion, one-line fix with an obvious cause | Skip steps 1–3. Change, test, self-review, PR. |
+| **Normal** | Most tasks. A bug fix, a new test, a tool change, a refactor inside one module | All nine steps. |
+| **Risky** | See below | All nine steps, and the lead reviews your plan in the draft PR **before** you write code. |
 
-**A task is Risky if it does any of these:**
+**Risky if it does any of these:**
 
 - Changes `research.json` or simplified-GedcomX **schema** — a new field, a new
-  value on a closed enum, or a tree-shape change. These have fixed multi-site
-  edit lists in [`CLAUDE.md`](../CLAUDE.md); getting one site wrong breaks
-  writer tools silently.
-- Touches **auth** (`packages/engine/mcp-server/src/auth/`) or anything holding
-  a credential.
-- Changes a **Cowork plugin agent** — anything under
-  `packages/engine/plugin/agents/` or `packages/engine/plugin/hooks/`, and
-  especially `tools:`/`disallowedTools:`. This is the class of change that has
-  broken production while CI stayed green. (Claude Code subagents under
-  `.claude/agents/` are *not* this — they're developer tooling that ships to
-  nobody, and they're Normal tier.)
-- Adds a **new MCP tool**, or changes an existing tool's contract.
-- Is **cross-cutting** — more than about three modules, or both the engine and
-  the web side.
-- **Reverses a decision** already recorded in [`docs/adrs/`](./adrs/), or
-  contradicts a rule in `CLAUDE.md`.
-- Is **hard to undo**: a data migration, anything that writes user state,
-  anything user-facing or that talks to an external service.
+  value on a closed enum, or a tree-shape change. Site lists:
+  [`CLAUDE.md`](../CLAUDE.md) § "Researcher profile in `research.json`".
+- Touches `packages/engine/mcp-server/src/auth/`, or anything holding a credential.
+- Changes a **Cowork plugin agent** — `packages/engine/plugin/agents/`,
+  `packages/engine/plugin/hooks/`, and especially `tools:`/`disallowedTools:`.
+  (Claude Code subagents under `.claude/agents/` are Normal.)
+- Adds an MCP tool, or changes an existing tool's contract.
+- Touches more than about three modules, or both the engine and the web side.
+- Reverses something in [`docs/adrs/`](./adrs/) or contradicts a `CLAUDE.md` rule.
+- Is hard to undo: a data migration, a write to user state, anything
+  user-facing or talking to an external service.
 
-When in doubt, it's Risky. The cost of over-classifying is one extra review of
-a document; the cost of under-classifying is discovering the problem in
-production.
+When in doubt, Risky.
 
 ---
 
 ## The loop
 
-### 0. Take the issue, and branch in a worktree
-
-Work happens on a branch in a worktree, never on `main`:
+### 0. Branch in a worktree
 
 ```sh
 git worktree add .claude/worktrees/<branch> -b <branch> origin/main
 ```
 
-The `post-checkout` hook links the shared gitignored files for you
-(run `make install-hooks` once per clone if you haven't). One task, one
-worktree, one PR. Two tasks in one branch means one reviewer has to hold both
-in their head, and neither gets reviewed properly.
+Never work on `main`. One task, one worktree, one PR. The `post-checkout` hook
+links the shared gitignored files (`make install-hooks` once per clone).
 
-### 1. Read the ground, not just the ticket
+### 1. Read the ground
 
-Issue bodies here are deliberately thin — the project's convention is that
-rationale lives in specs and in comments at the site it constrains, *not* in
-the issue. So an issue is a pointer, not a briefing. Before planning, read:
+Issue bodies here are pointers, not briefings. Before planning, read the issue,
+the spec under [`docs/specs/`](./specs/) if the thing you're touching has one,
+[`docs/architecture.md`](./architecture.md) (its "If you're asked to…" blocks
+name the sites your change touches), [`CLAUDE.md`](../CLAUDE.md), and the code.
 
-- the issue,
-- the spec, if the thing you're touching has one under
-  [`docs/specs/`](./specs/),
-- [`docs/architecture.md`](./architecture.md) — its "If you're asked to…"
-  blocks tell you which sites your change touches,
-- [`CLAUDE.md`](../CLAUDE.md) — project rules that override normal defaults,
-- and the actual code.
-
-Point Claude at all of it. Then **ask it to ask you questions.** Word it so you
-get the useful ones:
+Point Claude at all of it, then ask it to ask you questions:
 
 > Read this issue, the spec, and the code it touches. Before proposing
-> anything, ask me the questions where a different answer would change what
-> you build. Skip anything with an obvious default — make the call and tell
-> me what you chose.
+> anything, ask me the questions where a different answer would change what you
+> build. Skip anything with an obvious default — make the call and tell me what
+> you chose.
 
-That last sentence matters. Without it you get twelve questions of which ten
-have obvious answers, you rubber-stamp all twelve, and the exercise taught you
-nothing.
+The last sentence is what stops you rubber-stamping twelve questions that had
+ten obvious answers.
 
-### 2. Write the plan
+### 2. Write the plan to a file
 
-The plan is the artifact the rest of the process operates on. Four things,
-always:
+`PLAN.md` at your worktree root. It is gitignored; don't commit it. Four things:
 
-1. **What changes** — the actual file list. Not "update the validator," but the
-   path.
-2. **What doesn't change** — the tempting adjacent thing you're deliberately
-   not touching. This is what stops scope creep during implementation.
-3. **The acceptance check** — how we will know it worked, as something a
-   person can run. The strong form is a *named test that fails today and
-   passes after*. "The tests pass" is not an acceptance check; the tests pass
-   right now.
-4. **What you're deferring** — the things you'll file as issues in step 7.
+1. **What changes** — the file list, by path.
+2. **What doesn't change** — the tempting adjacent thing you're not touching.
+3. **The acceptance check** — a named test that fails today and passes after.
+   "The tests pass" is not one; they pass right now.
+4. **What you're deferring** — becomes issues in step 7.
 
-**Where it lives**, by tier:
-
-- **Normal:** write it to `PLAN.md` at the root of your worktree, *before*
-  step 3. Two later steps consume it — the plan critic and your own fresh-session
-  review — and both run in a context that can't see your chat. Paste it into
-  the PR description at step 8. It's a scratch artifact and is gitignored;
-  don't commit it.
-- **Risky:** a real file under [`docs/plan/`](./plan/), reviewed by the lead
-  before you write code. Note the conventions on that directory: its
-  `**Status:**` line is load-bearing, and the plan is **deleted when the work
-  ships** — the spec and the code become the record. If the decision has a
-  rejected alternative behind it, it wants an ADR too; see
-  [`docs/adrs/README.md`](./adrs/README.md).
-
-A plan that stays in the chat window doesn't exist. Nobody else can see it, so
-nobody can catch you having built something else — and a subagent can't read it
-either.
+A plan that stays in the chat can't be read by the critic, by your fresh-session
+review, or by your reviewer.
 
 ### 3. Attack the plan
 
 ```
-/critique-plan PLAN.md               # Normal tier
-/critique-plan docs/plan/<file>.md   # Risky tier
+/critique-plan PLAN.md
 ```
 
-The command dispatches to the `plan-critic` subagent. Use it rather than asking
-in prose: the session you're in *wrote* the plan, and asking it to review the
-plan gets you a Claude that is anchored on its own reasoning and holds Edit and
-Write. It will agree with itself, and it may start implementing. The command
-also points the critic at the plan **by path** — subagents start in fresh
-context and see only what they're handed, so "review this plan" passes along
-your paraphrase, which is exactly the input the critic is told not to trust.
-
-It reads the plan *and the code the plan claims to touch*, and reports findings
-with a severity and a concrete replacement. Its highest-value check is the
-dullest one: verifying that every file, function, field, and command the plan
-names actually exists. Plans written from an issue body invent call sites
-constantly, and it is a cheap thing to catch and an expensive thing to miss.
-
-**Two rounds maximum.** Round one finds real problems. Round two confirms
-they're fixed and usually finds one more. Round three finds style opinions and
-makes the plan longer without making it better — and reviewers, human or
-otherwise, drift toward agreeing with whatever's in front of them the third
-time they see it.
-
-**If round two still returns a BLOCKING finding, stop and go to the lead.**
-Two rounds of unresolved blocking findings is not a plan problem, it's a task
-problem — the task is underspecified or the approach is wrong, and another
-round of polishing won't fix either.
+Two rounds maximum. **If round two still returns a BLOCKING finding, stop and
+go to the lead** — the task is underspecified, not the plan.
 
 **Check each finding before acting on it.** Some will be wrong. Open the file,
-run the command, confirm the claim. Deciding which findings are real is part of
-the job, and it's the part that teaches you the codebase.
+run the command, confirm the claim. This covers what the critic *proposes* as
+much as what it criticizes: a suggested command, flag, or file name that you
+repeat unchecked reads like an established thing to whoever you hand it to.
 
-This applies to what the critic *proposes* as much as what it criticizes. A
-suggested command, flag, or file name that you pass along unchecked reads like
-an established thing to whoever you hand it to — that is how an invented name
-gets into a document and stays there. If you're going to repeat it, verify it
-first; if you haven't verified it, say so when you repeat it.
+**Risky tier:** open the draft PR now with the plan in its description, and get
+the lead's review before writing code.
 
 ### 4. Implement
 
-Then, and only then, write the code.
+**If reality contradicts the plan, stop and re-plan.** Update the plan (a
+sentence in the PR body is enough on Normal tier), then continue — your
+reviewer is reviewing against the plan, so an undocumented deviation is
+invisible to exactly the person whose job is catching it.
 
-**One rule during implementation: if reality contradicts the plan, stop and
-re-plan.** You will discover that the function doesn't work the way you
-thought, or that the fix needs a change in a third module. That is normal. What
-is not acceptable is quietly improvising around it — because your reviewer is
-reviewing against the plan, and an undocumented deviation is invisible to
-exactly the person whose job is to catch it. Update the plan (a sentence in the
-PR body is enough for Normal tier), then continue.
-
-Keep the diff scoped to the plan. If you spot something else worth fixing, it
-becomes an issue in step 7, not a hitchhiker in this PR.
+Keep the diff scoped to the plan. Anything else you spot becomes step 7.
 
 ### 5. Verify it yourself
 
-This step is not optional, and it is the one most often skipped. Your peer
-reviewer is not your test suite.
-
 ```sh
-make test-all        # typecheck + JS + server + engine + harness + CRUD UI
-scripts/test.sh      # what the PR template's checkbox actually requires
+make test-all      # == scripts/test.sh. Typecheck + JS + server + engine + CRUD UI + harness.
 ```
 
-**Run both.** Neither is a superset of the other, and this trips people up:
-`make test-all` reaches the harness via `make harness-test`, which excludes
-e2e-marked tests; `scripts/test.sh` runs the harness suite in full but skips
-the JS workspace, `apps/server`, and typecheck. The full breakdown of what each
-command does and does not cover is [`docs/architecture.md`](./architecture.md)
-§9.1 — read it once, and don't guess after that.
-
-Plus whatever your change actually touches:
+Plus whatever you actually touched:
 
 | If you changed | Also run |
 |---|---|
-| An MCP tool | `cd packages/engine/mcp-server && npx tsx dev/try-<tool>.ts` against the live API — if a `try-` script exists; write one if not, and run `dev/try-login.ts` first for an authenticated tool. Then re-read the tool's spec under `docs/specs/` against your implementation, quoting both sides. |
-| **Any file under `packages/engine/plugin/skills/`** | `make eval-skill SKILL=<name>`, **and commit the run log + its `.ann.json`**. `.github/workflows/check-runlogs.yml` blocks merge otherwise — even for a one-word change, and even on a task that is otherwise pure developer work. Follow [`docs/skill-lifecycle.md`](./skill-lifecycle.md) for the rest. |
-| Plugin agent frontmatter (`packages/engine/plugin/agents/`), hooks, or tool binding | `make agent-smoke` — the only check that reads what the runtime actually resolved. No CI job covers this path. **It exits 0 when it skips**, so confirm the output lists the resolved agents rather than `1 skipped`; that means no API key was reachable. |
+| An MCP tool | `npx tsx dev/try-<tool>.ts` from `packages/engine/mcp-server/` against the live API — write one if it doesn't exist, and run `dev/try-login.ts` first for an authenticated tool. Then read your implementation against `docs/specs/<tool>-tool-spec.md`, quoting both sides. |
+| Any file in a skill's run-log **snapshot** — `packages/engine/plugin/skills/<skill>/`, an agent it delegates to, `eval/tests/unit/<skill>/`, or a scenario/fixture it references | `make eval-skill SKILL=<name>`, and commit the run log **and its `.ann.json`**. `check-runlogs.yml` blocks merge otherwise — a comment or a typo counts, because the whole skill dir is in the snapshot. For a behaviour-neutral edit, ask a senior for the `eval-cosmetic-skip` label instead of burning a paid run. Rules and the exact snapshot set: [`eval/CLAUDE.md`](../eval/CLAUDE.md) § "Snapshot model" and § "GitHub Action rules". |
+| Plugin agent frontmatter, hooks, or tool binding | `make agent-smoke`. **It exits 0 when it skips**, so confirm the output lists resolved agents rather than `1 skipped` — that means no API key was reachable. |
 | An e2e fixture | `make e2e-validate TEST=<slug>` |
-| Anything user-facing | Actually run it. `make server` / `make web`, or the Claude Desktop install path. |
+| Anything user-facing | Run it. `make server` / `make web`, or the Claude Desktop install path. |
 
-Then **exercise the thing you built**, once, by hand. Not because the tests
-might be wrong — because they might not be testing what you think.
+Then exercise the thing you built, once, by hand.
 
 ### 6. Review your own diff, in a fresh session
 
-The session that wrote the code is the worst available reviewer of it. It is
-anchored on its own reasoning, it believes the plan was followed because it
-believes it followed the plan, and it will confirm both if you ask.
-
-So open a **new** session, give it the plan and the diff, and ask:
+Not the session that wrote the code — it will agree with you. Open a new one,
+give it the plan and the diff, and ask:
 
 > Here is the plan and here is the diff. Where do they diverge? What did the
 > implementation do that the plan didn't call for, and what did the plan call
 > for that isn't here?
 
-You're hunting one specific thing: **implement-vs-plan drift**. It is the most
-common failure mode
-in agent-assisted work and it is nearly invisible in a diff read on its own,
-because the code looks fine — it's just not the code that was agreed to.
-
-Fix what you find. Then read the whole diff yourself, top to bottom.
+You are hunting **implement-vs-plan drift**: code that looks fine and isn't the
+code that was agreed. Fix what you find, then read the whole diff yourself.
 
 ### 7. File the follow-on work
 
-Everything you decided not to do becomes a GitHub issue, in this PR:
+Everything you decided not to do becomes a GitHub issue, in this PR. The rules
+— which label, when to use `icebox`, how short to keep the body, why you must
+not run `gh project` — are in [`DEVELOPMENT.md`](../DEVELOPMENT.md) §
+"Follow-on work you find along the way".
 
-```sh
-gh issue create --label developer --title "…" --body "…"
-```
-
-**Creating the issue is the whole job** — a CI workflow adds it to Backlog, and
-you must not run `gh project` commands yourself. The rest of the rules — which
-label, the free-afternoon test for `icebox`, why the `gh project` write fails
-in a way that looks like success, how short to keep the body — are in
-[`DEVELOPMENT.md`](../DEVELOPMENT.md) under "Follow-on work you find along the
-way." Read them there; they are not repeated here, because two copies of a rule
-means one of them is wrong within a quarter and nobody can tell which.
-
-**Reference the issue numbers in your PR description**, so your reviewer can see
-what you chose not to do.
-
-**Don't leave a `TODO` comment, and don't start a to-do file.** A TODO isn't a
-queue — nobody is assigned to it, nobody is notified about it, and nobody reads
-it. That was tried at file scale: `docs/TODOs.md` reached 932 lines and 54
-unassignable items before it was retired (2026-08-02). **Do not reintroduce a
-queue file under any name.** If you were about to write a TODO, that is exactly
-the case the `icebox` label is for: file it as an issue, label it `icebox`, and
-it lands in Backlog where triage can see it and skip it until something
-changes. A `TODO` in the source
-is invisible to every one of those steps.
-
-And don't over-file. Fifteen issues from one PR isn't thoroughness, it's noise
-that someone has to triage. Use the free-afternoon test.
+Don't leave a `TODO` comment and don't start a to-do file. Reference the issue
+numbers in your PR description.
 
 ### 8. Open the PR
 
-**Fill in the PR template — don't replace it.** Its Test plan checkboxes are
-the repo's contract, and the first one names `scripts/test.sh` specifically.
-Don't tick a box for a command you didn't run; if a check doesn't apply, say
-why rather than deleting it.
+Fill in the template; don't replace it. Don't tick a box for a command you
+didn't run — if a check doesn't apply, say why rather than deleting it.
 
-Under Summary, add:
+Credit your pair: [`DEVELOPMENT.md`](../DEVELOPMENT.md) § "Crediting a
+co-author".
 
-- **The tier** you picked.
-- **The plan** (Normal tier — paste `PLAN.md`) or a link to it (Risky tier).
-- **What you verified** — which commands you ran, what you exercised by hand.
-- **The follow-on issue numbers.**
-
-Credit your pair in the commit — the GitHub **username**, bare, as the last
-line:
-
-```
-Co-authored-by: their-github-username
-```
-
-We squash-merge, so your local commits are the only place that credit can come
-from. A `commit-msg` hook and a CI check both nudge (neither blocks). AI
-co-authors don't satisfy it — the point is recording the human.
-
-Keep PRs small. A forty-file PR from one agentic session is not reviewable, and
-an unreviewable PR silently cancels both of the review steps that follow.
+Keep PRs small. A forty-file PR turns both review steps into rubber stamps.
 
 ### 9. Peer review, then senior review
 
-**Peer review** is another developer on the team. **Senior review** is the
-lead, and it's the last gate for developer tasks. By the time it gets to him,
-everything mechanical — tests, spec compliance, style, plan drift — should
-already be resolved. His time goes to whether the approach is right.
+Peer review is another developer. Senior review is the lead, and it is the last
+gate — by then everything mechanical should be settled, so his time goes to
+whether the approach is right.
 
-Expect revision rounds. One or two is normal. Three is a signal that something
-upstream was wrong: usually the plan, sometimes the task. Say so rather than
-grinding through a fourth.
+One or two revision rounds is normal. Three means something upstream was wrong,
+usually the plan. Say so rather than grinding through a fourth.
 
 ---
 
 ## The rule that holds it together
 
-**You must be able to explain every line you're shipping.**
-
-Not "Claude wrote it and the tests pass." If a reviewer asks why a function
-takes that parameter, or what happens when that value is null, you need an
-answer. If you don't have one, you're not ready to open the PR — go read it,
-and ask Claude to explain the parts you can't account for.
-
-This is the load-bearing rule, and it's the reason the whole process works. The
-lead can only be the last gate if everything before it was genuinely checked by
-someone who understood it. A developer who becomes a conduit — passing Claude's
-output to review without understanding it — moves all the real review onto one
-person and quietly removes their own name from the work.
+**You must be able to explain every line you're shipping.** Not "Claude wrote it
+and the tests pass." If a reviewer asks why a function takes that parameter, or
+what happens when that value is null, you need an answer. If you don't have one,
+go read it before you open the PR.
 
 ---
 
-## Using Claude to review someone else's PR
-
-You should. Just don't let it review *for* you.
+## Reviewing someone else's PR
 
 ```sh
 gh pr checkout <N>
 ```
 
-Then give Claude the PR description (which has the plan), the diff, and the
-relevant spec, and ask for findings with severity and a suggested replacement.
+Give Claude the PR description (which has the plan), the diff, and the relevant
+spec. Then:
 
-Three rules:
-
-1. **Verify every finding before you post it.** Claude review output has false
-   positives — a claim about a function three files away that turns out to be
-   wrong, an "unhandled case" that's handled upstream. Open the file and check.
-   Posting unverified findings wastes the author's time and burns your
-   credibility fast. This covers *suggestions* too: a proposed command or file
-   name, repeated without checking, arrives at the author looking like
-   something that already exists.
+1. **Verify every finding before you post it** — proposals included. Open the
+   file and check.
 2. **Post it in your own words, and state the edit.** Quote what they wrote,
-   give the replacement text. "This will throw when `standardPlace` is
-   unresolvable — resolve it before the map, or guard at line 40" beats a
-   paragraph describing the shape of the problem. Never paste a Claude review
-   verbatim; the author can run that themselves.
-3. **Review against the plan, not just the diff.** You have their plan in the
-   PR body. Ask the same question you ask of your own work: does this
-   implementation match what was agreed?
-
-The peer review that catches the most is usually the least clever one: read the
-plan, read the diff, and ask what's in one and not the other.
-
----
-
-## Failure modes to watch for
-
-Every one of these has happened somewhere, to someone competent.
-
-- **The plan lives only in chat.** Nobody can check the implementation against
-  it, so nobody does.
-- **Round three of plan review.** The plan gets longer, not better.
-- **Skipping step 5** and letting the peer reviewer find that it doesn't build.
-- **Reviewing your own diff in the session that wrote it.** It will agree
-  with you.
-- **Letting Claude apply review comments without re-reading the result.** The
-  fix for one comment routinely breaks the thing another comment was about.
-- **The hitchhiking refactor.** "While I was in there." It doubles the diff and
-  hides the actual change.
-- **"Claude said it was fine."** Not a review. Not a defense.
-- **Filing fifteen follow-on issues** because it's one command.
-- **A forty-file PR.** Both review steps become rubber stamps and everyone
-  involved knows it.
+   give the replacement text. Never paste a Claude review verbatim.
+3. **Review against the plan, not just the diff.** Does this implementation
+   match what was agreed?
 
 ---
 
@@ -452,15 +203,13 @@ git worktree add .claude/worktrees/<branch> -b <branch> origin/main
 # 2. write PLAN.md at the worktree root (gitignored)
 
 # 3. attack the plan (max 2 rounds)
-/critique-plan PLAN.md               # or docs/plan/<file>.md on Risky tier
+/critique-plan PLAN.md
 
-# 5. verify — run BOTH; neither is a superset of the other
-make test-all                        # typecheck + JS + server + engine + harness + CRUD UI
-scripts/test.sh                      # what the PR template requires
-make eval-skill SKILL=<name>         # any packages/engine/plugin/skills/ file
-make agent-smoke                     # plugin agents / hooks / tool binding
+# 5. verify
+make test-all                        # everything; == scripts/test.sh
+make eval-skill SKILL=<name>         # anything in a skill's run-log snapshot
+make agent-smoke                     # plugin agent frontmatter / hooks / tool binding
 make e2e-validate TEST=<slug>        # an e2e fixture changed
-cd packages/engine/mcp-server && npx tsx dev/try-<tool>.ts   # an MCP tool changed
 
 # 6. self-review, in a FRESH session
 #    → "Here is PLAN.md and the diff. Where do they diverge?"

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -18,13 +18,14 @@ Everything below is detail on those four.
 
 ## If you read nothing else, read this
 
-Two things are mandatory before you request review. Everything else in this
-document is guidance you can scale to the task; these two are not.
+Two things are mandatory on every task, and a third whenever you touch a skill.
+Everything else in this document is guidance you can scale to the task; these
+are not.
 
 > ### 1. Run **both** test commands
 >
 > ```sh
-> make test-all        # JS + server + engine + harness + typecheck
+> make test-all        # typecheck + JS + server + engine + harness + CRUD UI
 > scripts/test.sh      # what the PR template's checkbox actually requires
 > ```
 >
@@ -38,10 +39,20 @@ document is guidance you can scale to the task; these two are not.
 > Not the session that wrote the code — that one is anchored on its own
 > reasoning and will agree with you. Open a new one, hand it your plan and the
 > diff, and ask where they diverge.
+>
+> ### 3. If you touched `packages/engine/plugin/skills/`, run the eval
+>
+> ```sh
+> make eval-skill SKILL=<name>   # then commit the run log + its .ann.json
+> ```
+>
+> `.github/workflows/check-runlogs.yml` blocks merge otherwise, even for a
+> one-word change. It has no `paths:` filter — it runs on every PR — so this
+> catches you on a task that is otherwise pure developer work.
 
-Skipping either of these moves work onto your reviewer that a machine or a
-fresh context would have caught for free. Everything else here is about doing
-the task well; these two are about not wasting someone else's afternoon.
+Skipping these moves work onto your reviewer that a machine or a fresh context
+would have caught for free. Everything else here is about doing the task well;
+these are about not wasting someone else's afternoon.
 
 Details in [step 5](#5-verify-it-yourself) and [step 6](#6-review-your-own-diff-in-a-fresh-session).
 
@@ -184,7 +195,8 @@ either.
 ### 3. Attack the plan
 
 ```
-/critique-plan PLAN.md
+/critique-plan PLAN.md               # Normal tier
+/critique-plan docs/plan/<file>.md   # Risky tier
 ```
 
 The command dispatches to the `plan-critic` subagent. Use it rather than asking
@@ -294,25 +306,25 @@ Everything you decided not to do becomes a GitHub issue, in this PR:
 gh issue create --label developer --title "…" --body "…"
 ```
 
-- `--label developer` for anything with a mechanical pass/fail;
-  `--label genealogist` for fixture adjudication, record research, doctrine
-  prose.
-- Add `--label icebox` if it's a maybe. The test: would you do it given a free
-  afternoon? If yes it's not icebox.
-- **Creating the issue is the whole job.** A CI workflow adds it to Backlog.
-  Do not run `gh project` commands — a token without the `project` scope fails
-  the board write *while still creating the issue*, which looks like it worked.
-- Keep the body short: what the work is, and enough of why it's still open that
-  nobody re-opens a settled question. Reasoning goes in the spec or a comment
-  at the line it constrains — nobody re-reads an issue body after triage.
-- **Reference the numbers in your PR description**, so your reviewer can see
-  what you chose not to do.
+**Creating the issue is the whole job** — a CI workflow adds it to Backlog, and
+you must not run `gh project` commands yourself. The rest of the rules — which
+label, the free-afternoon test for `icebox`, why the `gh project` write fails
+in a way that looks like success, how short to keep the body — are in
+[`DEVELOPMENT.md`](../DEVELOPMENT.md) under "Follow-on work you find along the
+way." Read them there; they are not repeated here, because two copies of a rule
+means one of them is wrong within a quarter and nobody can tell which.
+
+**Reference the issue numbers in your PR description**, so your reviewer can see
+what you chose not to do.
 
 **Don't leave a `TODO` comment, and don't start a to-do file.** A TODO isn't a
 queue — nobody is assigned to it, nobody is notified about it, and nobody reads
-it. If you were about to write one, that is exactly the case the `icebox` label
-is for: file it as an issue, label it `icebox`, and it lands in Backlog where
-triage can see it and skip it until something changes. A `TODO` in the source
+it. That was tried at file scale: `docs/TODOs.md` reached 932 lines and 54
+unassignable items before it was retired (2026-08-02). **Do not reintroduce a
+queue file under any name.** If you were about to write a TODO, that is exactly
+the case the `icebox` label is for: file it as an issue, label it `icebox`, and
+it lands in Backlog where triage can see it and skip it until something
+changes. A `TODO` in the source
 is invisible to every one of those steps.
 
 And don't over-file. Fifteen issues from one PR isn't thoroughness, it's noise
@@ -440,10 +452,10 @@ git worktree add .claude/worktrees/<branch> -b <branch> origin/main
 # 2. write PLAN.md at the worktree root (gitignored)
 
 # 3. attack the plan (max 2 rounds)
-/critique-plan PLAN.md
+/critique-plan PLAN.md               # or docs/plan/<file>.md on Risky tier
 
 # 5. verify — run BOTH; neither is a superset of the other
-make test-all                        # JS + server + engine + harness + typecheck
+make test-all                        # typecheck + JS + server + engine + harness + CRUD UI
 scripts/test.sh                      # what the PR template requires
 make eval-skill SKILL=<name>         # any packages/engine/plugin/skills/ file
 make agent-smoke                     # plugin agents / hooks / tool binding

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -1,0 +1,401 @@
+# Task lifecycle — how a developer task gets done here
+
+**Audience:** developers on this project working with Claude Code.
+**Scope:** developer tasks — code, tools, tests, CI, tooling. If your task is
+improving a skill's prose from eval results, follow
+[`docs/skill-lifecycle.md`](./skill-lifecycle.md) instead; that loop is
+different and it wins for skill work.
+
+The short version:
+
+> **Plan before you code. Have the plan attacked before you code. Verify your
+> own work before you ask anyone to look at it. Never ship a line you can't
+> explain.**
+
+Everything below is detail on those four.
+
+---
+
+## Why this shape
+
+Working with Claude changes where the expensive mistakes happen. Writing code
+is no longer the slow part; *deciding what code to write* is, and a wrong
+decision now gets implemented very fast and very completely. A plan that is
+wrong in one sentence becomes a branch that is wrong in forty files.
+
+So the process front-loads scrutiny. The cheapest place to kill a bad approach
+is a paragraph in a plan. The second cheapest is your own review of your own
+diff. Peer review is third, and the lead's review is last and most expensive —
+by the time it reaches him, everything mechanical should already be settled.
+
+The second thing that changes: Claude is a fast, confident, and occasionally
+wrong collaborator. Every step below that says "have Claude do X" is paired
+with a step that says "and then check it." That pairing is the whole method.
+Drop the checking half and this process is worse than no process, because it
+produces work that *looks* reviewed.
+
+---
+
+## Pick a tier first
+
+Not every task earns the same ceremony. Decide which of these you're in before
+you start — and say which one in your PR description, so your reviewer knows
+what they're getting.
+
+| Tier | What it is | What you do |
+|---|---|---|
+| **Trivial** | Typo, comment, doc link, version bump, deleting dead code, a one-line fix with an obvious cause | Skip the plan. Make the change, run the tests, self-review, open the PR. Peer review still applies. |
+| **Normal** | Most tasks. A bug fix, a new test, a tool change, a refactor inside one module | The full loop below. |
+| **Risky** | See the trigger list | The full loop, **plus** the plan goes in a file and the lead reviews it *before* you write code. |
+
+**A task is Risky if it does any of these:**
+
+- Changes `research.json` or simplified-GedcomX **schema** — a new field, a new
+  value on a closed enum, or a tree-shape change. These have fixed multi-site
+  edit lists in [`CLAUDE.md`](../CLAUDE.md); getting one site wrong breaks
+  writer tools silently.
+- Touches **auth** (`packages/engine/mcp-server/src/auth/`) or anything holding
+  a credential.
+- Changes **agent frontmatter**, `tools:`/`disallowedTools:`, hooks, or
+  anything that decides which tools an agent can reach. This is the class of
+  change that has broken production while CI stayed green.
+- Adds a **new MCP tool**, or changes an existing tool's contract.
+- Is **cross-cutting** — more than about three modules, or both the engine and
+  the web side.
+- **Reverses a decision** already recorded in [`docs/adrs/`](./adrs/), or
+  contradicts a rule in `CLAUDE.md`.
+- Is **hard to undo**: a data migration, anything that writes user state,
+  anything user-facing or that talks to an external service.
+
+When in doubt, it's Risky. The cost of over-classifying is one extra review of
+a document; the cost of under-classifying is discovering the problem in
+production.
+
+---
+
+## The loop
+
+### 0. Take the issue, and branch in a worktree
+
+Work happens on a branch in a worktree, never on `main`:
+
+```sh
+git worktree add .claude/worktrees/<branch> -b <branch> origin/main
+```
+
+The `post-checkout` hook links the shared gitignored files for you
+(run `make install-hooks` once per clone if you haven't). One task, one
+worktree, one PR. Two tasks in one branch means one reviewer has to hold both
+in their head, and neither gets reviewed properly.
+
+### 1. Read the ground, not just the ticket
+
+Issue bodies here are deliberately thin — the project's convention is that
+rationale lives in specs and in comments at the site it constrains, *not* in
+the issue. So an issue is a pointer, not a briefing. Before planning, read:
+
+- the issue,
+- the spec, if the thing you're touching has one under
+  [`docs/specs/`](./specs/),
+- [`docs/architecture.md`](./architecture.md) — its "If you're asked to…"
+  blocks tell you which sites your change touches,
+- [`CLAUDE.md`](../CLAUDE.md) — project rules that override normal defaults,
+- and the actual code.
+
+Point Claude at all of it. Then **ask it to ask you questions.** Word it so you
+get the useful ones:
+
+> Read this issue, the spec, and the code it touches. Before proposing
+> anything, ask me the questions where a different answer would change what
+> you build. Skip anything with an obvious default — make the call and tell
+> me what you chose.
+
+That last sentence matters. Without it you get twelve questions of which ten
+have obvious answers, you rubber-stamp all twelve, and the exercise taught you
+nothing.
+
+### 2. Write the plan
+
+The plan is the artifact the rest of the process operates on. Four things,
+always:
+
+1. **What changes** — the actual file list. Not "update the validator," but the
+   path.
+2. **What doesn't change** — the tempting adjacent thing you're deliberately
+   not touching. This is what stops scope creep during implementation.
+3. **The acceptance check** — how we will know it worked, as something a
+   person can run. The strong form is a *named test that fails today and
+   passes after*. "The tests pass" is not an acceptance check; the tests pass
+   right now.
+4. **What you're deferring** — the things you'll file as issues in step 7.
+
+**Where it lives**, by tier:
+
+- **Normal:** the plan goes in the PR description when you open it. That's what
+  lets a reviewer check the diff against your *intent* instead of guessing at
+  it.
+- **Risky:** a real file under [`docs/plan/`](./plan/), reviewed by the lead
+  before you write code. Note the conventions on that directory: its
+  `**Status:**` line is load-bearing, and the plan is **deleted when the work
+  ships** — the spec and the code become the record. If the decision has a
+  rejected alternative behind it, it wants an ADR too; see
+  [`docs/adrs/README.md`](./adrs/README.md).
+
+A plan that stays in the chat window doesn't exist. Nobody else can see it, so
+nobody can catch you having built something else.
+
+### 3. Attack the plan
+
+Hand the plan to the `plan-critic` subagent:
+
+> Use the plan-critic agent to review this plan.
+
+It reads the plan *and the code the plan claims to touch*, and reports findings
+with a severity and a concrete replacement. Its highest-value check is the
+dullest one: verifying that every file, function, field, and command the plan
+names actually exists. Plans written from an issue body invent call sites
+constantly, and it is a cheap thing to catch and an expensive thing to miss.
+
+**Two rounds maximum.** Round one finds real problems. Round two confirms
+they're fixed and usually finds one more. Round three finds style opinions and
+makes the plan longer without making it better — and reviewers, human or
+otherwise, drift toward agreeing with whatever's in front of them the third
+time they see it.
+
+**If round two still returns a BLOCKING finding, stop and go to the lead.**
+Two rounds of unresolved blocking findings is not a plan problem, it's a task
+problem — the task is underspecified or the approach is wrong, and another
+round of polishing won't fix either.
+
+Read the findings yourself before acting on them. Some will be wrong. Deciding
+which is part of the job, and it's the part that teaches you the codebase.
+
+### 4. Implement
+
+Then, and only then, write the code.
+
+**One rule during implementation: if reality contradicts the plan, stop and
+re-plan.** You will discover that the function doesn't work the way you
+thought, or that the fix needs a change in a third module. That is normal. What
+is not acceptable is quietly improvising around it — because your reviewer is
+reviewing against the plan, and an undocumented deviation is invisible to
+exactly the person whose job is to catch it. Update the plan (a sentence in the
+PR body is enough for Normal tier), then continue.
+
+Keep the diff scoped to the plan. If you spot something else worth fixing, it
+becomes an issue in step 7, not a hitchhiker in this PR.
+
+### 5. Verify it yourself
+
+This step is not optional, and it is the one most often skipped. Your peer
+reviewer is not your test suite.
+
+```sh
+make test-all        # typecheck + every suite; this is the floor
+```
+
+Plus whatever your change actually touches:
+
+| If you changed | Also run |
+|---|---|
+| An MCP tool | `packages/engine/mcp-server/dev/try-<tool>.ts` against the live API, and re-read the tool's spec under `docs/specs/` against your implementation — quote both sides |
+| A skill's `SKILL.md` | `make eval-skill SKILL=<name>` — and follow [`docs/skill-lifecycle.md`](./skill-lifecycle.md), which is the real process for this |
+| Agent frontmatter, hooks, or tool binding | `make agent-smoke` — the only check that reads what the runtime actually resolved. No CI job covers this path. |
+| An e2e fixture | `make e2e-validate TEST=<slug>` |
+| Anything user-facing | Actually run it. `make server` / `make web`, or the Claude Desktop install path. |
+
+Then **exercise the thing you built**, once, by hand. Not because the tests
+might be wrong — because they might not be testing what you think.
+
+### 6. Review your own diff, in a fresh session
+
+The session that wrote the code is the worst available reviewer of it. It is
+anchored on its own reasoning, it believes the plan was followed because it
+believes it followed the plan, and it will confirm both if you ask.
+
+So open a **new** session, give it the plan and the diff, and ask:
+
+> Here is the plan and here is the diff. Where do they diverge? What did the
+> implementation do that the plan didn't call for, and what did the plan call
+> for that isn't here?
+
+You can also run `/code-review` on the branch. Either way, you're hunting one
+specific thing: **implement-vs-plan drift**. It is the most common failure mode
+in agent-assisted work and it is nearly invisible in a diff read on its own,
+because the code looks fine — it's just not the code that was agreed to.
+
+Fix what you find. Then read the whole diff yourself, top to bottom.
+
+### 7. File the follow-on work
+
+Everything you decided not to do becomes a GitHub issue, in this PR:
+
+```sh
+gh issue create --label developer --title "…" --body "…"
+```
+
+- `--label developer` for anything with a mechanical pass/fail;
+  `--label genealogist` for fixture adjudication, record research, doctrine
+  prose.
+- Add `--label icebox` if it's a maybe. The test: would you do it given a free
+  afternoon? If yes it's not icebox.
+- **Creating the issue is the whole job.** A CI workflow adds it to Backlog.
+  Do not run `gh project` commands — a token without the `project` scope fails
+  the board write *while still creating the issue*, which looks like it worked.
+- Keep the body short: what the work is, and enough of why it's still open that
+  nobody re-opens a settled question. Reasoning goes in the spec or a comment
+  at the line it constrains — nobody re-reads an issue body after triage.
+- **Reference the numbers in your PR description**, so your reviewer can see
+  what you chose not to do.
+
+**Don't leave a `TODO` comment instead.** A TODO isn't a queue — nobody is
+assigned to it and nobody reads it. Same reason `docs/TODOs.md` was retired
+(2026-08-02, after it reached 932 lines and 54 unassignable items). Don't
+recreate that file under any name.
+
+And don't over-file. Fifteen issues from one PR isn't thoroughness, it's noise
+that someone has to triage. Use the free-afternoon test.
+
+### 8. Open the PR
+
+The description carries:
+
+- **The tier** you picked.
+- **The plan** (Normal tier) or a link to it (Risky tier).
+- **What you verified** — which commands you ran, what you exercised by hand.
+- **The follow-on issue numbers.**
+
+Credit your pair in the commit — the GitHub **username**, bare, as the last
+line:
+
+```
+Co-authored-by: their-github-username
+```
+
+We squash-merge, so your local commits are the only place that credit can come
+from. A `commit-msg` hook and a CI check both nudge (neither blocks). AI
+co-authors don't satisfy it — the point is recording the human.
+
+Keep PRs small. A forty-file PR from one agentic session is not reviewable, and
+an unreviewable PR silently cancels both of the review steps that follow.
+
+### 9. Peer review, then senior review
+
+**Peer review** is another developer on the team. **Senior review** is the
+lead, and it's the last gate for developer tasks. By the time it gets to him,
+everything mechanical — tests, spec compliance, style, plan drift — should
+already be resolved. His time goes to whether the approach is right.
+
+Expect revision rounds. One or two is normal. Three is a signal that something
+upstream was wrong: usually the plan, sometimes the task. Say so rather than
+grinding through a fourth.
+
+---
+
+## The rule that holds it together
+
+**You must be able to explain every line you're shipping.**
+
+Not "Claude wrote it and the tests pass." If a reviewer asks why a function
+takes that parameter, or what happens when that value is null, you need an
+answer. If you don't have one, you're not ready to open the PR — go read it,
+and ask Claude to explain the parts you can't account for.
+
+This is the load-bearing rule, and it's the reason the whole process works. The
+lead can only be the last gate if everything before it was genuinely checked by
+someone who understood it. A developer who becomes a conduit — passing Claude's
+output to review without understanding it — moves all the real review onto one
+person and quietly removes their own name from the work.
+
+---
+
+## Using Claude to review someone else's PR
+
+You should. Just don't let it review *for* you.
+
+```sh
+gh pr checkout <N>
+```
+
+Then give Claude the PR description (which has the plan), the diff, and the
+relevant spec, and ask for findings with severity and a suggested replacement.
+`/code-review` does this on the current branch.
+
+Three rules:
+
+1. **Verify every finding before you post it.** Claude review output has false
+   positives — a claim about a function three files away that turns out to be
+   wrong, an "unhandled case" that's handled upstream. Open the file and check.
+   Posting unverified findings wastes the author's time and burns your
+   credibility fast.
+2. **Post it in your own words, and state the edit.** Quote what they wrote,
+   give the replacement text. "This will throw when `standardPlace` is
+   unresolvable — resolve it before the map, or guard at line 40" beats a
+   paragraph describing the shape of the problem. Never paste a Claude review
+   verbatim; the author can run that themselves.
+3. **Review against the plan, not just the diff.** You have their plan in the
+   PR body. Ask the same question you ask of your own work: does this
+   implementation match what was agreed?
+
+The peer review that catches the most is usually the least clever one: read the
+plan, read the diff, and ask what's in one and not the other.
+
+---
+
+## Failure modes to watch for
+
+Every one of these has happened somewhere, to someone competent.
+
+- **The plan lives only in chat.** Nobody can check the implementation against
+  it, so nobody does.
+- **Round three of plan review.** The plan gets longer, not better.
+- **Skipping step 5** and letting the peer reviewer find that it doesn't build.
+- **Reviewing your own diff in the session that wrote it.** It will agree
+  with you.
+- **Letting Claude apply review comments without re-reading the result.** The
+  fix for one comment routinely breaks the thing another comment was about.
+- **The hitchhiking refactor.** "While I was in there." It doubles the diff and
+  hides the actual change.
+- **"Claude said it was fine."** Not a review. Not a defense.
+- **Filing fifteen follow-on issues** because it's one command.
+- **A forty-file PR.** Both review steps become rubber stamps and everyone
+  involved knows it.
+
+---
+
+## Command card
+
+```sh
+# 0. branch
+git worktree add .claude/worktrees/<branch> -b <branch> origin/main
+
+# 3. attack the plan (max 2 rounds)
+#    → "Use the plan-critic agent to review this plan."
+
+# 5. verify
+make test-all                        # floor, always
+make eval-skill SKILL=<name>         # a SKILL.md changed
+make agent-smoke                     # agent frontmatter / hooks / tool binding
+make e2e-validate TEST=<slug>        # an e2e fixture changed
+cd packages/engine/mcp-server && npx tsx dev/try-<tool>.ts   # an MCP tool changed
+
+# 6. self-review, in a FRESH session
+/code-review
+
+# 7. follow-on work
+gh issue create --label developer --title "…" --body "…"
+
+# 9. review someone else's PR
+gh pr checkout <N>
+```
+
+## Where to read next
+
+| You need | Read |
+|---|---|
+| Build, test, and feature-addition recipes | [`DEVELOPMENT.md`](../DEVELOPMENT.md) |
+| Which sites a change touches | [`docs/architecture.md`](./architecture.md) |
+| The rules that override normal defaults | [`CLAUDE.md`](../CLAUDE.md) |
+| Why something is the way it is | [`docs/adrs/`](./adrs/) |
+| Improving a skill from eval results | [`docs/skill-lifecycle.md`](./skill-lifecycle.md) |
+| Contributing a skill or an MCP server | [`CONTRIBUTING.md`](../CONTRIBUTING.md) |

--- a/packages/engine/mcp-server/tests/packaging/adr-links.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/adr-links.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { citedPaths, pathResolves } from "./repo-paths.js";
 
 /**
  * ADR staleness lint.
@@ -22,24 +23,15 @@ import { fileURLToPath } from "node:url";
  * Scope note: a path is any backticked token containing "/" that starts with a
  * known top-level directory. That deliberately excludes bare filenames
  * (`research.json`), tool names (`mcp__genealogy__record_read`), and prose, so
- * the lint has no false positives to train people to ignore.
+ * the lint has no false positives to train people to ignore. The extraction
+ * rule lives in `./repo-paths.ts` and is shared with `doc-links.test.ts`,
+ * which applies it to `docs/task-lifecycle.md` and the `.claude/` tooling.
  */
 
 const here = dirname(fileURLToPath(import.meta.url));
 const engineRoot = join(here, "..", "..", ".."); // packages/engine/
 const projectRoot = join(engineRoot, "..", ".."); // repo root
 const adrDir = join(projectRoot, "docs", "adrs");
-
-/** Top-level dirs a cited path may start with. */
-const REPO_ROOTS = [
-  "docs/",
-  "packages/",
-  "apps/",
-  "eval/",
-  "scripts/",
-  ".github/",
-  ".claude/",
-];
 
 /** Sections whose paths must resolve. The rest of an ADR is frozen history. */
 const LIVE_SECTIONS = ["Applies to", "Enforcement"];
@@ -67,19 +59,6 @@ function liveSectionText(body: string): string {
   if (enforcement) parts.push(enforcement[1]);
 
   return parts.join("\n");
-}
-
-/** Backticked tokens that look like repo paths. */
-function citedPaths(text: string): string[] {
-  const found = new Set<string>();
-  for (const m of text.matchAll(/`([^`\n]+)`/g)) {
-    const token = m[1].trim();
-    if (!token.includes("/")) continue;
-    if (!REPO_ROOTS.some((r) => token.startsWith(r))) continue;
-    // Strip a trailing line/anchor reference: path.ts:123 or path.md#section
-    found.add(token.replace(/[:#].*$/, ""));
-  }
-  return [...found];
 }
 
 describe("ADR hygiene", () => {
@@ -148,7 +127,7 @@ describe("ADR hygiene", () => {
   it.each(files)("%s cites only paths that still exist", (file) => {
     const body = readFileSync(join(adrDir, file), "utf8");
     const missing = citedPaths(liveSectionText(body)).filter(
-      (p) => !existsSync(join(projectRoot, p)),
+      (p) => !pathResolves(projectRoot, p),
     );
 
     expect(

--- a/packages/engine/mcp-server/tests/packaging/doc-links.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/doc-links.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -15,13 +15,14 @@ import {
  * Staleness lint for the process doc and the Claude Code tooling under
  * `.claude/`.
  *
- * `adr-links.test.ts` does this for ADRs; this is the same check pointed at
- * two surfaces that had nothing linting them. The reason is on the record:
- * three subagents under `.claude/agents/` were deleted on 2026-08-02 (issue
- * #1161) because their paths rotted silently after `packages/engine/` was
- * introduced, and nothing noticed. `docs/task-lifecycle.md` names ~15 repo
- * paths, several make targets, and a CI workflow, and is read *while someone
- * is working* — a wrong pointer there is a wrong answer someone acts on.
+ * `adr-links.test.ts` does this for ADRs; this is the same check pointed at the
+ * surfaces that had nothing linting them. The reason is on the record: three
+ * subagents under `.claude/agents/` were deleted on 2026-08-02 (issue #1161)
+ * because their paths rotted silently after `packages/engine/` was introduced,
+ * and nothing noticed. `.claude/skills/` is in scope for the same reason — its
+ * six skills cite eval paths heavily, and eval paths move. Both it and
+ * `docs/task-lifecycle.md` are read *while someone is working*, so a wrong
+ * pointer is a wrong answer someone acts on.
  *
  * The extraction rule, and everything deliberately left unchecked, is
  * documented at the top of `./repo-paths.ts`. Three things resolve here:
@@ -53,31 +54,56 @@ const projectRoot = join(engineRoot, "..", ".."); // repo root
  */
 const LINTED_DOCS = ["docs/task-lifecycle.md"];
 
-/** Claude Code subagents and slash commands. Every `.md` in each is linted. */
-const LINTED_DIRS = [".claude/agents", ".claude/commands"];
+/**
+ * Claude Code subagents, slash commands, and project skills. Every `.md` at or
+ * below each is linted — `.claude/skills/` nests one level
+ * (`<skill>/SKILL.md`), so the walk recurses.
+ */
+const LINTED_DIRS = [".claude/agents", ".claude/commands", ".claude/skills"];
 
 /**
- * A path a document names *because it is gone*. Citing a retired file is not
- * rot, it is the record of a decision — so the exception is listed by name
- * with its reason, rather than inferred from the surrounding sentence. An
- * entry that stops firing fails the suite below, so this list cannot quietly
- * outlive the prose it excuses.
+ * A cited path the lint cannot resolve *and should not*: either it is named
+ * because it is gone, or it never exists on disk at rest. Each is listed by
+ * name with its reason rather than inferred from the surrounding sentence, and
+ * an entry that stops firing fails the suite below — so this list cannot
+ * quietly become a blanket exemption nobody can see.
  */
 const KNOWN_ABSENT: { file: string; path: string; why: string }[] = [
   {
-    file: "docs/task-lifecycle.md",
-    path: "docs/TODOs.md",
-    why: "retired 2026-08-02 (#1163); named because it is gone — the evidence for 'do not reintroduce a queue file'",
+    file: ".claude/skills/author-e2e-fixture/SKILL.md",
+    path: "eval/e2e-project/<slug>/",
+    why: "created at runtime by `make e2e-project`; gitignored, so it is absent at rest",
+  },
+  {
+    file: ".claude/skills/mine-unit-test/SKILL.md",
+    path: "eval/e2e-project/<slug>/",
+    why: "created at runtime by `make e2e-project`; gitignored, so it is absent at rest",
+  },
+  {
+    file: ".claude/skills/interpret-e2e-result/SKILL.md",
+    path: "eval/runlogs/e2e/smith-parents-1850/run-<latest>.json",
+    why: "`smith-parents-1850` is a fictional fixture in a worked example, not a real slug",
+  },
+  {
+    file: ".claude/skills/interpret-e2e-result/SKILL.md",
+    path: "eval/tests/e2e/smith-parents-1850/expected-findings.json",
+    why: "`smith-parents-1850` is a fictional fixture in a worked example, not a real slug",
   },
 ];
+
+function walkMarkdown(dir: string, out: string[]): void {
+  for (const entry of readdirSync(join(projectRoot, dir)).sort()) {
+    const rel = `${dir}/${entry}`;
+    if (statSync(join(projectRoot, rel)).isDirectory()) walkMarkdown(rel, out);
+    else if (entry.endsWith(".md")) out.push(rel);
+  }
+}
 
 function lintedFiles(): string[] {
   const files = [...LINTED_DOCS];
   for (const dir of LINTED_DIRS) {
     if (!existsSync(join(projectRoot, dir))) continue;
-    for (const f of readdirSync(join(projectRoot, dir)).sort()) {
-      if (f.endsWith(".md")) files.push(`${dir}/${f}`);
-    }
+    walkMarkdown(dir, files);
   }
   return files;
 }

--- a/packages/engine/mcp-server/tests/packaging/doc-links.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/doc-links.test.ts
@@ -67,6 +67,11 @@ const LINTED_DIRS = [".claude/agents", ".claude/commands", ".claude/skills"];
  * name with its reason rather than inferred from the surrounding sentence, and
  * an entry that stops firing fails the suite below — so this list cannot
  * quietly become a blanket exemption nobody can see.
+ *
+ * **An invented name in a worked example does not belong here.** Write it as a
+ * `<slug>` placeholder instead: the glob resolves, the example stops naming a
+ * fixture that does not exist, and no entry is needed. That is what the
+ * `interpret-e2e-result` example does.
  */
 const KNOWN_ABSENT: { file: string; path: string; why: string }[] = [
   {
@@ -78,16 +83,6 @@ const KNOWN_ABSENT: { file: string; path: string; why: string }[] = [
     file: ".claude/skills/mine-unit-test/SKILL.md",
     path: "eval/e2e-project/<slug>/",
     why: "created at runtime by `make e2e-project`; gitignored, so it is absent at rest",
-  },
-  {
-    file: ".claude/skills/interpret-e2e-result/SKILL.md",
-    path: "eval/runlogs/e2e/smith-parents-1850/run-<latest>.json",
-    why: "`smith-parents-1850` is a fictional fixture in a worked example, not a real slug",
-  },
-  {
-    file: ".claude/skills/interpret-e2e-result/SKILL.md",
-    path: "eval/tests/e2e/smith-parents-1850/expected-findings.json",
-    why: "`smith-parents-1850` is a fictional fixture in a worked example, not a real slug",
   },
 ];
 

--- a/packages/engine/mcp-server/tests/packaging/doc-links.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/doc-links.test.ts
@@ -63,7 +63,13 @@ const LINTED_DIRS = [".claude/agents", ".claude/commands"];
  * entry that stops firing fails the suite below, so this list cannot quietly
  * outlive the prose it excuses.
  */
-const KNOWN_ABSENT: { file: string; path: string; why: string }[] = [];
+const KNOWN_ABSENT: { file: string; path: string; why: string }[] = [
+  {
+    file: "docs/task-lifecycle.md",
+    path: "docs/TODOs.md",
+    why: "retired 2026-08-02 (#1163); named because it is gone — the evidence for 'do not reintroduce a queue file'",
+  },
+];
 
 function lintedFiles(): string[] {
   const files = [...LINTED_DOCS];

--- a/packages/engine/mcp-server/tests/packaging/doc-links.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/doc-links.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  citedMakeTargets,
+  citedPaths,
+  headingAnchors,
+  makefileTargets,
+  markdownLinkTargets,
+  pathResolves,
+} from "./repo-paths.js";
+
+/**
+ * Staleness lint for the process doc and the Claude Code tooling under
+ * `.claude/`.
+ *
+ * `adr-links.test.ts` does this for ADRs; this is the same check pointed at
+ * two surfaces that had nothing linting them. The reason is on the record:
+ * three subagents under `.claude/agents/` were deleted on 2026-08-02 (issue
+ * #1161) because their paths rotted silently after `packages/engine/` was
+ * introduced, and nothing noticed. `docs/task-lifecycle.md` names ~15 repo
+ * paths, several make targets, and a CI workflow, and is read *while someone
+ * is working* — a wrong pointer there is a wrong answer someone acts on.
+ *
+ * The extraction rule, and everything deliberately left unchecked, is
+ * documented at the top of `./repo-paths.ts`. Three things resolve here:
+ *
+ *  1. backticked repo-root-anchored paths (placeholders globbed),
+ *  2. markdown link destinations, relative to the citing file, plus same-file
+ *     `#anchor` links against that file's own headings,
+ *  3. `make <target>` written in code, against the root Makefile.
+ *
+ * Not checked, on purpose:
+ *  - anchors into *other* files (their heading set is not this file's, and a
+ *    homemade slugifier applied across files is a false-positive generator),
+ *  - `http(s)://` and `mailto:` links (no network in a unit test),
+ *  - paths written relative to a directory the prose established earlier
+ *    (`dev/try-login.ts` after a `cd packages/engine/mcp-server`) — resolving
+ *    those means guessing the cwd,
+ *  - bare commands other than `make` (`gh`, `git`, `npx tsx`), which are not
+ *    repo state.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const engineRoot = join(here, "..", "..", ".."); // packages/engine/
+const projectRoot = join(engineRoot, "..", ".."); // repo root
+
+/**
+ * Process docs under `docs/` that are linted. Deliberately a list and not all
+ * of `docs/`: the rest of the directory has never been swept, and widening it
+ * is its own task with its own backlog of real breaks to fix.
+ */
+const LINTED_DOCS = ["docs/task-lifecycle.md"];
+
+/** Claude Code subagents and slash commands. Every `.md` in each is linted. */
+const LINTED_DIRS = [".claude/agents", ".claude/commands"];
+
+/**
+ * A path a document names *because it is gone*. Citing a retired file is not
+ * rot, it is the record of a decision — so the exception is listed by name
+ * with its reason, rather than inferred from the surrounding sentence. An
+ * entry that stops firing fails the suite below, so this list cannot quietly
+ * outlive the prose it excuses.
+ */
+const KNOWN_ABSENT: { file: string; path: string; why: string }[] = [];
+
+function lintedFiles(): string[] {
+  const files = [...LINTED_DOCS];
+  for (const dir of LINTED_DIRS) {
+    if (!existsSync(join(projectRoot, dir))) continue;
+    for (const f of readdirSync(join(projectRoot, dir)).sort()) {
+      if (f.endsWith(".md")) files.push(`${dir}/${f}`);
+    }
+  }
+  return files;
+}
+
+function isExempt(file: string, path: string): boolean {
+  return KNOWN_ABSENT.some((e) => e.file === file && e.path === path);
+}
+
+describe("doc and .claude/ tooling links", () => {
+  const files = lintedFiles();
+
+  it("covers every surface it claims to", () => {
+    for (const doc of LINTED_DOCS) {
+      expect(
+        existsSync(join(projectRoot, doc)),
+        `${doc} is linted by this test but does not exist. If it moved, update LINTED_DOCS; ` +
+          `do not drop it — an unlinted process doc is how the deleted subagents rotted.`,
+      ).toBe(true);
+    }
+    for (const dir of LINTED_DIRS) {
+      const found = files.filter((f) => f.startsWith(`${dir}/`));
+      expect(
+        found.length,
+        `${dir}/ has no .md files, so this lint is covering nothing there`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it.each(files)("%s cites only paths that still exist", (file) => {
+    const body = readFileSync(join(projectRoot, file), "utf8");
+    const missing = citedPaths(body).filter(
+      (p) => !pathResolves(projectRoot, p) && !isExempt(file, p),
+    );
+
+    expect(
+      missing,
+      `${file} cites paths that no longer exist: ${missing.join(", ")}\n` +
+        `Fix the citation in the same PR that moved the code. If the path is named ` +
+        `*because* it was retired, add it to KNOWN_ABSENT in this test with the reason.`,
+    ).toEqual([]);
+  });
+
+  it.each(files)("%s links only to files that still exist", (file) => {
+    const abs = join(projectRoot, file);
+    const body = readFileSync(abs, "utf8");
+    const anchors = headingAnchors(body);
+    const broken: string[] = [];
+
+    for (const target of markdownLinkTargets(body)) {
+      if (/^([a-z][a-z0-9+.-]*:|\/\/)/i.test(target)) continue; // http(s), mailto, tel
+      if (target.startsWith("#")) {
+        // Same-file anchor: check it against this file's own headings.
+        if (!anchors.has(target.slice(1).toLowerCase())) broken.push(target);
+        continue;
+      }
+      const [pathPart] = target.split("#");
+      if (!pathPart) continue;
+      if (!pathResolves(dirname(abs), decodeURIComponent(pathPart))) broken.push(target);
+    }
+
+    expect(
+      broken,
+      `${file} has links that go nowhere: ${broken.join(", ")}\n` +
+        `Link targets resolve relative to the file that contains them; ` +
+        `a "#anchor" must match a heading in the same file.\n` +
+        `This file's headings produce: ${[...anchors].join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it.each(files)("%s names only make targets that still exist", (file) => {
+    const body = readFileSync(join(projectRoot, file), "utf8");
+    const targets = makefileTargets(projectRoot);
+    const missing = citedMakeTargets(body).filter((t) => !targets.has(t));
+
+    expect(
+      missing,
+      `${file} tells the reader to run make targets the Makefile does not define: ` +
+        `${missing.join(", ")}\nRename the citation or restore the target.`,
+    ).toEqual([]);
+  });
+
+  it("keeps no KNOWN_ABSENT exception the prose has stopped needing", () => {
+    const stale = KNOWN_ABSENT.filter((e) => {
+      const abs = join(projectRoot, e.file);
+      if (!existsSync(abs)) return true;
+      return !citedPaths(readFileSync(abs, "utf8")).includes(e.path);
+    });
+
+    expect(
+      stale.map((e) => `${e.file} -> ${e.path}`),
+      `these KNOWN_ABSENT entries no longer match anything cited, so they are now ` +
+        `blanket exemptions nobody can see: ${stale.map((e) => `${e.file} -> ${e.path}`).join(", ")}\n` +
+        `Delete them from ${relative(projectRoot, fileURLToPath(import.meta.url))}.`,
+    ).toEqual([]);
+  });
+});

--- a/packages/engine/mcp-server/tests/packaging/repo-paths.ts
+++ b/packages/engine/mcp-server/tests/packaging/repo-paths.ts
@@ -46,6 +46,10 @@ export function citedPaths(text: string): string[] {
   for (const m of text.matchAll(/`([^`\n]+)`/g)) {
     // First word only: a span is often a command with arguments
     // (`scripts/setup-feedback-case.sh <zip>`), and only the head is a path.
+    // Known false negative: when the head is itself a command (`cd`, `npx`,
+    // `make`), the whole span is dropped — including any repo path later in
+    // it, e.g. `cd packages/engine/mcp-server && npx tsx dev/try-<tool>.ts`
+    // contributes nothing. Tracked in issue #1180.
     const token = m[1].trim().split(/\s+/)[0];
     if (!token.includes("/")) continue;
     if (!REPO_ROOTS.some((r) => token.startsWith(r))) continue;

--- a/packages/engine/mcp-server/tests/packaging/repo-paths.ts
+++ b/packages/engine/mcp-server/tests/packaging/repo-paths.ts
@@ -1,0 +1,182 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Shared citation-resolving helpers for the doc-staleness lints in this
+ * directory (`adr-links.test.ts`, `doc-links.test.ts`).
+ *
+ * The lints all answer one question — *does the thing this document names
+ * still exist?* — over documents that are mostly prose. So the extraction rule
+ * has to be conservative: a lint with false positives gets `skip`ped inside a
+ * month, and a `skip`ped lint is worse than none because it still looks like
+ * protection.
+ *
+ * **The rule for "this string is a repo path I should check":** it is inside a
+ * single-backtick code span, it contains a `/`, and it starts with one of
+ * `REPO_ROOTS`. Everything else is left alone. That deliberately excludes bare
+ * filenames (`research.json`, `PLAN.md`), tool names (`record_search`),
+ * flags (`-m 'not e2e'`), variables (`$ARGUMENTS`), home-relative paths
+ * (`~/feedback/<slug>/`), and paths written relative to somewhere other than
+ * the repo root (`dev/try-login.ts`) — none of which can be resolved without
+ * guessing, and guessing is what produces the false positive.
+ *
+ * Placeholders inside an otherwise-real path — `<skill>`, `$ARGUMENTS`,
+ * `{N}`, `<tool>` — are not skipped, because skipping them would blind the
+ * lint to exactly the parameterised paths the `.claude/` tooling is built from.
+ * They are turned into `*` and globbed instead: the citation passes if at
+ * least one real file or directory matches. So
+ * `eval/tests/unit/<skill>/rubric.md` still catches a rename of
+ * `eval/tests/unit/`, while tolerating that `<skill>` names no one directory.
+ */
+
+/** Top-level dirs a cited path may start with. */
+export const REPO_ROOTS = [
+  "docs/",
+  "packages/",
+  "apps/",
+  "eval/",
+  "scripts/",
+  ".github/",
+  ".claude/",
+];
+
+/** Backticked tokens that look like repo paths. */
+export function citedPaths(text: string): string[] {
+  const found = new Set<string>();
+  for (const m of text.matchAll(/`([^`\n]+)`/g)) {
+    // First word only: a span is often a command with arguments
+    // (`scripts/setup-feedback-case.sh <zip>`), and only the head is a path.
+    const token = m[1].trim().split(/\s+/)[0];
+    if (!token.includes("/")) continue;
+    if (!REPO_ROOTS.some((r) => token.startsWith(r))) continue;
+    // Strip a trailing line/anchor reference: path.ts:123 or path.md#section
+    found.add(token.replace(/[:#].*$/, ""));
+  }
+  return [...found];
+}
+
+/**
+ * Placeholder spellings used across this repo's docs and `.claude/` prompts:
+ * `<skill>`, `{N}`, `$ARGUMENTS`, `${VAR}`. Each stands for "one path segment
+ * I cannot name here", so each becomes a `*`.
+ */
+const PLACEHOLDER = /<[^<>/]*>|\{[^{}/]*\}|\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$[A-Za-z_][A-Za-z0-9_]*/g;
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isDir(p: string): boolean {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Does at least one real file or directory match this single-`*` glob? */
+function globResolves(projectRoot: string, pattern: string): boolean {
+  const segments = pattern.split("/").filter((s) => s.length > 0);
+  let candidates = [projectRoot];
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    const next: string[] = [];
+
+    for (const dir of candidates) {
+      if (!segment.includes("*")) {
+        const child = join(dir, segment);
+        if (existsSync(child)) next.push(child);
+        continue;
+      }
+      const re = new RegExp(`^${segment.split("*").map(escapeRe).join("[^/]*")}$`);
+      let entries: string[];
+      try {
+        entries = readdirSync(dir);
+      } catch {
+        continue;
+      }
+      for (const entry of entries) if (re.test(entry)) next.push(join(dir, entry));
+    }
+
+    if (next.length === 0) return false;
+    candidates = i === segments.length - 1 ? next : next.filter(isDir);
+  }
+
+  return candidates.length > 0;
+}
+
+/** Does a cited repo path (possibly containing placeholders) still resolve? */
+export function pathResolves(projectRoot: string, cited: string): boolean {
+  const pattern = cited.replace(PLACEHOLDER, "*");
+  if (!pattern.includes("*")) return existsSync(join(projectRoot, pattern));
+  return globResolves(projectRoot, pattern);
+}
+
+/** Fenced ```code``` blocks, contents only. */
+export function fencedBlocks(text: string): string[] {
+  return [...text.matchAll(/^```[^\n]*\n([\s\S]*?)^```/gm)].map((m) => m[1]);
+}
+
+/** Markdown link destinations: the `target` of `[text](target)`. */
+export function markdownLinkTargets(text: string): string[] {
+  const found = new Set<string>();
+  for (const m of text.matchAll(/\[[^\]\n]*\]\(([^)\s]+)\)/g)) found.add(m[1]);
+  return [...found];
+}
+
+/**
+ * GitHub's heading-anchor slug: drop inline markup and punctuation, lowercase,
+ * spaces to hyphens. Only used to check *same-file* `#anchor` links, where both
+ * halves are computed from the same text.
+ */
+export function slugifyHeading(heading: string): string {
+  return heading
+    .trim()
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // [text](url) -> text
+    .replace(/[`*_~]/g, "")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N} -]/gu, "")
+    .trim()
+    .replace(/\s+/g, "-");
+}
+
+/** Anchors a reader could link to in this file, GitHub-style. */
+export function headingAnchors(text: string): Set<string> {
+  const outsideFences = text.replace(/^```[^\n]*\n[\s\S]*?^```/gm, "");
+  const anchors = new Set<string>();
+  for (const m of outsideFences.matchAll(/^#{1,6}\s+(.+?)\s*$/gm)) {
+    anchors.add(slugifyHeading(m[1]));
+  }
+  return anchors;
+}
+
+/**
+ * `make <target>` citations. Read only from code — inline spans and fenced
+ * blocks — never from prose, because "make sure", "make the call", and "make
+ * it fail" all parse as `make <target>` otherwise.
+ */
+export function citedMakeTargets(text: string): string[] {
+  const found = new Set<string>();
+  for (const m of text.matchAll(/`([^`\n]+)`/g)) {
+    const inline = m[1].trim().match(/^make\s+([A-Za-z0-9_.-]+)/);
+    if (inline) found.add(inline[1]);
+  }
+  for (const block of fencedBlocks(text)) {
+    for (const m of block.matchAll(/^[ \t]*make\s+([A-Za-z0-9_.-]+)/gm)) found.add(m[1]);
+  }
+  return [...found];
+}
+
+/** Every target name the root Makefile defines, including `.PHONY` lists. */
+export function makefileTargets(projectRoot: string): Set<string> {
+  const text = readFileSync(join(projectRoot, "Makefile"), "utf8");
+  const targets = new Set<string>();
+  for (const m of text.matchAll(/^([A-Za-z0-9_.\-/ ]+):(?!=)/gm)) {
+    for (const name of m[1].trim().split(/\s+/)) targets.add(name);
+  }
+  for (const m of text.matchAll(/^\.PHONY:\s*(.+)$/gm)) {
+    for (const name of m[1].trim().split(/\s+/)) targets.add(name);
+  }
+  return targets;
+}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,35 +1,47 @@
 #!/usr/bin/env bash
-# Run all project test suites. Exits non-zero if any suite fails.
+# Run every check in the repo. Exits non-zero if any suite fails.
 #
-# The two npm suites DELEGATE to their Makefile targets instead of invoking
-# `npm test` directly. Those targets carry the dependency prerequisites
-# ($(ENGINE_DEPS) / $(EVAL_APP_DEPS)), which install-and-stamp before running.
-# Calling `npm test` straight — what this script used to do — is what let an
-# empty packages/engine/mcp-server/node_modules surface as five cryptic
-# TS2307 "Cannot find module" errors instead of "deps not installed", on the
-# one command the PR template tells every contributor to run.
+# THIS IS THE SUPERSET. `make test-all` delegates here, and the PR template
+# names it. Nothing else needs running before a PR.
+#
+# The suites DELEGATE to their Makefile targets instead of invoking `npm test` /
+# `pnpm test` directly. Those targets carry the dependency prerequisites
+# ($(JS_DEPS) / $(ENGINE_DEPS) / $(EVAL_APP_DEPS)), which install-and-stamp
+# before running. Calling the package manager straight — what this script used
+# to do — is what let an empty packages/engine/mcp-server/node_modules surface
+# as five cryptic TS2307 "Cannot find module" errors instead of "deps not
+# installed".
 #
 # The harness suite stays a direct `uv run` — `make harness-test` deliberately
 # runs a NARROWER set (`-m 'not e2e'`), so delegating it would silently shrink
-# this gate's coverage — but it is preceded by `make engine-build`, because part
-# of that suite really does execute the compiled build/ (see below).
+# this gate's coverage. The e2e-marked harness test is the harness's own
+# contract test; it makes a real (billed) Anthropic call and skips itself when
+# no key is reachable. CI runs `-m 'not e2e'`, so this script is its only
+# execution path anywhere.
 
 set -uo pipefail   # not -e: run every suite, then report all failures together
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 failed=0
 
+run_suite() {  # run_suite <label> <cmd...>
+  local label="$1"; shift
+  echo ""
+  echo "=== $label ==="
+  "$@" || failed=1
+}
+
 # --- preflight ---------------------------------------------------------------
 # Name the missing piece up front. Each of these otherwise fails deep inside a
 # suite with an error that never mentions which tool is absent.
 missing=""
-for tool in make npm uv; do
+for tool in make npm pnpm uv; do
   command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
 done
 if [ -n "$missing" ]; then
   echo "ERROR: required tool(s) not on PATH:$missing" >&2
-  echo "  make / npm — see DEVELOPMENT.md 'Build commands'" >&2
-  echo "  uv         — https://docs.astral.sh/uv/getting-started/installation/" >&2
+  echo "  make / npm / pnpm — see DEVELOPMENT.md 'Build commands'" >&2
+  echo "  uv                — https://docs.astral.sh/uv/getting-started/installation/" >&2
   exit 1
 fi
 
@@ -54,15 +66,14 @@ if [ -L "$engine_modules" ] && [ -z "$(ls "$engine_modules/" 2>/dev/null)" ]; th
 fi
 
 # --- suites ------------------------------------------------------------------
-echo "=== MCP server tests (vitest) ==="
-make -C "$ROOT" engine-test || failed=1
+# typecheck first: turbo.json defines `test` and `typecheck` as separate tasks,
+# so no test suite ever runs tsc. It costs seconds.
+run_suite "Typecheck (turbo)"            make -C "$ROOT" typecheck
+run_suite "JS workspace tests (turbo)"   make -C "$ROOT" test-js
+run_suite "Control-plane tests (pytest)" make -C "$ROOT" server-test
+run_suite "MCP server tests (vitest)"    make -C "$ROOT" engine-test
+run_suite "Eval app tests (vitest)"      make -C "$ROOT" eval-ui-test
 
-echo ""
-echo "=== Eval app tests (vitest) ==="
-make -C "$ROOT" eval-ui-test || failed=1
-
-echo ""
-echo "=== Eval harness tests (pytest) ==="
 # The harness's mock MCP server shells out to the COMPILED
 # packages/engine/mcp-server/build/ for its live tool handlers, so the build is
 # a real dependency of this suite. build/ is gitignored and link-worktree.sh
@@ -70,13 +81,15 @@ echo "=== Eval harness tests (pytest) ==="
 # "AssertionError: staging must still happen" — a missing build wearing the
 # costume of a code regression. `make engine-build` is a no-op once the build
 # is current.
+echo ""
+echo "=== Eval harness tests (pytest, incl. e2e-marked) ==="
 make -C "$ROOT" engine-build || failed=1
 (cd "$ROOT/eval/harness" && uv run --frozen pytest) || failed=1
 
 echo ""
 if [ "$failed" -ne 0 ]; then
-  echo "FAIL: one or more test suites failed"
+  echo "FAIL: one or more suites failed"
   exit 1
 else
-  echo "All test suites passed"
+  echo "All checks passed"
 fi


### PR DESCRIPTION
## Summary

- **`docs/task-lifecycle.md`** (new) — how a developer task gets from issue to merge, written to be handed to a junior. Three risk tiers, nine steps, a command card, failure modes. Opens with an "If you read nothing else" section carrying the two mandatory steps: run **both** test commands, and self-review the diff in a **fresh** session.
- **`.claude/agents/plan-critic.md`** + **`.claude/commands/critique-plan.md`** (new) — a read-only subagent that adversarially reviews a plan *before* code exists, and the command that dispatches to it. A command rather than a skill because skills fire by description matching, and a silent miss leaves the session that *wrote* the plan reviewing the plan.
- **`tests/packaging/doc-links.test.ts`** + **`repo-paths.ts`** (new) — lints every repo path, markdown link, and `make` target cited by `docs/task-lifecycle.md`, `.claude/agents/`, and `.claude/commands/`. Nothing checked `.claude/` before; that gap is what silently rotted the three subagents deleted in #1161. `adr-links.test.ts` refactored to share the helper rather than keep a private copy.
- **`CLAUDE.md`** / **`DEVELOPMENT.md`** / **`docs/architecture.md`** — pointers to the new doc, plus two stale claims corrected (§0 and the §9.1 table both said `make test-all` doesn't typecheck; untrue since #1173). §9.2's lint table gains rows for **both** `adr-links.test.ts` and `doc-links.test.ts`; it had neither.
- **`.github/workflows/engine-tests.yml`** — `PATTERNS` now includes `.claude/`, `docs/adrs/` and `docs/task-lifecycle.md`. **Without this the new lint was dark**: a PR touching only a skill body, an agent or an ADR skipped vitest and reported success, and the §9.2 header ("Drift is CI-enforced") would have been a false claim. #1181 matches zero old patterns and ten new ones.
- **`Makefile`** / **`scripts/test.sh`** — `make test-all` now delegates to `scripts/test.sh` so the two stop covering different things. **This widens the harness suite from `-m 'not e2e'` to full pytest, which makes a real (billed) Anthropic call.** It skips itself with no key, and CI never runs it — so this script is its only execution path anywhere. Deliberate: otherwise that contract test never runs.
- **`.github/pull_request_template.md`** — tier + Plan + Follow-on-issues sections; the test-all checkbox now names the billed call and the **absence of any Windows equivalent** (issue #1185 — `eval\RunTests.bat` is the paid per-skill eval run, not this gate).
- **`.gitignore`** — root-anchored `/PLAN.md`.

**Tier:** Normal. Docs and developer tooling; nothing ships to a user, no schema, no auth, no plugin agent.

## What this branch learned about itself

The process was run on its own PR. Two adversarial passes found **seven** real defects in the original commit, including `/code-review` cited three times when it isn't installed here — the exact "authoritative-looking and wrong" failure the new lint exists to prevent, committed inside the doc that warns about it. All seven are fixed in `d20aea4c` and later. One reviewer finding was rejected as wrong (the "free afternoon" icebox test, which is verbatim from `DEVELOPMENT.md:149`), and one reviewer *suggestion* was relayed to the lead as though it were an existing command when it was invented — which is why "verify before you relay" now explicitly covers proposals, not just criticisms.

## Merge order with #1181

**Merge this first.** Both branches independently built a staleness lint over
`.claude/{agents,commands,skills}`. This one owns it (`doc-links.test.ts` +
the shared `repo-paths.ts`); #1181 has been updated to drop its copy and revert
`adr-links.test.ts` to main. After that the two merge cleanly — verified by
assembling the post-merge tree and running the suite: **231 packaging tests pass**,
up from 210, the extra 21 being #1181's new prompt files now covered by this lint.

Two collisions were removed on this side rather than left for the merge:

- The worked example in `interpret-e2e-result` named a fictional
  `smith-parents-1850` fixture. It is now `<slug>` — identical to #1181's fix, so
  that hunk merges as a no-op — and the two `KNOWN_ABSENT` entries are gone. Left
  as-is, this branch's own *"keeps no KNOWN_ABSENT exception the prose has stopped
  needing"* guard would have failed once #1181 landed, in a file neither PR's
  conflict markers point at.
- CLAUDE.md's Subagents heading drops its count. Both branches had independently
  changed "Two" → **"Three"**; after both land there are four. Identical text on
  both sides now merges without conflict, and the fact stops being self-desyncing.

## Deferred

- **#1180** (`icebox`) — two documented blind spots in the new lint: paths relative to a `cd` established earlier in prose, and paths appearing only inside a fenced block.

Not deferred, decided: the lint is deliberately **not** widened to `.claude/skills/`. All three apparent breaks there are false positives (`eval/e2e-project/<slug>/` is runtime-created; `smith-parents-1850` is a fictional fixture in a worked example), and a lint that cries wolf gets skipped within a month.

## Test plan

- [x] I ran `scripts/test.sh` and it passed. — 1382 passed. Also `make test-all` green, and `tests/packaging/` 161 → 187.
- [x] For every skill whose files I changed — **n/a, no skill files changed.** Nothing under `packages/engine/plugin/skills/` is touched by this branch.

Additionally verified by hand: broke a path in `.claude/commands/critique-plan.md` and confirmed the new lint fails with an actionable message, then restored; confirmed the stale-exemption guard fires on its own when a `KNOWN_ABSENT` entry stops matching.

**Not exercised:** `plan-critic` has not been run against a real plan, and `/critique-plan` needs a fresh session to load. Both are the post-merge check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
