### PR TITLE
eval-harness: one requires_engine_build marker for build-dependent tests

### DIFF
--- a/eval/harness/pyproject.toml
+++ b/eval/harness/pyproject.toml
@@ -49,3 +49,6 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 asyncio_mode = "auto"
+markers = [
+    "requires_engine_build: needs the compiled packages/engine/mcp-server/build/ (mock_mcp catalog + ts_validator); run make engine-build",
+]

--- a/eval/harness/tests/conftest.py
+++ b/eval/harness/tests/conftest.py
@@ -1,0 +1,78 @@
+"""Session hooks for the harness suite, incl. the ``requires_engine_build`` marker.
+
+This conftest lives at ``tests/`` (not ``tests/unit/``) so the marker and its hooks
+cover every test under ``testpaths = ["tests"]``, and to stay clear of
+``tests/unit/conftest.py`` -- which already exists (the autouse auth stub, #1240). The
+``pytest_terminal_summary`` hook below writes its own line regardless of verbosity, so
+it shows even under ``-q``.
+
+The ``requires_engine_build`` marker
+------------------------------------
+Six tests need the compiled ``packages/engine/mcp-server/build/`` (mock_mcp's tool
+catalog and the compiled TS validator). That build is a Makefile prerequisite of
+every ``make`` target and is built in CI, but a bare ``uv run pytest`` in a fresh
+worktree has none: the post-checkout hook links node_modules and the ``.env`` files,
+not ``build/``. Before this marker each test re-probed the dependency by hand; one
+site was forgotten for months (a red that was not a regression, #1265), and the fix
+for that made the skips *dark* -- ``pytest -q`` printed ``N skipped`` and moved on. A
+test that does not run protects nothing, so the drop is stated at session end.
+
+The probe is *behavioral*, not "does ``build/index.js`` exist". Both artifacts return
+their unavailable sentinel (``{}`` / ``None``) whenever the build is absent, ``node``
+is missing, or the engine's node_modules cannot be resolved. A path-existence probe
+would call a no-``node`` machine "build present" and turn three of these skips into
+hard crashes.
+
+Checking the *whole catalog is empty* (not one named tool) is deliberate: a build that
+exists but has lost a tool must FAIL loudly, the same way
+``run_tests._check_mcp_build_fresh`` treats a stale build. Only a wholly absent build
+is a skip; a missing tool is a regression.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import pytest
+
+_ENGINE_BUILD_SKIP_REASON = "engine build absent; run make engine-build"
+
+# Nodeids skipped by the requires_engine_build marker this session, so the terminal
+# summary reports marker-driven skips only -- never terminalreporter.stats["skipped"],
+# which would fold in the suite's unrelated skips. Process-local: the suite runs
+# single-process (no pytest-xdist), so the controller sees every skip; under `-n` the
+# count would need a worker-to-controller channel.
+_engine_build_skips: list[str] = []
+
+
+@lru_cache(maxsize=1)
+def _engine_build_available() -> bool:
+    """True iff the compiled engine build is usable this session.
+
+    Behavioral and computed once (``node`` is spawned at most twice per session, and
+    not at all past the first call). Short-circuits: an empty catalog means the build
+    is gone, so the validator is not probed in that case.
+    """
+    from harness.mock_mcp import _load_build_tool_catalog
+    from harness.ts_validator import validate_parsed
+
+    if not _load_build_tool_catalog():
+        return False
+    return validate_parsed({}, {}) is not None
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    if item.get_closest_marker("requires_engine_build") is None:
+        return
+    if _engine_build_available():
+        return
+    _engine_build_skips.append(item.nodeid)
+    pytest.skip(_ENGINE_BUILD_SKIP_REASON)
+
+
+def pytest_terminal_summary(terminalreporter) -> None:
+    count = len(_engine_build_skips)
+    if count:
+        terminalreporter.write_line(
+            f"{count} test{'' if count == 1 else 's'} skipped: {_ENGINE_BUILD_SKIP_REASON}"
+        )

--- a/eval/harness/tests/unit/test_mock_mcp.py
+++ b/eval/harness/tests/unit/test_mock_mcp.py
@@ -137,6 +137,7 @@ def test_fixture_input_schema_honored_for_tool_absent_from_build():
         assert "query" in tool_obj.input_schema["properties"]
 
 
+@pytest.mark.requires_engine_build
 def test_build_schema_advertised_for_fixture_backed_tool():
     """The core of the drift fix: a fixture-backed tool that exists in the
     compiled build advertises the real production input schema, not a
