### PR TITLE
tree_forget: spouses-of also strips person-level Marriage/Divorce/Annulment facts (#1417)

### DIFF
--- a/docs/specs/tree-forget-tool-spec.md
+++ b/docs/specs/tree-forget-tool-spec.md
@@ -77,7 +77,7 @@ the `{ operation, ...fields }` shape `tree_edit` takes:
 |---|---|---|
 | `parents-of` | `personId` | the person's parents, the ParentChild links to them, **and the person's own `Parents` documentary facts** (see §2.1.1) |
 | `children-of` | `personId` | the person's children, and the ParentChild links to them |
-| `spouses-of` | `personId` | the person's spouses, and the couple relationships |
+| `spouses-of` | `personId` | the person's spouses, the couple relationships, **and the person's own `Marriage`/`Divorce`/`Annulment` documentary facts** (see §2.1.1) |
 | `birth-of` | `personId` | that person's Birth facts |
 | `death-of` | `personId` | that person's Death facts |
 | `facts-of` | `personId`, `factType` | that person's facts of one type (e.g. `Marriage`); `factType` matches case-insensitively |
@@ -95,23 +95,27 @@ therefore fails loudly, which reads as "this was already forgotten." An unknown
 `personId` is likewise an error, phrased to distinguish a tree person id from a
 FamilySearch PID.
 
-#### 2.1.1 Parentage is carried twice — `parents-of` strips both
+#### 2.1.1 A conclusion is carried twice — the relative selectors strip both
 
-FamilySearch encodes a parentage conclusion **redundantly**: as `ParentChild`
-relationships *and* as a documentary `Parents` fact on the child's own record
-(a fact whose `value` names the parents, e.g. `"Geo… Wilcox - Caroline E
-Woodruff"`). `person_read` returns both. If `parents-of` stripped only the
-relationships, the answer would survive as that fact — and it can be the **sole**
-carrier, when the established parents were never added as tree persons at all.
-So `parents-of` also removes the subject's own `Parents`-type facts, matched by
-type — consistent with the structural, never-by-value rule, since the `Parents`
-*value* naming the parents is never read. Their presence also satisfies the
-"matched nothing" check: `parents-of` on a person with a `Parents` fact but no
-parent relationship succeeds rather than erroring. Reported as
-`factsByType: { Parents: n }`, a kind not a value.
+FamilySearch encodes a conclusion **redundantly**: as graph structure *and* as a
+documentary fact on the subject's own record. `person_read` returns both. If a
+relative selector stripped only the structure, the answer would survive as that
+fact — and the fact can be the **sole** carrier, when the related persons were
+never added as tree persons at all. So the relative selectors also remove the
+subject's own facts of the matching type(s), matched by type — consistent with
+the structural, never-by-value rule, since the fact *value* naming the relatives
+is never read. Their presence also satisfies the "matched nothing" check: the
+selector succeeds on a person with such a fact but no matching relationship
+rather than erroring. Reported as `factsByType`, a kind not a value.
 
-The same fact-vs-structure redundancy applies to `spouses-of` and person-level
-`Marriage` facts, which `spouses-of` does **not** yet strip.
+- **`parents-of`** strips the subject's `Parents`-type fact (a fact whose
+  `value` names the parents, e.g. `"Geo… Wilcox - Caroline E Woodruff"`).
+- **`spouses-of`** strips the subject's `Marriage`/`Divorce`/`Annulment`-type
+  facts, the person-level echo of the conclusion the `Couple` relationship also
+  carries as its own facts.
+
+`children-of` needs no such sweep: the redundant `Parents` fact lives on the
+child, whom `children-of` removes wholesale.
 
 ### 2.2 Cascade
 

--- a/packages/engine/mcp-server/src/tools/tree-forget.ts
+++ b/packages/engine/mcp-server/src/tools/tree-forget.ts
@@ -187,6 +187,20 @@ function factIdsOfType(
   );
 }
 
+/** factIdsOfType across several types, unioned — the person-level facts a
+ *  relative selector must sweep alongside the structure it removes. */
+function factIdsOfTypes(
+  tree: SimplifiedGedcomX,
+  personId: string,
+  factTypes: string[],
+): Set<string> {
+  const ids = new Set<string>();
+  for (const factType of factTypes) {
+    factIdsOfType(tree, personId, factType).forEach((id) => ids.add(id));
+  }
+  return ids;
+}
+
 // ─── selector resolution ─────────────────────────────────────────────────────
 
 interface Targets {
@@ -219,17 +233,25 @@ function resolveSelectors(tree: SimplifiedGedcomX, forget: ForgetSelector[]): Ta
           { "parents-of": "parents", "children-of": "children", "spouses-of": "spouses" } as const
         )[kind];
         const { people, rels } = relatives(tree, pid, relation);
