### PR TITLE
Split senior-developer review to path-scoped CODEOWNERS; add weekly merged-PR sampling skill

### DIFF
--- a/.claude/skills/audit-merged-prs/SKILL.md
+++ b/.claude/skills/audit-merged-prs/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: audit-merged-prs
+description: Use when the lead wants a weekly sample of recently-merged developer PRs that did not require senior review — "audit merged PRs", "spot-check last week's merges", "sample the peer-reviewed PRs", "weekly PR audit", or a bare "/audit-merged-prs". Pulls every developer-labeled PR merged in the last 7 days whose diff touched no `senior-developers`-owned path in `.github/CODEOWNERS`, samples a subset, and runs `/review` against each merge commit to surface what peer review may have missed: design drift, a missed multi-site edit, a check that cannot fail, cost regressions. Reports findings and any pattern worth turning into a new CODEOWNERS path or a `/review` checklist addition. Do NOT use to review a PR before merge (that is `/review`), to decide what the team works on next (`fill-ready`), or to audit the issue board (`audit-board`).
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+---
+
+# Audit merged PRs
+
+`docs/task-lifecycle.md` step 9 requires a `senior-developers` approval only
+on the paths `.github/CODEOWNERS` lists as high blast-radius. Everything
+else merges on a peer approval alone — which is the point, since one senior
+cannot review every PR for 10+ developers and also do strategic work. But a
+peer approval is not a senior's judgment, and CODEOWNERS only routes a
+senior to paths flagged high-risk *in advance*. It cannot catch a wrong
+abstraction, an architectural drift, or a "peer approved it without reading
+it closely" pattern on a path nobody flagged.
+
+This skill is that compensating control: the senior's one weekly touchpoint
+on the PRs they did not personally gate. Sampling **after** merge, not
+gating **before** it, is deliberate — it is what keeps the senior's time
+from being re-consumed by the exact bottleneck this whole review split
+exists to relieve.
+
+**You propose, then apply what is approved.** No reverts, no follow-up
+commits to someone else's merged branch, no re-opening a PR. You have no
+`Edit` or `Write` tool on purpose.
+
+**Sample, never audit the full pool.** Reviewing every peer-only-approved
+PR every week recreates the original bottleneck one week later. State the
+sample size or fraction you used in the report; a lead-set default lives in
+§2.
+
+## 0. Pool facts
+
+Repo `PioneerAIAcademy/cowork-genealogy`.
+
+```sh
+gh pr list --repo PioneerAIAcademy/cowork-genealogy --state merged \
+  --label developer --search "merged:>=$(date -d '7 days ago' +%Y-%m-%d)" \
+  --limit 100 --json number,title,author,mergedAt,mergedBy,files,reviews,mergeCommit
+```
+
+(On macOS/BSD `date`, use `date -v-7d +%Y-%m-%d` instead — the harness this
+skill runs in may differ from the lead's shell.)
+
+## 1. Filter to the peer-only pool
+
+Read `.github/CODEOWNERS` fresh every run — **do not hardcode its path list
+in this skill file.** CODEOWNERS is the single source of truth for which
+paths are `senior-developers`-owned (`docs/task-lifecycle.md` step 9 says
+the same); a copy here would drift the moment someone edits the real file.
+
+For each PR in the pool from §0, check whether any file in `.files[].path`
+falls under a `senior-developers`-owned path. If yes, drop it — that PR
+already got a senior's eyes at merge time via branch protection, and
+auditing it again duplicates work rather than covering a gap. Keep only
+PRs where **no** file matched a `senior-developers` path.
+
+**Also check `.reviews` for evidence of an actual senior approval**, not
+just CODEOWNERS ownership — the bypass-actor pattern documented in this
+plan's PR description (two bypass actors on `protect-main` with
+`bypass_mode: "always"`) means some PRs merge with `reviewDecision:
+REVIEW_REQUIRED`, i.e. no real peer approval either. A PR with zero
+reviews is not merely "peer-only" — it is **unreviewed**, and that is a
+stronger finding than anything `/review` would surface. Flag these
+separately in the report; don't fold them into the ordinary sample silently.
+
+## 2. Sample, don't audit all
+
+Default sample size: **~20% of the week's peer-only pool**, rounded up,
+with a floor of 1 and no fixed ceiling — confirm this against the lead's
+actual standing preference before the first run, since it is a time
+tradeoff only they can size against their available hours.
+
+Bias the sample toward, in this order:
+
+1. **PRs with zero reviews** (from §1) — always include every one of these;
+   they are not a sample, they are the finding.
+2. **PRs from newer contributors** — cross-reference `.author.login` against
+   `gh api repos/PioneerAIAcademy/cowork-genealogy/pulls --state all --json author --jq` history; a contributor with few merged PRs has had less exposure to this repo's own recurring failure modes (CLAUDE.md's multi-site edit lists, the dual/triple-spelled tool-name rule) that senior review would normally have caught them on.
+3. **PRs with no review comments at all**, only an approval — the "LGTM
+   without reading it closely" pattern; an approval with zero inline
+   comments on a non-trivial diff is a weak signal, not proof of a careful
+   read.
+4. **PRs touching a file three or more other recent PRs have also
+   touched** — drift risk; nobody reviewing any single one of them saw the
+   cumulative change.
+
+State which of these four reasons pulled each sampled PR into the report —
+"random" is not an allowed reason; every inclusion should be traceable to
+one of the four, or to being outside the sample and included only because
+it was zero-review (which bypasses sampling entirely per point 1).
+
+## 3. Run `/review` against each sampled PR
+
+The PR is already merged, so there is no open branch to check out. Diff the
+merge commit against its own first parent:
+
+```sh
+git fetch origin main --quiet
+git log -1 --format=%P <merge-commit-sha>   # first token is the first parent
+git diff <first-parent-sha> <merge-commit-sha>
+```
+
+Invoke `/review` against this diff the same way it reviews any PR — this
+reuses the existing skill and checklist rather than re-implementing it
+(CLAUDE.md § "Code reuse"). Treat its output exactly as `docs/task-lifecycle.md`
+§ "Reviewing someone else's PR" already instructs for a live PR: **an
+input, verify every finding before repeating it, never paste it verbatim.**
+
+## 4. Report, do not act
+
+Like `audit-board` and `review-icebox`, this skill proposes and never
+applies. Specifically:
+
+- **No reverts.** A finding here is retrospective — the PR already merged
+  and other work may already build on it. Reverting is the lead's call,
+  never this skill's.
+- **No follow-up commits** pushed to the author's now-merged branch.
+- **No re-opening the PR.**
+
+A confirmed finding becomes one of:
+
+- **A comment on the merged PR**, clearly tagged as retrospective (e.g.
+  prefixed `[audit-merged-prs, retrospective]`) so nobody mistakes it for
+  an active review blocking anything.
+- **A new GitHub issue**, `developer`-labeled, for anything that rises
+  above cosmetic — per this repo's "deferring work creates an issue"
+  convention (`CLAUDE.md` § "Repository layout").
+
+Confirm with the lead which channel to use before the first real run if it
+is not already decided — this skill defaults to "PR comment for anything
+the author could plausibly fix in five minutes, issue for anything larger,"
+but that split is a proposal, not doctrine.
+
+## 5. Surface patterns across the sample
+
+This is what separates the skill from running `/review` N times by hand.
+After all sampled PRs are reviewed, look across them:
+
+- **Do two or more sampled PRs miss the same class of thing?** That is the
+  signal the CODEOWNERS path list is incomplete — propose the specific
+  path to add, with the evidence (which PRs, which files).
+- **Does `/review`'s own checklist need a new category?** If a real bug
+  slipped through that `.claude/skills/review/SKILL.md` § "What to look
+  for" does not name, propose the addition there — quoting the finding
+  that motivated it, per that skill's own confidence-gate discipline.
+- **Is the zero-review count from §1 growing or shrinking week over
+  week?** A rising count means the bypass-actor pattern is spreading past
+  its original cases, which is a process question for the lead, not
+  something this skill can act on.
+
+Both proposals are decisions for the lead — list them explicitly, don't
+apply them. Adding a CODEOWNERS path or editing `/review`'s checklist is
+exactly the kind of change `docs/task-lifecycle.md` step 4 says to route
+through a human rather than resolve silently.
+
+## 6. Verify before you repeat anything
+
+Every claim carried into the report — a file path, a PR number, a review
+state, a `/review` finding — gets checked against the actual repo or `gh`
+output before it is repeated. This matters most for `/review`'s own
+findings, which are explicitly "an input to your review, never your
+review" per `docs/task-lifecycle.md`; this skill inherits that same
+discipline for its own output to the lead.
+
+## Cost
+
+Each `/review` run against a sampled PR is a real Claude Code session cost,
+same as any other skill invocation. Unlike the disabled
+`claude-code-review.yml` (a shared, recurring managed-service cost that
+failed on an expiring token), this has no standing liability — but sampling
+N PRs/week is still N sessions/week. State the sample count and an estimate
+of session cost in the report so the lead can size the sample deliberately,
+rather than defaulting to "review everything," which just re-creates the
+time cost this whole review split exists to remove.
+
+## Output shape
+
+1. **Zero-review PRs** — every one from §1, regardless of sample size; the
+   strongest finding this skill can surface, and never subject to sampling.
+2. **Sampled PRs and why each was pulled in** — one of the four reasons
+   from §2, plus the `/review` findings for each, verified per §6.
+3. **Cross-cutting patterns** — from §5, only the ones with a real finding
+   behind them across two or more PRs.
+4. **Decisions for the lead** — new CODEOWNERS paths to consider, `/review`
+   checklist additions to consider, and the zero-review-count trend.
+5. **What this run cost** — sample size, PRs sampled vs. pool size, session
+   count.
+
+Then stop and wait for approval. Apply only what the lead approves — a
+`gh pr comment`, a `gh issue create`, or nothing.

