### PR TITLE
feat(e2e): report declared-but-never-called tools per plugin agent (#…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -496,6 +496,19 @@ e2e-corpus: ## Three axes + violation detail over recent committed e2e runs: mak
 	# as `not_checked` and never counted as clean.
 	cd eval/harness && uv run python -m e2e.corpus_report $(if $(TEST),--test $(TEST),) $(if $(SINCE),--since $(SINCE),)
 
+.PHONY: e2e-agent-tools
+e2e-agent-tools: ## Declared-but-never-called tools per plugin agent over committed e2e runs (issue #1085): make e2e-agent-tools | TEST=<slug> | SINCE=all|N|YYYY-MM-DD
+	# Pure analysis over committed run JSONs — no live run, no API.
+	#
+	# For each plugin agent that declares tool X and appears in a run, did it
+	# ever actually call X? Unions two per-agent sources already in the runlog —
+	# `subagents[].turns[].blocks` and (since #1027) `tool_calls[].agent_type` —
+	# and diffs the union against each agent's `tools:` frontmatter, bare-named.
+	# `gps-mentor`'s never-called tools are the candidates for #1084's live
+	# binding probe. Windowed to 14 days like every reader; SINCE=all for the
+	# whole corpus. A report, not a gate (see its own "Limits" footer).
+	cd eval/harness && uv run python -m e2e.agent_tool_usage_report $(if $(TEST),--test $(TEST),) $(if $(SINCE),--since $(SINCE),)
+
 .PHONY: e2e-guardrail-shadow
 e2e-guardrail-shadow: ## Retroactive §4.1 shadow-window calibration over committed runs (issue #911): make e2e-guardrail-shadow | TEST=<slug> | WINDOWS=10,40 | SINCE=all|N|YYYY-MM-DD
 	# Also pure analysis, no API. Existed with no make target until #972.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1203,7 +1203,9 @@ and `make e2e-login` (the FS token lasts ~24h, and its absence looks exactly lik
 an agent failure). Then `make e2e-view TEST=<slug>` loads the run into the viewer,
 `make e2e-corpus` gives the three axes plus violation counts, the per-arm split
 and per-fixture concentration, across the last 14 days of committed runs —
