### PR TITLE
docs: make the task lifecycle readable for juniors

### DIFF
--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -19,17 +19,6 @@ Say which one in your PR description.
 | **Trivial** | Typo, comment, doc link, version bump, dead-code deletion, one-line fix with an obvious cause | Skip steps 1–3. Change, test, self-review, PR. |
 | **Normal** | Everything else | All nine steps. |
 
-**There is no risky tier, and that is deliberate.** Risk is classified once, at
-triage, by `task-reviewer` — before the task reaches you. Work that is
-schema-touching, credential-touching, plugin-agent-touching, or hard to undo
-carries the `senior` label and is assigned to the lead, not to the unassigned
-pool. So a task you were handed is a task somebody with the whole picture
-already decided a junior can land. Why:
-[ADR-0007](./adrs/ADR-0007-attack-the-plan-before-writing-code.md) §2.
-
-What that leaves you is the **stop rule** in step 4 — the case triage cannot
-see, because it only becomes visible once you are in the code.
-
 ---
 
 ## Ask early
@@ -37,38 +26,28 @@ see, because it only becomes visible once you are in the code.
 **When you aren't confident, ask a senior. At any step, about anything.** A
 question you can't answer, a mechanism you don't understand, a finding you can't
 tell is real, a task that is turning out bigger than it looked — all of it. Ask
-while you're still deciding, not after you've built.
+while you're still deciding, not after you've built. Post a message to the
+familysearch channel.
 
-This is not the step-4 stop rule and doesn't work like it. That rule hands the
-task back; this one keeps it yours and brings help in. Asking is not a signal
-that the work should be reassigned, and it will not be read as one.
+Asking doesn't hand the task back — it stays yours. (Step 4's stop rule is the
+one that hands it back.)
 
-Being handed a task means somebody decided it was landable by a junior. It does
-not mean they decided it was easy, and it does not mean they knew which part
-would be hard for *you* — triage sees the change, not the pairing. So the fact
-that a task reached you is not evidence you should already know how to do it.
-
-Two things make this specific rather than a platitude:
+Two things worth knowing:
 
 - **A senior is cheaper the earlier you ask.** Five minutes before you plan beats
   a review round on a branch built the wrong way, which beats three revision
   rounds in step 9.
 - **Claude will not stall on the thing you're unsure about.** It will pick,
-  confidently, and its choice will look settled in the diff — which is precisely
-  why the thing you couldn't resolve needs a human before it becomes code, not
-  after. The same reasoning is why `task-reviewer` escalates open decisions
-  instead of guessing at them.
-
-The one thing that is not fine is shipping past it — see "The rule that holds it
-together."
+  confidently, and its choice will look settled in the diff. So resolve it with a
+  human before it becomes code, not after.
 
 ---
 
 ## The commands in this document
 
 Every slash command below ships with Claude Code, except `/critique-plan`, which
-lives in this repo at [`.claude/agents/`](../.claude/agents/). Nothing here needs
-a plugin you have to install.
+lives in this repo at [`.claude/commands/`](../.claude/commands/). Nothing here
+needs a plugin you have to install.
 
 If you have a personal plugin that defines one of these names, **yours wins** —
 which is worth knowing before you wonder why `/review` did something else.
@@ -77,35 +56,33 @@ which is worth knowing before you wonder why `/review` did something else.
 
 ## The loop
 
-### 0. Branch in a worktree
+### 0. Create a branch
 
 ```sh
-git worktree add .claude/worktrees/<branch> -b <branch> origin/main
+git fetch origin
+git checkout -b <branch> origin/main
 ```
 
-Never work on `main`. One task, one worktree, one PR. The `post-checkout` hook
-links the shared gitignored files (`make install-hooks` once per clone).
+Never work on `main`. One task, one branch, one PR.
 
-### 1. Read the ground
+### 1. Have Claude read the ground
 
-Issue bodies here are pointers, not briefings. Before planning, read the issue,
-the spec under [`docs/specs/`](./specs/) if the thing you're touching has one,
-[`docs/architecture.md`](./architecture.md) (its "If you're asked to…" blocks
-name the sites your change touches), [`CLAUDE.md`](../CLAUDE.md), and the code.
+Issue bodies here are pointers, not briefings — most of what you need is in the
+specs and the code. Don't go read it all yourself; have Claude do it:
 
-Point Claude at all of it, then ask it to ask you questions:
+> Read GitHub issue #N and the code it touches. Also read: the spec in
+> `docs/specs/` if one covers what I'm changing, the "If you're asked to…"
+> blocks in `docs/architecture.md`, and `CLAUDE.md`. Summarize what you found in
+> a few sentences. Then ask me the questions where a different answer would
+> change what you build — skip anything with an obvious default, make the call
+> and tell me what you chose.
 
