### PR TITLE
resolve-record-hint: require the ark on every outcome, not just outcome 3

### DIFF
--- a/.claude/skills/resolve-record-hint/SKILL.md
+++ b/.claude/skills/resolve-record-hint/SKILL.md
@@ -64,9 +64,10 @@ Wait for their conclusion before continuing.
 
 Ask which of the three applies, and collect only what that outcome needs:
 
-1. **True match** — nothing further needed.
+1. **True match** — the confirming record's resolvable FamilySearch ark.
 2. **Answerable, but differently** — what's actually true (a different date,
-   record, or person) in place of what's there now.
+   record, or person) in place of what's there now, **and that record's
+   resolvable FamilySearch ark**.
 3. **False match, no findable substitute** — the specific claim the agent
    must not assert, plus the record that disproves it (an age impossibility,
    a date that contradicts another record, a directly-examined record that
@@ -77,6 +78,10 @@ Ask which of the three applies, and collect only what that outcome needs:
 In all three cases, also ask for their reasoning in plain language — this
 becomes the README's new "Notes for reviewers."
 
+Every outcome needs an ark: a resolved record-hint fixture whose
+`expected-findings.json` carries no literal `ark:/61903/...` in any finding's
+`supporting_sources` is a hard `ERROR` in Step 5 (issue #970).
+
 For outcome 3, the ark belongs to whichever record does the disproving —
 never to the absence itself. There is no ark for "no record establishes X";
 don't ask the genealogist to invent one, and don't accept a tree PID or the
@@ -86,9 +91,11 @@ it carries no record provenance). See spec §3.6.1 (issue #1025).
 ## Step 4 — Write the files
 
 - **`expected-findings.json`**
-  - Outcome 1: leave unchanged.
+  - Outcome 1: leave unchanged, except to append the confirming record's
+    `ark:/61903/...` to a `supporting_sources` entry if no finding has one.
   - Outcome 2: edit the existing finding(s)' `description` / `details` /
-    `supporting_sources` to the corrected answer.
+    `supporting_sources` to the corrected answer, with that record's
+    `ark:/61903/...` in `supporting_sources`.
   - Outcome 3: replace the findings with a `"polarity": "avoid"` finding
     naming the wrong claim, paired with a `required: true` finding
     documenting the negative conclusion. Copy the JSON *shape* from


### PR DESCRIPTION
`record_hint_citation_errors` (#1195) hard-errors any resolved record-hint fixture whose `expected-findings.json` cites no `ark:/61903/...`. The skill only collected one for **outcome 3**, and told outcome 1 *"nothing further needed"* / *"leave unchanged"* — so a true-match resolution produced exactly the state the gate rejects.

Both fixtures resolved since the gate landed hit it:

- `micaela-salgado-son` — PR #1057, fixed after the fact in #1277
- `gertrudis-hoffmans-daughter` — PR #1221, fixed in-branch

In both, the branch had forked before `f9c7093c`, so Step 5's validator did not carry the gate and CI was green right up to the merge.

## What changed

- **Step 3** asks for the ark on all three outcomes, and names the failure it prevents.
- **Step 4** says where it goes for outcomes 1 and 2.
- Outcome 3's disproving-record-vs-absence split (#1025, spec §3.6.1) is unchanged.

Prose only — no code, no tests affected.

## Not covered here

The reason CI was green in both cases is separate: `protect-main`'s `required_status_checks` has `strict_required_status_checks_policy: false`, so a branch that forked before a gate landed never re-runs against it. That is a ruleset setting, not a repo change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