-every run-log reader windows that way, `SINCE=all` to opt out — and the
+every run-log reader windows that way, `SINCE=all` to opt out — `make
+e2e-agent-tools` reports, per plugin agent, which declared tools it never
+actually called across those runs (issue #1085), and the
 `/interpret-e2e-result` skill exists to read the log for you. Mechanics:
 `docs/e2e-testing-guide.md`. Before concluding the agent regressed, rule out the
 four other causes: an eval defect, FamilySearch data drift, single-run jitter, and

--- a/eval/harness/e2e/agent_tool_usage_report.py
+++ b/eval/harness/e2e/agent_tool_usage_report.py
@@ -1,0 +1,397 @@
+"""Declared-but-never-called tools per plugin agent, over committed e2e runs.
+
+GitHub issue #1085. A free, post-hoc check: for each plugin agent that declares
+tool X and appears in a committed run, did it ever actually call X? It costs
+nothing (reads committed files, no model, no network) and catches a class the
+static checks structurally cannot — a tool spelled correctly, registered
+correctly, and still never used, either because it did not bind or because the
+agent body never reaches for it. The worked example is #693 / PR #1082, where
+`gps-mentor`'s `tools:` list passed every lint yet lacked the projection tools it
+needed, so it read `research.json` front-to-back instead. This is the mechanizable
+inverse of that: *declared but never called*.
+
+Pairs with #1084 (a live probe of "declared and actually bound"); this covers
+"declared but never reached for" from the committed corpus. `gps-mentor`'s
+never-called tools here are the candidates #1084's live probe would target.
+
+Adds NO instrumentation to a run (same posture as `corpus_report.py` /
+`guardrail_shadow_report.py` / `latency_report.py`): pure analysis over
+already-committed data.
+
+## Where the per-agent data comes from
+
+The obsolete `## Sketch` in the issue proposed reconstructing each subagent's
+tool window by joining `Agent` call descriptions. That is unnecessary — the
+committed runlog is already per-agent, two ways, and this unions both:
+
+1. Every capture carries `subagents[].agent_type` plus a per-turn
+   `tool_use:<bare_name>` ledger in `subagents[].turns[].blocks`
+   (`subagent_capture._block_label` / `_bare_tool_name`). Args are absent —
+   names only, which is all this check needs.
+2. Since **PR #1027** (merged 2026-08-03) `tool_calls[]` entries carry
+   `agent_type`/`agent_id` directly (the PreToolUse hook attributes in-process).
+   This never misses when present, unlike the ephemeral-cache capture, which is
+   empty in some runs that did delegate.
+
+The two sources are unioned per `agent_type`. Note the #1027 attribution only
+helps runs written after it shipped: pre-#1027 empty-capture runs stay
+unattributed, and the coverage line says how many.
+
+A tool counts as *used* if an agent was seen **invoking** it — an attempt, not
+necessarily a success. The capture source records `tool_use` blocks with no
+success/failure signal; the `tool_calls` source additionally drops entries the
+runlog marked `is_error`, so a call the harness recorded as failed does not read
+as "used" from that source. The consequence for the columns: a genuinely
+never-invoked tool is a real never-called candidate, but a non-empty
+`used-but-not-declared` set can be a denied/errored *attempt* the capture source
+could not mark, not only a non-binding allow-list — see the column's note.
+
+CLI (from eval/harness/):
+  uv run python -m e2e.agent_tool_usage_report                 # last 14 days
+  uv run python -m e2e.agent_tool_usage_report --since all     # whole corpus
+  uv run python -m e2e.agent_tool_usage_report --test bagley-father-1884
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from e2e.runlog_selection import (
+    add_since_arg,
+    all_result_jsons,
+    describe_window,
+    filter_since,
+    result_jsons_for,
+)
+from harness.allowed_tools import load_skill_frontmatter
+from harness.workspace import DEFAULT_PLUGIN_AGENTS
+
+# Always-in-session, non-MCP tools. Filtered from the `used-but-not-declared`
+# column ONLY: a built-in call is never evidence of a non-binding MCP allow-list
+# (built-ins bypass it), so leaving them in would make the "should be empty ⇒
+# allow-list not binding" invariant fire falsely the first time any agent calls
+# `Read`. Mirrors `allowed_tools.baseline`, plus `ToolSearch` (the deferred-tool
+# loader Cowork exposes, which shows up in `general-purpose` captures). They are
+# NOT filtered from the declared columns — an agent that declares `Read` and uses
+# it is a truthful declared-and-used.
+BUILTIN_TOOLS = frozenset(
+    {"Read", "Glob", "Grep", "Write", "Edit", "Skill", "Task", "ToolSearch"}
+)
+
+
+def bare_tool_name(name: str) -> str:
+    """`mcp__genealogy__project_context` -> `project_context`; leave others as-is.
+
+    Collapses BOTH server spellings an agent's `tools:` lists — `mcp__genealogy__X`
+    and `mcp__remote-devices__Genealogy_Research__X` — onto the same bare `X`,
+    which is why the declared set is built from these rather than the raw entries.
+    """
+    return name.split("__")[-1] if name.startswith("mcp__") else name
+
+
+def declared_tools_by_agent(
+    agents_dir: Path = DEFAULT_PLUGIN_AGENTS,
+) -> dict[str, set[str]]:
+    """Bare tool names each plugin agent declares in its `tools:` frontmatter.
+
+    Keyed by the frontmatter `name` (which matches the corpus `agent_type`), the
+    dual spellings collapsed to one bare name each. Built-ins (`Read`) pass
+    through as-is. Reuses `load_skill_frontmatter`, documented as working on
+    agent `.md` files, rather than re-parsing YAML.
+    """
+    out: dict[str, set[str]] = {}
+    for md in sorted(agents_dir.glob("*.md")):
+        fm = load_skill_frontmatter(md)
+        name = fm.get("name") or md.stem
+        out[name] = {bare_tool_name(t) for t in (fm.get("tools") or [])}
+    return out
+
+
+class UsageScan(NamedTuple):
+    """What one pass over the corpus collects.
+
+    `used` maps agent_type -> set of bare tool names it was seen calling, unioned
+    across both sources. `captures` counts `subagents[]` entries per agent_type.
+    The three coverage counters describe attribution reach — see `coverage_line`.
+    `problems` holds one message per unreadable file.
+    """
+
+    used: dict[str, set[str]]
+    captures: Counter
+    runs: int
+    with_captures: int  # runs with >=1 non-empty subagents entry
+    empty_captures: int  # runs with `subagents: []`
+    no_field: int  # runs with no `subagents` key at all
+    recovered_by_toolcalls: int  # capture-less runs still attributed via tool_calls
+    problems: list[str]
+
+
+def _tools_from_capture(sub: dict[str, Any]) -> set[str]:
+    """Bare tool names a single `subagents[]` capture called, from its turn blocks."""
+    tools: set[str] = set()
+    for turn in sub.get("turns") or []:
+        for block in turn.get("blocks") or []:
+            if isinstance(block, str) and block.startswith("tool_use:"):
+                tools.add(block.split(":", 1)[1])
+    return tools
+
+
+def scan(paths: list[Path]) -> UsageScan:
+    """Union the tools each agent_type called across every committed run.
+
+    Every read of one runlog — parse AND per-entry traversal — happens inside the
+    `try`, and no running total is touched until all of them succeed (the
+    `corpus_report.tally` contract). A malformed file (bad JSON, `subagents:
+    [null]`, a non-list `tool_calls`) lands in `problems` exactly once and
+    contributes to no counter, so the reported run count and the usage sets stay
+    consistent. The `except` mirrors `corpus_report`'s, `TypeError` included.
+    """
+    used: dict[str, set[str]] = {}
+    captures: Counter = Counter()
+    runs = with_captures = empty_captures = no_field = recovered = 0
+    problems: list[str] = []
+
+    for path in paths:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            subs = data.get("subagents")
+            subs_list = subs if isinstance(subs, list) else []
+            raw_calls = data.get("tool_calls")
+            tool_calls = raw_calls if isinstance(raw_calls, list) else []
+
+            # Compute this file's contribution into locals first; only merge into
+            # the running totals below, after every read has succeeded.
+            file_used: dict[str, set[str]] = {}
+            file_captures: Counter = Counter()
+            for sub in subs_list:
+                if not isinstance(sub, dict):
+                    continue
+                agent = sub.get("agent_type")
+                if not agent:
+                    continue  # a capture with no agent_type can't be attributed
+                file_captures[agent] += 1
+                file_used.setdefault(agent, set()).update(_tools_from_capture(sub))
+
+            # #1027 attribution: fold in tool_calls tagged with an agent_type,
+            # skipping entries the runlog marked `is_error` — a call the harness
+            # recorded as failed or denied did not "work", so it must not read as
+            # `used` (a denied write would otherwise surface as "not binding").
+            toolcall_attr = False
+            for call in tool_calls:
+                if not isinstance(call, dict) or call.get("is_error"):
+                    continue
+                agent = call.get("agent_type")
+                name = bare_tool_name(call.get("tool") or "")
+                if not agent or not name:
+                    continue
+                toolcall_attr = True
+                file_used.setdefault(agent, set()).add(name)
+        except (OSError, json.JSONDecodeError, TypeError, AttributeError) as e:
+            problems.append(f"{path}: {e}")
+            continue
+
+        runs += 1
+        for agent, tools in file_used.items():
+            used.setdefault(agent, set()).update(tools)
+        captures.update(file_captures)
+
+        # Bucket on the SHAPE of `subagents`, not on whether any entry was
+        # attributable: a non-empty list IS a captured delegation even if a
+        # missing .meta.json left its entries without an agent_type. Misreporting
+        # that as `subagents: []` is what finding 3 flagged.
+        if subs_list:
+            with_captures += 1
+        elif isinstance(subs, list):
+            empty_captures += 1
+            # A capture-less run the #1027 path still attributed — the reason both
+            # sources are unioned. (0 in the pre-#1027 corpus; see module docstring.)
+            if toolcall_attr:
+                recovered += 1
+        else:
+            no_field += 1
+
+    return UsageScan(
+        used, captures, runs, with_captures, empty_captures, no_field, recovered, problems
+    )
+
+
+class AgentDiff(NamedTuple):
+    agent: str
+    captures: int
+    declared_and_used: list[str]
+    declared_never_used: list[str]
+    used_not_declared: list[str]
+
+
+def diff_agents(
+    declared: dict[str, set[str]], scan_result: UsageScan
+) -> tuple[list[AgentDiff], dict[str, set[str]]]:
+    """Per plugin agent, the three-way split; plus the unattributed non-plugin set.
+
+    `general-purpose` (and any agent_type with no `tools:` frontmatter) is NOT a
+    plugin agent: folding it into the diff makes its whole tool set
+    "used-but-not-declared" and reads as *the allow-list is not binding*, which is
+    false. It is returned separately for a stand-alone section.
+    """
+    diffs: list[AgentDiff] = []
+    for agent in sorted(declared):
+        dec = declared[agent]
+        used = scan_result.used.get(agent, set())
+        diffs.append(
+            AgentDiff(
+                agent=agent,
+                captures=scan_result.captures.get(agent, 0),
+                declared_and_used=sorted(dec & used),
+                declared_never_used=sorted(dec - used),
+                # Built-ins bypass the MCP allow-list, so they can never evidence a
+                # non-binding grant — drop them from this column only.
+                used_not_declared=sorted((used - dec) - BUILTIN_TOOLS),
+            )
+        )
+
+    unattributed = {
+        agent: tools
+        for agent, tools in scan_result.used.items()
+        if agent not in declared
+    }
+    return diffs, unattributed
+
+
+def coverage_line(s: UsageScan) -> str:
+    """How much of the corpus this could attribute — the issue's explicit ask.
+
+    Absence of a call is sometimes absence of a capture, so the report states
+    which runs it could and could not attribute rather than averaging over both.
+    """
+    scanned = f"Attribution coverage: {s.with_captures} of {s.runs} readable run(s) carried a subagent capture"
+    if s.problems:
+        # State the skipped count on stdout too. `describe_window` counts every
+        # windowed file (readable + not); this line counts only the readable
+        # ones, so without saying so the two run counts on stdout disagree.
+        scanned += f" ({len(s.problems)} unreadable, excluded — see stderr)"
+    parts = [
+        scanned,
+        f"  {s.empty_captures} had `subagents: []`, {s.no_field} had no `subagents` "
+        f"field (pre-capture runs)",
+    ]
+    if s.empty_captures:
+        parts.append(
+            f"  of the empty-capture runs, {s.recovered_by_toolcalls} were still "
+            f"attributed via tool_calls (#1027)"
+        )
+    return "\n".join(parts)
+
+
+def format_report(
+    diffs: list[AgentDiff],
+    unattributed: dict[str, set[str]],
+    scan_result: UsageScan,
+) -> str:
+    lines = [coverage_line(scan_result), ""]
+
+    for d in diffs:
+        lines.append(f"{d.agent}  ({d.captures} capture(s))")
+        if not d.captures and not scan_result.used.get(d.agent):
+            # Declared but never seen in any run — say so rather than printing its
+            # whole tools: list as "never used", which would read as a defect.
+            lines.append("  never appeared in a captured run — nothing to diff")
+            lines.append("")
+            continue
+        lines.append(
+            f"  declared & used ({len(d.declared_and_used)}): "
+            f"{', '.join(d.declared_and_used) or '(none)'}"
+        )
+        # Named individually — this is the deliverable (the #1084 candidates).
+        lines.append(
+            f"  declared, NEVER called ({len(d.declared_never_used)}): "
+            f"{', '.join(d.declared_never_used) or '(none)'}"
+        )
+        # Should be empty. A non-empty set is usually the allow-list not binding —
+        # but the capture source counts attempts with no success/failure signal,
+        # so a denied/errored attempt the runlog couldn't mark can also land here.
+        lines.append(
+            f"  used, NOT declared ({len(d.used_not_declared)}): "
+            f"{', '.join(d.used_not_declared) or '(none)'}"
+        )
+        lines.append("")
+
+    if unattributed:
+        lines.append("Unattributed delegations (non-plugin agent_types) —")
+        lines.append("  not diffed: no `tools:` frontmatter to compare against.")
+        for agent in sorted(unattributed):
+            tools = sorted(unattributed[agent])
+            lines.append(
+                f"  {agent} ({scan_result.captures.get(agent, 0)} capture(s)): "
+                f"{', '.join(tools)}"
+            )
+        lines.append("")
+
+    lines.extend(
+        [
+            "Limits (this is a report, not a gate):",
+            "  - A rarely-needed declared tool showing never-called is not by "
+            "itself a defect;",
+            "    it is a candidate to check (#1084's live binding probe), not a "
+            "violation.",
+            "  - Capture coverage is partial (see the coverage line) — absence of "
+            "a call is",
+            "    sometimes absence of a capture, not proof the tool was never "
+            "reached for.",
+            "  - `used` means invoked (attempted), not succeeded: the capture "
+            "source carries no",
+            "    success/failure signal, so a declared-&-used tool may have only "
+            "ever errored, and a",
+            "    `used, NOT declared` entry can be a denied/errored attempt, not a "
+            "binding failure.",
+            "  - Corpus scans age; this windows to 14 days by default (SINCE=all "
+            "to opt out).",
+            "    A retroactive whole-corpus scan can measure a doctrine's landing "
+            "date rather",
+            "    than a real gap — split on that date (the #1006 445-violation "
+            "scan, settled",
+            "    2026-08-01 as a real gap by exactly that method).",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Declared-but-never-called tools per plugin agent, over committed "
+            "e2e runs (issue #1085)."
+        )
+    )
+    ap.add_argument("--test", help="restrict to one fixture slug")
+    add_since_arg(ap)
+    args = ap.parse_args(argv)
+
+    all_paths = result_jsons_for(args.test) if args.test else all_result_jsons()
+    cutoff = args.since
+    paths = filter_since(all_paths, cutoff)
+    if not paths:
+        where = f" on/after {cutoff.isoformat()}" if (cutoff and all_paths) else ""
+        print(f"No committed runs found{where}.", file=sys.stderr)
+        return 1
+
+    scan_result = scan(paths)
+    for problem in scan_result.problems:
+        print(f"  skip {problem}", file=sys.stderr)
+
+    declared = declared_tools_by_agent()
+    diffs, unattributed = diff_agents(declared, scan_result)
+
+    print(describe_window(cutoff, n_runs=len(paths), n_total=len(all_paths)))
+    print(format_report(diffs, unattributed, scan_result))
+    # A wholly-unreadable corpus is a failure, not an empty success (matches
+    # corpus_report): a caller keying on the exit code must tell the two apart.
+    return 0 if scan_result.runs else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/harness/e2e/subagent_capture.py
+++ b/eval/harness/e2e/subagent_capture.py
@@ -8,12 +8,14 @@ transcript is written to the *ephemeral* local cache:
     ~/.claude/projects/<cwd-slug>/<session-uuid>/subagents/agent-*.meta.json
 
 That directory is the temp-workspace-encoded path and is deleted with the
-workspace. The committed runlog only records the *parent's* tool calls plus a
-key-preserving `response_summary` per call (see
-`orchestrator._summarize_tool_response`; before `HARNESS_SCHEMA_VERSION` 2 it
-head-truncated anything over 500 chars, keeping 497 plus an ellipsis) — it stores
-**no** subagent transcript. So a failure that happens entirely inside a subagent
-is invisible from the committed runlog.
+workspace. The committed runlog records each tool call with a key-preserving
+`response_summary` (see `orchestrator._summarize_tool_response`; before
+`HARNESS_SCHEMA_VERSION` 2 it head-truncated anything over 500 chars, keeping 497
+plus an ellipsis), and since #1027 attributes each call to its `agent_type` /
+`agent_id` — but it stores **no** subagent *transcript*. So a failure that
+happens inside a subagent's own turns — no tool call to attribute, just thinking
+that burns the budget — is invisible from the committed runlog without the
+per-turn summaries this module adds.
 
 The failure that motivated this: a `record-extractor` subagent called
 `project_context` once, then emitted a single thinking-only turn that burned its

--- a/eval/harness/tests/unit/test_e2e_agent_tool_usage_report.py
+++ b/eval/harness/tests/unit/test_e2e_agent_tool_usage_report.py
@@ -1,0 +1,343 @@
+"""Unit tests for e2e.agent_tool_usage_report — declared-vs-called per plugin agent."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from e2e.agent_tool_usage_report import (
+    BUILTIN_TOOLS,
+    bare_tool_name,
+    declared_tools_by_agent,
+    diff_agents,
+    format_report,
+    main,
+    scan,
+)
+
+
+def _write(dir_: Path, name: str, payload: dict) -> Path:
+    path = dir_ / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _capture(agent_type, tools):
+    """A `subagents[]` entry that called `tools` (each as one turn block)."""
+    return {
+        "agent_type": agent_type,
+        "turns": [{"blocks": [f"tool_use:{t}" for t in tools]}],
+    }
+
+
+# ── the used side: two sources, unioned ──────────────────────────────────────
+
+
+def test_scan_unions_tools_from_capture_turn_blocks(tmp_path: Path):
+    _write(tmp_path, "run-1.json", {
+        "subagents": [
+            _capture("record-extractor", ["record_read", "project_context"]),
+            _capture("record-extractor", ["extraction_append"]),
+        ],
+    })
+    s = scan([tmp_path / "run-1.json"])
+    assert s.used["record-extractor"] == {
+        "record_read", "project_context", "extraction_append"
+    }
+    assert s.captures["record-extractor"] == 2
+    assert s.with_captures == 1
+
+
+def test_used_set_unions_toolcalls_when_capture_is_empty(tmp_path: Path):
+    """A run with `subagents: []` whose `tool_calls` still attribute (#1027) —
+    the reason both sources are unioned rather than trusting the capture alone."""
+    _write(tmp_path, "run-1.json", {
+        "subagents": [],
+        "tool_calls": [
+            {"tool": "mcp__genealogy__research_query", "agent_type": "gps-mentor"},
+            {"tool": "mcp__genealogy__project_context", "agent_type": "gps-mentor"},
+            {"tool": "mcp__genealogy__record_read"},  # unattributed — main thread
+        ],
+    })
+    s = scan([tmp_path / "run-1.json"])
+    # tool_calls attribution bare-names and collapses the mcp__ prefix.
+    assert s.used["gps-mentor"] == {"research_query", "project_context"}
+    assert "record_read" not in s.used.get("gps-mentor", set())
+    # This is an empty-capture run recovered purely by tool_calls.
+    assert s.with_captures == 0
+    assert s.empty_captures == 1
+    assert s.recovered_by_toolcalls == 1
+
+
+def test_capture_with_no_agent_type_is_skipped_not_crashed_on(tmp_path: Path):
+    """A capture the SDK wrote without an agent_type can't be attributed — it must
+    be dropped, not raise, and not inflate any agent's used set."""
+    _write(tmp_path, "run-1.json", {
+        "subagents": [
+            {"turns": [{"blocks": ["tool_use:record_read"]}]},  # no agent_type
+            _capture("record-extractor", ["project_context"]),
+        ],
+    })
+    s = scan([tmp_path / "run-1.json"])
+    assert s.used == {"record-extractor": {"project_context"}}
+
+
+def test_scan_reports_unreadable_files_instead_of_crashing(tmp_path: Path):
+    good = _write(tmp_path, "run-1.json", {"subagents": [_capture("gps-mentor", ["x"])]})
+    bad = tmp_path / "run-2.json"
+    bad.write_text("{not json", encoding="utf-8")
+    s = scan([good, bad])
+    assert s.runs == 1
+    assert len(s.problems) == 1 and "run-2.json" in s.problems[0]
+
+
+def test_scan_tolerates_malformed_shapes_without_killing_the_report(tmp_path: Path):
+    """`subagents: [null]` and a non-list `tool_calls` are handled in-line (the
+    per-entry `isinstance` guards skip them), so those runs still count — better
+    than the pre-fix behavior where the reads sat outside the try and one bad file
+    aborted the whole corpus (finding 2)."""
+    good = _write(tmp_path, "run-1.json", {"subagents": [_capture("gps-mentor", ["x"])]})
+    null_sub = _write(tmp_path, "run-2.json", {"subagents": [None]})
+    bad_tc = _write(tmp_path, "run-3.json", {"subagents": [], "tool_calls": "oops"})
+    s = scan([good, null_sub, bad_tc])
+    assert s.runs == 3 and s.problems == []  # none fatal
+    assert s.used == {"gps-mentor": {"x"}}  # the null/str shapes contribute nothing
+
+
+def test_scan_try_catches_a_shape_the_guards_do_not_cover(tmp_path: Path):
+    """The try is the backstop for a shape the in-line guards miss — a turn that
+    is not a dict makes `_tools_from_capture` raise `AttributeError`. It must skip
+    one file and land in `problems`, not abort. `TypeError` is in the `except`
+    for the same reason `corpus_report` includes it."""
+    good = _write(tmp_path, "run-1.json", {"subagents": [_capture("gps-mentor", ["x"])]})
+    bad = _write(tmp_path, "run-2.json", {
+        "subagents": [{"agent_type": "gps-mentor", "turns": [42]}],  # 42.get(...) raises
+    })
+    s = scan([good, bad])
+    assert s.runs == 1 and s.used == {"gps-mentor": {"x"}}
+    assert len(s.problems) == 1 and "run-2.json" in s.problems[0]
+
+
+def test_errored_toolcall_does_not_count_as_used(tmp_path: Path):
+    """A `tool_calls` entry the runlog marked `is_error` did not work — it must
+    not read as `used`, or a failed/denied call masks a never-worked tool and a
+    denied write surfaces as "allow-list not binding" (finding 1)."""
+    _write(tmp_path, "run-1.json", {
+        "subagents": [],
+        "tool_calls": [
+            {"tool": "mcp__genealogy__wiki_search", "agent_type": "gps-mentor",
+             "is_error": True},
+            {"tool": "mcp__genealogy__research_query", "agent_type": "gps-mentor"},
+        ],
+    })
+    s = scan([tmp_path / "run-1.json"])
+    assert s.used["gps-mentor"] == {"research_query"}  # the errored wiki_search dropped
+
+
+def test_captures_without_agent_type_still_count_as_a_delegation(tmp_path: Path):
+    """A run whose only captures lack an agent_type (a missing .meta.json sibling)
+    is a captured delegation, not `subagents: []`. Bucketing it as empty misreports
+    a delegation as none (finding 3)."""
+    _write(tmp_path, "run-1.json", {
+        "subagents": [{"turns": [{"blocks": ["tool_use:record_read"]}]}],  # no agent_type
+    })
+    s = scan([tmp_path / "run-1.json"])
+    assert (s.with_captures, s.empty_captures, s.no_field) == (1, 0, 0)
+
+
+def test_scan_counts_the_three_coverage_buckets(tmp_path: Path):
+    paths = [
+        _write(tmp_path, "run-1.json", {"subagents": [_capture("gps-mentor", ["x"])]}),
+        _write(tmp_path, "run-2.json", {"subagents": []}),
+        _write(tmp_path, "run-3.json", {"verdict": "pass"}),  # no subagents field
+    ]
+    s = scan(paths)
+    assert (s.runs, s.with_captures, s.empty_captures, s.no_field) == (3, 1, 1, 1)
+
+
+# ── the declared side: dual spellings collapse ───────────────────────────────
+
+
+def test_declared_tools_collapse_dual_spellings(tmp_path: Path):
+    (tmp_path / "demo.md").write_text(
+        "---\n"
+        "name: demo\n"
+        "tools:\n"
+        "  - Read\n"
+        "  - mcp__genealogy__record_read\n"
+        "  - mcp__remote-devices__Genealogy_Research__record_read\n"
+        "---\nbody\n",
+        encoding="utf-8",
+    )
+    declared = declared_tools_by_agent(agents_dir=tmp_path)
+    # Both server spellings collapse to one bare `record_read`; `Read` passes through.
+    assert declared == {"demo": {"Read", "record_read"}}
+
+
+def test_bare_tool_name_strips_only_the_mcp_prefix():
+    assert bare_tool_name("mcp__genealogy__record_read") == "record_read"
+    assert bare_tool_name("mcp__remote-devices__Genealogy_Research__x") == "x"
+    assert bare_tool_name("Read") == "Read"
+
+
+def test_declared_matches_the_real_committed_agents():
+    """The frontmatter `name` values must be the exact `agent_type` strings the
+    corpus records, or every diff silently misses. Pins the real four."""
+    declared = declared_tools_by_agent()
+    assert {"gps-mentor", "record-extractor", "image-reader", "image-reader-opus"} <= set(
+        declared
+    )
+    assert {"wiki_place_page", "wiki_search"} <= declared["gps-mentor"]
+
+
+# ── the diff: three-way split + the non-plugin carve-out ──────────────────────
+
+
+def test_declared_never_used_is_named_individually(tmp_path: Path):
+    _write(tmp_path, "run-1.json", {
+        "subagents": [_capture("gps-mentor", ["research_query"])],
+    })
+    s = scan([tmp_path / "run-1.json"])
+    declared = {"gps-mentor": {"research_query", "wiki_search", "wiki_place_page"}}
+    diffs, _ = diff_agents(declared, s)
+    (d,) = diffs
+    assert d.declared_and_used == ["research_query"]
+    # Named, sorted — not a count. This is the deliverable (#1084 candidates).
+    assert d.declared_never_used == ["wiki_place_page", "wiki_search"]
+
+
+def test_general_purpose_is_not_in_the_diff(tmp_path: Path):
+    """`general-purpose` has no `tools:` frontmatter. Folding it into the diff
+    makes its whole tool set "used-but-not-declared" and reads as *the allow-list
+    is not binding at all* — false. It belongs in the separate section."""
+    _write(tmp_path, "run-1.json", {
+        "subagents": [
+            _capture("record-extractor", ["record_read"]),
+            _capture("general-purpose", ["tree_edit", "research_append"]),
+        ],
+    })
+    s = scan([tmp_path / "run-1.json"])
+    declared = {"record-extractor": {"record_read", "extraction_append"}}
+    diffs, unattributed = diff_agents(declared, s)
+    assert [d.agent for d in diffs] == ["record-extractor"]  # only the plugin agent
+    assert unattributed == {"general-purpose": {"tree_edit", "research_append"}}
+
+
+def test_builtin_used_not_declared_is_filtered(tmp_path: Path):
+    """A built-in (`Read`) bypasses the MCP allow-list, so calling one an agent did
+    not declare is NOT evidence of a non-binding grant. It must not surface in the
+    used-but-not-declared column, or the invariant fires falsely. A real
+    undeclared MCP call still surfaces."""
+    _write(tmp_path, "run-1.json", {
+        "subagents": [_capture("record-extractor", ["Read", "place_population"])],
+    })
+    s = scan([tmp_path / "run-1.json"])
+    declared = {"record-extractor": {"record_read"}}
+    diffs, _ = diff_agents(declared, s)
+    (d,) = diffs
+    assert "Read" not in d.used_not_declared  # built-in filtered
+    assert d.used_not_declared == ["place_population"]  # real undeclared MCP call kept
+    assert "Read" in BUILTIN_TOOLS
+
+
+def test_agent_never_seen_in_a_run_is_reported_as_such(tmp_path: Path):
+    """A declared agent absent from the whole window must not have its entire
+    tools: list printed as "never called" — that reads as a defect when it is
+    just no data."""
+    _write(tmp_path, "run-1.json", {"subagents": [_capture("gps-mentor", ["x"])]})
+    s = scan([tmp_path / "run-1.json"])
+    declared = {"gps-mentor": {"x"}, "image-reader": {"image_transcribe"}}
+    diffs, _ = diff_agents(declared, s)
+    out = format_report(diffs, {}, s)
+    assert "image-reader  (0 capture(s))" in out
+    assert "nothing to diff" in out
+    # image_transcribe must NOT be listed as declared-never-called.
+    assert "declared, NEVER called (1): image_transcribe" not in out
+
+
+# ── output + windowing ────────────────────────────────────────────────────────
+
+
+def test_format_report_surfaces_never_called_and_the_unattributed_section(tmp_path: Path):
+    _write(tmp_path, "run-1.json", {
+        "subagents": [
+            _capture("gps-mentor", ["research_query"]),
+            _capture("general-purpose", ["tree_edit"]),
+        ],
+    })
+    s = scan([tmp_path / "run-1.json"])
+    declared = {"gps-mentor": {"research_query", "wiki_search"}}
+    diffs, unattributed = diff_agents(declared, s)
+    out = format_report(diffs, unattributed, s)
+    assert "declared, NEVER called (1): wiki_search" in out
+    assert "Unattributed delegations" in out
+    assert "general-purpose" in out and "tree_edit" in out
+    assert "Attribution coverage:" in out
+
+
+def test_coverage_line_states_the_skipped_count_on_stdout(tmp_path: Path, capsys):
+    """`describe_window` counts every windowed file; the coverage line counts only
+    readable ones. Without naming the skipped count on stdout the two run totals
+    silently disagree (finding 4) — the skip detail itself is on stderr."""
+    import e2e.agent_tool_usage_report as r
+
+    fixture = tmp_path / "fx"
+    fixture.mkdir()
+    good = _write(fixture, "run-2026-07-30_10-00-00.json",
+                  {"subagents": [_capture("gps-mentor", ["research_query"])]})
+    bad = fixture / "run-2026-07-30_11-00-00.json"
+    bad.write_text("{not json", encoding="utf-8")
+
+    orig = r.all_result_jsons
+    r.all_result_jsons = lambda: [good, bad]
+    try:
+        assert main(["--since", "all"]) == 0
+    finally:
+        r.all_result_jsons = orig
+    out = capsys.readouterr()
+    assert "entire corpus (2 run(s))" in out.out  # describe_window: both files
+    assert "of 1 readable run(s)" in out.out  # coverage: readable only
+    assert "1 unreadable, excluded" in out.out  # reconciles the two
+    assert "skip" in out.err
+
+
+def test_since_rejects_a_malformed_window(capsys):
+    for bad in ("2026-07-27_20:00:00", "07-27-2026", "yesterday"):
+        with pytest.raises(SystemExit) as e:
+            main(["--since", bad])
+        assert e.value.code == 2
+    assert "'all', a number of days, or YYYY-MM-DD" in capsys.readouterr().err
+
+
+def test_since_windows_the_corpus(tmp_path: Path, capsys):
+    import e2e.agent_tool_usage_report as r
+
+    fixture = tmp_path / "fx"
+    fixture.mkdir()
+    early = _write(fixture, "run-2026-07-01_10-00-00.json",
+                   {"subagents": [_capture("gps-mentor", ["research_query"])]})
+    late = _write(fixture, "run-2026-07-30_10-00-00.json",
+                  {"subagents": [_capture("gps-mentor", ["project_context"])]})
+
+    orig = r.all_result_jsons
+    r.all_result_jsons = lambda: [early, late]
+    try:
+        assert main(["--since", "2026-07-15"]) == 0
+    finally:
+        r.all_result_jsons = orig
+    out = capsys.readouterr().out
+    assert "Window: runs on/after 2026-07-15 — 1 of 2 run(s)" in out
+
+
+def test_empty_corpus_is_a_failure_exit(tmp_path: Path, capsys):
+    import e2e.agent_tool_usage_report as r
+
+    orig = r.all_result_jsons
+    r.all_result_jsons = lambda: []
+    try:
+        assert main(["--since", "all"]) == 1
+    finally:
+        r.all_result_jsons = orig
+    assert "No committed runs found." in capsys.readouterr().err


