### PR TITLE
feat(e2e): record run provenance (git_sha + skills_hash) so a run tie…

### DIFF
--- a/docs/specs/e2e-test-spec.md
+++ b/docs/specs/e2e-test-spec.md
@@ -1146,6 +1146,8 @@ editing one unreadable line, and it had already accreted a duplicated clause.
 | `cli_version` | So a harness-vs-Cowork gap can be checked against a CLI-version delta. |
 | `timeline[]` | Per-message `[elapsed_seconds, kind]`, plus the `caps` used. |
 | `subagents[]` | One summary per plugin subagent from the SDK's ephemeral cache: `agent_type`, per-turn `stop_reason` / `output_tokens` / block shape, and `runaway_thinking` (a turn that hit `max_tokens` on thinking alone with no tool call). The runlog stores no subagent transcript, so this is what makes a subagent freeze diagnosable from the committed log rather than only from `subagent_capture.py`'s local cache. |
+| `git_sha` | `git rev-parse HEAD` at run start, or `null` outside a checkout. The tree the run started from — check it out to reproduce. §8.1.3. |
+| `skills_hash` | One sha256 over the sorted `{path: hash}` of every skill + agent file the run staged. Ties the run to the prompt that produced it — and unlike `git_sha` catches an **uncommitted** SKILL.md edit. §8.1.3. |
 
 Together the five reasoning-config fields (`agent_model` through `cli_version`)
 make an A/B across model × effort × output-budget self-describing from the log
@@ -1163,6 +1165,38 @@ A PreToolUse **deny** does reach this array: the denied call appears with the
 deny reason as its `response_summary` and `is_error: true`. `blocked_tree_reads`
 is the parallel structured record, not the only one — which is why an
 `is_error: true` entry is not automatically an upstream failure (§15).
+
+#### 8.1.3 `git_sha` / `skills_hash` — run provenance
+
+These two fields exist because a graded run once landed alongside a
+`search-records` SKILL.md edit and claimed to demonstrate it, yet nothing in the
+committed artifact said which skill version had run — the reconstruction from the
+transcript contradicted the claim. They make that claim checkable.
+
+`skills_hash` is a **single digest**, not a per-file map and not a full snapshot.
+The trade, measured when it was decided: a full snapshot (the unit-runlog form)
+was 43% of every unit run log's bytes, storing prose nothing reads back — e2e
+runs are not gated on activeness, so the content is never diffed. A per-file
+`{path: hash}` map names *which* file changed but costs ~15.8 KB/run (≈6% of the
+263 KB median e2e envelope) to answer what `git_sha` plus a re-hash already answer
+whenever the tree was clean. So the identity, not the content, is what is stored.
+
+It hashes **exactly what `build_workspace` stages** — every non-dot subdirectory
+of the skills dir, recursively, plus the top-level agent `.md` files — and
+nothing else. The fixture, `eval/tests/unit/**`, MCP fixtures, and the compiled
+engine are deliberately out of scope: folding any of them in would flip the hash
+on every record-hint-resolution PR and destroy the signal. (`__pycache__` and
+dotfiles a `copytree` would carry are excluded as gitignored non-prompt noise.)
+Implementation: `eval/harness/e2e/provenance.py`.
+
+**Known limit, by design:** a hash proves *whether* two runs used the same
+prompt; it can never tell you *what* changed. When the diff is needed, the git
+SHA plus the hash reconstruct it from the repo in the common case where the tree
+was clean. Like the absence of a `skills_invoked` field (§15), this is a chosen
+boundary, not an oversight — and, like every provenance field here, it is
+**evidence for a human reviewer, not a CI gate**: an e2e run is graded days after
+the tree has moved, so a "committed hash matches working tree" check would red
+every e2e PR.
 
 #### 8.1.2 `usage` when the `ResultMessage` never arrived
 

