### PR TITLE
Gate follow-on issue filing on "fold it in first"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,22 @@ mocks (no E2B/Anthropic/OAuth needed).
 - `docs/specs/` — Finalized specs (what the tool must do). Specs are the
   source of truth an implementation is checked against.
   This is the durable tier; a live tool must have a live spec.
+- **Fold it into the current PR unless there's a real reason not to.** Finding
+  a related gap while working a PR is not by itself a reason to file a new
+  issue — it's a reason to ask "does landing *this* PR require fixing that
+  too, or can I just fix it now while I'm here?" Default to yes. A stray
+  ticket is easy to create and easy to forget; a PR that actually closes the
+  gap it found needs nothing else to remember it. File a new issue instead
+  only when at least one of these is true, and say which when you file:
+  the fix needs a different reviewer or skill (a code fix surfaced during a
+  genealogist's fixture work, or vice versa); it would blow the PR's own
+  scope enough to slow its review meaningfully; it depends on something not
+  yet decided (a Gate-2 question only the lead can answer); or it's a
+  genuinely separate skill-eval slot (§ "Gate 4" in `/fill-ready`) that would
+  force a second paid run if bundled. "I noticed this in passing" and "I'm
+  not sure if this is in scope" are not reasons — they're the two most common
+  ways a foldable fix turns into an orphaned ticket. When genuinely unsure,
+  ask rather than defaulting to filing.
 - **Deferring work creates an issue, not a file entry.** In the same PR that
   defers something, file it — one command, no board write:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -133,7 +133,22 @@ did these jobs until 2026-08-02, when all three were deleted as stale — see
 ### Follow-on work you find along the way
 
 Implementing one task almost always turns up others — a stale doc, a missing
-test, a defect you're not fixing here. **File each one as a GitHub issue in the
+test, a defect you're not fixing here. The rest of this section is about
+filing what you *defer* — it assumes you've already decided not to fix it now.
+Make that decision first, and default toward not deferring:
+
+**Fold it into the current PR unless there's a real reason not to.** A stray
+issue is easy to create and easy to forget; a PR that closes the gap it found
+needs nothing else to remember it. File a new issue instead of fixing it here
+only when at least one of these holds, and say which in the PR description:
+the fix needs a different reviewer or skill (a code fix found during fixture
+work, or vice versa); it would blow this PR's own scope enough to slow its
+review meaningfully; it depends on a decision only the lead can make; or it's
+a different skill's eval slot and bundling it would force a second paid run.
+"I noticed it in passing" is not one of these — on its own it's a reason to
+fix it now, not to file it.
+
+For whatever you do decide to defer: **file each one as a GitHub issue in the
 same PR that defers it.** Ask Claude to do it; it is one command and needs no
 board access:
 


### PR DESCRIPTION
## Summary
- CLAUDE.md and DEVELOPMENT.md both told Claude to file a GitHub issue for anything found while working a PR, with no step asking whether it should just be fixed in the same PR instead.
- Adds a gate to both: fold a found gap into the current PR by default; file a new issue only when it needs a different reviewer/skill, would blow the PR's own scope, depends on an undecided lead call, or is a different skill's eval slot (a second paid run). "Noticed in passing" is explicitly called out as not a reason to file.
- DEVELOPMENT.md's "Follow-on work you find along the way" section is the one that actually drives the habit today (no such gate existed there at all); CLAUDE.md's summary now matches it.

## Test plan
- [x] Read both edits in context to confirm they don't contradict the existing filing-mechanics rules below them (label picking, `**Touches:**` line, "file even if you think it's a duplicate")
- Doc-only change; no code/build/test surface affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)