### PR TITLE
fix(e2e): abort fast when the genealogy MCP server never connects

### DIFF
--- a/eval/harness/e2e/orchestrator.py
+++ b/eval/harness/e2e/orchestrator.py
@@ -57,6 +57,8 @@ from harness.skill_invocation import (
 from e2e.result import E2eResult, timestamp_slug, write_result_files
 from e2e.stop_checker import (
     derive_stop_reason,
+    genealogy_mcp_status,
+    genealogy_mcp_terminal_fault,
     read_research_json,
     read_tree_json,
     should_continue_run,
@@ -71,6 +73,16 @@ DEFAULT_RUNLOG_ROOT = REPO_ROOT / "eval" / "runlogs" / "e2e"
 DEFAULT_FIXTURES_ROOT = REPO_ROOT / "eval" / "tests" / "e2e"
 DEFAULT_PLUGIN_SKILLS = REPO_ROOT / "packages" / "engine" / "plugin" / "skills"
 DEFAULT_PLUGIN_AGENTS = REPO_ROOT / "packages" / "engine" / "plugin" / "agents"
+
+# MCP connection guard (stop_checker.genealogy_mcp_*). When the init message
+# reports the genealogy MCP server still `pending` (not yet connected), give it
+# this many tool calls to actually produce a reachable genealogy tool before
+# concluding it never will and aborting. Generous on purpose: it only arms when
+# init already flagged the server as not-connected, and a healthy /research flow
+# reaches a genealogy tool well within this budget — so a `connected` run never
+# trips it. A terminal status (failed/needs-auth/disabled) aborts at init and
+# never waits for this. See the never-reachable watchdog in _run_and_collect.
+MCP_UNREACHABLE_TOOLCALL_LIMIT = 25
 
 
 # Tools always allowed alongside MCP tools. See e2e-test-spec.md §6.
@@ -779,6 +791,16 @@ def _timeline_tool_label(tool: str, args: dict | None) -> str:
     return _bare_tool_name(tool)
 
 
+def _is_genealogy_tool_name(name: str) -> bool:
+    """Whether a tool-call name belongs to the genealogy MCP server, under
+    either server spelling (the e2e harness registers it as `genealogy`; the
+    Cowork remote-device bridge namespaces it `Genealogy_Research`). Used by
+    the never-reachable watchdog to tell a real genealogy tool call from the
+    ToolSearch/filesystem flailing that happens when the server never connects.
+    """
+    return name.startswith("mcp__genealogy__") or "Genealogy_Research__" in name
+
+
 _USAGE_FIELDS = (
     "input_tokens",
     "output_tokens",
@@ -917,6 +939,15 @@ async def _run_agent(
     usage: dict[str, Any] = {}
     aborted_reason: str | None = None
     error: str | None = None
+    # MCP connection guard state. `mcp_servers_init` is the raw `mcp_servers`
+    # list from the init system message (persisted in the runlog for diagnosis);
+    # `genealogy_init_status` is the genealogy server's status from it; and
+    # `genealogy_tool_seen` flips true the first time a genealogy MCP tool call
+    # appears. Together they drive the fast-abort so a server that never connects
+    # doesn't burn the whole run budget. See MCP_UNREACHABLE_TOOLCALL_LIMIT.
+    mcp_servers_init: dict[str, Any] = {"v": None}
+    genealogy_init_status: dict[str, str | None] = {"v": None}
+    genealogy_tool_seen = {"v": False}
     # mcp__-only, for the tool_calls budget cap. Distinct from activity_count
     # below, which powers the no-progress stop check.
     tool_call_count = {"n": 0}
@@ -1396,6 +1427,8 @@ async def _run_agent(
                                 _emit(f">> skill: {(block.input or {}).get('skill', '?')}")
                             elif block.name.startswith("mcp__"):
                                 _emit(f"   - {_bare_tool_name(block.name)}")
+                                if _is_genealogy_tool_name(block.name):
+                                    genealogy_tool_seen["v"] = True
                             progressed = True
                     # Record before the timeline append so a message that
                     # arrives moments before a timeout still counts.
@@ -1403,6 +1436,26 @@ async def _run_agent(
                     timeline.append(
                         [round(now - run_started, 1), "assistant", assistant_tool_names]
                     )
+                    # MCP never-reachable watchdog: init reported the genealogy
+                    # server still `pending`, and it has produced no reachable
+                    # tool after many calls — it is not going to connect. Abort
+                    # before the whole budget is spent flailing (issue #1354).
+                    if (
+                        aborted_reason is None
+                        and genealogy_init_status["v"] == "pending"
+                        and not genealogy_tool_seen["v"]
+                        and len(tool_calls) >= MCP_UNREACHABLE_TOOLCALL_LIMIT
+                    ):
+                        aborted_reason = "error"
+                        error = (
+                            "genealogy MCP server never left 'pending' — no "
+                            f"genealogy tool was reachable across {len(tool_calls)} "
+                            "tool calls, so the agent could not research. The MCP "
+                            "server did not connect; rebuild/reconnect it (see "
+                            "docs/e2e-testing-guide.md) and re-run."
+                        )
+                        _emit(f"[mcp-guard] {error}")
+                        return
                 elif isinstance(message, UserMessage):
                     # Tool results return as UserMessages with ToolResultBlock content.
                     content = message.content
@@ -1447,6 +1500,27 @@ async def _run_agent(
                     ver = data.get("version") or data.get("cli_version")
                     if ver:
                         cli_version["v"] = ver
+                    if message.subtype == "init":
+                        # MCP connection guard. The CLI reports each server's
+                        # connection state here. A terminal fault (failed /
+                        # needs-auth / disabled / absent) will never recover, so
+                        # abort now rather than let the agent flail for tools
+                        # that never arrive. `pending` is left to the
+                        # never-reachable watchdog in the tool-call branch below.
+                        servers = data.get("mcp_servers")
+                        mcp_servers_init["v"] = servers
+                        genealogy_init_status["v"] = genealogy_mcp_status(servers)
+                        fault = genealogy_mcp_terminal_fault(servers)
+                        if fault is not None:
+                            aborted_reason = "error"
+                            error = (
+                                f"{fault} — aborting before the run. The genealogy "
+                                "MCP tools are unreachable, so the agent cannot "
+                                "research. Rebuild/reconnect the server (see "
+                                "docs/e2e-testing-guide.md) and re-run."
+                            )
+                            _emit(f"[mcp-guard] {error}")
+                            return
                     timeline.append(
                         [round(now - run_started, 1), f"system:{message.subtype}", []]
                     )
@@ -1556,6 +1630,11 @@ async def _run_agent(
         "session_id": session_id["id"],
         "resumes": resumes["n"],
         "resume_on_stall": resume_on_stall,
+        # Raw `mcp_servers` list from the init system message — the genealogy
+        # server's connection status at session start. Persisted so a run that
+        # failed on an unconnected server is diagnosable from the runlog alone,
+        # and so `pending`-vs-`failed` frequency can be calibrated later.
+        "mcp_servers_init": mcp_servers_init["v"],
         "timeline": timeline,
         # Reasoning knobs actually used, so a run is self-describing when we
         # A/B effort × output-budget against subagent behavior. `effort_level`

--- a/eval/harness/e2e/stop_checker.py
+++ b/eval/harness/e2e/stop_checker.py
@@ -98,3 +98,70 @@ def derive_stop_reason(
     if project_completed(research):
         return "completed"
     return "natural_end"
+
+
+# ── MCP connection guard ─────────────────────────────────────────────────
+# The e2e run spawns the genealogy MCP server over stdio and the agent
+# researches through its tools. When that server never connects, the agent
+# can't call a single research/writer tool — but nothing stops it: it flails
+# (ToolSearch loops, filesystem probing, subagent connection probes) until a
+# cap fires, wasting the whole wall-clock and dollar budget. Observed live:
+# 65 min / $9.38 / 202 turns with zero genealogy tool calls. The CLI reports
+# each server's connection state in the init system message's `mcp_servers`
+# list; these helpers read it so the orchestrator can abort fast instead.
+
+GENEALOGY_MCP_SERVER_NAME = "genealogy"
+
+# Statuses a server will NOT recover from within the run — abort immediately.
+# `pending` is deliberately excluded: it may still connect, so the orchestrator
+# handles it with a slower never-reachable watchdog rather than a hard abort.
+_TERMINAL_MCP_FAULTS = frozenset({"failed", "needs-auth", "disabled"})
+
+
+def genealogy_mcp_status(
+    mcp_servers: Any, server_name: str = GENEALOGY_MCP_SERVER_NAME
+) -> str | None:
+    """The genealogy server's reported connection status, or None.
+
+    None means "cannot assess": the init message carried no `mcp_servers`
+    list (older CLI), the genealogy server was not listed, or its entry had
+    no string status. Callers that must distinguish "absent from a populated
+    list" from "no list at all" use ``genealogy_mcp_terminal_fault``.
+    """
+    if not isinstance(mcp_servers, list):
+        return None
+    for server in mcp_servers:
+        if isinstance(server, dict) and server.get("name") == server_name:
+            status = server.get("status")
+            return status if isinstance(status, str) else None
+    return None
+
+
+def genealogy_mcp_terminal_fault(
+    mcp_servers: Any, server_name: str = GENEALOGY_MCP_SERVER_NAME
+) -> str | None:
+    """A human-readable reason if the genealogy server is in a terminal-bad
+    state at session init (won't recover), else None.
+
+    Returns None when the CLI reported no ``mcp_servers`` at all — can't
+    assess, so stay backward-compatible and don't abort. Returns a reason
+    when the list IS present but the genealogy server is absent from it (not
+    registered) or carries a terminal status. ``connected``/``pending`` → None
+    (``pending`` is left to the orchestrator's never-reachable watchdog).
+    """
+    if not isinstance(mcp_servers, list):
+        return None
+    entry = next(
+        (s for s in mcp_servers if isinstance(s, dict) and s.get("name") == server_name),
+        None,
+    )
+    if entry is None:
+        others = [s.get("name") for s in mcp_servers if isinstance(s, dict)]
+        return (
+            f"genealogy MCP server '{server_name}' is absent from the init "
+            f"mcp_servers list (servers reported: {others or 'none'})"
+        )
+    status = entry.get("status")
+    if status in _TERMINAL_MCP_FAULTS:
+        return f"genealogy MCP server '{server_name}' init status is '{status}'"
+    return None

--- a/eval/harness/tests/unit/test_e2e_stop_checker.py
+++ b/eval/harness/tests/unit/test_e2e_stop_checker.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 from e2e.stop_checker import (
     derive_stop_reason,
+    genealogy_mcp_status,
+    genealogy_mcp_terminal_fault,
     project_completed,
     read_research_json,
     read_tree_json,
@@ -179,3 +181,65 @@ def test_should_continue_blocks_first_nudge_even_with_equal_counts():
         research=_INCOMPLETE, nudges_used=0, max_nudges=5,
         tool_count=5, tool_count_at_last_nudge=-1,
     ) is True
+
+
+# ── MCP connection guard ─────────────────────────────────────────────────
+
+
+def test_genealogy_mcp_status_reads_connected():
+    servers = [{"name": "genealogy", "status": "connected"}]
+    assert genealogy_mcp_status(servers) == "connected"
+
+
+def test_genealogy_mcp_status_reads_pending():
+    servers = [{"name": "genealogy", "status": "pending"}]
+    assert genealogy_mcp_status(servers) == "pending"
+
+
+def test_genealogy_mcp_status_none_when_no_list():
+    # Older CLI that emits no mcp_servers on init — cannot assess.
+    assert genealogy_mcp_status(None) is None
+
+
+def test_genealogy_mcp_status_none_when_server_absent():
+    assert genealogy_mcp_status([{"name": "other", "status": "connected"}]) is None
+
+
+def test_terminal_fault_none_when_connected():
+    assert genealogy_mcp_terminal_fault([{"name": "genealogy", "status": "connected"}]) is None
+
+
+def test_terminal_fault_none_when_pending():
+    # `pending` may still connect — left to the orchestrator watchdog, not a hard abort.
+    assert genealogy_mcp_terminal_fault([{"name": "genealogy", "status": "pending"}]) is None
+
+
+def test_terminal_fault_none_when_no_list():
+    # No mcp_servers at all → don't abort (backward-compatible with older CLI).
+    assert genealogy_mcp_terminal_fault(None) is None
+
+
+def test_terminal_fault_reports_failed():
+    fault = genealogy_mcp_terminal_fault([{"name": "genealogy", "status": "failed"}])
+    assert fault is not None and "failed" in fault
+
+
+def test_terminal_fault_reports_needs_auth():
+    fault = genealogy_mcp_terminal_fault([{"name": "genealogy", "status": "needs-auth"}])
+    assert fault is not None and "needs-auth" in fault
+
+
+def test_terminal_fault_reports_disabled():
+    fault = genealogy_mcp_terminal_fault([{"name": "genealogy", "status": "disabled"}])
+    assert fault is not None and "disabled" in fault
+
+
+def test_terminal_fault_reports_absent_from_populated_list():
+    # A populated list that does NOT include genealogy means it isn't registered.
+    fault = genealogy_mcp_terminal_fault([{"name": "some-other", "status": "connected"}])
+    assert fault is not None and "absent" in fault
+
+
+def test_terminal_fault_names_other_servers_when_absent():
+    fault = genealogy_mcp_terminal_fault([{"name": "some-other", "status": "connected"}])
+    assert "some-other" in fault


### PR DESCRIPTION
## What

Aborts an e2e run fast when the genealogy MCP server never connects, instead of letting the agent flail until a cap fires.

Observed live on `mary-mcandrew-son` (`run-2026-08-05_18-11-41`): **65 min / $9.38 / 202 turns with zero genealogy tool calls**, ending in `natural_end`. The agent spent the whole budget on ToolSearch loops, subagent connection probes, and filesystem prodding — none of which could succeed, because every research/writer tool routes through that server.

## How

Two-tier guard, keyed off the init `SystemMessage`'s `mcp_servers` status list:

1. **Terminal-fault abort at init** — if genealogy is `failed` / `needs-auth` / `disabled`, or absent from a populated server list, abort immediately with `stop_reason: error` and an actionable message.
2. **Never-reachable watchdog** — if init reports `pending` (this run's actual case) and no genealogy tool becomes reachable after `MCP_UNREACHABLE_TOOLCALL_LIMIT` (25) tool calls, abort. It **only arms when init already flagged the server not-connected**, so a healthy `connected` run can never trip it — no false-aborts.

The raw init `mcp_servers` list is persisted to `usage.mcp_servers_init` so the next occurrence is diagnosable straight from the run log. (This failing run persisted nothing, which is why `pending`-vs-`failed` had to be inferred from the agent's narration.)

## Files

- `eval/harness/e2e/stop_checker.py` — pure, testable helpers `genealogy_mcp_status` / `genealogy_mcp_terminal_fault`.
- `eval/harness/e2e/orchestrator.py` — init capture + both abort paths + `_is_genealogy_tool_name` + status persistence.
- `eval/harness/tests/unit/test_e2e_stop_checker.py` — 11 new unit tests.

## Verification

- 35 stop_checker unit tests pass (11 new), imports/parse OK, ruff clean.
- 112 orchestrator tests passed at authoring time (on the fixture branch base; unchanged by the rebase onto `main`).

## Known limitation

The watchdog's `pending`-forever path is inferred — the failing run didn't persist the actual init status, so I couldn't verify it was `pending` rather than `failed`. Either way it's now covered (terminal-fault path catches `failed`; watchdog catches `pending`), and `usage.mcp_servers_init` means the next occurrence won't be a guessing game. Follow-ups tracked in #1354: (1) confirm the real init status from accrued data and tighten the threshold; (2) make infra-aborts treeless/judge-skipped so they don't trip the CI grading gate.

Closes #1354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
