### PR TITLE
docs: correct the 1024-cap comment, and record why .claude/ is exempt

### DIFF
--- a/eval/harness/scripts/check_skill_frontmatter.py
+++ b/eval/harness/scripts/check_skill_frontmatter.py
@@ -14,12 +14,25 @@ Hard rules (fail the build, exit 1):
     both limits on the folded value, and these are exactly the two failures
     that used to escape to install time: an over-length multi-line
     description, and a `<placeholder>` sitting on a continuation line. The
-    1024 cap is a self-imposed standard, not a Cowork limit: every
-    description is always resident in the orchestrator's context and the
-    descriptions compete for its attention on every turn, so a tight
-    description triggers more precisely. Angle brackets can collide with
+    1024 cap is an Agent SDK limit, not a house style — over it the entry
+    fails to load, silently. (A tight description also triggers more
+    precisely, since every description is resident in the orchestrator's
+    context and they compete for attention on every turn, but that is a
+    reason to stay well under the cap, not the reason the cap exists.)
+    Angle brackets can collide with
     prompt scaffolding — write "before 1850" in the description, not
     "<1850" (the body may use `<`). See docs/skill-authoring-guide.md §3.
+
+Scope: `packages/engine/plugin/` only, and deliberately not `.claude/`.
+The repo's own `.claude/skills/` and `.claude/agents/` are *developer*
+tooling read by a Claude Code session in this repo; nothing stages them
+into an Agent SDK run. The `.claude/skills/` tree the SDK does see is a
+temp-dir mirror of `packages/engine/plugin/skills/` built per test by
+`eval/harness/harness/workspace.py`, and the hosted path loads the plugin
+via `plugins=[{"type": "local", ...}]`. So the SDK limits above do not
+reach `.claude/` and two of those descriptions have long exceeded 1024
+while loading fine. Do not "fix" that by widening this check; the reason
+they are exempt is the load path, not an oversight.
 
 Soft rules (warning annotation only, never block) — skills only:
   - Unrecognized top-level frontmatter key (catches typos like


### PR DESCRIPTION
## Summary

**Reduced to a comment fix.** The original version of this PR widened the description-length lint to `.claude/` and trimmed two descriptions. That was wrong — see below — and is reverted. What remains is one docstring.

`check_skill_frontmatter.py`'s docstring said the 1024-char cap was *"a self-imposed standard, not a Cowork limit"* and justified it on attention economics. It is an **Agent SDK limit**: over it the entry fails to load, silently. That comment is the one someone editing a description reads first, and as written it invites raising the cap.

The same docstring now also records the scope reasoning, which is the part I got wrong.

## Why `.claude/` is exempt, and why that is not an oversight

Nothing stages the repo's own `.claude/skills/` or `.claude/agents/` into an Agent SDK run. They are developer tooling read by a Claude Code session in this repo.

- `eval/harness/harness/workspace.py:5` — the `.claude/skills/` tree the SDK sees is a **temp-dir mirror of `packages/engine/plugin/skills/`**, built per test. Confirmed by the absolute paths in committed e2e run logs (`/T/e2e-<slug>-<hash>/.claude/skills/...`).
- `apps/server/app/agent/real_agent.py:232-233` — the hosted path loads `plugins=[{"type": "local", "path": _PLUGIN_DIR}]` plus `stage_plugin_agents`, both plugin-tree.
- `git grep '\.claude/skills'` over code returns only those temp-dir writers and their tests.

So the cap does not reach `.claude/`. Two descriptions there have exceeded it for a long time — `author-e2e-fixture` at 1117, `resolve-record-hint` at 1031 — and load fine; the complete, untruncated 1117-char description is visible in a live Claude Code session's skill list. Widening the check would have enforced a limit that does not bind and forced churn on prose that was correct.

**#1186 is closed as invalid**, not fixed.

## Test plan

- [x] I ran `make test-all` (or `scripts/test.sh` — the same command) and it passed. — `check_skill_frontmatter.py` clean (27 skills + 4 agents); packaging 210 pass.
- [x] For every skill whose **run-log snapshot** I changed — **n/a**, comment-only, nothing under `packages/engine/plugin/skills/` touched.

Comment-only. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)