@@ -144,11 +145,6 @@ def test_build_schema_advertised_for_fixture_backed_tool():
     schema, so the model probed with `{}`). Skips gracefully if the build
     is absent (the loader degrades to a permissive schema, no schema to
     assert)."""
-    from harness.mock_mcp import _load_build_tool_catalog
-
-    if not _load_build_tool_catalog().get("record_person_matches"):
-        pytest.skip("mcp-server build not present; build catalog unavailable")
-
     with tempfile.TemporaryDirectory() as tmp:
         tmp = Path(tmp)
         # A fixture with NO input_schema of its own — the schema must come
@@ -166,16 +162,12 @@ def test_build_schema_advertised_for_fixture_backed_tool():
         assert schema.get("additionalProperties") is not True
 
 
+@pytest.mark.requires_engine_build
 def test_live_tool_advertises_build_schema():
     """Live tools pull their input schema from the same build catalog. The
     `ops` batch array on research_append is the field the old hand-maintained
     mirror once dropped — assert it is advertised. Skips if the build is
     absent."""
-    from harness.mock_mcp import _load_build_tool_catalog
-
-    if not _load_build_tool_catalog().get("research_append"):
-        pytest.skip("mcp-server build not present; build catalog unavailable")
-
     # Live tools register regardless of fixtures, so any fixture set works.
     server, _, tools_by_name = create_mock_server(
         ["wikipedia-search-schuylkill-county"], FIXTURES_DIR
@@ -185,6 +177,7 @@ def test_live_tool_advertises_build_schema():
     assert schema["properties"]["ops"]["type"] == "array"
 
 
+@pytest.mark.requires_engine_build
 def test_record_search_folds_in_ranked_when_subject_given(tmp_path):
     """record_search ranks host-side when given a subjectId, so the mock must
     compose the test's own rank fixture in — otherwise a skill that correctly
