### PR TITLE
feat(feedback): open a GitHub issue for every feedback submission

### DIFF
--- a/.claude/skills/fill-ready/SKILL.md
+++ b/.claude/skills/fill-ready/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fill-ready
-description: Use when the lead wants the day's work chosen off the cowork-genealogy kanban board — "what should the team work on today", "fill the Ready column", "review the backlog", "groom the board", "what should I take on", or a bare "/fill-ready". The follow-on to triage-standup, which files new issues into Backlog; this skill decides which of them the team starts. Ranks the Backlog against the two committed milestones and holds Ready at three standing depths — ~10 unassigned developer tasks, ~10 unassigned genealogist tasks, 3-5 items assigned to the lead — promoting only what is unblocked and swapping a lower-ranked item back when a pool is at target. Routes by seniority before priority: the team's developers are juniors working with Claude Code, so senior-required work goes to the lead. Gates the developer shortlist through review-ready before promoting. Labels, splits, and grooms; verifies claims against the repo first. Proposes, then applies only what the lead approves; never starts the work.
+description: Use when the lead wants the day's work chosen off the cowork-genealogy kanban board — "what should the team work on today", "fill the Ready column", "review the backlog", "groom the board", "what should I take on", or a bare "/fill-ready". The follow-on to triage-standup, which files new issues into Backlog; this skill decides which of them the team starts. Ranks the Backlog against the two committed milestones and holds Ready at three standing depths — ~10 unassigned developer tasks, ~10 unassigned genealogist tasks, 1-2 items assigned to the lead — promoting only what is unblocked and swapping a lower-ranked item back when a pool is at target. Routes by seniority before priority: the team's developers are juniors working with Claude Code, so senior-required work goes to the lead. Gates the developer shortlist through review-ready before promoting. Labels, splits, and grooms; verifies claims against the repo first. Proposes, then applies only what the lead approves; never starts the work.
 allowed-tools:
   - Read
   - Bash
@@ -44,6 +44,31 @@ Two labels carry the routing:
 |---|---|
 | `developer` | Lints, CI, validators, harness/Python, MCP tools, refactors, tooling bugs — anything with a mechanical pass/fail |
 | `genealogist` | Fixture adjudication, run-log annotation, record research, doctrine prose, prepared doctrine questions |
+
+**`feedback` items are fixed in Ready, and they displace.** An issue labelled
+`feedback` is a user's bug report, filed automatically into Ready by
+`add-to-project.yml`. It counts toward the ~10 unassigned `genealogist` target
+exactly like any other `genealogist` item, and you never move it — never promote
+one from Backlog, never return one to Backlog, never unassign one. **Anyone on
+the roster may claim a `feedback` item**, so a developer holding one is not a
+mis-route.
+
+Because a `feedback` item cannot be the loser of a swap, **every return to
+Backlog comes from the non-`feedback` members of the pool.** Over target, return
+the lowest-ranked non-`feedback` genealogist items until the pool is at target —
+and when `feedback` alone reaches ~10, that means all of them. Ten feedback items
+and four `test <slug>` items in Ready is fourteen against a target of ten: the
+four go back. Name them and say why, as with any swap.
+
+**Under target, nothing about `feedback` changes how you promote.** Six feedback
+items in Ready is a pool of six against a target of ten, so promote the best four
+genealogist items out of Backlog as usual. A quiet feedback week is when the rest
+of the genealogist queue moves.
+
+§7 may close a `feedback` item — a duplicate submission, one that doesn't
+reproduce, junk — and that is the only way one leaves Ready. Never propose
+closing one on age or body length; a four-line body and a Drive link is what
+every one of them looks like.
 
 **Exclude `label:icebox` from the Backlog when ranking.** Those are candidates
 with no decision behind them, filed there deliberately; `/review-icebox` owns
@@ -466,7 +491,8 @@ gh project item-edit --id "$ITEM_ID" --project-id "$PROJ_ID" \
 
 Verify with a fresh `gh project item-list`. New issues land in Backlog via an
 auto-add workflow that sets nothing else — a freshly filed issue that belongs in
-Ready still needs this move.
+Ready still needs this move. (The exception is a `feedback` item, which the same
+workflow files directly into Ready and which you never move at all.)
 
 **Gate the unassigned `developer` shortlist through `/review-ready` before you
 promote it.** Your seniority test (§1) is a pre-filter read off the issue body;

--- a/.claude/skills/review-ready/SKILL.md
+++ b/.claude/skills/review-ready/SKILL.md
@@ -46,9 +46,11 @@ Other entry points:
   those, in any column. This is also how a re-review is asked for.
 - **Bare `/review-ready`** — the standing pool: unassigned `developer`-labeled
   items in Ready. A first run, or a run after a gap.