--- a/docs/specs/e2e-test-spec.md
+++ b/docs/specs/e2e-test-spec.md
@@ -1147,7 +1147,7 @@ editing one unreadable line, and it had already accreted a duplicated clause.
 | `timeline[]` | Per-message `[elapsed_seconds, kind]`, plus the `caps` used. |
 | `subagents[]` | One summary per plugin subagent from the SDK's ephemeral cache: `agent_type`, per-turn `stop_reason` / `output_tokens` / block shape, and `runaway_thinking` (a turn that hit `max_tokens` on thinking alone with no tool call). The runlog stores no subagent transcript, so this is what makes a subagent freeze diagnosable from the committed log rather than only from `subagent_capture.py`'s local cache. |
 | `git_sha` | `git rev-parse HEAD` at run start, or `null` outside a checkout. The tree the run started from — check it out to reproduce. §8.1.3. |
-| `skills_hash` | One sha256 over the sorted `{path: hash}` of every skill + agent file the run staged. Ties the run to the prompt that produced it — and unlike `git_sha` catches an **uncommitted** SKILL.md edit. §8.1.3. |
+| `skills_hash` | One sha256 over the sorted `{path: hash}` of every skill + agent **source** file the run stages. Ties the run to the prompt that produced it — and unlike `git_sha` catches an **uncommitted** SKILL.md edit. Does not move with `--agent-model` (read `subagent_model_override` alongside it). §8.1.3. |
 
 Together the five reasoning-config fields (`agent_model` through `cli_version`)
 make an A/B across model × effort × output-budget self-describing from the log
@@ -1165,6 +1165,25 @@ A PreToolUse **deny** does reach this array: the denied call appears with the
 deny reason as its `response_summary` and `is_error: true`. `blocked_tree_reads`
 is the parallel structured record, not the only one — which is why an
 `is_error: true` entry is not automatically an upstream failure (§15).
+
+#### 8.1.2 `usage` when the `ResultMessage` never arrived
+
+Every abort path (wall-clock timeout, inactivity silence, no-progress stall) cuts
+the stream before that message, which used to leave `usage` with no turns,
+duration or tokens at all — blinding exactly the runs worth investigating. The
+fallback reconstructs the block from the streamed assistant messages:
+
+- token counts are **exact**, deduplicated by message id (the SDK re-emits one
+  message per content block, each copy repeating that message's *cumulative*
+  usage, so summing on arrival multiplies the totals);
+- `duration_ms` comes from the monotonic clock;
+- the distinct-message count is reported as `assistant_messages`;
+- `num_turns`, `duration_api_ms` and `total_cost_usd` are **null** rather than
+  synthesized — the SDK counts turns differently from distinct assistant
+  messages, only it knows the API/local split, and a run spans several models so
+  one price lookup would be wrong.
+
+**Never compare a `streamed_fallback` cost against a clean run's.**
 
 #### 8.1.3 `git_sha` / `skills_hash` — run provenance
 
@@ -1189,6 +1208,12 @@ on every record-hint-resolution PR and destroy the signal. (`__pycache__` and
 dotfiles a `copytree` would carry are excluded as gitignored non-prompt noise.)
 Implementation: `eval/harness/e2e/provenance.py`.
 
+It hashes the **source** files, not the staged copies, so a `--agent-model` run
+(which rewrites each staged agent's `model:` frontmatter — see
+`_override_agent_model`) carries the same `skills_hash` as an unforced run of the
+same tree. That override is recorded separately as `subagent_model_override`;
+read the two together.
+
 **Known limit, by design:** a hash proves *whether* two runs used the same
 prompt; it can never tell you *what* changed. When the diff is needed, the git
 SHA plus the hash reconstruct it from the repo in the common case where the tree
@@ -1197,25 +1222,6 @@ boundary, not an oversight — and, like every provenance field here, it is
 **evidence for a human reviewer, not a CI gate**: an e2e run is graded days after
 the tree has moved, so a "committed hash matches working tree" check would red
 every e2e PR.
