### PR TITLE
Step 6's drift check becomes /check-drift + a read-only drift-critic

### DIFF
--- a/.claude/agents/drift-critic.md
+++ b/.claude/agents/drift-critic.md
@@ -1,0 +1,91 @@
+---
+name: drift-critic
+description: Use to check a finished implementation against the plan it was supposed to follow. Trigger phrases include "does this match the plan", "check for drift", "did I build what we agreed", "compare PLAN.md to my diff", "implement-vs-plan drift". Reads the plan file and the branch's full diff and reports what the implementation did that the plan did not call for, what the plan called for that is not there, and what contradicts it. Read-only — reports findings for a human to act on, never edits the plan or the code. Do NOT use to find bugs in a diff (that is a code review), to review a plan before code exists (that is plan-critic), or when there is no plan file.
+tools: Read, Grep, Glob, Bash
+---
+
+# Drift Critic (read-only)
+
+Find the code that looks fine and is not the code that was agreed.
+
+You **never edit** the plan or any code. You report findings; a human decides
+what to do with them.
+
+You are not a bug finder. Whether the code is *correct* is another tool's job
+and another reviewer's. Your only question is whether it is the code the plan
+described.
+
+Adversarial does not mean padded: **a diff that matches its plan must be
+reported as matching**, plainly. Inventing a divergence to look thorough is the
+failure mode that makes this agent worthless.
+
+## What you read
+
+1. **The plan** — always a file, handed to you as a path. If you were given a
+   description of a plan rather than a path, say so and stop.
+2. **The diff.** All three, or you will miss the most visible shape drift takes:
+   - `git diff origin/main...HEAD` — committed work, merge-base relative.
+   - `git diff HEAD` — staged and unstaged.
+   - `git status --porcelain` — **untracked files**, which neither of the above
+     shows.
+3. **The approved-deviation record**, if you were handed one: the PR body, or
+   the plan's own revision notes. A plan is allowed to change mid-flight
+   (`docs/task-lifecycle.md` step 4). What was written down is not drift.
+4. **The code itself**, wherever the diff is not enough to tell whether a change
+   is what the plan meant. Open the file.
+
+## What to look for
+
+Every finding carries a **class** and a **severity**. They are orthogonal.
+
+Classes:
+
+- **MISSING** — the plan called for it; the diff does not have it. Check the
+  plan's file list path by path, and its acceptance check: a named test the plan
+  promised and the diff does not add is the highest-value finding you produce.
+- **UNPLANNED** — in the diff, not in the plan. Widened scope is the common one
+  and the one a later reviewer cannot see, because a diff does not show what was
+  supposed to be in it.
+- **CONTRADICTS** — the diff does the opposite of what the plan said. The plan's
+  "what doesn't change" list is where this hides: a file named there and touched
+  here is always a finding.
+
+Severities: `BLOCKING` (ship-stopping — the work is not what was agreed and a
+reviewer would be misled), `SHOULD-FIX` (real divergence, costs a review round),
+`NOTE` (worth a sentence in the PR).
+
+## What is not a finding
+
+- **A deviation that was written down.** In the plan, in its revision notes, or
+  in the PR body you were handed. That is the process working.
+- **Mechanical consequences of a planned change.** If the plan says rename `X`
+  to `Y`, the twelve import sites the diff also touches are the rename, not
+  unplanned work. Judge intent, not file count.
+- **Bugs, style, naming, formatting, test coverage.** Not your question. If the
+  code is wrong *and* matches the plan, that is a correct implementation of a
+  bad plan — say nothing; `/code-review` owns it.
+- **A plan that is vaguer than the diff.** Plans are prose and do not enumerate
+  every line. Only report absence when the plan was specific.
+
+## Output
+
+Findings first, most-severe first. For each:
+
+```
+**UNPLANNED · BLOCKING** — `src/foo.ts:12` adds a retry loop the plan does not mention.
+```
+
+Then one or two sentences citing `file:line`, and **the change** — stated as the
+concrete thing to do, not as the problem: "delete the retry loop, or add a
+sentence to `PLAN.md` saying why it is there", not "the retry loop may be out of
+scope."
+
+End with one verdict line, exactly one of:
+
+- `VERDICT: drift found — N`
+- `VERDICT: no drift`
+
+If you were handed no plan, or a plan too vague to compare against — no file
+list, no acceptance check — say that instead of guessing. "This cannot be
+checked for drift as written, here is what the plan is missing" is a legitimate
+result.