--- a/.claude/skills/audit-merged-prs/SKILL.md
+++ b/.claude/skills/audit-merged-prs/SKILL.md
@@ -11,13 +11,17 @@ allowed-tools:
 # Audit merged PRs
 
 `docs/task-lifecycle.md` step 9 requires a `senior-developers` approval only
-on the paths `.github/CODEOWNERS` lists as high blast-radius. Everything
-else merges on a peer approval alone — which is the point, since one senior
-cannot review every PR for 10+ developers and also do strategic work. But a
-peer approval is not a senior's judgment, and CODEOWNERS only routes a
-senior to paths flagged high-risk *in advance*. It cannot catch a wrong
-abstraction, an architectural drift, or a "peer approved it without reading
-it closely" pattern on a path nobody flagged.
+on code/infrastructure file types — `.github/CODEOWNERS` routes
+`.ts`/`.js`/`.py`/`.json`/`.yml` and similar to `senior-developers`
+repo-wide, carving genealogist-authored content (plugin skills, plugin
+agents, eval fixtures/tests, run logs, docs) back out even where it's one
+of those extensions. Everything without a `senior-developers` match merges
+on a peer approval alone — which is the point, since one senior cannot
+review every PR for 10+ developers and also do strategic work. But a peer
+approval is not a senior's judgment, and CODEOWNERS only routes by file
+type *in advance*. It cannot catch a wrong abstraction, an architectural
+drift, or a "peer approved it without reading it closely" pattern in code
+a senior never saw.
 
 This skill is that compensating control: the senior's one weekly touchpoint
 on the PRs they did not personally gate. Sampling **after** merge, not