-> Read this issue, the spec, and the code it touches. Before proposing
-> anything, ask me the questions where a different answer would change what you
-> build. Skip anything with an obvious default — make the call and tell me what
-> you chose.
-
-The last sentence is what stops you rubber-stamping twelve questions that had
-ten obvious answers.
+Read the issue yourself too, and read Claude's summary. You should be able to
+say what the task is in a sentence before you plan it.
 
 ### 2. Write the plan to a file
 
-`PLAN.md` at your worktree root. It is gitignored; don't commit it. Four things:
+`PLAN.md` at the repo root. It is gitignored; don't commit it. Four things:
 
 1. **What changes** — the file list, by path.
 2. **What doesn't change** — the tempting adjacent thing you're not touching.
@@ -137,27 +114,22 @@ sentence in the PR body is enough), then continue — your reviewer is reviewing
 against the plan, so an undocumented deviation is invisible to exactly the
 person whose job is catching it.
 
-**Stop and go to the lead** — do not re-plan around it — if the change turns out
-to do any of these. Triage said a junior could land this; finding one of these
-means triage was working from something the issue did not say, and the fix is to
-the issue, not to your branch.
+**Stop and go to the lead** — don't re-plan around it — if the change turns out
+to do any of these:
 
 - Changes `research.json` or simplified-GedcomX **schema** — a new field, a new
   value on a closed enum, or a tree-shape change. Site lists:
   [`CLAUDE.md`](../CLAUDE.md) § "Researcher profile in `research.json`".
 - Touches `packages/engine/mcp-server/src/auth/`, or anything holding a credential.
-- Changes a **Cowork plugin agent** — `packages/engine/plugin/agents/`,
-  `packages/engine/plugin/hooks/`, and especially `tools:`/`disallowedTools:`.
-  (Claude Code subagents under `.claude/agents/` are not this.)
-- Adds an MCP tool, or changes an existing tool's contract.
+- Widens what a Cowork plugin agent is allowed to call — the `tools:` or
+  `disallowedTools:` lists in `packages/engine/plugin/agents/`. Editing an
+  agent's prompt is ordinary work; changing its permissions is not.
 - Reverses something in [`docs/adrs/`](./adrs/) or contradicts a `CLAUDE.md` rule.
 - Is hard to undo: a data migration, a write to user state, anything
   user-facing or talking to an external service.
 
-Saying so costs one message. It is not an admission that you got something
-wrong — every stop is a signal that the `senior` triggers in
-[`.claude/agents/task-reviewer.md`](../.claude/agents/task-reviewer.md) missed a
-shape, which is the only feedback that gate gets.
+Saying so costs one message, and it isn't a mark against you — it means the task
+was scoped from something the issue didn't say.
 
 Keep the diff scoped to the plan. Anything else you spot becomes step 7.
 
@@ -182,8 +154,8 @@ Then exercise the thing you built, once, by hand.
 
 ### 6. Review your own diff, in a fresh session
 
-Not the session that wrote the code — it will agree with you. Open a new one and
-do both halves there.
+Not the session that wrote the code — it will agree with you. Open a new
+terminal tab in the same folder, start `claude`, and do both halves there.
 
 **Bugs.** In the fresh session:
 
@@ -202,12 +174,12 @@ Don't pass `--fix`: you have to be able to explain every line you ship, and
 those edits also land outside `/rewind`. Don't pass `--comment` either — review
 comments go up in your own words.
 
-**Drift.** No bug-finder checks this. Give the same session the plan and the
-diff, and ask:
+**Drift.** No bug-finder checks this. You don't have to paste anything — the
+fresh session is on your branch and can read both sides off disk:
 
-> Here is the plan and here is the diff. Where do they diverge? What did the
-> implementation do that the plan didn't call for, and what did the plan call
-> for that isn't here?
+> Read `PLAN.md`, then read my full diff against `main` — committed and
+> uncommitted. Where do they diverge? What did the implementation do that the
+> plan didn't call for, and what did the plan call for that isn't here?
 
 You are hunting **implement-vs-plan drift**: code that looks fine and isn't the
 code that was agreed. Fix what you find, then read the whole diff yourself.
@@ -217,13 +189,20 @@ approach is right, not to what a free command would have caught.
 
 ### 7. File the follow-on work
 
-Everything you decided not to do becomes a GitHub issue, in this PR. The rules
-— which label, when to use `icebox`, how short to keep the body, why you must
-not run `gh project` — are in [`DEVELOPMENT.md`](../DEVELOPMENT.md) §
-"Follow-on work you find along the way".
+Everything you decided not to do becomes a GitHub issue, in this PR. Have Claude
+file them:
 
-Don't leave a `TODO` comment and don't start a to-do file. Reference the issue
-numbers in your PR description.
+> File a GitHub issue with `gh issue create` for each thing we decided not to
+> do. A few sentences each: what the work is, and why it's still open. Label it
+> `developer` if it has a mechanical pass/fail — lints, CI, validators,
+> harness/Python, MCP tools, refactors, tooling bugs — or `genealogist` for
+> fixture adjudication, run-log annotation, record research, doctrine prose. Add
+> `icebox` as well if it's a maybe rather than a decision. Don't run any
+> `gh project` command.
+
+The board takes care of itself — a workflow files the card. Don't leave a `TODO`
+comment and don't start a to-do file. Put the issue numbers in your PR
+description; the lead reads every issue.
 
 ### 8. Open the PR
 