@@ -193,11 +186,6 @@ def test_record_search_folds_in_ranked_when_subject_given(tmp_path):
     Skips when the build is absent, like the two tests above: staging runs
     through the COMPILED stager, so with no build `staged` is never set and
     this fails for an environmental reason rather than a real one."""
-    from harness.mock_mcp import _load_build_tool_catalog
-
-    if not _load_build_tool_catalog().get("record_search"):
-        pytest.skip("mcp-server build not present; build catalog unavailable")
-
     server, call_log, tools_by_name = create_mock_server(
         ["record-search-1850-census-flynn", "rank-search-matches-flynn-census"],
         FIXTURES_DIR,

--- a/eval/harness/tests/unit/test_validator_runner.py
+++ b/eval/harness/tests/unit/test_validator_runner.py
@@ -801,14 +801,10 @@ def test_no_duplicate_tree_ids_flags_a_repeat():
     assert ok is not None and ok.passed
 
 
+@pytest.mark.requires_engine_build
 def test_full_validation_catches_reference_integrity():
-    # Drives the compiled TS validateParsed; skip (never fail) when build/ is
-    # absent, matching the validator's own skip-not-fail contract.
-    from harness.ts_validator import validate_parsed
-
-    if validate_parsed({}, {}) is None:
-        pytest.skip("compiled TS validator (build/) unavailable — skip, not fail")
-
+    # Drives the compiled TS validateParsed via _run_universal; the marker skips
+    # (never fails) when build/ is absent, matching the skip-not-fail contract.
     # A dangling ParentChild endpoint passes jsonschema but must fail full
     # validation (reference integrity jsonschema cannot express).
     dangling = {
@@ -822,13 +818,11 @@ def test_full_validation_catches_reference_integrity():
     assert ok is not None and ok.passed, "a clean project must pass full validation"
 
 
+@pytest.mark.requires_engine_build
 def test_full_validation_catches_cross_file_subject_person_id():
     # #987 plan §2/§6: the most likely init-project defect — subject_person_ids
     # naming a person the tree does not contain (init-project hand-writes both).
     from harness.ts_validator import validate_parsed
-
-    if validate_parsed({}, {}) is None:
-        pytest.skip("compiled TS validator (build/) unavailable — skip, not fail")
 
     research = _empty_research_state()["research_json"]
     research = {**research, "project": {**research["project"], "subject_person_ids": ["I9"]}}
@@ -837,15 +831,13 @@ def test_full_validation_catches_cross_file_subject_person_id():
     assert any("subject_person_ids" in e and "I9" in e for e in errors), errors
 
 
+@pytest.mark.requires_engine_build
 def test_validator_crash_is_not_reported_as_missing_build():
     # #987 review finding 1: a node crash (non-zero exit, empty stdout) must NOT
     # be reported as None ("build missing") and silently passed. A bare string in
     # persons trips a TypeError in the TS validator — exactly the malformed tree
     # this feature exists to catch.
     from harness.ts_validator import validate_parsed
-
-    if validate_parsed({}, {}) is None:
-        pytest.skip("compiled TS validator (build/) unavailable — skip, not fail")
 
     research = _empty_research_state()["research_json"]
     crash_tree = {"persons": ["I1"], "relationships": [], "sources": []}


### PR DESCRIPTION
## Summary

Normal tier. Issue #1265. Replaces six hand-rolled "is the compiled engine build present?"
skip-guards in the harness suite with one declared `requires_engine_build` marker plus a
behavioral, session-cached probe, and prints a session-end summary line so a build-absent skip
is stated instead of buried in `-rs` output.

Why it matters: those tests need `packages/engine/mcp-server/build/`, a Makefile prerequisite
of every `make` target that CI always builds, but a bare `uv run pytest` in a fresh worktree
has none. One guard was forgotten for months (a red that was not a regression, the bug behind
this issue), and the fix for that made the skips dark: `pytest -q` printed `N skipped` and
moved on. A test that does not run protects nothing, so the drop is now stated.

## Review guidance

**Start here:** `eval/harness/tests/conftest.py`. The load-bearing pieces are the behavioral
probe `_engine_build_available()` (returns False when the build is absent, `node` is missing,
or node_modules is unresolvable, so a path-existence check would turn three skips into crashes
on a no-`node` machine), and the `pytest_runtest_setup` / `pytest_terminal_summary` pair that
skips marked tests and reports only the marker-driven count.

**Unsure about:** nothing blocking. One deliberate design choice to confirm: the probe uses one
combined gate (catalog present AND validator present), so a rare asymmetric partial build would
skip all six even though three have their real dependency. `tsc` builds `build/` atomically, so
that state cannot arise from `make engine-build`, and the task-reviewer specified the unified
gate. Flagging so it reads as a decision, not an omission.

## Plan

**Didn't change:** `eval/harness/validators/**` (not run by pytest, so a marker there is inert
and deleting its own guard would make asserts pass vacuously); `apps/server/tests/`; the
post-checkout hook (symlinking `build/` into worktrees would silently test main's compiled
output); and `tests/unit/conftest.py` (#1240's autouse auth stub). Behavior tightening: the
mock_mcp tests previously skipped when a specific tool was missing; they now skip only when the
whole catalog is empty, so a build-present-but-tool-missing case fails loudly.

**Acceptance check:** with the build moved aside, `cd eval/harness && uv run --frozen pytest -q`
exits 0, skips exactly the six marked tests, and prints
`6 tests skipped: engine build absent; run make engine-build`; with the build restored, all six
run and no summary line appears. Verified by running (`mv build`), not inspection: build-absent
gave `1593 passed, 6 skipped`, exit 0, summary present; build-present gave `1599 passed`, no
summary. `make harness-test` cannot show this (its `$(ENGINE_BUILD)` prerequisite rebuilds the
thing being removed).

**Deviated from the plan:** nothing.

Step-4 stop rule: not hit. Test-infra only; no schema, auth, plugin-agent binding, or ADR change.

## Test plan

- [x] `make test-all` passed in a single clean run (exit 0): typecheck, JS 248, control-plane
      pytest 135, MCP engine vitest 2046, eval app 148, eval harness 1599 (build present, so the
      6 marker tests ran).
- [x] No skill run-log snapshot changed (touches only `eval/harness/`), so no `make eval-skill`
      run is needed. `check_runlogs.py` marks no skill touched: no eval cost.

Nothing in CI exercises the new skip path or the summary line: `eval-harness-tests.yml` and
every `make` target build the engine first, so both are dark until a fresh worktree hits them.
Called out rather than implied.

## Follow-on issues

None filed. One optional item the task-reviewer flagged and I did not build: a pytester test of
the hook, so a later refactor cannot silently delete it. CI never exercises the skip path, so
there is a real argument for it, but testing the real conftest hook via pytester means
replicating it in an isolated dir (testing a copy, not the real hook), so its value is limited
and the specified acceptance is the manual `mv build` check. Happy to add it, or file it, if you
want it tracked.

Closes #1265.