-
-#### 8.1.2 `usage` when the `ResultMessage` never arrived
-
-Every abort path (wall-clock timeout, inactivity silence, no-progress stall) cuts
-the stream before that message, which used to leave `usage` with no turns,
-duration or tokens at all — blinding exactly the runs worth investigating. The
-fallback reconstructs the block from the streamed assistant messages:
-
-- token counts are **exact**, deduplicated by message id (the SDK re-emits one
-  message per content block, each copy repeating that message's *cumulative*
-  usage, so summing on arrival multiplies the totals);
-- `duration_ms` comes from the monotonic clock;
-- the distinct-message count is reported as `assistant_messages`;
-- `num_turns`, `duration_api_ms` and `total_cost_usd` are **null** rather than
-  synthesized — the SDK counts turns differently from distinct assistant
-  messages, only it knows the API/local split, and a run spans several models so
-  one price lookup would be wrong.
-
-**Never compare a `streamed_fallback` cost against a clean run's.**
 
 Any **gradeable** run — verdict `pass`, `partial`, or `fail` — is committed
 under the `run-<timestamp>.*` names above and must be graded (§7.4). A committed

--- a/eval/harness/e2e/orchestrator.py
+++ b/eval/harness/e2e/orchestrator.py
@@ -54,6 +54,7 @@ from harness.skill_invocation import (
     unguarded_new_person_evidence_links,
 )
 