### PR DESCRIPTION
…1085)

New committed-corpus reader e2e/agent_tool_usage_report.py + make e2e-agent-tools: for each plugin agent that appears in a run, diff its tools: frontmatter against what it actually called. Unions the two per-agent sources already in the runlog (subagents[].turns[].blocks and, since #1027, tool_calls[].agent_type); collapses dual server spellings; filters built-ins from the used-not-declared column so the 'allow-list not binding' invariant stays MCP-only; carves non-plugin agent_types (general-purpose) into a separate section. Windowed like every corpus reader.

Reproduces the issue's expected table: gps-mentor never calls wiki_place_page / wiki_search (the #1084 live-probe candidates); the other three agents clean.

No orchestrator/result edit and no skills/ change, so no run-log re-run. Also corrects the now-stale subagent_capture.py docstring and adds the reader to architecture.md §9. Pairs with #1084 (declared-and-bound); this is the declared-but-never-reached-for half.

## Summary

<!-- 1-3 bullets describing what changed and why. Name the tier
     (Trivial / Normal) — docs/task-lifecycle.md. -->

## Review guidance

<!-- Two lines. The diff shows what you changed; these say what a reviewer
     can't work out from it. Both a human and the Claude session they point at
     the diff read this, so write it for someone who has not seen your branch.

     Start here — the file or function where the actual decision lives, and
     what you want checked about it. Not a file list; the diff has that.

     Unsure about — anything you couldn't resolve. "Nothing" is a valid answer
     on a mechanical change. If it's a question you should have asked before
     building, ask it now rather than shipping past it (task-lifecycle.md
     § "Ask early"). -->

**Start here:**

**Unsure about:**

## Plan

<!-- Normal: the two parts of PLAN.md nothing else here carries. Trivial:
     delete this section. Don't paste PLAN.md whole — its file list is the
     diff, its deferrals are "Follow-on issues", and by the time you open
     the PR it may be a plan you knowingly deviated from (step 4).

     Didn't change — the tempting adjacent thing you left alone, so a
     reviewer reads it as a decision rather than an omission.

     Acceptance check — the named test that fails on `main` and passes on
     this branch. Not "the tests pass"; they passed before.

     Deviated from the plan — anything you re-planned mid-flight (step 4).
     "Nothing" is the common answer. PLAN.md is gitignored, so this line is
     the only way a deviation reaches your reviewer.

     Hit the step-4 stop rule (schema, auth, plugin-agent binding, an ADR
     reversal, anything hard to undo)? Say so here and name the message
     where you raised it. -->

**Didn't change:**

**Acceptance check:**

**Deviated from the plan:**

## Test plan

- [ ] I ran `make test-all` (or `scripts/test.sh` — the same command) and it passed.
      <!-- No Windows equivalent exists (issue #1185): `eval\RunTests.bat` is the
           paid per-skill eval run, not this gate. On Windows, say so here and
           lean on CI, which runs the same suites. -->
      <!-- Note: every suite in it is offline and free — nothing here calls a
           model, which is what keeps it around 30s. Keep it that way. -->

- [ ] For every skill whose **run-log snapshot** I changed (anything under its
      skill dir, an agent it delegates to, its `eval/tests/unit/<skill>/`, or a
      scenario/fixture it references), I ran `make eval-skill SKILL=<name>` —
      Windows: `RunTests.bat` — and committed the run log **and its
      `.ann.json`** under `eval/runlogs/unit/<skill>/`.
      <!-- Behaviour-neutral skill edit (typo, rewording, comment)? Ask a senior
           for the `eval-cosmetic-skip` label instead of burning a paid run.
           Rules: eval/CLAUDE.md § "GitHub Action rules". -->

## Follow-on issues

<!-- Numbers filed for work you deferred. DEVELOPMENT.md § "Follow-on work". -->
