### PR TITLE
docs+ci: turn off automatic Claude PR review; ask the template for the plan's load-bearing half

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,10 +23,24 @@
 
 ## Plan
 
-<!-- Normal: paste PLAN.md. Trivial: delete this section.
-     If you hit the step-4 stop rule (schema, auth, plugin-agent binding,
-     an ADR reversal, or anything hard to undo), say so here and name the
-     message where you raised it. -->
+<!-- Normal: the two parts of PLAN.md nothing else here carries. Trivial:
+     delete this section. Don't paste PLAN.md whole — its file list is the
+     diff, its deferrals are "Follow-on issues", and by the time you open
+     the PR it may be a plan you knowingly deviated from (step 4).
+
+     Didn't change — the tempting adjacent thing you left alone, so a
+     reviewer reads it as a decision rather than an omission.
+
+     Acceptance check — the named test that fails on `main` and passes on
+     this branch. Not "the tests pass"; they passed before.
+
+     Hit the step-4 stop rule (schema, auth, plugin-agent binding, an ADR
+     reversal, anything hard to undo)? Say so here and name the message
+     where you raised it. -->
+
+**Didn't change:**
+
+**Acceptance check:**
 
 ## Test plan
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,7 +44,18 @@ concurrency:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.draft == false
+    # ⏸ DISABLED 2026-08-03. Automatic review is off while we choose a
+    # replacement; the job now skips on every PR. To restore, delete the
+    # `if: false` and uncomment the line under it.
+    #
+    # Turned off after four consecutive failures (runs 30842086216,
+    # 30844301739, 30845357111, and the santiago-gonzalez-son run) — the last
+    # three returned in ~500ms at one turn and $0, which is the seat failing
+    # before any review ran, not this repo. `CLAUDE_CODE_OAUTH_TOKEN` is shared
+    # with `claude.yml`, so `@claude` tagging fails the same way until the
+    # token is re-minted.
+    if: false
+    # if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/docs/adrs/ADR-0007-attack-the-plan-before-writing-code.md
+++ b/docs/adrs/ADR-0007-attack-the-plan-before-writing-code.md
@@ -10,7 +10,7 @@
 
 - **Status:** Accepted
 - **Decided:** 2026-08-02 (#1177), risk half 2026-08-02 (#1188)
-- **Last updated:** 2026-08-02 (#1188)
+- **Last updated:** 2026-08-03
 - **Deciders:** Dallan Quass
 - **Supersedes:** —
 - **Superseded by:** —
@@ -91,7 +91,7 @@ And for risk:
 | **A general-purpose subagent** | Buys the fresh context but not the tool restriction, which is the only part a prompt cannot buy | ADR-0006 is the general form: capability is restricted by tool identity, not by prompt |
 | **Three or more critique rounds** | Round one finds real problems; round two confirms fixes and usually finds one more; round three yields style opinions and a longer plan | Argued, not measured. The originating branch ran two adversarial passes and found seven real defects; the value was in rounds one and two |
 | **Let the critic apply its own findings** | Collapses the verification step the design rests on. Read-only forces someone to decide which findings are real — the part that teaches the codebase | That branch's own round: one finding was rejected as wrong, and one *proposal* was relayed as though it existed when it did not |
-| **Per-task plans as files under `docs/plan/`** | That directory holds multi-week design docs reviewed with a designer and an engineer; a per-task plan is a different genre with a different lifespan. Filing one there means it lands on `main` and must be deleted when the work ships | `CLAUDE.md` § `docs/plan/`: "Two files here spent weeks claiming 'not yet implemented' and 'not yet branched' for things that had shipped" |
+| **Per-task plans as files under `docs/plan/`** | That directory holds multi-week design docs reviewed with a designer and an engineer; a per-task plan is a different genre with a different lifespan. Filing one there means it lands on `main` and must be deleted when the work ships | `CLAUDE.md` § `docs/plan/`: "Two files here spent weeks claiming 'not yet implemented' and 'not yet branched' for things that had shipped." Reopened 2026-08-03 and re-declined: across 8 merged developer PRs (#1178, #1179, #1192, #1195, #1196, #1197, #1202, #1203) the plan's load-bearing half — scope, rejected alternatives, what the PR deliberately does *not* close — was already in the descriptions, unprompted. The template asks for that half directly rather than for the file |
 | **A developer-chosen Risky tier, with the lead reviewing the plan pre-code** *(the original #1177 decision, retired in #1188)* | Duplicated the `senior` verdict at the worst-positioned point: least context, work already handed over, and a weaker consequence than the verdict it duplicated. Its "when in doubt" tie-break converted junior uncertainty into lead interrupts. Nothing enforced it | `docs/specs/task-review-spec.md` §3 (`senior` → assign `DallanQ`, swap out) vs. the tier (lead reviews the plan). Enforcement below: nothing blocks a PR leaving the tier blank |
 | **Collapse to one tier — everything is Normal** | Taxes the highest-frequency, lowest-risk changes: a typo or doc-link fix would carry `PLAN.md` plus a `/critique-plan` round. Trivial is a call a junior makes reliably from the diff in front of them; Risky is one that needs the architecture guide. Deleting both treats two different qualities of judgment as one | Argued, not measured |
 | **Keep Risky but drop the pre-code plan review** | The plan review *was* the tier's consequence. Without it the tier is a label with no action, which is the shape that rots — nobody notices when it is wrong | Enforcement below |

--- a/docs/adrs/ADR-0007-attack-the-plan-before-writing-code.md
+++ b/docs/adrs/ADR-0007-attack-the-plan-before-writing-code.md
@@ -10,7 +10,7 @@
 
 - **Status:** Accepted
 - **Decided:** 2026-08-02 (#1177), risk half 2026-08-02 (#1188)
-- **Last updated:** 2026-08-03
+- **Last updated:** 2026-08-03 (#1210)
 - **Deciders:** Dallan Quass
 - **Supersedes:** —
 - **Superseded by:** —

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -263,9 +263,12 @@ returns as an input to your review, never as your review.
    file and check.
 2. **Post it in your own words, and state the edit.** Quote what they wrote,
    give the replacement text. Never paste a Claude review verbatim.
-3. **Review against the plan, not just the diff.** `/review` can't see the plan.
-   Give Claude the PR description (which has it), the diff, and the relevant
-   spec, then ask directly: does this implementation match what was agreed?
+3. **Review against what was agreed, not just the diff.** `/review` reads the
+   diff; it can't tell you whether that was the right change to make. The PR's
+   Summary, "Start here", and Plan sections are where the author says what they
+   set out to do. Give Claude those, the issue, and the relevant spec, then ask
+   directly: does this implementation match what was agreed, and what does it do
+   that nobody asked for?
 
 `.github/workflows/claude-code-review.yml` has already posted an automated pass on the PR. Read it
 before you start — but verify anything you repeat, the same as your own

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -229,9 +229,9 @@ so their time goes to whether the approach is right.
 this process. Turning up with `make test-all` green, `/code-review` run, and its
 findings resolved is what keeps that gate spent on judgment.
 
-`.github/workflows/claude-code-review.yml` posts an automated pass on every PR. Treat it as a peer
-whose findings you verify, not a gate — it can be wrong, and a senior's review
-still has to happen.
+**Automatic Claude review is off** (`.github/workflows/claude-code-review.yml`,
+disabled 2026-08-03). Nothing reviews your PR before a human opens it, so step 6
+is the only pass it gets — arrive with it done.
 
 One or two revision rounds is normal. Three means something upstream was wrong,
 usually the plan. Say so rather than grinding through a fourth.
@@ -269,11 +269,6 @@ returns as an input to your review, never as your review.
    set out to do. Give Claude those, the issue, and the relevant spec, then ask
    directly: does this implementation match what was agreed, and what does it do
    that nobody asked for?
-
-`.github/workflows/claude-code-review.yml` has already posted an automated pass on the PR. Read it
-before you start — but verify anything you repeat, the same as your own
-findings, and don't treat it as having covered the ground you're responsible
-for.
 
 ---
 


### PR DESCRIPTION
## Summary

**Tier: Normal.** Two changes to how PRs get reviewed here.

- **Automatic Claude review is off.** It failed on four consecutive PRs today. The last three — `worktree-drop-billed-harness-e2e`, `santiago-gonzalez-son`, and this branch — returned in ~500ms at one turn, $0, and zero permission denials, which is the seat failing before any review ran rather than anything in those diffs. The run before them did review, for 13 turns and $3.10, and errored anyway with 10 permission denials. Off until we pick a replacement.
- **The PR template asks for the plan's load-bearing half, not a `PLAN.md` paste.** `docs/task-lifecycle.md` told reviewers to get the plan from the PR description "(which has it)". The template's `## Plan` section — added yesterday in #1177 — does ask, but as a verbatim paste. Three of `PLAN.md`'s four parts are already on the PR: the file list *is* the diff, the deferrals are `## Follow-on issues`, and the acceptance check is half-covered by `## Test plan`. The template now asks for the two parts nothing else carries.
- ADR-0007 gains evidence on its already-rejected `docs/plan/` row; the decision is unchanged.

## Review guidance

**Start here:** two independent spots.

1. `.github/workflows/claude-code-review.yml` — the disable is `if: false` on the job with the real condition kept commented beneath it, so restoring is one edit. Check that shape against the alternatives I rejected: commenting out `on:` makes the workflow invalid and GitHub annotates the repo as broken; renaming or deleting the file breaks `doc-links.test.ts`, which resolves the path `docs/task-lifecycle.md` cites, and throws away the tuned config. The cost is that the job shows as *skipped* on every PR — I read that as deliberate-looking, but it's a judgment call.
2. `.github/pull_request_template.md` `## Plan` — the call is that **Didn't change** + **Acceptance check** is the right replacement for the paste. The second argument for not pasting is worth checking: a verbatim `PLAN.md` is the *pre*-implementation state, and step 4 already makes the PR body the plan of record ("a sentence in the PR body is enough"), so a paste can hand a reviewer a document the author knowingly deviated from.

Evidence for that premise: across #1178, #1179, #1192, #1195, #1196, #1197, #1202, #1203, the plan's load-bearing half is already in the descriptions unprompted — #1202's "What this does not solve (so #1031 stays open)", #1178's and #1192's "Scope" sections. #1195 is the thin one, and it's thin on scope specifically.

**Unsure about:** whether `## Plan` should stay named that now it holds no plan. I kept it because ADR-0007's Enforcement line says "the template carries the tier and the plan," and renaming would quietly falsify it — but "Scope" describes the contents better. Your call.

## Plan

**Didn't change:** `PLAN.md` stays gitignored and step 2 is untouched — this is not a move toward checking plans in, the option ADR-0007 rejected and whose revisit condition ("a per-task plan needs review by someone who is not on the PR") still isn't met. I didn't add a lint for a blank `## Plan` section; ADR-0007's Enforcement already records this layer as convention, and a lint would check presence, not substance. I also left `.github/workflows/claude.yml` alone — `@claude` tagging is a different trigger and worth keeping once the token works.

**Acceptance check:** none, honestly — markdown and one YAML condition, and no test discriminates before from after. `doc-links.test.ts` guards the paths and links in `docs/task-lifecycle.md`, `adr-links.test.ts` guards ADR-0007's `Applies to`/`Enforcement`, and both passed before this branch too. The disable's real check is the next PR opened after merge: the `claude-review` job should report **skipped**.

## Test plan

- [ ] Did not run `make test-all`. The diff is three markdown files plus one workflow condition — no TypeScript, Python, schema, or skill file. I ran the suite that can break on it instead: `npx vitest run tests/packaging` — **231/231 pass**, including the two lints that read these exact files. Also parsed the workflow with `js-yaml` to confirm it's valid and that `jobs.claude-review.if` is boolean `false`. Flagging rather than deleting the box; leaning on CI for the rest.
- [x] No skill run-log snapshot changed — nothing under a skill dir, a delegated agent, or `eval/tests/unit/**`. No `make eval-skill` run required.

## Follow-on issues

None filed yet. Two things known and deliberately not fixed here:

- `CLAUDE_CODE_OAUTH_TOKEN` is shared with `claude.yml`. This stops the automatic spend but not an expired token — `@claude` on an issue or PR keeps failing the same way until it's re-minted with `/install-github-app`.
- The 18:37 failure (13 turns, $3.10, **10 permission denials**) is a different bug from the seat failures and is unexamined.