+from e2e import provenance
 from e2e.result import E2eResult, timestamp_slug, write_result_files
 from e2e.stop_checker import (
     derive_stop_reason,
@@ -1742,6 +1743,15 @@ async def run_e2e_test(
 
     started_at = time.time()  # real clock (counts system sleep)
     started_mono = time.monotonic()  # active clock (pauses during macOS sleep)
+
+    # Provenance (#1091), captured at run start from the repo files this run
+    # stages — the prompt identity, so a committed run ties back to what produced
+    # it. `agents_dir` MUST match the one `build_workspace` uses below (it takes
+    # its default, DEFAULT_PLUGIN_AGENTS); if an `--agents-dir` override is ever
+    # threaded there, thread it here too or the hash silently diverges.
+    run_git_sha = provenance.git_sha(REPO_ROOT)
+    run_skills_hash = provenance.skills_hash(skills_dir, DEFAULT_PLUGIN_AGENTS)
+
     with tempfile.TemporaryDirectory(prefix=f"e2e-{fixture.id}-") as tmp:
         workspace = build_workspace(
             fixture, Path(tmp), skills_dir, effort_level=effort_level, agent_model=agent_model
@@ -1866,6 +1876,8 @@ async def run_e2e_test(
             guardrail_shadow_violations=guardrail_shadow_violations,
             protected_writes_by_unnamed_delegate=unnamed_delegate_violations,
             subagents=subagents,
+            git_sha=run_git_sha,
+            skills_hash=run_skills_hash,
         )
 
         runlog_dir = runlog_root / fixture.id

--- a/eval/harness/e2e/provenance.py
+++ b/eval/harness/e2e/provenance.py
@@ -1,0 +1,125 @@
+"""Provenance of an e2e run — which prompt produced it.
+
+GitHub issue #1091. An e2e run log records the run's result but not the prompt
+it ran: a graded run committed alongside a SKILL.md edit could not be tied to the
+version of the skill that produced it (PR #1079, the case that filed this). Two
+small fields close that:
+
+- ``git_sha`` — ``git rev-parse HEAD`` at run start. Lets a reviewer check out
+  the exact tree the run started from.
+- ``skills_hash`` — a single sha256 over the sorted ``{path: hash}`` map of every
+  skill and agent file the run **stages**. Unlike ``git_sha`` it also catches an
+  *uncommitted* local edit to a SKILL.md — the PR #1079 situation exactly — since
+  it hashes working-tree content, not a commit.
+
+**Decided (2026-08-01, refined 2026-08-04): a single digest, not a full
+snapshot, and not a per-file map.** A full snapshot would add ~43% to a corpus
+issue #985 is actively shrinking, to store prose nothing reads back (e2e runs are
+not gated on activeness, so the content is never diffed). A per-file map answers
+"which file changed" but costs ~15.8 KB/run to answer what a git SHA plus a
+re-hash already answer whenever the tree was clean.
+
+**Known limit, by design:** a hash proves *whether* two runs used the same
+prompt; it can never tell you *what* changed. Reconstruct the diff from the git
+SHA plus the hash when the tree was clean.
+
+This is **evidence for a human reviewer, not a gate.** An e2e run is graded days
+after the tree has moved, so any "committed hash matches working tree" check would
+red every e2e PR. Nothing in CI reads these fields.
+
+Reuses ``normalize`` / ``hash_content`` from ``harness.snapshot`` (importing
+``harness.*`` from ``e2e.*`` is the established pattern). It deliberately does
+**not** call ``harness.snapshot.build_snapshot``: that is the unit harness's
+per-skill function — it covers one skill dir plus ``eval/tests/unit/<skill>/**``
+plus that skill's MCP fixtures, none of which is what an e2e run executes.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from harness.snapshot import hash_content, normalize
+
+def _is_excluded(parts: tuple[str, ...]) -> bool:
+    """A staged file dropped from the hash — mirrors `harness.snapshot._embed_tree`.
+
+    `build_workspace`'s `copytree` carries dotfiles and `__pycache__`, but they
+    are gitignored non-prompt noise; dropping them keeps the hash stable across a
+    local harness run that left a `.pyc` in a skill's `scripts/` dir.
+    """
+    return any(p.startswith(".") or p == "__pycache__" for p in parts)
+
+
+def staged_file_hashes(skills_dir: Path, agents_dir: Path) -> dict[str, str]:
+    """`{staging-relative path: sha256(normalized content)}` for exactly the
+    prompt files `orchestrator.build_workspace` stages, minus dotfiles/__pycache__.
+
+    Mirrors `build_workspace` (`orchestrator.py`): every **non-dot subdirectory**
+    of `skills_dir`, recursively, plus `agents_dir.glob("*.md")` top level only.
+    Loose files directly in `skills_dir` are not staged, so they are not hashed.
+
+    Keys are **staging-relative** (`skills/<skill>/...`, `agents/<name>.md`), not
+    repo-relative, so a `--skills-dir` pointing outside the repo still hashes
+    deterministically. The key's extension is all `normalize` needs; none live
+    under `eval/tests/unit/`, so its cosmetic-test-field strip never fires here.
+    """
+    out: dict[str, str] = {}
+
+    skills_dir = Path(skills_dir)
+    if skills_dir.is_dir():
+        for skill in sorted(skills_dir.iterdir()):
+            if not skill.is_dir() or skill.name.startswith("."):
+                continue
+            for path in sorted(skill.rglob("*")):
+                if not path.is_file():
+                    continue
+                rel_parts = path.relative_to(skill).parts
+                if _is_excluded(rel_parts):
+                    continue
+                key = "skills/" + path.relative_to(skills_dir).as_posix()
+                out[key] = hash_content(normalize(key, path.read_bytes()))
+
+    agents_dir = Path(agents_dir)
+    if agents_dir.is_dir():
+        for agent_file in sorted(agents_dir.glob("*.md")):
+            key = "agents/" + agent_file.name
+            out[key] = hash_content(normalize(key, agent_file.read_bytes()))
+
+    return out
+
+
+def skills_hash(skills_dir: Path, agents_dir: Path) -> str:
+    """One sha256 over the sorted `{path: hash}` map — the run's prompt identity.
+
+    Built from `staged_file_hashes` so a test can inspect the map (which file is
+    in scope) while the run stores only the ~40-byte digest.
+    """
+    file_map = staged_file_hashes(skills_dir, agents_dir)
+    return hash_content(json.dumps(file_map, sort_keys=True, ensure_ascii=False))
+
+
+def git_sha(repo_root: Path) -> str | None:
+    """`git rev-parse HEAD` at `repo_root`, or `None` on any failure.
+
+    Best-effort — never raises, so a run outside a git checkout (or with no git on
+    PATH) still logs; the field is simply absent. Matches the capture helpers'
+    posture (`subagent_capture`, the session-transcript copy): provenance must
+    never fail an otherwise-loggable run.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    sha = out.stdout.strip()
+    return sha or None

--- a/eval/harness/e2e/result.py
+++ b/eval/harness/e2e/result.py
@@ -19,6 +19,10 @@ The three files per run ({prefix} = `run-` or `scratch_`):
 - {prefix}<timestamp>.final-tree.gedcomx.json — agent's final tree
 - {prefix}<timestamp>.final-research.json — agent's final research.json
 
+Each run also carries provenance (issue #1091): `git_sha` (the tree it started
+from) and `skills_hash` (a digest of the skill + agent prompts it staged), so a
+committed run can be tied to the prompt that produced it. See e2e/provenance.py.
+
 See e2e-test-spec.md §8.
 """
 
@@ -197,6 +201,19 @@ class E2eResult:
     # forbidden to read `judge_output` at all, so burying it there made it
     # invisible to the one reader whose job is explaining a run (issue #972).
     guardrail_bypass_violations: list[str] = field(default_factory=list)
+
+    # Provenance — which prompt produced this run (issue #1091). Both default so
+    # every historical run log stays a valid E2eResult. See e2e/provenance.py.
+    #
+    # `git_sha` — `git rev-parse HEAD` at run start; lets a reviewer check out the
+    # exact tree. `skills_hash` — one sha256 over the sorted {path: hash} of every
+    # skill + agent file the run staged; catches an UNCOMMITTED SKILL.md edit that
+    # `git_sha` cannot (the PR #1079 case this was filed for), since it hashes
+    # working-tree content. Known limit: a hash proves WHETHER two runs used the
+    # same prompt, never WHAT changed — reconstruct that from the SHA + a re-hash
+    # on a clean tree. Evidence for a reviewer, not a gate: no CI reads either.
+    git_sha: str | None = None
+    skills_hash: str | None = None
 
     # Schema marker for readers. See HARNESS_SCHEMA_VERSION.
     harness_schema_version: int = HARNESS_SCHEMA_VERSION

--- a/eval/harness/e2e/result.py
+++ b/eval/harness/e2e/result.py
@@ -246,8 +246,10 @@ class E2eResult:
     # because it is a `default_factory` field its key is emitted
     # unconditionally — which makes its mere PRESENCE the only reliable
     # fingerprint of "the code that wrote this runlog had the detector" for
-    # the 122 pre-v1 logs. There is no other signal: `usage.cli_version` is
-    # absent or null in every committed run, and nothing records a git sha.
+    # the 122 pre-v1 logs. There is no other signal *on those logs*:
+    # `usage.cli_version` is absent or null in every committed run, and none of
+    # them records a git sha. (`git_sha` below landed later — issue #1091 — so it
+    # fingerprints runs from that point on, not the pre-v1 corpus this is about.)
     # `test_e2e_result.py` pins the 6 known-fingerprint runs so removing this
     # field fails loudly instead of silently reclassifying them.
     # (Logs written from HARNESS_SCHEMA_VERSION >= 1 carry `compliance`

--- a/eval/harness/tests/unit/test_e2e_result.py
+++ b/eval/harness/tests/unit/test_e2e_result.py
@@ -628,3 +628,116 @@ def test_no_transcript_artifact_is_written(tmp_path: Path):
     )
     assert "transcript" not in paths
     assert list(tmp_path.glob("*.transcript.md")) == []
+
+
+# --- Provenance: git_sha + skills_hash (issue #1091) ------------------------
+
+
+def _mini_skill_tree(tmp_path: Path) -> tuple[Path, Path]:
+    """A synthetic, dotfile-free skills/ + agents/ pair — no __pycache__ or
+    dotfile for `copytree` and the helper to diverge on (see the equality test).
+    Includes a nested `references/*.md` and a LOOSE file directly in skills/
+    (which build_workspace does NOT stage) to pin both edges."""
+    skills = tmp_path / "skills"
+    agents = tmp_path / "agents"
+    skill = skills / "search-records"
+    (skill / "references").mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# search-records\n", encoding="utf-8")
+    (skill / "references" / "guide.md").write_text("guide\n", encoding="utf-8")
+    (skills / "README.md").write_text("loose — not under a skill subdir\n", encoding="utf-8")
+    agents.mkdir()
+    (agents / "gps-mentor.md").write_text("---\nname: gps-mentor\n---\nbody\n", encoding="utf-8")
+    return skills, agents
+
+
+def test_skills_hash_covers_exactly_what_build_workspace_stages(tmp_path: Path):
+    """The under-scoping guard: the helper's key set must equal the file set
+    `build_workspace` actually stages under .claude/skills + .claude/agents. A
+    wrong hash is otherwise a plausible-looking 64-hex string nothing catches.
+    """
+    from types import SimpleNamespace
+
+    from e2e import provenance
+    from e2e.orchestrator import build_workspace
+
+    skills, agents = _mini_skill_tree(tmp_path)
+    research = tmp_path / "research.json"
+    tree = tmp_path / "tree.gedcomx.json"
+    research.write_text("{}", encoding="utf-8")
+    tree.write_text("{}", encoding="utf-8")
+    # `dir` is read for a `provided-documents/` subdir (absent here); the other
+    # two are the only fixture attrs build_workspace copies.
+    fixture = SimpleNamespace(
+        dir=tmp_path, starting_research_path=research, starting_tree_path=tree
+    )
+
+    target = tmp_path / "ws"
+    target.mkdir()
+    build_workspace(fixture, target, skills, agents_dir=agents)
+
+    staged: set[str] = set()
+    for base, prefix in ((target / ".claude" / "skills", "skills"),
+                         (target / ".claude" / "agents", "agents")):
+        for p in base.rglob("*"):
+            if p.is_file():
+                staged.add(f"{prefix}/{p.relative_to(base).as_posix()}")
+
+    keys = set(provenance.staged_file_hashes(skills, agents))
+    assert keys == staged, f"hash scope != staged scope: {keys ^ staged}"
+    # The loose file in the skills root is staged by neither — build_workspace
+    # only descends non-dot subdirs.
+    assert "skills/README.md" not in keys
+
+
+def test_skills_hash_changes_on_a_staged_file_and_not_on_an_excluded_one(tmp_path: Path):
+    """Mutating a staged prompt file moves the digest; a __pycache__/dotfile the
+    run would carry but that is not prompt content does not."""
+    from e2e import provenance
+
+    skills, agents = _mini_skill_tree(tmp_path)
+    h0 = provenance.skills_hash(skills, agents)
+
+    # A nested staged file moves the hash.
+    (skills / "search-records" / "references" / "guide.md").write_text("CHANGED\n", encoding="utf-8")
+    h1 = provenance.skills_hash(skills, agents)
+    assert h1 != h0
+
+    # An agent edit moves it too.
+    (agents / "gps-mentor.md").write_text("---\nname: gps-mentor\n---\nedited\n", encoding="utf-8")
+    h2 = provenance.skills_hash(skills, agents)
+    assert h2 != h1
+
+    # A __pycache__ file and a dotfile inside a skill do NOT — they are excluded.
+    pyc = skills / "search-records" / "scripts" / "__pycache__"
+    pyc.mkdir(parents=True)
+    (pyc / "helper.cpython-312.pyc").write_bytes(b"\x00compiled")
+    (skills / "search-records" / ".DS_Store").write_bytes(b"junk")
+    assert provenance.skills_hash(skills, agents) == h2
+
+
+def test_e2e_result_carries_provenance_keys_with_defaults():
+    """Both keys serialize through asdict(), defaulting to None so every
+    historical run log stays a valid E2eResult."""
+    r = E2eResult(
+        test_id="t", captured_at="2026-05-26_14-30-45",
+        verdict="pass", stop_reason="completed",
+    )
+    d = dataclasses.asdict(r)
+    assert d["git_sha"] is None
+    assert d["skills_hash"] is None
+
+    populated = E2eResult(
+        test_id="t", captured_at="2026-05-26_14-30-45",
+        verdict="pass", stop_reason="completed",
+        git_sha="a" * 40, skills_hash="b" * 64,
+    )
+    pd = dataclasses.asdict(populated)
+    assert pd["git_sha"] == "a" * 40
+    assert pd["skills_hash"] == "b" * 64
+
+
+def test_git_sha_returns_none_outside_a_git_repo(tmp_path: Path):
+    """Best-effort: a run outside a checkout logs no SHA rather than raising."""
+    from e2e import provenance
+
+    assert provenance.git_sha(tmp_path) is None


### PR DESCRIPTION
research-plan… no — **e2e: record run provenance (git_sha + skills_hash) so a committed run ties to its prompt (#1091)**

A committed e2e run recorded its result but not the prompt that produced it, so a graded run landing alongside a SKILL.md edit could not be tied to the skill version that ran. Add two fields to the e2e run-log envelope:

- `git_sha` — `git rev-parse HEAD` at run start (check out the exact tree)
- `skills_hash` — one sha256 over the sorted `{path: hash}` of every skill + agent file the run stages; catches an UNCOMMITTED SKILL.md edit `git_sha` cannot

New helper `e2e/provenance.py` reuses `harness.snapshot.normalize`/`hash_content` and hashes exactly what `build_workspace` stages (non-dot skill subdirs + top-level agent `.md`), minus dotfiles/`__pycache__`. A single digest, not a full snapshot (would add ~43% to a corpus #985 is shrinking) and not a per-file map. Evidence for a reviewer, not a CI gate: no bump to HARNESS_SCHEMA_VERSION, no schema mirror, no CI check. Documented in `e2e-test-spec.md` §8.1.3.

## Summary

- Adds `git_sha` + `skills_hash` to the e2e run-log envelope so a committed run can be tied back to the exact prompt (skill + agent files) that produced it — the gap PR #1079 exposed.
- Single digest, not a full snapshot or per-file map: identity, not content, is what was missing. No `HARNESS_SCHEMA_VERSION` bump, no schema mirror, no CI gate — evidence for a reviewer.
- Tier: **Normal**.

## Review guidance

**Start here:** `eval/harness/e2e/provenance.py::staged_file_hashes` — it must hash **exactly** what `build_workspace` stages (non-dot skill subdirs, recursive, + top-level agent `.md`) and nothing else; under/over-scoping is the whole failure mode, and a wrong hash is a plausible-looking 64-hex string. The acceptance test asserts the helper's key set equals what `build_workspace` actually stages — I broke the helper two ways to confirm it goes red. Also worth a glance: `orchestrator.py` hashes agents from `DEFAULT_PLUGIN_AGENTS`, correct only because the single `build_workspace` call site takes that default — there's a comment tying them so a future `--agents-dir` can't silently diverge the hash.

**Unsure about:** Nothing structural. One judgment call: entries are keyed staging-relative (`skills/…`, `agents/…`) not repo-relative, so a `--skills-dir` outside the repo still hashes — flag if you'd rather repo-relative.

## Plan

**Didn't change:** No `HARNESS_SCHEMA_VERSION` bump (additive fields with defaults — the rule at `result.py:47-54`). No `run-log.schema.json` mirror (that's the *unit* envelope; the e2e result has none). No CI check on the fields (a run is graded days after the tree moves, so a "hash matches working tree" rule would red every e2e PR).

**Acceptance check:** `eval/harness/tests/unit/test_e2e_result.py::test_skills_hash_covers_exactly_what_build_workspace_stages` — fails on `main` (module `e2e.provenance` absent), passes here; it stages a synthetic tree through the real `build_workspace` and asserts its file set equals the helper's key set.

**Deviated from the plan:** Nothing structural. Post-`/critique-plan` I tightened three flagged points (stated the "minus dotfiles/`__pycache__`" invariant precisely, tied the agents constant to what `build_workspace` uses, named the #1239 test-file collision). An independent code-review pass then found no critical issues and one doc nit (§8.1.3 sat before §8.1.2), now fixed. Did **not** hit the step-4 stop rule.

## Test plan

- [x] Ran `make test-all`. Every suite this PR affects is green: eval harness pytest **1603**, engine vitest doc-links **113**, control-plane **135**, eval-app **148**. One unrelated failure — `apps/electron … buildFeedbackZip > drops the largest files …` times out at 5000ms; it's in `apps/electron` (untouched here) and is the known flake **#1366**.
- [x] N/A — no skill run-log snapshot changed. Harness-only change (`eval/harness/**` + a spec doc); `check_runlogs` marks no skill touched, so no `make eval-skill` run is owed.

## Follow-on issues

None. If a reviewer ever needs the prompt *diff* (not just identity), `git_sha` + `skills_hash` reconstruct it from the repo on a clean tree — recorded in §8.1.3, not refiled.

**Dependency:** land after **#1239** (open) — it edits all four of my existing files; conflicts are additive and I'll rebase once it merges.