@@ -143,8 +147,11 @@ This is what separates the skill from running `/review` N times by hand.
 After all sampled PRs are reviewed, look across them:
 
 - **Do two or more sampled PRs miss the same class of thing?** That is the
-  signal the CODEOWNERS path list is incomplete — propose the specific
-  path to add, with the evidence (which PRs, which files).
+  signal CODEOWNERS' extension/carve-out rules are incomplete — propose the
+  specific fix, with the evidence (which PRs, which files): a missing file
+  extension in the developer-owned list, a directory that needs a
+  genealogist carve-out it doesn't have, or a carve-out that's too broad
+  and is hiding real code from senior review.
 - **Does `/review`'s own checklist need a new category?** If a real bug
   slipped through that `.claude/skills/review/SKILL.md` § "What to look
   for" does not name, propose the addition there — quoting the finding

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,29 @@
 # write access. Enforced together with branch protection's
 # "required_approving_review_count: 2" + "require_code_owner_reviews".
 * @PioneerAIAcademy/senior-genealogists
+
+# --- Developer paths: senior-developer review required on high-blast- ---
+# --- radius surfaces only; everything else in packages/engine and     ---
+# --- apps/ falls through to peer-only review (last-match-wins means   ---
+# --- these paths get ONLY senior-developers, not senior-genealogists  ---
+# --- too — see PLAN.md / the PR description for the correction note   ---
+# --- on why the "*" rule above is deliberately left untouched).       ---
+
+# Auth/token handling — CLAUDE.md § "Auth architecture"
+/packages/engine/mcp-server/src/auth/ @PioneerAIAcademy/senior-developers
+
+# research.json / simplified-GedcomX schema — CLAUDE.md § "Researcher
+# profile in research.json"; the closed-enum and tree-shape allow-lists
+/docs/specs/schemas/ @PioneerAIAcademy/senior-developers
+/packages/schema/schemas/ @PioneerAIAcademy/senior-developers
+/packages/engine/mcp-server/src/validation/ @PioneerAIAcademy/senior-developers
+
+# Plugin agent tool bindings — CLAUDE.md § "Cowork plugin agents";
+# widening tools:/disallowedTools: is a step-4 stop-rule item
+/packages/engine/plugin/agents/ @PioneerAIAcademy/senior-developers
+
+# Plugin hooks — the only guardrail that reaches Cowork
+/packages/engine/plugin/hooks/ @PioneerAIAcademy/senior-developers
+
+# CI/workflows and branch protection itself
+/.github/ @PioneerAIAcademy/senior-developers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,28 +4,50 @@
 # "required_approving_review_count: 2" + "require_code_owner_reviews".
 * @PioneerAIAcademy/senior-genealogists
 
