### PR TITLE
research_query: name NaN/Infinity in the offset rejection instead of "null"

### DIFF
--- a/packages/engine/mcp-server/src/tools/research-query.ts
+++ b/packages/engine/mcp-server/src/tools/research-query.ts
@@ -208,8 +208,15 @@ export async function researchQuery(input: ResearchQueryInput): Promise<Research
     // as a ResearchQueryError so the catch returns the tool's { ok:false } shape
     // (a plain Error would escape to index.ts as a different { error } shape).
     if (input.offset !== undefined && (!Number.isInteger(input.offset) || input.offset < 0)) {
+      // JSON.stringify renders NaN and Infinity as `null`, which would make the
+      // message name a value the caller never sent; Number.isFinite picks those
+      // off. Everything else keeps JSON.stringify so a string "50" stays quoted.
+      const got =
+        typeof input.offset === "number" && !Number.isFinite(input.offset)
+          ? String(input.offset)
+          : JSON.stringify(input.offset);
       throw new ResearchQueryError(
-        `offset must be a non-negative whole number (got ${JSON.stringify(input.offset)}). ` +
+        `offset must be a non-negative whole number (got ${got}). ` +
           `Send it as a number, not a string.`,
       );
     }

--- a/packages/engine/mcp-server/tests/tools/research-query.test.ts
+++ b/packages/engine/mcp-server/tests/tools/research-query.test.ts
@@ -377,4 +377,33 @@ describe("research_query", () => {
     if (result.ok) return;
     expect(result.errors.join(" ")).toMatch(/offset must be a non-negative whole number/);
   });
+
+  // The error names what was actually sent. JSON.stringify renders NaN and
+  // Infinity as `null`, which would report a value no caller ever sent — the
+  // dev script's `Number(value)` coercion makes `offset=abc` land here as NaN.
+  it("names NaN and Infinity in the rejection instead of reporting 'null'", async () => {
+    await writeResearch({ assertions: [{ id: "a_0" }] });
+    for (const [bad, shown] of [
+      [NaN, "NaN"],
+      [Infinity, "Infinity"],
+    ] as const) {
+      const result = await researchQuery({ projectPath: dir, section: "assertions", offset: bad });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.errors.join(" ")).toContain(`(got ${shown})`);
+      expect(result.errors.join(" ")).not.toContain("got null");
+    }
+  });
+
+  it("still quotes a string offset so the type mismatch is visible", async () => {
+    await writeResearch({ assertions: [{ id: "a_0" }] });
+    const result = await researchQuery({
+      projectPath: dir,
+      section: "assertions",
+      offset: "50" as any,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join(" ")).toContain('(got "50")');
+  });
 });


### PR DESCRIPTION
Follow-on to PR #1202 (review nit, caught after merge).

## The issue

`JSON.stringify` renders `NaN` and `Infinity` as `null`, so a rejected `offset`
named a value the caller never sent:

```
offset must be a non-negative whole number (got null). Send it as a number, not a string.
```

That is reachable today. `dev/try-research-query.ts` coerces with `Number(value)`
so the tool sees a real number, which means `offset=abc` from the shell arrives as
`NaN` and produces the message above — telling the caller to send a number when
they just did.

## The fix

Non-finite numbers render via `String()`; everything else keeps `JSON.stringify`,
so a string `"50"` still comes back quoted and the type mismatch stays visible.
A bare swap to `String()` would have fixed the NaN case by breaking that one.

```
offset=abc   ->  (got NaN)
offset: "50" ->  (got "50")
```

## Verification

`research-query.test.ts`: 29 of 29 pass (27 from PR #1202 plus 2 new — one per
half, so neither direction can regress silently). `tsc --noEmit` clean.

Message text only; no behavior change. The same inputs are accepted and rejected
as before.