-- **`--all`** — also include unassigned `genealogist` items. Off by default
-  because the three passes are developer-shaped; the reason and what would change
-  it are in the spec, §6. Say so if asked rather than re-arguing it.
+- **`--all`** — also include unassigned `genealogist` items, **except those
+  labelled `feedback`**, which are user bug reports rather than vetted tasks and
+  have nothing to review. Off by default because the three passes are
+  developer-shaped; the reason and what would change it are in the spec, §6. Say
+  so if asked rather than re-arguing it.
 
 ### Review on entry, not daily
 

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -2,7 +2,10 @@ name: add-to-project
 
 # Puts every new issue on the kanban board (org project
 # PioneerAIAcademy/projects/1) in Backlog, so triage is a column move rather
-# than a periodic archaeology sweep.
+# than a periodic archaeology sweep. One exception: an issue labelled
+# `feedback` goes straight to Ready — it is filed by the feedback endpoint,
+# nobody triages it, and `/fill-ready` never promotes one out of Backlog, so
+# a card that lands there is stranded.
 #
 # WHY. Nothing has ever linked issue creation to the board. On 2026-07-30 a
 # sweep found 28 open issues with no card — 13 of them filed in the previous
@@ -120,6 +123,9 @@ jobs:
             const PROJECT_NUMBER = 1;
             const STATUS_FIELD   = 'Status';
             const NEW_ITEM_STATUS = 'Backlog';
+            // An issue carrying this label skips triage entirely.
+            const READY_LABEL       = 'feedback';
+            const READY_ITEM_STATUS = 'Ready';
 
             const dryRun = process.env.DRY_RUN === 'true';
             const { owner, repo } = context.repo;
@@ -159,13 +165,27 @@ jobs:
                 `Was it renamed? New cards would land with no status.`);
               return;
             }
-            const targetOption = statusField.options.find(o => o.name === NEW_ITEM_STATUS);
-            if (!targetOption) {
-              core.setFailed(
-                `"${STATUS_FIELD}" has no option "${NEW_ITEM_STATUS}" — found: ` +
-                statusField.options.map(o => o.name).join(', '));
-              return;
+            // Both options are resolved up front, and a missing one fails the
+            // job. Resolving Ready lazily inside act() would mean a renamed
+            // column surfaced only on the first feedback submission — as a
+            // stranded card, not as a failed run.
+            const options = {};
+            for (const name of [NEW_ITEM_STATUS, READY_ITEM_STATUS]) {
+              const option = statusField.options.find(o => o.name === name);
+              if (!option) {
+                core.setFailed(
+                  `"${STATUS_FIELD}" has no option "${name}" — found: ` +
+                  statusField.options.map(o => o.name).join(', '));
+                return;
+              }
+              options[name] = option;
             }
+
+            // Feedback issues are filed by the Apps Script endpoint and nobody
+            // triages them; `/fill-ready` never promotes one out of Backlog, so
+            // Backlog is a dead end for this label rather than a waiting room.
+            const statusFor = issue =>
+              issue.labels.includes(READY_LABEL) ? READY_ITEM_STATUS : NEW_ITEM_STATUS;
 
             // ---- which issues to consider -----------------------------------
             const sweep = context.eventName === 'workflow_dispatch';
@@ -175,10 +195,12 @@ jobs:
                 { owner, repo, state: 'open', per_page: 100 });
               // listForRepo returns PRs too; they are not this board's business.
               issues = all.filter(i => !i.pull_request)
-                          .map(i => ({ number: i.number, node_id: i.node_id, title: i.title }));
+                          .map(i => ({ number: i.number, node_id: i.node_id, title: i.title,
+                                       labels: (i.labels || []).map(l => l.name) }));
             } else {
               const i = context.payload.issue;
-              issues = [{ number: i.number, node_id: i.node_id, title: i.title }];
+              issues = [{ number: i.number, node_id: i.node_id, title: i.title,
+                          labels: (i.labels || []).map(l => l.name) }];
             }
 
             // Where this issue already sits on OUR board, or null. An issue can
@@ -212,7 +234,7 @@ jobs:
             //      at all for the ~90% of issues already carded;
             //   2. add only when absent (still idempotent, so losing a race with
             //      Claude costs nothing);
-            //   3. re-read the status and set Backlog ONLY if it is empty — this
+            //   3. re-read the status and set the chosen one ONLY if it is empty — this
             //      is what makes it impossible to demote a card that Claude or a
             //      human created in Ready a moment earlier.
             //
@@ -220,6 +242,7 @@ jobs:
             // because it short-circuited before step 1 — 113 identical rows that
             // told you nothing. Step 1 is what makes the dry run worth running.
             async function act(issue) {
+              const status = statusFor(issue);
               const before = await existingCard(issue);
               if (before) {
                 return [`#${issue.number}`,
@@ -227,7 +250,7 @@ jobs:
                         issue.title.slice(0, 60)];
               }
               if (dryRun) {
-                return [`#${issue.number}`, `WOULD add to ${NEW_ITEM_STATUS}`, issue.title.slice(0, 60)];
+                return [`#${issue.number}`, `WOULD add to ${status}`, issue.title.slice(0, 60)];
               }
 
               const added = await github.graphql(`
@@ -261,9 +284,9 @@ jobs:
                   }) { projectV2Item { id } }
                 }`, {
                   project: project.id, item: itemId,
-                  field: statusField.id, option: targetOption.id });
+                  field: statusField.id, option: options[status].id });
 
