### PR TITLE
triage-standup: apply `icebox` at filing time, and stop setting Ready

### DIFF
--- a/.claude/skills/triage-standup/SKILL.md
+++ b/.claude/skills/triage-standup/SKILL.md
@@ -204,6 +204,10 @@ Also flag, per row:
 - **Sequencing** — which tasks collide on the same files, or contend for the same
   paid run, or should go to one person as a pair. The lead will ask "can I do
   these in parallel?", so answer it before he asks.
+- **Icebox.** Mark any row that is a *candidate* rather than a decision — worth
+  not losing, but nothing the lead has committed to. He is approving the label,
+  not just the task, and a row he waves through as "sure, someday" filed without
+  it silently joins every morning's ranking.
 - **What you deliberately did NOT file, and why.** Over-filing is its own
   failure; a Backlog nobody can read is the same as no Backlog.
 
@@ -278,22 +282,37 @@ direct, no preamble, no praise sandwich.
 Only after the lead approves List 2.
 
 ```sh
-gh issue create --assignee <login> --title "..." --body "..."
+gh issue create --label developer|genealogist [--label icebox] \
+  --assignee <login> --title "..." --body "..."
 ```
 
-A workflow auto-adds new issues to the project board in **Backlog**. It does not
-set any other status and does not assign anyone, so set those yourself when the
-task belongs in **Ready** — which is where a prepared doctrine question goes,
-because it is ready for a genealogist to pick up:
+Add `--label icebox` to every row the lead approved as a candidate. That label is
+the only thing separating a task from an idea once both are cards in Backlog:
+`fill-ready` skips icebox items instead of re-ranking them every morning, and
+`review-icebox` sweeps them on their own cadence. An icebox body must state its
+**unblock condition** — the trigger to watch, the blocking issue, the gate that
+must land — because that is what the sweep reads. An icebox card with no stated
+trigger is the shape that rots.
 
-```sh
-PROJ_ID="PVT_kwDOC-DkVc4BUEYb"; STATUS_FIELD="PVTSSF_lADOC-DkVc4BUEYbzhBPBf8"
-# Backlog 0207fe08 / Ready f75ad846 / In Progress 47fc9ee4 / Review 4dc1cd86 / Done 98236657
-gh project item-edit --id "$ITEM" --project-id "$PROJ_ID" \
-  --field-id "$STATUS_FIELD" --single-select-option-id "f75ad846"
-```
+**Everything you file lands in Backlog and stays there. Never set Ready.**
+`.github/workflows/add-to-project.yml` fires on `issues: opened` and puts the
+card in Backlog; that is the finished state for a triage-filed issue. Do not
+call `gh project item-edit`, and do not move a card to Ready even for a fully
+prepared doctrine question — preparing it well is what makes it *rankable*, not
+what makes it started.
 
-Then verify placement with `gh project item-list 1 --owner PioneerAIAcademy`.
+Promotion is `fill-ready`'s job, and it is a separate decision made against the
+milestones with the whole Backlog in view. Triage cannot make that call from one
+morning's updates, and a card jumped straight to Ready skips the `review-ready`
+gate that vets work before a junior picks it up.
+
+Assignee and label are yours to set, and both matter: an issue with no label
+routes by whoever happens to pick it up. If the lane is genuinely undecided,
+leave it unlabeled **and say so in the body**, so the missing label reads as a
+decision rather than an oversight.
+
+Then verify placement with `gh project item-list 1 --owner PioneerAIAcademy` —
+every card you filed should read `Backlog`.
 
 Write issue bodies so a fresh session can act with no other context: the
 evidence, the file paths, the sequencing constraint, and what *not* to re-derive.


### PR DESCRIPTION
## Summary

**Tier: Trivial.** Prose only, one file — `.claude/skills/triage-standup/SKILL.md`.

- **`icebox` was never applied.** The label appeared in the skill exactly once, as a
  dedup check ("don't propose something already iceboxed"), so every triage-filed
  task landed as a fully-ranked Backlog card — the thing the label exists to
  prevent. `/fill-ready` re-ranked all of them every morning and `/review-icebox`
  had nothing to sweep. §5 now files with `[--label icebox]` for rows the lead
  approved as candidates, and requires the body to state an **unblock condition**,
  because that is what the sweep reads. List 2 gains a matching per-row flag so the
  call is visible where the lead approves, not only at filing time.
- **Ready was still reachable.** The old §5 told triage to move a prepared doctrine
  question to Ready via `gh project item-edit`, skipping the `review-ready` gate
  that vets work before a junior picks it up. Promotion is `/fill-ready`'s call,
  made against the milestones with the whole Backlog in view — not from one
  morning's updates.

`icebox` is a **label on Backlog cards**, not a column; promotion is dropping the
label. The prose says it that way throughout.

First use: #1184 was labelled and given a trigger under this rule.

## Test plan

- [x] I ran `make test-all` and it passed — 1394 passed in 42.9s.
- [x] Not applicable: no run-log snapshot changed. `.claude/skills/` is a Claude Code
      skill dir, outside `check_runlogs.py`'s scope (which gates
      `packages/engine/plugin/skills/`). No paid eval run is owed.
- [x] `packages/engine/mcp-server/tests/packaging/skill-description-length.test.ts`
      passes (32 skills) — the description is unchanged, body only.

## Follow-on issues

None filed from this PR.

Two observations from applying the new rule to today's issues, for the lead rather
than the backlog: **#1189** carries no lane label and, unlike #1191, no stated reason
for it — the oversight shape §5 now warns about. And the icebox pool is at 3 from
today (#1180, #1184, #1185).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