--- a/.claude/commands/check-drift.md
+++ b/.claude/commands/check-drift.md
@@ -1,0 +1,71 @@
+---
+description: Check a finished implementation against the plan it was supposed to follow. Dispatches to the read-only drift-critic agent; never edits the plan or the code.
+argument-hint: [path-to-plan] (defaults to PLAN.md)
+---
+
+Run the **`drift-critic`** agent against the plan named in `$ARGUMENTS` and the
+current branch's diff.
+
+Step 6 of [`docs/task-lifecycle.md`](../../docs/task-lifecycle.md). Dispatch —
+do not do the comparison yourself. Rationale:
+[ADR-0007](../../docs/adrs/ADR-0007-attack-the-plan-before-writing-code.md).
+
+## Step 1 — Resolve the plan to a file
+
+- `$ARGUMENTS` names a path that exists → use it.
+- `$ARGUMENTS` names a path that does **not** exist → say so and stop.
+- `$ARGUMENTS` empty → look for `PLAN.md` at the repo root.
+
+**No `$ARGUMENTS` and no `PLAN.md` → say so and stop.** Do not fall back to the
+PR body, a `docs/plan/` search, or the conversation. A Trivial task has no plan
+by design, and a baseline you invent produces confident findings about an
+agreement nobody made.
+
+## Step 2 — Establish the diff base
+
+Confirm all three, and tell the agent which are non-empty:
+
+```sh
+git diff origin/main...HEAD --stat
+git diff HEAD --stat
+git status --porcelain
+```
+
+If `origin/main` is stale, `git fetch origin` first — a diff against a
+weeks-old base reports other people's merged work as unplanned.
+
+## Step 3 — Find the approved-deviation record
+
+Step 4 of the lifecycle permits re-planning, so a deviation that was written
+down is not drift. Two places carry it:
+
+- `PLAN.md` itself — revision notes, or a sentence in the affected section.
+- The PR body, when a PR already exists: `gh pr view --json body -q .body`.
+
+At step 6 there is usually **no PR yet**. When there is none, say so in the
+dispatch — "no PR; `PLAN.md` is the only deviation record" — so the agent does
+not read silence as approval.
+
+## Step 4 — Dispatch
+
+Call the Agent tool with `subagent_type: "drift-critic"`, passing the plan's
+path, the three diff commands, and the deviation record from step 3. Do not
+summarize the plan or the diff for it, and do not tell it where you think the
+diff wandered — a pre-digest biases which parts it examines, and the parts you
+already doubt are not the ones that need finding.
+
+## Step 5 — Relay, and verify before acting
+
+Print the findings substantially intact, with classes, severities, and the
+verdict line.
+
+**Then check each one before acting on it.** Open the file, run the command,
+confirm the claim. This applies to the agent's *proposals* as much as its
+criticisms: a suggested command, flag, or file name relayed without checking
+reads like an established thing to whoever you hand it to.
+
+Report what you rejected and why, alongside what you accepted.
+
+**Do not apply the fixes yourself unless asked.** Each finding resolves one of
+two ways, and only the author can say which: change the code back to the plan,
+or write the deviation into `PLAN.md` because the plan was wrong.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,6 +34,10 @@
      Acceptance check — the named test that fails on `main` and passes on
      this branch. Not "the tests pass"; they passed before.
 
+     Deviated from the plan — anything you re-planned mid-flight (step 4).
+     "Nothing" is the common answer. PLAN.md is gitignored, so this line is
+     the only way a deviation reaches your reviewer.
+
      Hit the step-4 stop rule (schema, auth, plugin-agent binding, an ADR
      reversal, anything hard to undo)? Say so here and name the message
      where you raised it. -->
@@ -41,6 +45,8 @@
 **Didn't change:**
 
 **Acceptance check:**
+
+**Deviated from the plan:**
 
 ## Test plan
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -631,6 +631,12 @@ explicitly with the Agent tool.
   and rejects plans with no falsifiable acceptance check. Step 3 of
   [`docs/task-lifecycle.md`](./docs/task-lifecycle.md), capped at two rounds
   (ADR-0007). `/critique-plan [path]`.