-              return [`#${issue.number}`, `added to ${NEW_ITEM_STATUS}`, issue.title.slice(0, 60)];
+              return [`#${issue.number}`, `added to ${status}`, issue.title.slice(0, 60)];
             }
 
             const rows = [];

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,8 @@ mocks (no E2B/Anthropic/OAuth needed).
   **Creating the issue is the whole job: do not call the Projects API yourself**
   (no `gh project` commands, no `addProjectV2ItemById`).
   `.github/workflows/add-to-project.yml` fires on `issues: opened` and puts the
-  card in Backlog. A `gh` token without the `project` scope — the default after
+  card in Backlog; the one exception is the `feedback` label, which routes to
+  Ready. A `gh` token without the `project` scope — the default after
   `gh auth login` — fails a board write *while still creating the issue*, which
   looks like success. Reference the number in the PR body.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -149,7 +149,8 @@ gh issue create --label developer --title "…" --body "…"
   If you'd actually do it given a free afternoon, it isn't icebox.
 - **Creating the issue is all you do — the board takes care of itself.** A CI
   workflow (`add-to-project.yml`) adds the card to Backlog the moment the issue
-  opens, and the lead's `/fill-ready` pass moves it from there. Don't run
+  opens — the one exception is the `feedback` label, which routes to Ready — and
+  the lead's `/fill-ready` pass moves it from there. Don't run
   `gh project` commands to place it yourself: a `gh` token without the `project`
   scope (the default from `gh auth login`) fails a board write *while still
   creating the issue*, which looks like it worked.

--- a/apps/electron/server/feedback-endpoint/Code.gs
+++ b/apps/electron/server/feedback-endpoint/Code.gs
@@ -13,7 +13,8 @@
  *   1. Create a Google Drive folder for feedback storage
  *   2. Set FOLDER_ID below to that folder's ID
  *   3. Optionally set NOTIFICATION_EMAIL to receive alerts
- *   4. Deploy as web app (Execute as: me, Access: anyone)
+ *   4. Set the GITHUB_TOKEN and GITHUB_REPO Script Properties (see README)
+ *   5. Deploy as web app (Execute as: me, Access: anyone)
  */
 
 // ── Configuration ──────────────────────────────────────────────────
@@ -23,6 +24,16 @@ var FOLDER_ID = 'YOUR_FOLDER_ID_HERE';
 
 // Optional: email address to notify on new feedback. Leave empty to disable.
 var NOTIFICATION_EMAIL = '';
+
+// Bump this when you paste a new Code.gs into the console. doGet() returns it,
+// so `curl <exec-url>` says which version is actually deployed — otherwise an
+// unpublished edit is indistinguishable from a working one.
+var SCRIPT_VERSION = '2026-08-04';
+
+// Labels applied to every feedback issue, in the same POST that creates it.
+// `genealogist` puts it in that pool and counts it; `feedback` is what
+// add-to-project.yml matches on to route the card to Ready instead of Backlog.
+var ISSUE_LABELS = ['genealogist', 'feedback'];
 
 // ── Endpoint ───────────────────────────────────────────────────────
 
