### PR TITLE
e2e(micaela-salgado-son): cite the baptism ark so the fixture clears #1195's gate

### DIFF
--- a/eval/tests/e2e/micaela-salgado-son/expected-findings.json
+++ b/eval/tests/e2e/micaela-salgado-son/expected-findings.json
@@ -13,7 +13,7 @@
         }
       },
       "supporting_sources": [
-        "Honduras, Catholic Church Records, 1633-1978 — baptismal entry, 20 Oct 1889, San Miguel, Tegucigalpa, naming mother Micaila Salgado, no father recorded"
+        "Honduras, Catholic Church Records, 1633-1978 — baptismal entry, 20 Oct 1889, San Miguel, Tegucigalpa, naming mother Micaila Salgado, no father recorded (ark:/61903/1:1:KXP9-FP6)"
       ],
       "required": true
     }


### PR DESCRIPTION
Clears `main`. Two PRs merged eight minutes apart today left a failing test on `main`:

| | merged | |
|---|---|---|
| #1195 — added the ark gate | 17:05:21 | @johnmarkpeterbrown |
| #1057 — resolved the fixture | 17:13:15 | @Paaboat |

#1195 made a resolvable `ark:/61903/...` a hard error for every **resolved** record-hint fixture. #1057 flipped `micaela-salgado-son` from draft to resolved, which brought it into scope. #1057's CI was green when it ran — the gate did not exist yet — and nothing re-ran it against the new gate. Neither author did anything wrong.

Result on `main`:

```
FAILED tests/unit/test_e2e_fixture_corpus.py::
  test_committed_fixture_passes_the_hard_gates[micaela-salgado-son]
```

## The ark is verified, not guessed

Issue #868 (the "test micaela-salgado-son" assignment) records the hint record, and reading it live confirms every element of the citation already in the fixture:

| Fixture claims | Record says |
|---|---|
| baptismal entry, 20 Oct 1889 | Baptism `20 Oct 1889` ✓ |
| San Miguel, Tegucigalpa | `San Miguel, Tegucigalpa, Francisco Morazán, Honduras` ✓ |
| naming mother Micaila Salgado | ParentChild: `Micaila Salgado` → `Guillermo Salgado` ✓ |
| no father recorded | only two personas in the record; no father ✓ |
| Honduras, Catholic Church Records, 1633-1978 | collection `sd_c_1823595`, same title ✓ |

- `ark:/61903/1:1:KXP9-FP6` — Guillermo Salgado (child persona)
- `ark:/61903/1:1:KXP9-FPD` — Micaila Salgado (mother persona; this is the hint ark in #868)

Citing **`KXP9-FP6`**: the finding is about Guillermo, and that is the ark FamilySearch's own citation string for this entry uses. Both resolve to the same entry. Format matches the sibling fixtures — cf. `isabel-carvajal-daughter`'s `… (ark:/61903/1:1:6BT8-1TRV)`.

## Why it slipped

#1057 only ever touched `README.md` and `fixture.json`. `expected-findings.json` is still the auto-generated draft transcription from #887 (2026-07-24, the 32-fixture batch), so the resolution's "the `expected-findings.json` transcribed from the hint record stands as written" verdict left it with no ark to expand.

Not a systemic gap: all 17 other resolved record-hint fixtures already carry arks, the 18 drafts are exempt via `DRAFT PENDING ADJUDICATION`, and `/resolve-record-hint` already teaches this (that guidance landed in #1195 itself).

## Verification

- `uv run pytest tests/unit/test_e2e_fixture_corpus.py` — **167 passed** (was 1 failed / 166 passed)
- `make harness-test` — **1484 passed**

## Not in scope, flagged for the lead

`eval-harness-tests.yml` is `on: pull_request` only, so a red `main` is invisible until an innocent PR inherits it — and its path filters cover `packages/engine/mcp-server/`, `packages/engine/plugin/skills/`, and `eval/**`, three of the busiest paths in the repo. Prevention for the *class* is branch protection's **"Require branches to be up to date before merging"**, which would have forced #1057 to rebase onto #1195 and re-run. Deliberately not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)