-# --- Developer paths: senior-developer review required on high-blast- ---
-# --- radius surfaces only; everything else in packages/engine and     ---
-# --- apps/ falls through to peer-only review (last-match-wins means   ---
-# --- these paths get ONLY senior-developers, not senior-genealogists  ---
-# --- too — see PLAN.md / the PR description for the correction note   ---
-# --- on why the "*" rule above is deliberately left untouched).       ---
+# --- Developer infrastructure: senior-developer review required on code ---
+# --- and infra file types, repo-wide (last-match-wins means these       ---
+# --- extensions get ONLY senior-developers, not senior-genealogists     ---
+# --- too — see the carve-out block below for the exception).           ---
+# --- Intent: genealogists review skills and runlogs; developers review ---
+# --- infrastructure. CODEOWNERS has no concept of PR labels, so this   ---
+# --- is scoped by file type/path, not by the "developer" label.        ---
 
-# Auth/token handling — CLAUDE.md § "Auth architecture"
-/packages/engine/mcp-server/src/auth/ @PioneerAIAcademy/senior-developers
+*.ts @PioneerAIAcademy/senior-developers
+*.tsx @PioneerAIAcademy/senior-developers
+*.js @PioneerAIAcademy/senior-developers
+*.mjs @PioneerAIAcademy/senior-developers
+*.cjs @PioneerAIAcademy/senior-developers
+*.py @PioneerAIAcademy/senior-developers
+*.json @PioneerAIAcademy/senior-developers
+*.yml @PioneerAIAcademy/senior-developers
+*.yaml @PioneerAIAcademy/senior-developers
 
-# research.json / simplified-GedcomX schema — CLAUDE.md § "Researcher
-# profile in research.json"; the closed-enum and tree-shape allow-lists
+# --- Carve-out: genealogist-authored content that happens to live in   ---
+# --- .py/.json/.md files, re-asserted below the extension rules above  ---
+# --- so it stays senior-genealogists (last-match-wins). ---
+
+# Cowork plugin skills — SKILL.md prose, templates, references, and their
+# stdlib-only Python scripts (CLAUDE.md § "Skills") are genealogist-
+# reviewed content, not developer infrastructure, even though scripts/
+# holds .py files.
+/packages/engine/plugin/skills/ @PioneerAIAcademy/senior-genealogists
+
+# Cowork plugin agents — agent .md bodies are genealogist/doctrine prose.
+/packages/engine/plugin/agents/ @PioneerAIAcademy/senior-genealogists
+
+# Eval fixtures and tests — genealogist-adjudicated scenario/expected-
+# findings JSON and e2e/unit test fixtures (docs/skill-lifecycle.md: these
+# are one co-edited unit with the skills they test).
+/eval/fixtures/ @PioneerAIAcademy/senior-genealogists
+/eval/tests/ @PioneerAIAcademy/senior-genealogists
+
+# Run logs and their .ann.json calibration annotations.
+/eval/runlogs/ @PioneerAIAcademy/senior-genealogists
+
+# docs/ prose, including specs — narrative and doctrine content. Schema
+# JSON Schema files under docs/specs/schemas/ are the one exception: they
+# are a code contract (validator.ts is generated/checked against them),
+# so they are deliberately NOT carved out here and stay under the *.json
+# rule above (senior-developers).
+/docs/ @PioneerAIAcademy/senior-genealogists
 /docs/specs/schemas/ @PioneerAIAcademy/senior-developers
