### PR TITLE
triage-standup: add Marc and Richard to the roster

### DIFF
--- a/.claude/skills/triage-standup/references/roster.md
+++ b/.claude/skills/triage-standup/references/roster.md
@@ -11,9 +11,10 @@ people as missing, which is worse than not checking at all.
 
 **Role is load-bearing, not decoration.** `fill-ready` routes work by it — a
 `developer`-labeled issue must not be assigned to a genealogist, and vice versa.
-Roles below were given by the lead on 2026-07-31 (11 developers, 10
-genealogists); before that this table had no role column, and an eval-harness
-Python issue was assigned to a genealogist because nothing here said otherwise.
+Roles below were given by the lead on 2026-07-31 and extended 2026-08-05 (13
+developers, 10 genealogists); before that this table had no role column, and an
+eval-harness Python issue was assigned to a genealogist because nothing here
+said otherwise.
 All developers are **junior**, working with Claude Code; the lead is the only
 senior developer.
 
@@ -40,6 +41,8 @@ senior developer.
 | precious | Precious Onotu | `clack391` | developer | confirmed |
 | edmund | Edmund Asante Oware | `EdmondOware` | genealogist | confirmed |
 | pascal | Pascal Okezie | `Gennecis` | developer | confirmed |
+| marc | Marc Mangum | `MMagnum` | developer | confirmed by the lead 2026-08-05 |
+| richard | Richard | `chesworthrm` | developer | confirmed by the lead 2026-08-05 |
 
 ## How the mappings were derived
 
@@ -78,6 +81,16 @@ what issue #970 becomes.
 - **Ernest** commits as `ernestjacob789@gmail.com` while his GitHub account is
   `aghadiayeamayanvboernest`. Any roll call derived from git activity rather than
   from this roster will count him twice, as two different people.
+- **Richard** (`chesworthrm`) had not posted a standup as of 2026-08-05 while
+  holding PR #1328 and five open `record_search` issues. He is a full roster
+  member, so report him missing on days he does not post.
+- **Christopher** (`chrisedeson`) is not an org member and contributes by fork —
+  a deliberate arrangement, not lapsed access. He is a repo collaborator at
+  `read`, which is **below the bar GitHub requires to be an assignee**, so
+  `gh issue create --assignee chrisedeson` and `gh issue edit --add-assignee`
+  both return success and assign nobody. Verified 2026-08-05 on issue #1341;
+  `GET /repos/:owner/:repo/assignees/chrisedeson` returns 404 where every other
+  handle here returns 204. Assign work to him only after that is resolved.
 
 ## Daily summary
 

--- a/.claude/skills/triage-standup/references/roster.md
+++ b/.claude/skills/triage-standup/references/roster.md
@@ -84,13 +84,19 @@ what issue #970 becomes.
 - **Richard** (`chesworthrm`) had not posted a standup as of 2026-08-05 while
   holding PR #1328 and five open `record_search` issues. He is a full roster
   member, so report him missing on days he does not post.
-- **Christopher** (`chrisedeson`) is not an org member and contributes by fork —
-  a deliberate arrangement, not lapsed access. He is a repo collaborator at
-  `read`, which is **below the bar GitHub requires to be an assignee**, so
-  `gh issue create --assignee chrisedeson` and `gh issue edit --add-assignee`
-  both return success and assign nobody. Verified 2026-08-05 on issue #1341;
-  `GET /repos/:owner/:repo/assignees/chrisedeson` returns 404 where every other
-  handle here returns 204. Assign work to him only after that is resolved.
+- **Christopher** (`chrisedeson`) is not an org member and contributes by fork.
+  That is deliberate, not lapsed access — do not report it as an anomaly.
+- **Assigning below `triage` fails silently.** A collaborator at `read` is under
+  GitHub's assignability bar, and `gh issue create --assignee`, `gh issue edit
+  --add-assignee` and the raw `addAssigneesToAssignable` mutation all return
+  **success while assigning nobody** — the mutation echoes an empty
+  `assignees.nodes` in the same response. Nothing errors, so re-read the issue
+  after assigning. To check a handle, use
+  `GET /repos/:owner/:repo/assignees/:login` (204 assignable, 404 not). Do
+  **not** use `collaborators/:login/permission` — its `permission` field has no
+  value for triage and reports `read` even afterwards, so it reads as still
+  broken; its `role_name` is the accurate one. Hit 2026-08-05 on Christopher,
+  resolved by a `triage` bump, which grants issue management without push.
 
 ## Daily summary
 


### PR DESCRIPTION
## Summary

**Trivial.** Two new rows in the standup roster, plus two notes so a future roll call reads correctly.

- **Marc Mangum** (`MMagnum`) — posted his first standup 2026-08-05, holds issue #1092 and PR #1329. Developer.
- **Richard** (`chesworthrm`) — has PR #1328 open and filed five `record_search` issues (issues #1093, #1323–#1326), but has not posted a standup. Developer, full roster member.

Both roles confirmed by the lead 2026-08-05. Header count updated 11 → 13 developers.

## Two notes added under "Known identity quirks"

**Richard has never posted a standup.** Placing him in the main table means the roll call will report him missing on days he does not post. That is the intended behaviour, so it is written down — otherwise the next run reads it as a bug in the roster and "fixes" it.

**Assigning a collaborator below `triage` fails silently.** Found while filing issue #1341 for Christopher, who is not an org member and contributes by fork by design. At `read` he was under GitHub's assignability bar, and three separate paths — `gh issue create --assignee`, `gh issue edit --add-assignee`, and the raw `addAssigneesToAssignable` GraphQL mutation — all returned **success while assigning nobody**. The mutation even echoed an empty `assignees.nodes` in the same response. Nothing errored.

Resolved the same day by a `triage` bump, which grants issue management without push access, so the fork workflow is unchanged. Christopher accepted and self-assigned issue #1341.

The note keeps the failure mode rather than the resolved blocker, and records **which check to trust** — because the obvious one is wrong:

```
collaborators/chrisedeson/permission  ->  {"permission": "read", "role_name": "triage"}
assignees/chrisedeson                 ->  204
```

The legacy `permission` field has no value for triage and still reads `read` after the fix. Anyone diagnosing this a second time with that field would conclude nothing had changed. Use `role_name`, or the assignees endpoint.

## Review guidance

One file, docs-only, no code paths. The only judgement call is Richard's placement — main table (reported missing when absent) versus the non-standup section that Shaunese and Clorinda sit in. The lead chose the main table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)