### PR TITLE
test: fix two Windows-only POSIX path assumptions in the test suite

### DIFF
--- a/apps/electron/src/main/__tests__/feedback.test.ts
+++ b/apps/electron/src/main/__tests__/feedback.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdtemp, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, isAbsolute } from 'node:path'
 import JSZip from 'jszip'
 import {
   buildFeedbackZip,
@@ -101,7 +101,7 @@ describe('buildFeedbackZip — feedback.json', () => {
     const result = await buildFeedbackZip(makeOptions(folder))
     const payload = await readFeedbackJson(result.zipBase64)
     expect(typeof payload.project_folder_path).toBe('string')
-    expect((payload.project_folder_path as string).startsWith('/')).toBe(true)
+    expect(isAbsolute(payload.project_folder_path as string)).toBe(true)
   })
 
   it('emits submitted_at as an ISO 8601 UTC string with Z suffix', async () => {

--- a/packages/engine/mcp-server/tests/packaging/doc-links.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/doc-links.test.ts
@@ -382,7 +382,7 @@ function docsMarkdown(root: string): string[] {
         if (entry === "plan") continue;
         walk(full);
       } else if (entry.endsWith(".md")) {
-        out.push(relative(root, full));
+        out.push(relative(root, full).replace(/\\/g, "/"));
       }
     }
   };


### PR DESCRIPTION
Both suites pass on Linux CI but fail on native Windows. (1) doc-links.test.ts: docsMarkdown built its lookup keys with relative(), which yields backslash paths on Windows, so they never matched the forward-slash keys in GRANDFATHERED_LINE_CITES and every grandfathered line-cite was falsely flagged as an offender; normalize separators to '/'. (2) feedback.test.ts: the absolute-path assertion used startsWith('/'), which is POSIX-only; use path.isAbsolute so a Windows C:\ path is accepted too. After this, make test-all is green on native Windows except gen-enums-guards.test.ts (a shebang in an imported .mjs not stripped on Windows), filed separately.

## Summary

- Fix two Windows-only failures in `make test-all` — both suites pass on Linux CI but fail on native Windows:
  - **doc-links.test.ts** (engine): `docsMarkdown` built its lookup keys via `relative()`, which yields backslash paths on Windows; those never matched the forward-slash keys in `GRANDFATHERED_LINE_CITES`, so every grandfathered line-cite was falsely flagged as an offender. Normalize separators to `/`.
  - **feedback.test.ts** (electron): the absolute-path assertion used `startsWith('/')` (POSIX-only); use `path.isAbsolute` so a Windows `C:\…` path is accepted. Production code is unchanged.
- **Tier: Trivial** — two one-line, test-only fixes with an obvious cause.
- After this, `make test-all` is green on native Windows **except** `gen-enums-guards.test.ts` (a shebang in an imported `.mjs` not stripped on Windows), filed as #1370.

## Review guidance

**Start here:** the two changed lines. Both are test-only separator / absolute-path portability fixes — production code is untouched and correct, and both suites stay green on Linux CI.

**Unsure about:** Nothing — each failure reproduces on native Windows and passes after the fix.

## Test plan

- [ ] `make test-all` — run on **Windows**. The doc-links and feedback suites now pass; the only remaining failure is `gen-enums-guards.test.ts` (#1370, separate root cause). CI (Linux) runs the same suites and is fully green for this change.
- [ ] Skill run-log snapshot — **N/A**: test-only edits; no skill dir, delegated agent, or `eval/tests/unit/<skill>/` touched.

## Follow-on issues

- #1370 — `gen-enums-guards.test.ts` shebang-in-`.mjs` failure on native Windows (the one remaining Windows `make test-all` failure).