@@ -259,13 +238,15 @@ usually the plan. Say so rather than grinding through a fourth.
 
 ---
 
-## The rule that holds it together
+## Know what you're shipping
 
-**You must be able to explain every line you're shipping.** Not "Claude wrote it
-and the tests pass." If a reviewer asks why a function takes that parameter, or
-what happens when that value is null, you need an answer. If you don't have one,
-go read it — or ask a senior — before you open the PR. Not knowing is normal and
-costs nothing; shipping anyway is the failure.
+Be ready to explain your diff. A reviewer will ask things like why a function
+takes that parameter, or what happens when that value is null — "Claude wrote it
+and the tests pass" isn't an answer.
+
+So before you open the PR, read the diff and pick out anything you couldn't
+explain. Ask Claude to walk you through it; ask a senior if that doesn't settle
+it. Not knowing is normal. Opening the PR without finding out is the problem.
 
 ---
 
@@ -307,7 +288,7 @@ thread, and push a branch.
 
 Use it for a question you would otherwise answer by hand, and for mechanical
 edits. Don't use it to implement a task — a task goes through the loop above,
-starting at step 0 with a worktree and a plan.
+starting at step 0 with a branch and a plan.
 
 Each tag bills a shared subscription seat, so it costs the team whether or not
 the answer was useful. One tag with the whole question beats five refining it.
@@ -320,9 +301,9 @@ Config: [`.github/workflows/claude.yml`](../.github/workflows/claude.yml).
 
 ```sh
 # 0. branch
-git worktree add .claude/worktrees/<branch> -b <branch> origin/main
+git fetch origin && git checkout -b <branch> origin/main
 
-# 2. write PLAN.md at the worktree root (gitignored)
+# 2. write PLAN.md at the repo root (gitignored)
 
 # 3. attack the plan (max 2 rounds)
 /critique-plan PLAN.md
@@ -336,10 +317,11 @@ make e2e-validate TEST=<slug>        # an e2e fixture changed
 
 # 6. self-review, in a FRESH session — not the one that wrote the code
 /code-review high                    # bugs; verify each finding, no --fix/--comment
-#    → "Here is PLAN.md and the diff. Where do they diverge?"
+#    → "Read PLAN.md and my full diff against main. Where do they diverge?"
 
-# 7. follow-on work
-gh issue create --label developer --title "…" --body "…"
+# 7. follow-on work — ask Claude to file it; don't run gh yourself
+#    → "File a GitHub issue for each thing we decided not to do. Label it
+#       developer or genealogist. Don't run any gh project command."
 
 # 9. review someone else's PR
 gh pr checkout <N>


### PR DESCRIPTION
## Summary

- **Tier: Normal.** Rewrites `docs/task-lifecycle.md` for the audience that actually reads it — junior developers working with Claude Code. Cuts rationale, history, and internal mechanism names; keeps what to do and how.
- Sits on top of #1199. Everything that PR added (the commands section, `/security-review`, `/code-review high`, "Start here", the volunteers paragraph, `/review <N>`, the `@claude` section) is preserved.
- Two corrections to the prose it now sits next to: `/critique-plan` lives in `.claude/commands/`, not `.claude/agents/`, and the `@claude` section still said a task starts at step 0 "with a worktree".

## Review guidance

**Start here:** step 6 and step 7. Step 6 is where this PR interacts with #1199 — the fresh session stays (`/code-review` forks the session it's invoked from, so a subagent can't do the bug half), but the drift half now says *how* to hand over the plan and the diff: the fresh session is on the branch and reads both off disk, so there's nothing to paste. Step 7 inlines the label rules and has the junior ask Claude to file the issues rather than running `gh` themselves.

Also worth a look: the step-4 stop list. "Changes a Cowork plugin agent" and "adds an MCP tool" are gone — both are ordinary junior work and step 5 already verifies them. What's left of the agent case is the part that isn't mechanical: widening `tools:`/`disallowedTools:`.

**Unsure about:** whether the narrowed plugin-agent bullet should be there at all, or whether agent permissions should just come off the stop list with the rest.

## Plan

No `PLAN.md`. The plan was Dallan's line-by-line instruction list in session, applied directly; `/critique-plan` was not run.

## Test plan

- [ ] `make test-all` — **not run.** Docs-only change; the suites that read this file are `doc-links.test.ts` and `adr-links.test.ts`, and `make test-all` makes a billed Anthropic call. Ran `npx vitest run tests/packaging/` instead: 231 passed, 8 files. CI runs the full engine suite on this path anyway (`engine-tests.yml` matches `^docs/task-lifecycle\.md$`).

- [ ] No skill run-log snapshot touched — no eval run needed.

## Follow-on issues

None deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)