-/packages/schema/schemas/ @PioneerAIAcademy/senior-developers
-/packages/engine/mcp-server/src/validation/ @PioneerAIAcademy/senior-developers
-
-# Plugin agent tool bindings — CLAUDE.md § "Cowork plugin agents";
-# widening tools:/disallowedTools: is a step-4 stop-rule item
-/packages/engine/plugin/agents/ @PioneerAIAcademy/senior-developers
-
-# Plugin hooks — the only guardrail that reaches Cowork
-/packages/engine/plugin/hooks/ @PioneerAIAcademy/senior-developers
-
-# CI/workflows and branch protection itself
-/.github/ @PioneerAIAcademy/senior-developers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,11 +50,13 @@
 
 ## Test plan
 
-<!-- If this PR touches a path owned in .github/CODEOWNERS by
-     @senior-developers (auth, schema, agent tool bindings, plugin hooks,
-     CI/workflows), a senior-developers approval is required by branch
-     protection — a peer approval alone will not unblock merge. This is a
-     convenience note; GitHub's merge button is the actual enforcement. -->
+<!-- If this PR touches a code/infra file (.ts/.tsx/.js/.mjs/.cjs/.py/.json/
+     .yml/.yaml) outside packages/engine/plugin/skills/, packages/engine/
+     plugin/agents/, eval/fixtures/, eval/tests/, eval/runlogs/, or docs/,
+     a senior-developers approval is required by branch protection — see
+     .github/CODEOWNERS for the exact rule. Peer approval alone will not
+     unblock merge. This is a convenience note; GitHub's merge button is
+     the actual enforcement. -->
 
 - [ ] I ran `make test-all` (or `scripts/test.sh` — the same command) and it passed.
       <!-- No Windows equivalent exists (issue #1185): `eval\RunTests.bat` is the

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,6 +50,12 @@
 
 ## Test plan
 
+<!-- If this PR touches a path owned in .github/CODEOWNERS by
+     @senior-developers (auth, schema, agent tool bindings, plugin hooks,
+     CI/workflows), a senior-developers approval is required by branch
+     protection — a peer approval alone will not unblock merge. This is a
+     convenience note; GitHub's merge button is the actual enforcement. -->
+
 - [ ] I ran `make test-all` (or `scripts/test.sh` — the same command) and it passed.
       <!-- No Windows equivalent exists (issue #1185): `eval\RunTests.bat` is the
            paid per-skill eval run, not this gate. On Windows, say so here and

--- a/.github/workflows/genealogist-queue.yml
+++ b/.github/workflows/genealogist-queue.yml
@@ -4,12 +4,15 @@ name: genealogist-queue
 # CI green, an approving review from someone other than the author, and no
 # outstanding changes-requested.
 #
-# WHY. `.github/CODEOWNERS` is `* @PioneerAIAcademy/senior-genealogists`, so
-# GitHub requests the team the instant a PR opens — when CI is usually red and
-# nobody has read it. On 2026-07-29 that put all 22 open PRs in their queue,
-# including 5 with failing CI and 2 blocked on their authors. The review-request
-# is therefore accurate as "a PR exists" and useless as "this needs you". The
-# label is the signal that means the second thing:
+# WHY. `.github/CODEOWNERS`'s `* @PioneerAIAcademy/senior-genealogists` rule
+# still matches every path with no more specific rule below it (six
+# `senior-developers` paths were added below `*` later — last-match-wins
+# means only those six resolve differently), so GitHub requests the
+# genealogist team the instant a matching PR opens — when CI is usually red
+# and nobody has read it. On 2026-07-29 that put all 22 open PRs in their
+# queue, including 5 with failing CI and 2 blocked on their authors. The
+# review-request is therefore accurate as "a PR exists" and useless as "this
+# needs you". The label is the signal that means the second thing:
 #
 #   is:open is:pr label:ready-for-senior
 #

--- a/.github/workflows/genealogist-queue.yml
+++ b/.github/workflows/genealogist-queue.yml
@@ -5,14 +5,15 @@ name: genealogist-queue
 # outstanding changes-requested.
 #
 # WHY. `.github/CODEOWNERS`'s `* @PioneerAIAcademy/senior-genealogists` rule
-# still matches every path with no more specific rule below it (six
-# `senior-developers` paths were added below `*` later — last-match-wins
-# means only those six resolve differently), so GitHub requests the
-# genealogist team the instant a matching PR opens — when CI is usually red
-# and nobody has read it. On 2026-07-29 that put all 22 open PRs in their
-# queue, including 5 with failing CI and 2 blocked on their authors. The
-# review-request is therefore accurate as "a PR exists" and useless as "this
-# needs you". The label is the signal that means the second thing:
+# still matches every path with no more specific rule below it — later
+# entries route code/infra file types to `senior-developers` instead
+# (last-match-wins), but everything else still resolves to the genealogist
+# team — so GitHub requests that team the instant a matching PR opens, when
+# CI is usually red and nobody has read it. On 2026-07-29 that put all 22
+# open PRs in their queue, including 5 with failing CI and 2 blocked on
+# their authors. The review-request is therefore accurate as "a PR exists"
+# and useless as "this needs you". The label is the signal that means the
+# second thing:
 #
 #   is:open is:pr label:ready-for-senior
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,22 @@ mocks (no E2B/Anthropic/OAuth needed).
 - `docs/specs/` — Finalized specs (what the tool must do). Specs are the
   source of truth an implementation is checked against.
   This is the durable tier; a live tool must have a live spec.
+- **Fold it into the current PR unless there's a real reason not to.** Finding
+  a related gap while working a PR is not by itself a reason to file a new
+  issue — it's a reason to ask "does landing *this* PR require fixing that
+  too, or can I just fix it now while I'm here?" Default to yes. A stray
+  ticket is easy to create and easy to forget; a PR that actually closes the
+  gap it found needs nothing else to remember it. File a new issue instead
+  only when at least one of these is true, and say which when you file:
+  the fix needs a different reviewer or skill (a code fix surfaced during a
+  genealogist's fixture work, or vice versa); it would blow the PR's own
+  scope enough to slow its review meaningfully; it depends on something not
+  yet decided (a Gate-2 question only the lead can answer); or it's a
+  genuinely separate skill-eval slot (§ "Gate 4" in `/fill-ready`) that would
+  force a second paid run if bundled. "I noticed this in passing" and "I'm
+  not sure if this is in scope" are not reasons — they're the two most common
+  ways a foldable fix turns into an orphaned ticket. When genuinely unsure,
+  ask rather than defaulting to filing.
 - **Deferring work creates an issue, not a file entry.** In the same PR that
   defers something, file it — one command, no board write:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -133,7 +133,22 @@ did these jobs until 2026-08-02, when all three were deleted as stale — see
 ### Follow-on work you find along the way
 
 Implementing one task almost always turns up others — a stale doc, a missing
-test, a defect you're not fixing here. **File each one as a GitHub issue in the
+test, a defect you're not fixing here. The rest of this section is about
+filing what you *defer* — it assumes you've already decided not to fix it now.
+Make that decision first, and default toward not deferring:
+
+**Fold it into the current PR unless there's a real reason not to.** A stray
+issue is easy to create and easy to forget; a PR that closes the gap it found
+needs nothing else to remember it. File a new issue instead of fixing it here
+only when at least one of these holds, and say which in the PR description:
+the fix needs a different reviewer or skill (a code fix found during fixture
+work, or vice versa); it would blow this PR's own scope enough to slow its
+review meaningfully; it depends on a decision only the lead can make; or it's
+a different skill's eval slot and bundling it would force a second paid run.
+"I noticed it in passing" is not one of these — on its own it's a reason to
+fix it now, not to file it.
+
+For whatever you do decide to defer: **file each one as a GitHub issue in the
 same PR that defers it.** Ask Claude to do it; it is one command and needs no
 board access:
 

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -237,14 +237,19 @@ Keep PRs small. A forty-file PR turns both review steps into rubber stamps.
 ### 9. Peer review, then senior review — on the paths that need it
 
 Peer review is another developer, and it is now **sufficient to merge** on
-any path with no `senior-developers` entry in
-[`.github/CODEOWNERS`](../.github/CODEOWNERS) — most of the repo. Senior
-review is a senior developer or the lead, and branch protection requires it
-specifically on the handful of high-blast-radius paths CODEOWNERS lists
-(auth, schema, agent tool bindings, plugin hooks, CI/workflows) — by then
-everything mechanical should be settled, so their time goes to whether the
-approach is right, on the PRs where that specifically needs a senior's
-judgment.
+files with no `senior-developers` entry in
+[`.github/CODEOWNERS`](../.github/CODEOWNERS). Senior review is a senior
+developer or the lead, and branch protection requires it specifically on
+code and infrastructure file types — `.ts`/`.tsx`/`.js`/`.mjs`/`.cjs`/`.py`/
+`.json`/`.yml`/`.yaml`, repo-wide — with an explicit carve-out putting
+genealogist-authored content (plugin skills, plugin agents, eval fixtures
+and tests, run logs, and `docs/` prose) back under `senior-genealogists`
+even where it happens to be `.py`, `.json`, or otherwise one of those
+extensions. The split is **genealogists review skills and runlogs;
+developers review infrastructure** — by the time a senior developer looks
+at a PR, everything mechanical should be settled, so their time goes to
+whether the approach is right, on the PRs where that specifically needs a
+senior's judgment.
 
 **CODEOWNERS is the source of truth for which paths need a senior, not this
 paragraph.** Read the file rather than trusting a path list here — it can
@@ -254,11 +259,11 @@ drift out of sync with what's actually enforced and this one can't.
 this process. Turning up with `make test-all` green, `/code-review` run, and its
 findings resolved is what keeps that gate spent on judgment.
 
-**A PR touching both an owned and an unowned path needs both approvals.**
-GitHub resolves CODEOWNERS per file, not per PR — a nine-file PR that
-happens to touch one line under `src/auth/` still requires a
-`senior-developers` approval for that file, on top of whatever else the
-other files need.
+**A PR touching both kinds of file needs both approvals.** GitHub resolves
+CODEOWNERS per file, not per PR — a PR that changes a `.ts` tool
+implementation alongside a `SKILL.md` still requires a `senior-developers`
+approval for the `.ts` file and a `senior-genealogists` approval for the
+`SKILL.md`, on top of whatever else the other files need.
 
 **Peer-only merges aren't reviewed by a senior zero times — they're sampled
 after merge, not before.** `/audit-merged-prs` is the lead's weekly pass

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -234,19 +234,46 @@ co-author".
 
 Keep PRs small. A forty-file PR turns both review steps into rubber stamps.
 
-### 9. Peer review, then senior review
+### 9. Peer review, then senior review — on the paths that need it
 
-Peer review is another developer. Senior review is a senior developer or the
-lead, and it is the last gate — by then everything mechanical should be settled,
-so their time goes to whether the approach is right.
+Peer review is another developer, and it is now **sufficient to merge** on
+any path with no `senior-developers` entry in
+[`.github/CODEOWNERS`](../.github/CODEOWNERS) — most of the repo. Senior
+review is a senior developer or the lead, and branch protection requires it
+specifically on the handful of high-blast-radius paths CODEOWNERS lists
+(auth, schema, agent tool bindings, plugin hooks, CI/workflows) — by then
+everything mechanical should be settled, so their time goes to whether the
+approach is right, on the PRs where that specifically needs a senior's
+judgment.
+
+**CODEOWNERS is the source of truth for which paths need a senior, not this
+paragraph.** Read the file rather than trusting a path list here — it can
+drift out of sync with what's actually enforced and this one can't.
 
 **The senior developers are volunteers.** Their time is the scarcest thing in
 this process. Turning up with `make test-all` green, `/code-review` run, and its
 findings resolved is what keeps that gate spent on judgment.
 
+**A PR touching both an owned and an unowned path needs both approvals.**
+GitHub resolves CODEOWNERS per file, not per PR — a nine-file PR that
+happens to touch one line under `src/auth/` still requires a
+`senior-developers` approval for that file, on top of whatever else the
+other files need.
+
+**Peer-only merges aren't reviewed by a senior zero times — they're sampled
+after merge, not before.** `/audit-merged-prs` is the lead's weekly pass
+over recently-merged, peer-only-approved developer PRs: it samples a subset
+and runs `/review` against each merge commit to catch what peer review
+alone tends to miss — design drift, a missed multi-site edit, a check that
+cannot fail. It reports and files issues; it never reverts or re-opens a
+merged PR.
+
 **Automatic Claude review is off** (`.github/workflows/claude-code-review.yml`,
-disabled 2026-08-03). Nothing reviews your PR before a human opens it, so step 6
-is the only pass it gets — arrive with it done.
+disabled 2026-08-03) and this plan does not turn it back on. Nothing
+reviews your PR before a human opens it, so step 6 is the only pass it
+gets — arrive with it done. Peer review via `/review`, senior review on
+CODEOWNERS-listed paths, and `/audit-merged-prs`'s weekly sampling are the
+chosen replacement for the disabled bot, not another automated first pass.
 
 One or two revision rounds is normal. Three means something upstream was wrong,
 usually the plan. Say so rather than grinding through a fourth.


### PR DESCRIPTION
## Summary

- Tier: **Normal**
- One senior developer can't peer-review every PR for 10+ developers and also do strategic work. Adds a `senior-developers` CODEOWNERS entry on six high-blast-radius paths (auth, schema, agent tool bindings, plugin hooks, CI) below the existing, untouched `* @senior-genealogists` rule, so ordinary developer PRs merge on a peer approval alone while these paths keep senior review.
- Adds `/audit-merged-prs`, a new Claude Code skill for a weekly sampling pass over recently-merged, peer-only-approved developer PRs — the compensating control for what path-scoped review can't catch in advance (design drift, a missed multi-site edit, a "approved without reading closely" pattern).

## Review guidance

**Start here:** `.github/CODEOWNERS` — specifically, that the `*` rule is left completely untouched. An earlier draft of this change tried narrowing `*` to a genealogist-content path list instead of appending below it; that rested on a wrong premise (CODEOWNERS is last-match-wins, not additive) confirmed against GitHub's own docs, and was reverted. What's shipped here is the simpler original approach: append path-scoped rules below the intact `*`. Please double check the last-match-wins behavior against your own understanding of CODEOWNERS — it's the one piece of GitHub platform behavior this whole PR depends on, and I want a second pair of eyes on it specifically, not just on the diff.

**Unsure about:**
- Whether the six paths in CODEOWNERS are the complete right list. They're derived from CLAUDE.md's own high-blast-radius/multi-site call-outs (auth, schema, agent tool bindings, hooks), not from an existing "senior-review-required" designation — that consequence is new, assigned by this PR.
- Real merge history on `main` shows the *existing* `protect-main` ruleset's 2-approval/code-owner gate is already being bypassed on developer PRs via an admin bypass actor (PRs #1433, #1390 merged with `reviewDecision: REVIEW_REQUIRED`; #1425 has zero reviews). This PR doesn't change the bypass-actor list either way, but it's worth knowing this gate is currently more formal than real in practice — flagged as its own decision below, not something I resolved.
- Sample size/fraction for `/audit-merged-prs`, and which channel its findings should land in (PR comment vs. new issue vs. something else) — both proposed as defaults in the skill body, not decided.

## Plan

**Didn't change:** the `senior-genealogists` CODEOWNERS rule and the genealogist review process; `.claude/skills/review/SKILL.md` itself (used as-is by peer reviewers and by the new skill); `claude-code-review.yml` stays disabled — this PR is the chosen replacement (peer review + path-scoped senior review + weekly sampling), not another automated first-pass bot.

**Acceptance check:** three throwaway-PR scenarios verifying GitHub's actual `reviewRequests` behavior — (1) a PR touching only a `senior-developers` path requests `senior-developers` and not `senior-genealogists`; (2) a PR touching neither list still requests `senior-genealogists` via `*` (confirming this is not a repo-wide peer-only default); (3) a PR touching both requests both, since CODEOWNERS resolves per file, not per PR. Not yet run against a live throwaway PR — needs the `senior-developers` team to exist first (see below).

**Deviated from the plan:** yes, twice, both self-corrected in `PLAN.md` (gitignored, not in this diff) rather than hidden. First: the plan initially claimed `main` had no branch protection, checked via the legacy `branches/protection` endpoint, which 404s even when GitHub's newer rulesets API has active protection — it does here (`protect-main`, 2 approvals + code-owner review + 6 status checks). Second: after fixing that, I incorrectly proposed narrowing the `*` CODEOWNERS rule based on a wrong belief that CODEOWNERS matches are additive; GitHub's docs confirm last-match-wins, so that edit was unnecessary and was reverted. Both went through a `plan-critic` adversarial review round each (3 rounds total, no blocking findings survive in the final round).

## Test plan

- [x] I ran `make test-all` and it passed — 2072 engine tests, 148 eval-app tests, 1774 harness tests, all green, including `tests/packaging/doc-links.test.ts` (117/117), which specifically lints `docs/task-lifecycle.md` and every `.claude/skills/*/SKILL.md` for broken citations.
- [ ] No skill run-log snapshot changed — `.claude/skills/` is Claude Code dev tooling, not a `packages/engine/plugin/skills/` Cowork plugin skill, so it isn't covered by the eval run-log gate.
- [ ] No skill `description`/DO NOT clauses changed on an existing plugin skill.

## Follow-on issues

None filed yet — this PR intentionally does not touch the `*` CODEOWNERS rule or the bypass-actor list; whether either becomes its own issue is one of the open questions above rather than something I've pre-decided.