### PR TITLE
fix(gedcomx): select the preferred name as the primary, not an alternate (#1318)

### DIFF
--- a/docs/specs/gedcomx-convert-spec.md
+++ b/docs/specs/gedcomx-convert-spec.md
@@ -284,8 +284,12 @@ nameForms missing                                  →  all four fields omitted
 - Input GedcomX has `preferred: true` on a name → simplified has `preferred: true`
 - Input GedcomX omits `preferred` (or sets it `false`) → simplified omits it
 
-The conversion preserves the order of `names[]` as it appears in the input;
-it does **not** reorder by `preferred`.
+`simplifyPerson` stable-reorders `preferred: true` names to the front so
+`names[0]` upholds the first-position convention (`simplified-gedcomx-spec.md`
+§2) even when FamilySearch orders an alternate (e.g. `AlsoKnownAs`) before the
+preferred name; relative order within the preferred and non-preferred groups is
+preserved. Without this, every `names[0]` consumer (`person_read`,
+`person_ancestors`) can show an alternate as the primary name.
 
 `toGedcomX` is the mirror image: if simplified has `preferred: true`, emit
 `preferred: true` on the GedcomX name; otherwise omit. Never emit
@@ -895,6 +899,7 @@ fall into the `fullText` fallback path and emit a warning.
 | 7 | Mononym `"Plato"` → `given: ""`, `surname: "Plato"`, with `console.warn` | Rule 3 mononym |
 | 8 | `preferred: true` is passed through when set on input; omitted otherwise | Rule 4 |
 | 9 | Multiple names can independently have `preferred: true` | Rule 4 |
+| 9b | Preferred name is moved to `names[0]` when an alternate precedes it | Rule 4 |
 | 10 | `primary: true` is passed through when set on input; omitted otherwise | Rule 5 |
 | 11 | Multiple facts of different types can each be `primary: true` | Rule 5 |
 | 12 | `date.formal` is dropped, only `date.original` surfaces as `date` | Rule 6 |

--- a/docs/specs/person-read-tool-spec.md
+++ b/docs/specs/person-read-tool-spec.md
@@ -378,7 +378,7 @@ For each person in `response.persons[]`:
 | `id` | `id` | Copy directly |
 | `living` | `living` | Copy directly |
 | `gender.type` | `gender` | Last segment of URI (e.g., `"Male"`) |
-| `names[0].nameForms[0].parts[]` | `names[0].given`, `names[0].surname`, `names[0].prefix`, `names[0].suffix` | Extract `Given` → `given`, `Surname` → `surname`, `Prefix` → `prefix`, `Suffix` → `suffix` |
+| `names[].nameForms[0].parts[]` | `names[].given`, `names[].surname`, `names[].prefix`, `names[].suffix` | Extract `Given` → `given`, `Surname` → `surname`, `Prefix` → `prefix`, `Suffix` → `suffix`. Names marked `preferred: true` are stable-reordered to the front, so simplified `names[0]` is the preferred name even when FS lists an alternate first (`gedcomx-convert-spec.md` § "Rule 4") |
 | `facts[]` | `facts[]` | See fact conversion below |
 
 Strip: `display`, `links`, `sortKey`, `evidence`, `personInfo`,
@@ -416,7 +416,7 @@ Strip: `id`, `attribution`, `links`.
 
 #### 4. Names
 
-Extract from `names[0].nameForms[0].parts[]`:
+Extract from each name's `nameForms[0].parts[]`:
 
 - Find part with `type` containing `"Given"` → `given` value
 - Find part with `type` containing `"Surname"` → `surname` value
@@ -425,6 +425,11 @@ Extract from `names[0].nameForms[0].parts[]`:
 - Ignore other part types (e.g., `Title`)
 
 If no Given found, use `""`. If no Surname found, use `""`.
+
+The converter stable-reorders `preferred: true` names to the front, so
+`names[0]` is the preferred name regardless of the order FS returned. A
+consumer reading `names[0]` therefore gets the primary name, not an
+`AlsoKnownAs` alternate.
 
 #### 5. Relationships (when `relatives: true`)
 

--- a/packages/engine/mcp-server/src/utils/gedcomx-convert.ts
+++ b/packages/engine/mcp-server/src/utils/gedcomx-convert.ts
@@ -157,7 +157,16 @@ function simplifyPerson(person: GedcomXPerson): SimplifiedPerson {
   if (gender !== undefined) out.gender = gender;
 
   if (Array.isArray(person.names) && person.names.length > 0) {
-    out.names = person.names.map(simplifyName);
+    // #1318: uphold the simplified-format first-position convention
+    // (simplified-gedcomx-spec.md §2) — a name FamilySearch marked
+    // `preferred` must be names[0], even when FS lists an alternate
+    // (e.g. AlsoKnownAs) before it. Stable: relative order within the
+    // preferred and non-preferred groups is preserved.
+    const names = person.names.map(simplifyName);
+    out.names = [
+      ...names.filter((n) => n.preferred === true),
+      ...names.filter((n) => n.preferred !== true),
+    ];
   }
 
   if (Array.isArray(person.facts) && person.facts.length > 0) {

--- a/packages/engine/mcp-server/tests/utils/gedcomx-convert.test.ts
+++ b/packages/engine/mcp-server/tests/utils/gedcomx-convert.test.ts
@@ -343,6 +343,45 @@ describe("gedcomx-convert — transformation rules", () => {
     expect(names[1].preferred).toBe(true);
   });
 
+  // Test 9b — #1318: the preferred name is moved to names[0] even when
+  // FamilySearch lists an alternate (AlsoKnownAs) before it. A wrong primary
+  // manufactures a phantom conflict downstream — person_read / person_ancestors
+  // read names[0].
+  it("puts the preferred name first when GedcomX lists an alternate before it (#1318)", () => {
+    const result = toSimplified({
+      persons: [
+        {
+          id: "p1",
+          names: [
+            {
+              type: "http://gedcomx.org/AlsoKnownAs",
+              nameForms: [{ parts: [{ type: "http://gedcomx.org/Given", value: "Alternate Given" }] }],
+            },
+            {
+              preferred: true,
+              nameForms: [
+                {
+                  parts: [
+                    { type: "http://gedcomx.org/Given", value: "Preferred Given" },
+                    { type: "http://gedcomx.org/Surname", value: "Preferred Surname" },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const names = result.persons?.[0].names ?? [];
+    // The preferred name leads, so every names[0] consumer picks it.
+    expect(names[0].preferred).toBe(true);
+    expect(names[0].given).toBe("Preferred Given");
+    expect(names[0].surname).toBe("Preferred Surname");
+    // The alternate is retained, just not first.
+    expect(names[1].given).toBe("Alternate Given");
+    expect(names[1].type).toBe("AlsoKnownAs");
+  });
+
   // Test 10 — Rule 5: primary passes through, never synthesized from position
   it("preserves primary: true when set; omits the field when absent", () => {
     const result = toSimplified({


### PR DESCRIPTION
## Summary

Normal tier. Alpha feedback tool bug (PID KLYC-JX5). `simplifyPerson` mapped a person's names in
FamilySearch's array order and never moved the `preferred` name to the front, so when FS listed an
alternate (`type: AlsoKnownAs`) before the preferred name, simplified `names[0]` was the alternate.
Every `names[0]` consumer (`person_read`, `person_ancestors`) then showed the alternate as the
primary, manufacturing a phantom conflict the agent spent turns resolving.

- Stable-reorder `preferred: true` names to the front in `simplifyPerson`, upholding the simplified
  format's first-position convention (`simplified-gedcomx-spec.md` section 2) that `names[0]` is the
  preferred name.
- Rewrote `gedcomx-convert-spec.md` section 4, which asserted the opposite ("does not reorder by
  preferred") and directly contradicted the simplified spec.

## Review guidance

**Start here:** `simplifyPerson` in `gedcomx-convert.ts`. The fix is a stable partition:
`[...names.filter(n => n.preferred === true), ...names.filter(n => n.preferred !== true)]`.
`simplifyName` only ever sets `preferred = true` (never false), so the two filters partition every
element exhaustively and `filter` preserves relative order within each group. It sits on the single
shared per-person path both `toSimplified` and `toSimplifiedStandardized` use, so it fixes
`person_read`, `person_ancestors`, and every `names[0]` consumer at once; the
`find(preferred) ?? names[0]` selectors return the same name either way.

**Unsure about:** nothing structural. I fixed the converter rather than only `person-read` because a
consumer-only fix leaves `person_ancestors` and the spec invariant broken. The issue lists
`person-read.ts` as a touch site, but with the converter upholding the invariant, `person-read`'s
`names[0]` is correct unchanged (a redundant `find(preferred)` there would be dead code).

## Plan

**Didn't change:** the three `find(preferred) ?? names[0]` selectors (relatives, person-warnings,
project-context) are order-independent and unaffected; consolidating them is follow-up #1389.
`merge-gedcomx.ts` sets its own preferred; `record-search.ts` reads full GedcomX. No
schema/enum/tree-shape field change.

**Acceptance check:** `tests/utils/gedcomx-convert.test.ts` Test 9b — convert a synthetic person
with `[AlsoKnownAs alternate first, preferred second]` and assert `names[0]` is the preferred one.
Fails on `main` (order preserved, `names[0].preferred === undefined`), passes here. Proven by
mutation: reverting the reorder makes Test 9b fail with "expected undefined to be true"; existing
Tests 8/9 stay green (their inputs are already preferred-first / all-preferred, so a stable sort is
a no-op).

**Deviated from the plan:** nothing structural. Two `/critique-plan` rounds moved the fix from a
`person-read` consumer patch to the converter (which also fixes `person_ancestors` and the spec
invariant) and moved the acceptance test from an isolated-helper unit test (a fake win) to the
converter output. Self-review then caught two things, now fixed: the test used the real feedback
person's names (replaced with synthetic values, since this file is committed), and a stray issue-ref
in the spec tripped the doc-links ratchet (removed; the fact is stated, not the ticket).

Step-4 stop rule: not hit. Name-order normalization in a shared converter; no schema, auth,
plugin-agent binding, or ADR change.

## Test plan

- [x] `make test-all` passed in a single clean run (exit 0): typecheck, JS 248, control-plane
      pytest 135, MCP engine vitest 2049, eval app 148, eval harness 1599. Plus
      `npx vitest run tests/utils/gedcomx-convert.test.ts` (53 pass) and the mutation check above.
- [x] No skill run-log snapshot changed (touches only `packages/engine/mcp-server/**` and a spec
      doc), so no `make eval-skill` run is owed; `check_runlogs` marks no skill touched.

The live `person_read`/`person_ancestors` pass-through is not CI-covered (architecture section 9.4);
the fix is in the pure converter, which is unit-tested.

## Follow-on issues

- #1389 consolidate the three `find(preferred) ?? names[0]` selectors into one shared helper, and
  assess `merge-gedcomx.ts` for the same latent issue.

Closes #1318.