@@ -43,6 +54,8 @@ function doPost(e) {
     var zipKB = Math.round(bytes.length / 1024);
     var email = payload.email || 'unknown';
     var feedbackMd = extractFeedbackMarkdown(zipBlob);
+
+    createFeedbackIssue(payload.filename, file.getUrl(), zipBlob);
 
     if (NOTIFICATION_EMAIL) {
       MailApp.sendEmail({
@@ -83,8 +96,131 @@ function extractFeedbackMarkdown(zipBlob) {
   }
 }
 
+/**
+ * Create the GitHub issue that makes this zip findable.
+ *
+ * Never throws. A GitHub failure must not tell the user their submission
+ * failed — the zip is already saved by the time this runs, and a false
+ * failure makes them resubmit. Logs and returns instead.
+ *
+ * Never reads user-typed text. The repo is public, so email, project paths,
+ * the prompt, and the four prose answers are not touched here. Only
+ * submitted_at and platform are permitted, and both are clamped.
+ */
+function createFeedbackIssue(filename, driveUrl, zipBlob) {
+  try {
+    var props = PropertiesService.getScriptProperties();
+    var token = props.getProperty('GITHUB_TOKEN');
+    var repo = props.getProperty('GITHUB_REPO');
+
+    if (!token || !repo) {
+      Logger.log('No GITHUB_TOKEN/GITHUB_REPO Script Property — skipping issue creation.');
+      return;
+    }
+
+    // Script clock, never the bundle's: the timestamp is the burst signal that
+    // tells a reviewer these three submissions are one tester resubmitting.
+    var stamp = Utilities.formatDate(new Date(), 'UTC', "yyyy-MM-dd'T'HH:mm'Z'");
+
+    var body = [
+      '**Zip:** ' + driveUrl,
+      '',
+      '```',
+      'make feedback-case ZIP=~/Downloads/' + clampFilename(filename),
+      '```',
+      '',
+      'Workflow: `docs/alpha-feedback-guide.md`'
+    ];
+
+    // Optional, and the issue never depends on them. A missing entry, a renamed
+    // entry, or a parse error costs these two lines — not the issue, which is
+    // the only thing standing between this zip and nobody ever finding it.
+    var meta = readFeedbackJson(zipBlob);
+    if (meta) {
+      if (meta.submitted_at) body.push('', '- Submitted: ' + clampField(meta.submitted_at));
+      if (meta.platform) body.push('- Platform: ' + clampField(meta.platform));
+    }
+
+    var response = UrlFetchApp.fetch('https://api.github.com/repos/' + repo + '/issues', {
+      method: 'post',
+      contentType: 'application/json',
+      headers: {
+        Authorization: 'Bearer ' + token,
+        Accept: 'application/vnd.github+json'
+      },
+      // One POST. Labels added in a follow-up call are invisible to
+      // add-to-project.yml, which reads them off the `opened` payload and has
+      // no `labeled` trigger — the card would land in Backlog and stay there.
+      payload: JSON.stringify({
+        title: '[feedback] ' + stamp,
+        body: body.join('\n'),
+        labels: ISSUE_LABELS
+      }),
+      muteHttpExceptions: true
+    });
+
+    var code = response.getResponseCode();
+    if (code >= 200 && code < 300) {
+      Logger.log('Created feedback issue for ' + filename);
+    } else {
+      Logger.log('GitHub returned ' + code + ' creating issue for ' + filename
+               + ': ' + response.getContentText());
+    }
+  } catch (err) {
+    Logger.log('Failed to create feedback issue for ' + filename + ': ' + err.message);
+  }
+}
+
+/**
+ * Read _feedback/feedback.json out of the bundle. Returns null on any failure.
+ *
+ * extractFeedbackMarkdown matches a root-level name; this entry is nested, and
+ * whether Utilities.unzip reports it with its directory prefix is not something
+ * we can assume — so match on the suffix.
+ */
+function readFeedbackJson(zipBlob) {
+  try {
+    var parts = Utilities.unzip(zipBlob);
+    for (var i = 0; i < parts.length; i++) {
+      if (/feedback\.json$/.test(parts[i].getName())) {
+        return JSON.parse(parts[i].getDataAsString());
+      }
+    }
+    return null;
+  } catch (err) {
+    Logger.log('Could not read feedback.json: ' + err.message);
+    return null;
+  }
+}
+
+/**
+ * Both permitted fields are untrusted strings — doPost validates presence and
+ * nothing else, so neither the 10,000-char cap nor the platform vocabulary the
+ * legitimate clients honor is enforced by the time a value reaches here.
+ * `@` goes with the newlines and pipes: 120 characters of @-mentions would
+ * notify real people from an issue body.
+ */
+function clampField(value) {
+  return String(value).slice(0, 120).replace(/[\r\n|@]/g, ' ');
+}
+
+/**
+ * The filename is untrusted too — doPost checks that it is present, nothing
+ * more — and it lands inside a fenced code block. A backtick run would close
+ * the fence and render everything after it as markdown, @-mentions included.
+ * The legitimate clients send `feedback-<timestamp>.zip`, so reduce to that
+ * alphabet rather than blacklisting the characters we happened to think of.
+ */
+function clampFilename(value) {
+  var safe = String(value).slice(0, 120).replace(/[^A-Za-z0-9._-]/g, '_');
+  return safe || 'feedback.zip';
+}
+
 function doGet() {
   return ContentService
-    .createTextOutput(JSON.stringify({ status: 'Feedback endpoint is running' }))
+    .createTextOutput(JSON.stringify({
+      status: 'Feedback endpoint is running',
+      version: SCRIPT_VERSION
+    }))
     .setMimeType(ContentService.MimeType.JSON);
 }

--- a/apps/electron/server/feedback-endpoint/README.md
+++ b/apps/electron/server/feedback-endpoint/README.md
@@ -1,14 +1,23 @@
 # Feedback Endpoint (Google Apps Script)
 
-Receives feedback POSTs from the Research Viewer Electron app and saves each
-payload as a JSON file in a shared Google Drive folder.
+Receives feedback POSTs from the Research Viewer Electron app, saves each
+payload as a zip file in a shared Google Drive folder, and opens a GitHub issue
+so the zip is findable.
+
+**`Code.gs` here is a template, not the deployed script.** The deployed copy is
+edited in the Apps Script console and already differs from this file — the
+committed `FOLDER_ID` is still `YOUR_FOLDER_ID_HERE`. Nothing in CI checks the
+two against each other. The smoke test below is the only check that the deployed
+script works at all, so run it after every console edit.
 
 ## Setup
 
 ### 1. Create the Drive folder
 
 - Create a folder in Google Drive (e.g. "Research Viewer Feedback")
-- Share it with your interns/team (Editor or Viewer access)
+- Share it **Viewer**-only, to a Google Group of the team's accounts — never
+  "anyone with the link". Editor access lets any member delete a zip, and the
+  zip is the immutable record the feedback workflow depends on.
 - Copy the folder ID from the URL: `drive.google.com/drive/folders/<FOLDER_ID>`
 
 ### 2. Create the Apps Script project
@@ -17,27 +26,96 @@ payload as a JSON file in a shared Google Drive folder.
 - Replace the contents of `Code.gs` with the file from this directory
 - Set `FOLDER_ID` to your Drive folder ID
 - Optionally set `NOTIFICATION_EMAIL` to your email address
+- **Bump `SCRIPT_VERSION`** to today's date, here and in the committed copy
 
-### 3. Deploy as a web app
+Checking what is deployed is then one command — no submission needed:
 
-- Click **Deploy → New deployment**
-- Type: **Web app**
-- Execute as: **Me** (your account)
-- Who has access: **Anyone**
-- Click **Deploy** and authorize when prompted
-- Copy the web app URL (looks like `https://script.google.com/macros/s/.../exec`)
+```bash
+curl -sL <exec-url>
+# {"status":"Feedback endpoint is running","version":"2026-08-04"}
+```
 
-### 4. Configure the Electron app
+A version older than the committed `Code.gs` means the console copy is stale or
+the deployment was never published.
+
+### 3. Set the Script Properties
+
+**Project Settings → Script Properties.** Both are required for issue creation;
+without them the endpoint still saves zips and returns success, and silently
+creates no issues.
+
+| Property | Value |
+|---|---|
+| `GITHUB_TOKEN` | A fine-grained PAT scoped to the one repo, `Issues: Read and write` and nothing else. Org-owned repos additionally need fine-grained PAT access enabled on the org and an owner to approve the token — an unapproved token creates nothing and reports no error. |
+| `GITHUB_REPO` | `PioneerAIAcademy/cowork-genealogy` |
+
+### 4. Deploy as a web app
+
+**First install only.** Click **Deploy → New deployment**, Type **Web app**,
+Execute as **Me**, Who has access **Anyone**, then **Deploy** and authorize when
+prompted. Copy the web app URL
+(`https://script.google.com/macros/s/.../exec`).
+
+**To redeploy after an edit — do not use "New deployment".** It mints a new
+`/exec` URL, and the current one is hardcoded in two shipped clients
+(`apps/electron/src/main/index.ts`, `apps/server/app/config.py`), so a new URL
+orphans every installed Electron build. Instead:
+
+**Manage deployments → edit the existing deployment (pencil) → Version: New
+version → Deploy.**
+
+Editing the script alone changes nothing that is served — an unpublished edit
+looks exactly like a working deployment from the client's side.
+
+**Re-authorize when the scopes change.** The GitHub call adds
+`script.external_request`. Until the owner grants it under "Execute as: Me",
+every issue-creation call throws into its own `try/catch` and submissions keep
+returning success with no issue created.
+
+### 5. Configure the Electron app
 
 Update the fetch URL in `src/main/index.ts` (in the `feedback:submit` IPC handler)
 to point to your deployed Apps Script URL instead of `http://localhost:3000/feedback`.
 
 ## How it works
 
-- Each feedback submission is saved as `feedback-<timestamp>.json` in the Drive folder
-- Files are pretty-printed JSON for easy reading
+- Each feedback submission is saved as `feedback-<timestamp>.zip` in the Drive folder
+- Each submission also opens a GitHub issue titled `[feedback] <timestamp>`,
+  labelled `genealogist` + `feedback`, carrying the Drive link and the
+  `make feedback-case` command. The `feedback` label routes the card straight to
+  **Ready**; see `.github/workflows/add-to-project.yml`.
+- **The issue body never contains user-typed text.** The repo is public. Only
+  `submitted_at` and `platform` are read out of the bundle, and both are clamped.
+- **A GitHub failure never fails the submission.** The zip is already saved by
+  then, so the user gets success either way and the failure is logged. The cost
+  is an orphaned zip with no issue — which is exactly what the smoke test checks.
 - If `NOTIFICATION_EMAIL` is set, you get an email with a summary and link to the file
 - Your team accesses feedback by opening the shared Drive folder — no special accounts needed
+
+## Smoke test
+
+Nothing in CI can reach this — the script runs in Google's runtime against a real
+Drive folder and the real GitHub API. Run this at rollout **and after every
+console edit**.
+
+1. `curl -sL <exec-url>` and check `version` matches the committed `Code.gs`.
+   This rules out the stale-console and unpublished-deployment cases before you
+   spend a submission on them.
+2. Submit a bundle with a throwaway email. Confirm an issue exists, labelled
+   `genealogist` + `feedback`, titled `[feedback] …`, sitting in **Ready** on
+   project 1.
+   **If there is no issue and no error, and step 1 was clean, suspect an
+   ungranted `script.external_request` scope before you suspect the PAT** — the
+   `try/catch` makes both look identical from the client. Executions in the Apps
+   Script console tell them apart.
+3. Confirm the body contains no `@`, no `/Users/`, no `C:\`, and none of
+   `email`, `project_folder_path`, `user_prompt`, `agent_did`,
+   `agent_should_have`, `correct_answer`, `notes`.
+4. **Delete the `GITHUB_TOKEN` Script Property** and submit again. The user must
+   still get a success response, with no issue created. Restore the value
+   afterwards. This is the step that proves the `try/catch`, and the one most
+   likely to be skipped. Do not prove it by revoking the PAT instead — that is
+   irreversible and re-minting drags the org-owner approval back through the loop.
 
 ## Limits
 

--- a/docs/alpha-feedback-guide.md
+++ b/docs/alpha-feedback-guide.md
@@ -145,9 +145,18 @@ which surface she used.
 That three-part note is the most valuable thing produced all day. Everything
 below is mechanics.
 
-## Step 1 — Branch before you touch anything ⌨️ Terminal
+## Step 1 — Claim the issue, then branch ⌨️ Terminal
 
 *(Step 0 happened days earlier, and by someone else. Your work starts here.)*
+
+Every submission opens a GitHub issue titled `[feedback] <timestamp>`, sitting in
+**Ready** on the board. Pick one with no assignee and **assign it to yourself
+before you start** — that is the claim, and it is the only thing stopping two
+people working the same case. If it already has an assignee, take another one.
+The zip link is in the issue body; download it now, you need it in Step 2.
+
+Two issues with timestamps a few minutes apart are usually one tester
+resubmitting, not two bugs. Open both before you start.
 
 One task, one branch, always cut from an up-to-date `main` — you open a PR from
 it at the end. Name it with a few hyphenated words describing the fix — no
@@ -172,8 +181,7 @@ still on `main` and your test ends up on `main`.
 
 ## Step 2 — Unpack the case ⌨️ Terminal
 
-The bundle lands in the shared Drive folder. Download it and, **from the repo
-root**, run:
+With the zip from Step 1 in hand, **from the repo root**, run:
 
 **macOS / Linux:**
 
@@ -487,6 +495,21 @@ runlog gate checks every skill the PR touches. What to avoid is bundling two
 You push and open the PR; the senior genealogist reviews and
 merges.
 
+**Put `Closes #<issue>` in the PR body** — the number of the `[feedback]` issue
+you claimed in Step 1. That line is the only thing that closes the issue and
+moves its card off the board when the PR merges; a PR with no linked issue moves
+no card, and Ready fills up with finished work. It is one line and it is easy to
+forget.
+
+**Not every case ends in a fix, and those still close.** Say which it was and
+close the issue by hand:
+
+- **Doesn't reproduce** — close, with a comment saying what you tried.
+- **Tool bug, not a skill bug** — file a `developer` issue, link it from the
+  feedback issue, close the feedback issue.
+- **Duplicate of another submission** — close as a duplicate, naming the one it
+  duplicates.
+
 **Then tell Marta what changed.** An alpha tester who never hears back stops
 reporting, and the reports are the entire point of the alpha.
 
@@ -507,7 +530,7 @@ Drive folder as the immutable record, so re-importing later is always possible.
 | Step | What you do | Where |
 |---|---|---|
 | 0 Notice | research; spot it; write Did/Should | 🌐 Workbench |
-| 1 Branch | `git checkout -b <short-task-name>` | ⌨️ Terminal (repo) |
+| 1 Claim + branch | assign the `[feedback]` issue to yourself; download the zip; `git checkout -b <short-task-name>` | 🌐 GitHub → ⌨️ Terminal (repo) |
 | 2 Unpack | `make feedback-case ZIP=<zip>`; copy the prompt it prints | ⌨️ Terminal (repo) |
 | 3 Reproduce | paste the user's prompt; viewer open; `/compare-state --against=what-went-wrong` | 🤖 Claude Code (case dir) + Viewer |
 | 4 Classify | skill, tool, or grading fault? | 🤖 Claude Code (case dir) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1171,6 +1171,7 @@ tools — what happens after you grant one). And
 | **Nothing treats "the writer tools are absent" as a halt condition.** | Three runs once made zero MCP calls, wrote `research.json` raw 33 times, and burned their full budget. The raw-write path is closed since #984/#989; the silent failure is not. | #941 |
 | **A `Skill()` callee can bind toolless** in the unit-harness path. | A delegated skill runs with zero tools. | #1012 |
 | **Nothing exercises the live Agent SDK path.** Every harness test monkeypatches `run_skill`, so no gate constructs real SDK options or loads the plugin. | An SDK-options or plugin-loading break passes `make test-all` green and surfaces only on a paid `make eval-skill` run. | #1207 |
+| **Nothing checks that the deployed Apps Script's GitHub write works.** The script is edited in Google's console; CI cannot reach it. `doGet` reports `SCRIPT_VERSION`, so `curl <exec-url>` catches a stale or unpublished copy — but an ungranted `script.external_request` scope or a bad PAT still cannot be seen without submitting. | A submission produces a zip and no issue, and the client still returns `ok:true`. | Version check + smoke test in `apps/electron/server/feedback-endpoint/README.md`, run after every console edit |
 
 ### If you're asked to…
 

--- a/docs/feedback-rollout.md
+++ b/docs/feedback-rollout.md
@@ -1,0 +1,139 @@
+# Feedback → issues: rollout worklist
+
+**One-time. Delete this file once step 8 passes.** It is a checklist for a single
+rollout, not a reference doc — leaving it here after the fact makes the next
+reader think there is pending work.
+
+Everything below is the lead's, and none of it is in the repo: Google console,
+GitHub settings, Drive. The code half shipped in the PR that added this file.
+
+**Do these in order.** Steps 1–2 must be on `main` before step 5, because
+workflows for `issues:` events run from the default branch. Backwards, and every
+submission in the window lands in Backlog — where nothing rescues it, since
+`/fill-ready` never promotes a `feedback` item out of Backlog.
+
+---
+
+### 1. Merge the PR
+
+Nothing else works until `add-to-project.yml` is on `main`.
+
+### 2. Create the label
+
+```sh
+gh label create feedback --repo PioneerAIAcademy/cowork-genealogy \
+  --description "User feedback submission — routes straight to Ready" \
+  --color D4C5F9
+```
+
+It does not exist yet. The workflow matches on it by name; without it every
+submission lands in Backlog.
+
+### 3. Mint the PAT
+
+Fine-grained, scoped to `PioneerAIAcademy/cowork-genealogy` only, **Issues: Read
+and write** and nothing else.
+
+The repo is org-owned, so this also needs fine-grained PAT access enabled on the
+org **and** an owner to approve the token. Neither errors at the call site — an
+unapproved token creates nothing, which looks exactly like the script not
+running.
+
+**Confirm before moving on:** create one issue by hand with the token.
+
+```sh
+curl -s -X POST https://api.github.com/repos/PioneerAIAcademy/cowork-genealogy/issues \
+  -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github+json" \
+  -d '{"title":"[feedback] token check","labels":["genealogist","feedback"]}'
+```
+
+Close it afterwards. If this fails, everything downstream fails silently.
+
+### 4. Set the Script Properties
+
+Apps Script console → **Project Settings → Script Properties**:
+
+| Property | Value |
+|---|---|
+| `GITHUB_TOKEN` | the PAT from step 3 |
+| `GITHUB_REPO` | `PioneerAIAcademy/cowork-genealogy` |
+
+### 5. Deploy the script
+
+Paste the new `Code.gs` from `apps/electron/server/feedback-endpoint/` into the
+console.
+
+**Re-authorize when prompted.** The GitHub call adds the
+`script.external_request` scope. Until it is granted under "Execute as: Me",
+every issue-creation call throws into its own `try/catch` and submissions keep
+returning success with no issue created.
+
+Then **Manage deployments → edit the existing deployment (pencil) → Version: New
+version → Deploy.**
+
+**Do not use "Deploy → New deployment".** It mints a new `/exec` URL, and the
+current one is hardcoded in two shipped clients
+(`apps/electron/src/main/index.ts`, `apps/server/app/config.py`) — a new URL
+orphans every installed Electron build.
+
+**Confirm:**
+
+```sh
+curl -sL <exec-url>
+# {"status":"Feedback endpoint is running","version":"2026-08-04"}
+```
+
+An older `version` means the paste or the publish did not take.
+
+### 6. Re-share the Drive folder
+
+To a Google Group of the junior accounts, **Viewer** — never "anyone with the
+link", and not Editor. Editor lets any of them delete a zip, and the zip is the
+immutable record the whole workflow rests on.
+
+### 7. Tell the team
+
+The claim rule is new and nothing enforces it. Two people can both self-assign,
+and the only thing preventing it is that everyone knows to check.
+
+> Feedback now arrives as GitHub issues in Ready, titled `[feedback] <time>`.
+> Assign one to yourself before you start — that's the claim. If it already has
+> an assignee, take another. Everything else is the same guide:
+> `docs/alpha-feedback-guide.md`.
+
+Anyone on the roster may claim one, not just genealogists.
+
+### 8. Smoke test
+
+The full version, including the failure-path checks, is in
+`apps/electron/server/feedback-endpoint/README.md` § Smoke test. Run it now and
+after **every** future console edit — CI cannot reach any of this.
+
+Four checks: version matches; a submission creates a labelled issue in Ready;
+the body leaks no user text; and with `GITHUB_TOKEN` deleted, the user still
+gets a success response.
+
+---
+
+## Then delete this file
+
+Once step 8 passes, `git rm docs/feedback-rollout.md`. The durable record is the
+endpoint README (setup + smoke test), `docs/alpha-feedback-guide.md` (the
+workflow), and `docs/architecture.md` §9.4 (what still isn't checked).
+
+## Known and accepted
+
+Not steps — things to recognize rather than fix, so they don't get rediscovered
+as bugs.
+
+- **This widens issue #1121, and does not fix it.** The endpoint takes
+  unauthenticated writes and its URL is in a public repo. After this, the same
+  POST creates issues in a public repo, auto-routed to Ready. The clamping and
+  script-clock title bound what an attacker can write, not whether they can. A
+  flood is cleared by closing the issues.
+- **Ready's genealogist half tracks the feedback rate.** Six feedback items in
+  Ready leaves four slots, and the rest of the genealogist queue promotes as
+  usual. Ten leaves none, and `/fill-ready` returns the non-feedback items to
+  Backlog. The `test <slug>` queue moves on quiet weeks and stalls on busy ones.
+- **Repeat submissions each open their own issue.** Adjacent timestamps are the
+  signal; the guide says to check.

--- a/docs/specs/task-review-spec.md
+++ b/docs/specs/task-review-spec.md
@@ -154,6 +154,14 @@ Gating that pool needs a different and much shorter agent — does the hint reco
 exist, is the ark resolvable, is anyone else on this fixture — not a wider
 fan-out of this one. That agent does not exist yet.
 
+**`feedback`-labeled items are out of scope even under `--all`.** They carry
+`genealogist`, so they would otherwise land in that fan-out, but they are user
+bug reports filed automatically by the feedback endpoint — the body is a Drive
+link and a `make feedback-case` command, and every question this agent asks
+(staleness, refuted premise, blast radius, what verifies it) is answered by
+working the case, not by reading the issue. Reviewing one costs ~110k tokens to
+learn nothing. The triage they do need is `docs/alpha-feedback-guide.md`.
+
 ## 7. Measurements
 
 From the first run, 2026-08-02, over the unassigned `developer` pool:


### PR DESCRIPTION
Every feedback zip that lands in Drive now becomes a GitHub issue in **Ready**, labelled `genealogist` + `feedback`, carrying a link to the zip. Juniors claim by self-assigning. No lead involvement.

Today a zip lands in Drive with nothing pointing at it — the guide says "the bundle lands in the shared Drive folder, download it" with no way to tell which one is yours.

## How

`doPost` opens the issue in the same request that saves the zip. Unzip (already happening), POST, done. No scheduled trigger, no cursor, no retry state — `doPost` only ever sees a new submission, so the zips already in Drive are untouched.

**Labels go in the same POST.** `add-to-project.yml` reads labels off `context.payload.issue` and triggers only on `[opened, reopened, transferred]` — a label added in a second call is never seen, and the card would land in Backlog where nothing promotes it.

**The GitHub call has its own `try/catch`.** The zip is already saved by then, so a failure must not report failure to the user and send them resubmitting — a plausible cause of the 13 uploads on 2026-08-03.

**Nothing user-typed reaches the body.** The repo is public. The seven prose/PII fields are never read; `submitted_at` and `platform` are read individually (never spread or stringified) and clamped; and the filename is clamped to `[A-Za-z0-9._-]` because it lands inside a code fence where a backtick run would break out and render `@`-mentions.

## Board behavior

One rule in `fill-ready`: a `feedback` item counts toward the ~10 genealogist target and is never promoted, demoted, or unassigned. Since it can't lose a swap, returns to Backlog come only from the non-feedback members — ten feedback items and four `test <slug>` items is fourteen against a target of ten, so the four go back.

Under target nothing changes. Six feedback items leaves four slots and the genealogist queue promotes as usual; a quiet feedback week is when the rest of that queue moves. The `test <slug>` stream is not retired.

`review-ready --all` skips them — they're user bug reports, not vetted tasks, and reviewing one costs ~110k tokens to learn nothing.

## Verification

Nothing in CI can reach Apps Script. `doGet` now reports `SCRIPT_VERSION`, so `curl <exec-url>` catches a stale or unpublished console copy without spending a submission. The rest is the smoke test in the endpoint README, run after every console edit — including the step that deletes `GITHUB_TOKEN` and confirms the user still gets a success response.

`make test-all` green (1400 passed). Workflow YAML parses, its embedded JS syntax-checks, and the routing function is unit-tested across five label shapes including a payload with no `labels` key.

New §9.4 row: nothing checks that the deployed script's GitHub write works.

## Before this can work

`docs/feedback-rollout.md` — 8 ordered steps, merge-first, each with its confirm command. **The order matters:** workflows for `issues:` events run from the default branch, so the workflow must be on `main` before the script can create anything. That file carries a delete-when-done line.

## Security

**Refs #1121 — this widens it and does not fix it.** The endpoint takes unauthenticated writes and its URL is hardcoded in a public repo. Today the worst case is junk zips in a private Drive folder; after this, the same POST creates issues in a public repo, auto-routed into Ready. The clamping and script-clock title bound what an attacker can write, not whether they can. A flood is cleared by closing the issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)