### PR TITLE
record_search: stop placeParts leaving a stray "." on abbreviated counties (#1267)

### DIFF
--- a/docs/specs/record-search-tool-spec-v2.md
+++ b/docs/specs/record-search-tool-spec-v2.md
@@ -463,6 +463,50 @@ as a behavioural change and re-verify against a live run, not unit tests alone.
 
 #### Place matching
 
+> **Live-run exemption for tokenizer-only changes.** The mandate above — treat a
+> ranking change as behavioural and re-verify against a live run — has one
+> measured exception. A `placeParts`/tokenizer change is exempt when **nothing a
+> run would actually feed to `placeParts` tokenizes differently** before and after.
+> That is exactly two input classes, and the criterion must be checked against
+> both:
+>
+> 1. **Tree facts** — `place`/`standard_place` in every
+>    `eval/tests/e2e/*/starting-tree.gedcomx.json` (what the harness stages) **and**
+>    every `*.final-tree.gedcomx.json` in `eval/runlogs/` (the run's *mutable* tree
+>    is what `record_search` reads, not the starting one). Note `standard_place ||
+>    place` — the standardized form wins where both exist.
+> 2. **Recorded search arguments** — `marriagePlace` and `recordSubdivision` in
+>    `eval/runlogs/e2e/`, which is where `searchedPlace` comes from.
+>
+> Deliberately **not** in the criterion: `unstripped-tree.gedcomx.json` (an
+> authoring artifact, never staged into a run), `research.json` assertion places,
+> README prose, and transcript text. A change may move those and still qualify —
+> which is exactly what happened below, so read the two classes above as the whole
+> test, not as a summary of a wider scan.
+>
+> Applied once, for the `\bco\.?\b` fix below, and the numbers are the criterion
+> run verbatim: **class 1 — 1623 distinct tree-fact places** (1405 from
+> `starting-tree.gedcomx.json`, the rest across 144 `*.final-tree.gedcomx.json`),
+> **0 changed**; **class 2 — 54 distinct recorded search arguments, 0 changed**.
+> Exempt.
+>
+> Seven strings *did* change elsewhere in `eval/` — run-log outputs, one fixture
+> README line, and two `unstripped-tree.gedcomx.json` files. That is why the
+> criterion is scoped to the two input classes rather than to a corpus-wide diff: a
+> wider scan is the wrong test and would have refused an exemption that is correct.
+> A live run here would have sampled run-to-run jitter rather than the change.
+>
+> **Unexercised is not unreachable, and the distinction is the whole point.** Real
+> FamilySearch tree data does spell counties this way — `ruse-children`'s
+> `unstripped-tree.gedcomx.json` carries `place: "Seneca Co., O."` and
+> `mcaloney-mother`'s carries `"Hants Co.,Nova Scotia,Canada"` — so a fact whose
+> `standard_place` is absent would put the abbreviated form straight into
+> `placeParts` (`marriage-jurisdictions.ts` reads `standard_place || place`). That
+> has not happened in the corpus: of the 10,730 placed facts across every tree
+> file, the 150 with no `standard_place` contain no `co` token. A change that moves
+> a tokenized value any fixture actually feeds to `samePlace` still needs the live
+> run. This exemption is not a general licence to skip one.
+
 `searchedPlace` is the caller's `marriagePlace` when given, otherwise
 `recordSubdivision` + `recordCountry` joined — the caller usually scopes a marriage
 search with the latter pair, and reading only `marriagePlace` left the exclusion
@@ -480,17 +524,30 @@ string — so it would let TypeScript narrow an `else` to `undefined`. Callers t
 need the string narrowed test `!== undefined` themselves; that explicit check is
 what makes `jurisdictionHints.searchedPlace` a sound required `string`.
 
-**Known wart, recorded rather than fixed.** `isSubCountryPlace("Co., USA")` returns
-`true`. `placeParts` strips `co` out of `co.` and leaves the bare `"."`, which
-survives the empty-string filter and counts as a locality. The failure mode is
-precisely the one this guard exists to prevent — a country-wide search reading as
-scoped — so it is worth an eventual fix. It is left alone here because `placeParts`
-also feeds `placeTokens` → `samePlace`, i.e. the jurisdiction **exclusion and
-ordering** this spec flags as load-bearing and requiring a live run to re-verify,
-and because no real caller produces that input (`marriagePlace` and
-`recordSubdivision` always carry a name). Pinned by a `KNOWN WART` test in
-`tests/utils/marriage-jurisdictions.test.ts` so a future change to `placeParts`
-surfaces it.
+**The `Co.` qualifier, and why the first spelling of the regex was wrong.**
+`placeParts` drops `County`/`Co.` with `/\bcounty\b|\bco\b\.?/`. The abbreviation's
+dot is part of the qualifier and must be consumed with it. The original
+`\bco\.?\b` could not: after matching `co.` the trailing `\b` fails, so the engine
+backtracks and matches bare `co`, leaving a `"."` that survives the empty-string
+filter and counts as a locality. `\bco\b\.?` asserts the boundary first, then eats
+the dot.
+
+That stray token had two effects, and the reported one was the smaller. It made
+`isSubCountryPlace("Co., USA")` return `true`, so a country-wide search read as
+scoped — the failure this guard exists to prevent. More importantly it made
+`placeParts("Hill Co., Texas")` return `["hill .", "texas"]`, so `samePlace` did
+not match a tree place of `"Hill, Texas, United States"`: the **exclusion** failed
+and the jurisdiction a search had just come back empty on was offered back as an
+alternative (with its sub-places alongside it). It also split one jurisdiction into
+two candidates, since `placeTokens(...).join("|")` is the dedupe key.
+
+Reachable in principle — real tree data spells counties this way, and a fact with
+no `standard_place` feeds the abbreviated form straight into `placeParts` — though
+nothing in the corpus exercises it, which is why the fix qualified for the live-run
+exemption at the top of this section. Pinned by two tests in
+`tests/utils/marriage-jurisdictions.test.ts`: the `isSubCountryPlace` case, and an
+exclusion case scoped `"Hill Co., Texas"` that pins the root cause rather than the
+symptom.
 
 It is compared to each candidate on comma-separated tokens, lowercased, with
 `County`/`Co.` dropped and the country term dropped unless it is all that remains.

--- a/packages/engine/mcp-server/src/utils/marriage-jurisdictions.ts
+++ b/packages/engine/mcp-server/src/utils/marriage-jurisdictions.ts
@@ -84,13 +84,25 @@ interface TreeLike {
  */
 const COUNTRY_TERMS = new Set(["united states", "usa", "us"]);
 
-/** Comma-separated locality parts, lowercased, with `County`/`Co.` dropped. */
+/**
+ * Comma-separated locality parts, lowercased, with `County`/`Co.` dropped.
+ *
+ * The abbreviation's dot is part of the qualifier and must go with it. `\bco\b\.?`
+ * asserts the word boundary FIRST and then eats the dot; the earlier `\bco\.?\b`
+ * could not, because after consuming `co.` the trailing `\b` fails and the engine
+ * backtracks to bare `co` — leaving a `"."` that survives the empty-string filter
+ * and counts as a locality. That stray token made `"Hill Co., Texas"` tokenize as
+ * `["hill .", "texas"]`, so `samePlace` did not match the tree's
+ * `"Hill, Texas, United States"` and the jurisdiction a search had just come back
+ * empty on was offered back as an alternative — with its sub-places alongside it,
+ * and counted twice, since `placeTokens(...).join("|")` is also the dedupe key.
+ */
 function placeParts(place: string): string[] {
   return place
     .toLowerCase()
     .split(",")
     .map((part) => part.trim().replace(/\s+/g, " "))
-    .map((part) => part.replace(/\bcounty\b|\bco\.?\b/g, "").trim())
+    .map((part) => part.replace(/\bcounty\b|\bco\b\.?/g, "").trim())
     .filter((part) => part !== "");
 }
 

--- a/packages/engine/mcp-server/tests/utils/marriage-jurisdictions.test.ts
+++ b/packages/engine/mcp-server/tests/utils/marriage-jurisdictions.test.ts
@@ -99,6 +99,20 @@ describe("marriageJurisdictionCandidates — excluding the place already searche
     expect(out.map((c) => c.place)).not.toContain("Hill, Texas, United States");
   });
 
+  // #1267, and the root cause the `isSubCountryPlace("Co., USA")` symptom pointed
+  // at. `placeParts`' old `\bco\.?\b` left a stray "." on every abbreviated
+  // county, so "Hill Co., Texas" tokenized as ["hill .", "texas"] and `samePlace`
+  // did not match the tree's ["hill", "texas"] — the exclusion silently failed and
+  // the jurisdiction just searched came back as an alternative, sub-places and
+  // all. Reachable in principle (real tree data spells counties this way, and a
+  // fact with no `standard_place` feeds the abbreviated form straight in), though
+  // nothing in the corpus exercises it. Without this test the root cause is
+  // untested and the next refactor of that regex reintroduces it.
+  it("excludes a jurisdiction searched with an abbreviated County qualifier", () => {
+    const out = marriageJurisdictionCandidates(tree(), "LKYG-VKB", { ...WINDOW, searchedPlace: "Hill Co., Texas" });
+    expect(out.map((c) => c.place)).not.toContain("Hill, Texas, United States");
+  });
+
   it("excludes a narrower tree place when a broader place was searched", () => {
     const out = marriageJurisdictionCandidates(tree(), "LKYG-VKB", { searchedPlace: "Texas, United States" });
     expect(out.map((c) => c.place).filter((p) => p.includes("Texas"))).toEqual([]);
@@ -281,22 +295,15 @@ describe("isSubCountryPlace", () => {
     expect(isSubCountryPlace("Hill County, Texas")).toBe(true);
   });
 
-  it("KNOWN WART: an abbreviated qualifier leaves punctuation that reads as scoped", () => {
-    // `placeParts` strips `co` out of `co.` and leaves the ".", which survives
-    // the empty-string filter and counts as a locality. So a place that is only
-    // an abbreviated qualifier plus a country reads as sub-country.
+  it("does not mistake an abbreviated County qualifier for a locality", () => {
+    // Was a KNOWN WART asserting `true` until #1267. `\bco\.?\b` could not consume
+    // the dot — after `co.` the trailing `\b` fails and the engine backtracks to
+    // bare `co` — so a "." survived the empty-string filter and counted as a
+    // locality. `\bco\b\.?` asserts the boundary first, then eats the dot.
     //
-    // Worth fixing eventually: the failure mode is exactly the one this guard
-    // exists to prevent, a country-wide search reading as scoped.
-    //
-    // Recorded rather than fixed here, deliberately. `placeParts` also feeds
-    // `placeTokens` -> `samePlace`, i.e. the jurisdiction EXCLUSION and ordering
-    // that the spec flags as load-bearing and requiring a live run to re-verify.
-    // "Co., USA" is not an input any real caller produces — `marriagePlace` and
-    // `recordSubdivision` always carry a name — so the risk of touching ranking
-    // code in a PR about something else is worse than the wart. Also written up
-    // in `docs/specs/record-search-tool-spec-v2.md` § Place matching, so it does
-    // not live only in a test comment.
-    expect(isSubCountryPlace("Co., USA")).toBe(true);
+    // The symptom recorded here was the smaller half. The same stray token fed
+    // `placeTokens` -> `samePlace`, which is what the exclusion test below pins.
+    expect(isSubCountryPlace("Co., USA")).toBe(false);
+    expect(isSubCountryPlace("Hill Co., Texas")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- **Normal tier.** `placeParts` drops the `County`/`Co.` qualifier with `\bco\.?\b`, which cannot consume the abbreviation's dot — after matching `co.` the trailing `\b` fails, the engine backtracks to bare `co`, and a `"."` survives the empty-string filter as a locality. `\bco\b\.?` asserts the boundary first, then eats the dot.
- **The reported symptom was the smaller half.** `isSubCountryPlace("Co., USA")` returning `true` is real, but the same stray token feeds `placeTokens` → `samePlace`: `"Hill Co., Texas"` tokenized as `["hill .", "texas"]` and so did **not** match a tree place of `"Hill, Texas, United States"`. The exclusion silently failed and the jurisdiction a search had just come back empty on was offered back as an alternative — sub-places alongside it, and counted twice, since `placeTokens(...).join("|")` is also the dedupe key.
- Three behaviour changes, not one: the hint gate (`record-search.ts:826`), candidate **exclusion**, candidate **dedupe**.

Closes #1267.

## Review guidance

**Start here:** the one changed line, `src/utils/marriage-jurisdictions.ts` `placeParts`. The regex is the whole fix; the other `+15` in that file is an explanatory docstring. What to check is the *scope* of the new pattern, not the pattern itself — I'd want a second pair of eyes on whether `\bco\b\.?` can strip something it shouldn't. What I did: exhaustive enumeration over `c o . space x , - 1 _ ñ '` for all strings up to length 5, comparing match offsets and text — 0 violations of "same start offsets, new match text == old or old + `.`". Spot-checked `Colorado`, `Cocke`, `Coos`, `Rio Coco`, `Cook County`, `Co-operative`, `Coeur d'Alene`, `Comté de Nice`, `Denver, CO` — all unchanged.

Second, the spec's new **live-run exemption** (§ "Place matching"). It is a durable rule, not a one-off note, so it deserves more scrutiny than the code. It went through three drafts because the first two were falsified by their own first application — they said in effect "exempt when nothing in the corpus changes" while 7 strings do change. It now names the two input classes that actually reach `placeParts` and explicitly excludes `unstripped-tree.gedcomx.json`, `research.json` places, README prose and transcripts, with the reason, so the next reader doesn't "fix" it by widening the scan. Run verbatim for this change: class 1 — 1623 distinct tree places (1405 from staged trees, rest across 144 final trees), 0 changed; class 2 — 54 recorded search arguments, 0 changed. **Exempt.**

**Unsure about:** nothing blocking, but two things you should not have to discover:

1. **The issue's site list is wrong in a way that matters.** Its review notes say `record-search.ts` mentions `isSubCountryPlace` "in comments only" and cite `:757`. It **imports** it at `:31` and **calls** it at `:826`, inside the `jurisdictionHints` gate; `:757` is unrelated code. The conclusion (no edit needed there) still holds — but that call site is where the production behaviour change lands, so the reason on the issue hid the thing a reviewer most wants to know.
2. **The stated justification for skipping the live e2e run is too strong**, and this PR does not repeat it. The notes say the `jimmie-jewel-neal` fixture "cannot reach the changed branch". `searchedPlace` is built from the model's *live* search arguments and `record_search` reads the run's *mutable* `tree.gedcomx.json`, so a fresh run could in principle reach it. What is true and sufficient: nothing in the corpus exercises it — 0 of 133 `marriagePlace` occurrences, 0 of 24 distinct `recordSubdivision` values, and 0 `place`/`standard_place` across all 144 `*.final-tree.gedcomx.json`. @DallanQ, the no-live-run decision was yours and it still looks right to me on the weaker premise; flagging it because it was made on the stronger one.

One deliberate non-discriminating assertion: `expect(isSubCountryPlace("Hill Co., Texas")).toBe(true)` passes under **both** spellings. It is not a check that can't fail — it guards against a *future* over-stripping regex, next to the case that does discriminate. Calling it out so it doesn't read as an oversight.

## Plan

**Didn't change:** the tempting fix, explicitly. Filtering punctuation-only parts — in `isSubCountryPlace` or in `placeParts`' `.filter()` — flips the symptom, greens CI, and invites deleting the spec note as "fixed" while `placeTokens("Hill Co., Texas")` stays `["hill .", "texas"]` and the exclusion bug survives with its written record gone. No blanket `[^a-z0-9 ]` strip either: wider than this issue, and it rewrites `"Seneca Co., O."` and every other place holding a period. `samePlace`, `placeTokens`, `rankKey` and the ordering logic are not edited — though their *outputs* move wherever `placeParts` does, which is the point. `src/tools/record-search.ts` and `src/types/record-search.ts` are untouched.

**Acceptance check:** `tests/utils/marriage-jurisdictions.test.ts` → `"excludes a jurisdiction searched with an abbreviated County qualifier"`. Fails on `main` (the stray `"."` makes `samePlace` false, so the searched jurisdiction returns as its own alternative) and passes here. Chosen over the inverted `KNOWN WART` case deliberately: the wart is the symptom, this pins the root cause. Verified falsifiable by reverting the regex — exactly the two new/changed assertions fail and 23 others still pass.

**Deviated from the plan:** nothing structural. Two claims were corrected mid-flight after `/code-review` disproved them, both of which I had originally taken from the issue or the plan critic rather than checking: that the model writes `"Hill Co., Texas"` into the tree `record_search` reads (it does not — the string lives in `research.json` assertions and transcripts, paired with a `standard_place` that `marriage-jurisdictions.ts:233` reads first), and that the jurisdiction came back as its own **top** alternative (it returns at rank 2). Both are corrected in the spec, the source docstring and the test comment.

No step-4 stop rule was hit: no schema, no `src/auth/`, no plugin-agent permissions, no ADR reversal.

## Test plan

- [x] I ran `make test-all` (or `scripts/test.sh` — the same command) and it passed.

  Engine **2054 passed**, control-plane 135, eval-ui 148, harness 1681, typecheck clean. `test-js` flakes on the pre-existing 5s timeouts in `apps/electron`'s `feedback.test.ts` (#1366) — a package this diff does not touch, previously reproduced on a clean tree with unrelated work stashed.

- [x] No `SKILL.md`, plugin agent, `eval/tests/unit/` file or fixture is touched, so `check_runlogs.py` gates nothing here and **no `make eval-skill` re-run or run-log annotation is owed.** Confirmed against the workflow's `touched_skills` derivation, not just its path filter — the filter does include `^docs/`, so the job runs; it just has no target.

- [x] **No live `make e2e-run`,** per @DallanQ's 2026-08-04 decision, now recorded in the spec as a scoped exemption rather than a one-off. See "Review guidance" for the correction to its stated premise.

## Follow-on issues

- **#1426** — `placeParts`' qualifier stripping mangles non-ASCII places (`"Coïmbra"` → `["ïmbra"]`; JS `\b` is ASCII-only) and eats the `CO` state abbreviation, so `samePlace("Denver, Iowa", "Denver, CO")` is `true` and a valid alternative jurisdiction is suppressed — the same class of failure this feature exists to prevent. Both verified identical under the old and new spelling, i.e. pre-existing and untouched here. Case 1 needs a disambiguation decision (`co` vs `CO` is not resolvable from the token alone), so it is not a patch someone can just apply.