+- **`drift-critic`** — read-only. The step-6 counterpart: reads the plan and the
+  branch's full diff (including untracked files) and reports what the
+  implementation did that the plan didn't call for, what the plan called for
+  that isn't there, and what contradicts it. Not a bug finder — `/code-review`
+  owns correctness. A deviation recorded in `PLAN.md` or the PR body is not
+  drift. `/check-drift [path]`.
 - **`rubric-critic`** — read-only. Audits a skill's eval rubric and judge
   quality from its run logs; flags non-discriminating, flaky, and unexercised
   dimensions. `/audit-rubric <skill>`.

--- a/docs/adrs/ADR-0007-attack-the-plan-before-writing-code.md
+++ b/docs/adrs/ADR-0007-attack-the-plan-before-writing-code.md
@@ -6,15 +6,16 @@
 > plans filed under `docs/plan/` · want the critic to fix what it finds · want
 > to add a "Risky" tier to the lifecycle · wonder why a junior does not classify
 > their own task's risk · are about to hand a schema, auth, or plugin-agent
-> change to a junior.
+> change to a junior · wonder why the drift check is a second agent instead of a
+> `/code-review` flag · want to record a mid-flight re-plan in only one place.
 
 - **Status:** Accepted
 - **Decided:** 2026-08-02 (#1177), risk half 2026-08-02 (#1188)
-- **Last updated:** 2026-08-03 (#1210)
+- **Last updated:** 2026-08-03 (drift half)
 - **Deciders:** Dallan Quass
 - **Supersedes:** —
 - **Superseded by:** —
-- **Applies to:** `docs/task-lifecycle.md`, `.claude/agents/plan-critic.md`, `.claude/commands/critique-plan.md`, `.claude/agents/task-reviewer.md`, `docs/specs/task-review-spec.md`
+- **Applies to:** `docs/task-lifecycle.md`, `.claude/agents/plan-critic.md`, `.claude/commands/critique-plan.md`, `.claude/agents/drift-critic.md`, `.claude/commands/check-drift.md`, `.claude/agents/task-reviewer.md`, `docs/specs/task-review-spec.md`, `.github/pull_request_template.md`
 - **Related:** ADR-0006, `docs/skill-lifecycle.md`, `docs/specs/task-review-spec.md` §3.1
 
 ## Context
@@ -53,7 +54,8 @@ a plan review, which is the interrupt `review-ready` exists to remove.
 ## Decision
 
 **The plan is a file, a read-only subagent attacks it before any code is
-written, and task risk is classified once — at triage, not by the developer.**
+written, a second read-only subagent checks the finished diff back against it,
+and task risk is classified once — at triage, not by the developer.**
 
 Concretely, for the plan:
 
@@ -64,6 +66,19 @@ Concretely, for the plan:
   lead as a task problem, not a plan problem.
 - Findings are verified by the author before being acted on or relayed —
   proposals included.
+
+And once the code exists:
+
+- `/check-drift` dispatches the `drift-critic` subagent, same tool grant, at
+  step 6. It asks only whether the diff is the code the plan described; whether
+  the code is *correct* stays with `/code-review`.
+- One pass, not two rounds. There is nothing to negotiate with a finished diff.
+- A mid-flight re-plan is recorded in **both** `PLAN.md` (which the critic
+  reads, and which is gitignored) and the PR's **Deviated from the plan** line
+  (which the reviewer reads). A deviation in one place only is invisible to the
+  other.
+- With no `PLAN.md`, the command stops rather than inventing a baseline —
+  Trivial tasks have no plan by design.
 
 And for risk:
 
@@ -89,6 +104,8 @@ And for risk:
 | **Ask in prose** — "review this plan", no command, no subagent | Two mechanisms, both silent. Description matching can miss, and a miss hands the job to main-context Claude — which wrote the plan and holds `Edit`/`Write`, so it agrees with itself and may begin implementing. Prose also passes a *paraphrase*; a critique of a paraphrase is indistinguishable from a real one by the time it reaches the author | Argued, not measured. The anchoring half is the same effect `docs/task-lifecycle.md` step 6 exists for |
 | **A skill instead of a command** | Same defect — skills fire by description matching. A command is invoked by name and cannot silently no-op | The three deleted subagents (#1161) are the standing evidence that silent `.claude/` failure modes go unnoticed |
 | **A general-purpose subagent** | Buys the fresh context but not the tool restriction, which is the only part a prompt cannot buy | ADR-0006 is the general form: capability is restricted by tool identity, not by prompt |
+| **Leave the drift check as a pasted prompt in step 6** *(what shipped in #1177, replaced here)* | The half of a step that is homework is the half that gets skipped, and a blockquote has no budget for what the check needs to be correct: resolving the plan when `PLAN.md` was never written, a diff base that includes untracked files, and the rule that a recorded deviation is not drift. It also forced the whole step into a fresh terminal tab, when only `/code-review` needs one | The step's own asymmetry — one half a command, the other half copy-paste. `/code-review` forks the session it runs in; a subagent does not, so the drift half never needed the tab |
+| **Fold drift into `/code-review`** | Different question, different input. `/code-review` reads the diff and asks whether the code is wrong; drift reads the diff *against the plan* and asks whether it is the code that was agreed. Code that is entirely correct and entirely unplanned is invisible to the first and is the whole point of the second | Argued, not measured. `/code-review` is not given the plan and cannot be, since `PLAN.md` is gitignored and absent from the diff it reads |
 | **Three or more critique rounds** | Round one finds real problems; round two confirms fixes and usually finds one more; round three yields style opinions and a longer plan | Argued, not measured. The originating branch ran two adversarial passes and found seven real defects; the value was in rounds one and two |
 | **Let the critic apply its own findings** | Collapses the verification step the design rests on. Read-only forces someone to decide which findings are real — the part that teaches the codebase | That branch's own round: one finding was rejected as wrong, and one *proposal* was relayed as though it existed when it did not |
 | **Per-task plans as files under `docs/plan/`** | That directory holds multi-week design docs reviewed with a designer and an engineer; a per-task plan is a different genre with a different lifespan. Filing one there means it lands on `main` and must be deleted when the work ships | `CLAUDE.md` § `docs/plan/`: "Two files here spent weeks claiming 'not yet implemented' and 'not yet branched' for things that had shipped." Reopened 2026-08-03 and re-declined: across 8 merged developer PRs (#1178, #1179, #1192, #1195, #1196, #1197, #1202, #1203) the plan's load-bearing half — scope, rejected alternatives, what the PR deliberately does *not* close — was already in the descriptions, unprompted. The template asks for that half directly rather than for the file |
@@ -141,9 +158,13 @@ instances and grow that list with entries nothing can check. So `task-reviewer`'
 `ready` row names the part most likely to need a senior, and
 `docs/task-lifecycle.md` § "Ask early" tells developers to ask.
 
-**Risks.** `plan-critic` has no eval the way a shipped skill does, so its
-judgement can degrade silently if the prompt drifts. The lint below catches stale
-paths, not weak criticism. And nothing measures how often triage misses a risk
+**Risks.** Neither `plan-critic` nor `drift-critic` has an eval the way a shipped
+skill does, so their judgement can degrade silently if the prompt drifts. The
+lint below catches stale paths and dead command names, not weak criticism.
+`drift-critic` carries one failure mode of its own: reporting an *approved*
+deviation as drift. A critic that cries wolf on its first run is a critic nobody
+runs twice, which is why the deviation record is specified in two places rather
+than left to convention. And nothing measures how often triage misses a risk
 category, so that cost is unquantified in either direction — the stop rule is the
 only instrument that would surface it, and it depends on a junior volunteering
 that their task was mis-scoped.
@@ -151,8 +172,11 @@ that their task was mis-scoped.
 ## Enforcement
 
 > `packages/engine/mcp-server/tests/packaging/doc-links.test.ts` — every repo
-> path, markdown link, and `make` target cited in `.claude/agents/`,
-> `.claude/commands/`, `.claude/skills/`, and `docs/task-lifecycle.md` resolves.
+> path, markdown link, `make` target, and **slash command** cited in
+> `.claude/agents/`, `.claude/commands/`, `.claude/skills/`, and
+> `docs/task-lifecycle.md` resolves. A slash command resolves to
+> `.claude/commands/<name>.md`, `.claude/skills/<name>/SKILL.md`,
+> `packages/engine/plugin/skills/<name>/SKILL.md`, or a named `BUILT_INS` entry.
 > `packages/engine/mcp-server/tests/packaging/adr-links.test.ts` — the same for
 > this file's `Applies to` and `Enforcement`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,7 +124,7 @@ routing surface — find your task, then open that ADR.
 | [0004](adrs/ADR-0004-dual-spell-mcp-tool-names-in-agent-frontmatter.md) | Dual-spell every MCP tool name in agent frontmatter | grant or deny a tool to a plugin agent · write a `ToolSearch` query · rename the desktop extension |
 | [0005](adrs/ADR-0005-ship-the-write-lockdown-as-a-plugin-hook.md) | Ship the write lockdown as a plugin `PreToolUse` hook | add a guardrail · restrain the main thread · try to stop the agent doing something with an allow-list · change `PROTECTED_PROJECT_FILES` |
 | [0006](adrs/ADR-0006-restrict-capability-by-tool-identity.md) | Restrict capability by tool identity, not by prompt or parameter | need a delegated agent to do *part* of what a tool can do · write "you must only use this for X" in an agent body · add a `mode` parameter to scope a writer tool |
-| [0007](adrs/ADR-0007-attack-the-plan-before-writing-code.md) | Attack the plan before writing code, with a read-only critic; settle task risk at triage (§2) | wonder why `/critique-plan` is a command and not a sentence · want a third critique round · want to skip `PLAN.md` because the plan is in the chat · want per-task plans filed under `docs/plan/` · want to add a "Risky" tier back to the lifecycle · are about to hand a schema, auth, or plugin-agent change to a junior |
+| [0007](adrs/ADR-0007-attack-the-plan-before-writing-code.md) | Attack the plan before writing code and check the diff back against it, with read-only critics; settle task risk at triage (§2) | wonder why `/critique-plan` is a command and not a sentence · want a third critique round · want to skip `PLAN.md` because the plan is in the chat · want per-task plans filed under `docs/plan/` · want to add a "Risky" tier back to the lifecycle · are about to hand a schema, auth, or plugin-agent change to a junior · wonder why the drift check is a second agent instead of a `/code-review` flag |
 
 Conventions, and how to add one: [`docs/adrs/README.md`](adrs/README.md).
 Not yet written: state and the writer/projection tools, self-contained agent
@@ -204,7 +204,8 @@ The four agents are `gps-mentor`, `record-extractor`, `image-reader`, and
 > Plugin agents (`packages/engine/plugin/agents/`) are consumed by the **Cowork
 > runtime** and are a different thing from Claude Code subagents
 > (`.claude/agents/`, which are developer tooling for this repo — today
-> `plan-critic`, `rubric-critic`, `skill-improver`, and `task-reviewer`). The
+> `plan-critic`, `drift-critic`, `rubric-critic`, `skill-improver`, and
+> `task-reviewer`). The
 > dual-spelling rule in §5.2 applies to plugin agents only; these declare bare
 > tool names.
 
@@ -1123,7 +1124,7 @@ Drift is CI-enforced, not conventional. In `packages/engine/mcp-server/tests/pac
 | `skill-guidance.test.ts` | 8 `places-guidance.md` copies byte-identical to the canonical |
 | `enum-drift.test.ts` | prose enum tables ↔ `enums.schema.json` |
 | `adr-links.test.ts` | ADR required fields; every repo path cited in an ADR's **live** `Applies to` / `Enforcement` still resolves (the frozen-history sections are exempt) |
-| `doc-links.test.ts` | every repo path, markdown link and `make` target cited by `docs/task-lifecycle.md` and by **`.claude/{agents,commands,skills}`** still resolves. These have no frozen-history half — every line is an instruction a model acts on. Shares its extraction rules with `adr-links.test.ts` via `repo-paths.ts` |
+| `doc-links.test.ts` | every repo path, markdown link, `make` target and **slash command** cited by `docs/task-lifecycle.md` and by **`.claude/{agents,commands,skills}`** still resolves. These have no frozen-history half — every line is an instruction a model acts on. Shares its extraction rules with `adr-links.test.ts` via `repo-paths.ts` |
 
 Plus, from `.github/workflows/check-runlogs.yml`:
 `check_skill_frontmatter.py` (for **skills and agents**: description length and

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -45,9 +45,10 @@ Two things worth knowing:
 
 ## The commands in this document
 
-Every slash command below ships with Claude Code, except `/critique-plan`, which
-lives in this repo at [`.claude/commands/`](../.claude/commands/). Nothing here
-needs a plugin you have to install.
+Every slash command below ships with Claude Code, except `/critique-plan` and
+`/check-drift`, which live in this repo at
+[`.claude/commands/`](../.claude/commands/). Nothing here needs a plugin you
+have to install.
 
 If you have a personal plugin that defines one of these names, **yours wins** —
 which is worth knowing before you wonder why `/review` did something else.
@@ -113,10 +114,12 @@ repeat unchecked reads like an established thing to whoever you hand it to.
 
 ### 4. Implement
 
-**If reality contradicts the plan, stop and re-plan.** Update the plan (a
-sentence in the PR body is enough), then continue — your reviewer is reviewing
-against the plan, so an undocumented deviation is invisible to exactly the
-person whose job is catching it.
+**If reality contradicts the plan, stop and re-plan.** Write the deviation into
+`PLAN.md` — a sentence is enough — then continue, and carry it into the PR's
+**Deviated from the plan** line at step 8. Both, because they have different
+readers: `PLAN.md` is what step 6's drift check reads, and it is gitignored, so
+it never reaches your reviewer. An undocumented deviation is invisible to
+exactly the person whose job is catching it.
 
 **Stop and go to the lead** — don't re-plan around it — if the change turns out
 to do any of these:
@@ -156,10 +159,10 @@ Plus whatever you actually touched:
 
 Then exercise the thing you built, once, by hand.
 
-### 6. Review your own diff, in a fresh session
+### 6. Review your own diff
 
-Not the session that wrote the code — it will agree with you. Open a new
-terminal tab in the same folder, start `claude`, and do both halves there.
+Two checks. The first needs a session that didn't write the code — open a new
+terminal tab in the same folder and start `claude`. The second brings its own.
 
 **Bugs.** In the fresh session:
 
@@ -178,15 +181,23 @@ Don't pass `--fix`: you have to be able to explain every line you ship, and
 those edits also land outside `/rewind`. Don't pass `--comment` either — review
 comments go up in your own words.
 
-**Drift.** No bug-finder checks this. You don't have to paste anything — the
-fresh session is on your branch and can read both sides off disk:
+**Drift.** No bug-finder checks this — `/code-review` asks whether the code is
+wrong, not whether it is the code you agreed to write. Normal tier only; Trivial
+tasks have no plan to drift from.
 
-> Read `PLAN.md`, then read my full diff against `main` — committed and
-> uncommitted. Where do they diverge? What did the implementation do that the
-> plan didn't call for, and what did the plan call for that isn't here?
+```
+/check-drift
+```
+
+It reads `PLAN.md` and your full diff against `main`, and reports what the
+implementation did that the plan didn't call for, what the plan called for that
+isn't there, and anything that contradicts it. Unlike `/code-review` it runs in
+a read-only subagent, so it starts fresh wherever you invoke it — the authoring
+session is fine.
 
 You are hunting **implement-vs-plan drift**: code that looks fine and isn't the
-code that was agreed. Fix what you find, then read the whole diff yourself.
+code that was agreed. Verify each finding as in step 3, fix what's real, then
+read the whole diff yourself.
 
 Arrive at step 9 with this done. A reviewer's round should go to whether the
 approach is right, not to what a free command would have caught.
@@ -317,9 +328,9 @@ make agent-smoke                     # plugin agent frontmatter / hooks / tool b
 make e2e-validate TEST=<slug>        # an e2e fixture changed
 /security-review                     # route, auth, token, or user state touched
 
-# 6. self-review, in a FRESH session — not the one that wrote the code
-/code-review high                    # bugs; verify each finding, no --fix/--comment
-#    → "Read PLAN.md and my full diff against main. Where do they diverge?"
+# 6. self-review
+/code-review high                    # bugs; in a FRESH session — it forks the one it runs in
+/check-drift                         # PLAN.md vs the diff; own subagent, so any session
 
 # 7. follow-on work — ask Claude to file it; don't run gh yourself
 #    → "File a GitHub issue for each thing we decided not to do. Label it

--- a/packages/engine/mcp-server/tests/packaging/doc-links.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/doc-links.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import {
   citedMakeTargets,
   citedPaths,
+  citedSlashCommands,
   headingAnchors,
   makefileTargets,
   markdownLinkTargets,
@@ -85,6 +86,37 @@ const KNOWN_ABSENT: { file: string; path: string; why: string }[] = [
     why: "created at runtime by `make e2e-project`; gitignored, so it is absent at rest",
   },
 ];
+
+/**
+ * Slash commands that ship with Claude Code, so no file in this repo defines
+ * them. Listed by name with a reason, the same shape as `KNOWN_ABSENT` — a
+ * regex escape hatch here would exempt the repo's own commands too, which are
+ * the ones that rot.
+ */
+const BUILT_INS: Record<string, string> = {
+  "code-review": "ships with Claude Code; step 6 of docs/task-lifecycle.md",
+  review: "ships with Claude Code; used when reviewing someone else's PR",
+  "security-review": "ships with Claude Code; step 5 of docs/task-lifecycle.md",
+  rewind: "ships with Claude Code; named in step 6's warning about --fix",
+};
+
+/**
+ * Where a repo-defined slash command's body lives. A command resolves if any
+ * root has it: `.claude/commands/` and `.claude/skills/` are this repo's own
+ * Claude Code tooling, and `packages/engine/plugin/skills/` is the shipped
+ * Cowork plugin, whose skills the `.claude/` tooling legitimately names
+ * (`/research` in author-e2e-fixture).
+ */
+const COMMAND_ROOTS = [
+  (name: string) => `.claude/commands/${name}.md`,
+  (name: string) => `.claude/skills/${name}/SKILL.md`,
+  (name: string) => `packages/engine/plugin/skills/${name}/SKILL.md`,
+];
+
+function slashCommandResolves(name: string): boolean {
+  if (name in BUILT_INS) return true;
+  return COMMAND_ROOTS.some((root) => existsSync(join(projectRoot, root(name))));
+}
 
 function walkMarkdown(dir: string, out: string[]): void {
   for (const entry of readdirSync(join(projectRoot, dir)).sort()) {
@@ -177,6 +209,34 @@ describe("doc and .claude/ tooling links", () => {
       missing,
       `${file} tells the reader to run make targets the Makefile does not define: ` +
         `${missing.join(", ")}\nRename the citation or restore the target.`,
+    ).toEqual([]);
+  });
+
+  it.each(files)("%s names only slash commands that still exist", (file) => {
+    const body = readFileSync(join(projectRoot, file), "utf8");
+    const missing = citedSlashCommands(body).filter((c) => !slashCommandResolves(c));
+
+    expect(
+      missing,
+      `${file} tells the reader to run slash commands that resolve to nothing: ` +
+        `${missing.map((c) => `/${c}`).join(", ")}\n` +
+        `A repo command is .claude/commands/<name>.md, .claude/skills/<name>/SKILL.md, ` +
+        `or packages/engine/plugin/skills/<name>/SKILL.md. If it ships with Claude Code, ` +
+        `add it to BUILT_INS in this test with the reason.`,
+    ).toEqual([]);
+  });
+
+  it("keeps no BUILT_INS entry the prose has stopped naming", () => {
+    const cited = new Set(
+      files.flatMap((f) => citedSlashCommands(readFileSync(join(projectRoot, f), "utf8"))),
+    );
+    const stale = Object.keys(BUILT_INS).filter((name) => !cited.has(name));
+
+    expect(
+      stale.map((c) => `/${c}`),
+      `these BUILT_INS entries are no longer cited anywhere, so they are exemptions ` +
+        `nobody can see: ${stale.map((c) => `/${c}`).join(", ")}\n` +
+        `Delete them from ${relative(projectRoot, fileURLToPath(import.meta.url))}.`,
     ).toEqual([]);
   });
 

--- a/packages/engine/mcp-server/tests/packaging/repo-paths.ts
+++ b/packages/engine/mcp-server/tests/packaging/repo-paths.ts
@@ -172,6 +172,31 @@ export function citedMakeTargets(text: string): string[] {
   return [...found];
 }
 
+/**
+ * Slash-command citations: `/critique-plan`, `/code-review`. Read from code
+ * only — inline spans and fenced blocks, the same rule as `citedMakeTargets`
+ * — because prose is full of tokens that parse as one otherwise
+ * (`annotations: complete/partial/absent`, `and/or`, a bare URL path).
+ *
+ * A command may carry arguments in the citation (`/critique-plan PLAN.md`,
+ * `/review <N>`), so only the leading token is taken.
+ */
+export function citedSlashCommands(text: string): string[] {
+  const found = new Set<string>();
+  const add = (token: string) => {
+    const m = token.match(/^\/([a-z][a-z0-9-]+)$/);
+    if (m) found.add(m[1]);
+  };
+  for (const m of text.matchAll(/`([^`\n]+)`/g)) add(m[1].trim().split(/\s+/)[0]);
+  for (const block of fencedBlocks(text)) {
+    for (const line of block.split("\n")) {
+      const first = line.trim().split(/\s+/)[0];
+      if (first) add(first);
+    }
+  }
+  return [...found];
+}
+
 /** Every target name the root Makefile defines, including `.PHONY` lists. */
 export function makefileTargets(projectRoot: string): Set<string> {
   const text = readFileSync(join(projectRoot, "Makefile"), "utf8");


### PR DESCRIPTION
## Summary

- Turns `docs/task-lifecycle.md` step 6's drift half — today a blockquote prompt you paste into a fresh terminal tab — into `/check-drift`, dispatching a read-only `drift-critic` subagent. Same shape as `/critique-plan` → `plan-critic`.
- Adds a fourth arm to the `doc-links` staleness lint: **slash commands must resolve.** Nothing checked these before, and `/critique-plan` occurs 9 times across 5 files.
- Records a mid-flight re-plan in **both** `PLAN.md` (which the critic reads) and a new PR-template line (which the reviewer reads). `PLAN.md` is gitignored, so one place was never enough.

Tier: **Normal**.

## Review guidance

**Start here:** `.claude/agents/drift-critic.md` § "What is not a finding". That section is the whole design risk. A drift critic that reports *approved* deviations is one nobody runs twice, so the exclusions — a deviation that was written down, mechanical consequences of a planned change, bugs — are what decide whether this is usable. Everything else is mechanics.

**Unsure about:** whether `BUILT_INS` in `doc-links.test.ts` should list built-in Claude Code commands at all, or whether an unresolvable command should just be tolerated. I went with a named list plus a staleness sweep so an exemption can't outlive its citation, but it does mean a new built-in used in the docs needs a one-line entry.

## Plan

**Didn't change:** `/code-review` stays a fresh-session command — it forks the session it runs in, so a subagent can't replace it; only the drift half loses the tab requirement. `plan-critic` and `/critique-plan` are untouched. `LINTED_DOCS` stays `["docs/task-lifecycle.md"]` — widening it is its own task. No ADR-0008: 0007 is amended in place, since it already carried "the author, not the reviewer, discovers implement-vs-plan drift" as a consequence. Nothing under `packages/engine/plugin/`, so no skill snapshot and no paid eval run.

**Acceptance check:** `doc-links.test.ts` → `"%s names only slash commands that still exist"`. Commit 1 (`50e049bf`) cites `/check-drift` and its tree fails on exactly that command; commit 2 (`822c06c8`) adds the command file and it passes. The two citations are deliberately one inline span and one fenced block, so both halves of the extraction rule are exercised by the check itself.

Both new arms were watched failing before being kept: moving `.claude/commands/critique-plan.md` aside reddens the resolver, and a bogus `BUILT_INS` entry reddens the staleness sweep.

**Deviated from the plan:** one, recorded in `PLAN.md`. Following `KNOWN_ABSENT`'s pattern turned out to mean **two** `it()` blocks, not the one the plan described — `BUILT_INS` gets a matching staleness sweep, without which an exemption outlives the citation that justified it.

Found by running `/check-drift` on its own branch, which is also the readiness bar the plan set for it.

## Test plan

- [x] I ran `make test-all` (or `scripts/test.sh` — the same command) and it passed.

- [x] For every skill whose **run-log snapshot** I changed — none. This PR touches no skill directory, no plugin agent, and no `eval/tests/unit/` fixture, so `check-runlogs` does not fire.

Additionally, the behavioral gate the plan required: a throwaway branch carrying a planned-but-missing file, an unplanned untracked file, and a deviation recorded in `PLAN.md`. `drift-critic` reported the first two and explicitly excluded the third as "the process working, not drift".

**One thing a reviewer should confirm that I could not:** `subagent_type: "drift-critic"` does not resolve in a session started before this branch existed, so the behavioral runs above went through a general-purpose agent carrying the same body. That exercises the prompt but not the frontmatter binding or the `Read, Grep, Glob, Bash` restriction. Please run `/check-drift` once from a session started in a checkout of this branch.

## Follow-on issues

- issue #1236 (`icebox`) — neither critic has any instrument on output quality; ADR-0007 § Risks already recorded the gap for `plan-critic` and this adds a second agent under it. Iceboxed because there is nothing to measure until enough PRs have run both.
- issue #1237 — widen `LINTED_DOCS` past `docs/task-lifecycle.md`. The test comment says the rest of `docs/` has never been swept and expects real breaks.

Not re-filed: issue #1180 already covers `citedPaths` dropping backticked spans whose head is a command (`cd`, `npx`, `make`). The new slash-command arm does not touch it.