-        // FamilySearch carries parentage TWICE: as ParentChild relationships
-        // and as a documentary `Parents` fact on the child's own record
-        // (person_read returns both). Forgetting a person's parents must take
-        // that fact too, or the answer survives on the child. It can even be
-        // the SOLE carrier — when the established parents were never added as
-        // tree persons, only the `Parents` fact remains — so its presence also
-        // keeps the selector from erroring as "matched nothing" (issue #1314).
-        // Scoped to parents-of; the spouses-of/`Marriage`-fact variant is #1417.
-        const parentageFactIds =
-          kind === "parents-of" ? factIdsOfType(tree, pid, "Parents") : new Set<string>();
-        if (people.size === 0 && rels.size === 0 && parentageFactIds.size === 0) {
+        // FamilySearch carries a conclusion TWICE: as structure AND as a
+        // documentary fact on the subject's own record (person_read returns
+        // both). Forgetting the structure must take the fact too, or the answer
+        // survives on the subject. Each fact can even be the SOLE carrier — when
+        // the related persons were never added as tree persons — so its presence
+        // also keeps the selector from erroring as "matched nothing".
+        //   parents-of  → the subject's `Parents` fact       (issue #1314)
+        //   spouses-of  → the subject's `Marriage`/`Divorce`/`Annulment` facts,
+        //                 the person-level echo of the Couple relationship's own
+        //                 facts (issue #1417)
+        // children-of is unaffected: the `Parents` fact lives on the child, whom
+        // children-of removes wholesale.
+        const redundantFactIds =
+          kind === "parents-of"
+            ? factIdsOfType(tree, pid, "Parents")
+            : kind === "spouses-of"
+              ? factIdsOfTypes(tree, pid, ["Marriage", "Divorce", "Annulment"])
+              : new Set<string>();
+        if (people.size === 0 && rels.size === 0 && redundantFactIds.size === 0) {
           throw new TreeForgetError(
             `'${kind}' matched nothing — ${pid} has no ${relation} in the tree, ` +
               `so there is nothing to forget.`,
@@ -237,7 +259,7 @@ function resolveSelectors(tree: SimplifiedGedcomX, forget: ForgetSelector[]): Ta
         }
         people.forEach((p) => t.persons.add(p));
         rels.forEach((r) => t.relationships.add(r));
-        parentageFactIds.forEach((f) => t.facts.add(f));
+        redundantFactIds.forEach((f) => t.facts.add(f));
         break;
       }
       case "birth-of":
@@ -485,8 +507,9 @@ export const treeForgetSchema = {
               description:
                 "parents-of/children-of/spouses-of: the person's relatives AND the links to " +
                 "them (cascades). parents-of ALSO removes the person's own `Parents` " +
-                "documentary facts, so the forgotten parentage does not survive as a fact " +
-                "on the child. birth-of/death-of: that person's Birth/Death facts. " +
+                "documentary facts, and spouses-of ALSO removes the person's own " +
+                "`Marriage`/`Divorce`/`Annulment` facts, so the forgotten conclusion does not " +
+                "survive as a fact on the subject. birth-of/death-of: that person's Birth/Death facts. " +
                 "facts-of: that person's facts of one type (needs factType). person: one " +
                 "person, cascading every relationship touching them. fact/relationship: one " +
                 "specific entity by id.",

--- a/packages/engine/mcp-server/tests/tools/tree-forget.test.ts
+++ b/packages/engine/mcp-server/tests/tools/tree-forget.test.ts
@@ -214,6 +214,102 @@ describe("tree_forget", () => {
     expect(tree.relationships.map((x: any) => x.id)).not.toContain("R6");
   });
 
+  it("spouses-of also strips the subject's own person-level `Marriage` fact", async () => {
+    // FamilySearch carries a marriage twice — as the Couple relationship's own
+    // facts AND as a `Marriage` fact on the subject's record (issue #1417).
+    // Both present here: I1 has the Couple link to I5 and a person-level fact.
+    const tree = family();
+    tree.persons[0].facts.push({ id: "FM", type: "Marriage", date: "1875", place: "Cork" } as any);
+    await writeProject(tree);
+
+    const r = await treeForget({
+      projectPath: dir,
+      forget: [{ selector: "spouses-of", personId: "I1" }],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    // The spouse and couple relationship still go, and the person-level
+    // `Marriage` fact goes too.
+    expect(r.removed.persons).toBe(1);
+    expect(r.removed.factsByType).toEqual({ Marriage: 1 });
+
+    const after = await readTree();
+    expect(after.persons.map((p: any) => p.id)).not.toContain("I5");
+    const i1 = after.persons.find((p: any) => p.id === "I1");
+    expect(i1.facts.map((f: any) => f.type)).not.toContain("Marriage");
+    // No spouse name or marriage value leaked into the redacted result.
+    expect(JSON.stringify(r)).not.toContain("Ellen");
+    expect(JSON.stringify(r)).not.toContain("Walsh");
+    expect(JSON.stringify(r)).not.toContain("1875");
+  });
+
+  it("spouses-of succeeds on a person-level `Marriage` fact alone, with no couple relationship", async () => {
+    // The reported case: the spouse was never added as a tree person — the
+    // marriage survives ONLY as a `Marriage` fact on the subject. spouses-of
+    // must still succeed here rather than erroring "matched nothing" (#1417).
+    const tree: any = {
+      persons: [
+        {
+          id: "I1",
+          gender: "Male",
+          names: [{ id: "N1", given: "Patrick", surname: "Ryan", preferred: true }],
+          facts: [
+            { id: "F1", type: "Birth", date: "1850", primary: true },
+            { id: "FM", type: "Marriage", date: "1875", value: "Ellen Walsh" },
+          ],
+        },
+      ],
+      relationships: [],
+      sources: [],
+    };
+    await writeProject(tree);
+
+    const r = await treeForget({
+      projectPath: dir,
+      forget: [{ selector: "spouses-of", personId: "I1" }],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.removed).toMatchObject({ persons: 0, relationships: 0, factsByType: { Marriage: 1 } });
+
+    const i1 = (await readTree()).persons.find((p: any) => p.id === "I1");
+    expect(i1.facts.map((f: any) => f.id)).toEqual(["F1"]);
+  });
+
+  it("spouses-of also sweeps person-level `Divorce` and `Annulment` facts", async () => {
+    const tree = family();
+    tree.persons[0].facts.push(
+      { id: "FD", type: "Divorce", date: "1890" } as any,
+      { id: "FA", type: "Annulment", date: "1892" } as any,
+    );
+    await writeProject(tree);
+
+    const r = await treeForget({
+      projectPath: dir,
+      forget: [{ selector: "spouses-of", personId: "I1" }],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.removed.factsByType).toEqual({ Divorce: 1, Annulment: 1 });
+
+    const i1 = (await readTree()).persons.find((p: any) => p.id === "I1");
+    expect(i1.facts.map((f: any) => f.type)).not.toContain("Divorce");
+    expect(i1.facts.map((f: any) => f.type)).not.toContain("Annulment");
+  });
+
+  it("spouses-of still errors when there is neither a spouse link nor a marriage-class fact", async () => {
+    await writeProject(family());
+    const r = await treeForget({
+      projectPath: dir,
+      // I4 is a sibling only: no couple relationship, no Marriage/Divorce/Annulment fact.
+      forget: [{ selector: "spouses-of", personId: "I4" }],
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors[0]).toMatch(/matched nothing/);
+  });
+
   it("birth-of removes only the Birth fact and never cascades", async () => {
     await writeProject(family());
     const r = await treeForget({


### PR DESCRIPTION
## Summary

- **Trivial** tier. `spouses-of` removed the spouse person and the `Couple` relationship (with the `Marriage` facts that live *on* that relationship), but a `Marriage`-type fact on the **subject's own** person record survived — leaking the very relationship the forget was meant to strip. This is the marriage instance of the fact-vs-structure redundancy class that #1314 fixed for `parents-of` + `Parents` facts (surfaced in the #1314 review).
- `spouses-of` now also removes the subject's own `Marriage`/`Divorce`/`Annulment`-type facts, matched by type (never by value), and — mirroring #1314's tolerant match — succeeds rather than erroring "matched nothing" when such a fact is the sole carrier (spouse never added as a tree person).
- `children-of` is deliberately untouched: the redundant `Parents` fact lives on the child, whom `children-of` removes wholesale.

## Review guidance

**Start here:** `resolveSelectors` in `tree-forget.ts` — the `redundantFactIds` branch. It generalizes #1314's `parentageFactIds` to cover `spouses-of` via a new `factIdsOfTypes` helper (union of `factIdsOfType` over several types). Check the type list `["Marriage", "Divorce", "Annulment"]` is the right set of divorce-class facts to sweep.

**Unsure about:** Nothing — the type set follows the issue's explicit "consider Divorce/Annulment too". Stacked on the #1314 branch since that PR (#1419) is unmerged and this extends the same code block; retarget to `main` once #1419 lands.

## Plan

**Didn't change:** `children-of` (see Summary), and the `Couple`-relationship-level `Marriage` facts, which the existing cascade already removes with the relationship.

**Acceptance check:** the two new `spouses-of` fact-stripping tests in `tests/tools/tree-forget.test.ts` (both-present, and person-level fact alone) — fail on base, pass on this branch.

**Deviated from the plan:** Nothing.

## Test plan

- [x] `npx vitest run` in `packages/engine/mcp-server` — 2055 tests pass (including the `doc-links` spec-ratchet lint, which caught two ticket refs I'd left in the spec prose; removed).
- No skill run-log snapshot changed — no paid eval run required.

## Follow-on issues

None.