### PR TITLE
docs: unresolved threads now block merge

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -86,10 +86,14 @@ unresolved, **stop**. Report which, and that the PR is not ready for another
 review. Reviewing anyway produces a second copy of findings the author has not
 answered yet, and spends the scarcer reviewer to do it.
 
-Two things this is not. It is not a merge gate — unresolved threads do not block
-merge in this repo, which is exactly why a reader has to look. And it does not
-apply when you *are* the first review: no prior standing, nothing to wait on,
-carry on.
+Unresolved threads block merge here too (ruleset `protect-main`,
+`required_review_thread_resolution: true`), so stopping is not what keeps a
+half-answered PR out of `main` — it is what keeps the second reviewer from
+spending a pass on findings nobody has answered. An outstanding
+`CHANGES_REQUESTED` blocks neither, which is why you check both.
+
+This does not apply when you *are* the first review: no prior standing, nothing
+to wait on, carry on.
 
 These two queries return review **states and counts, never bodies**. That is
 deliberate — knowing a round is open costs you nothing, whereas reading what the

--- a/.github/workflows/senior-queue.yml
+++ b/.github/workflows/senior-queue.yml
@@ -13,9 +13,10 @@ name: senior-queue
 #
 # The senior review is the SECOND review, and it happens only after the first
 # round has been answered. That is what the changes-requested and unresolved-
-# thread rules are for: neither blocks merge on its own
-# (`required_review_thread_resolution` is false in the ruleset), so without them
-# a PR reaches the senior queue with round one still open.
+# thread rules are for. The ruleset blocks merge on an unresolved thread
+# (`required_review_thread_resolution: true`) but not on an outstanding
+# changes-requested, and neither of them keeps a PR out of a review QUEUE —
+# so without these two rules a PR is surfaced to a senior with round one open.
 #
 # WHY A LABEL AND NOT THE REVIEW REQUEST. CODEOWNERS makes GitHub request the
 # owning team the instant a matching PR opens, when CI is usually red and nobody
@@ -253,10 +254,9 @@ jobs:
                 github.paginate(github.rest.pulls.listFiles,
                   { owner, repo, pull_number: number, per_page: 100 }),
                 // Unresolved review comments mean round one is still open. Only
-                // GraphQL exposes resolution state, and nothing else here sees it:
-                // `required_review_thread_resolution` is false in the ruleset, so an
-                // unresolved thread blocks neither merge nor a CHANGES_REQUESTED-free
-                // approval.
+                // GraphQL exposes resolution state. The ruleset blocks MERGE on an
+                // unresolved thread, but nothing stops such a PR being surfaced to a
+                // senior as ready — which is what this check is for.
                 github.graphql(`
                   query($owner:String!, $repo:String!, $number:Int!) {
                     repository(owner:$owner, name:$repo) {

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -316,6 +316,18 @@ returns as an input to your review, never as your review.
    lists, your approval doesn't unblock merge. Say which is still owed rather
    than leaving the author to discover it at the merge button.
 
+### "It says approved, but it won't merge"
+
+Three rules can each hold a green, approved PR. Check them in this order:
+
+- **Someone pushed after the approvals.** At least one approval has to land
+  *after* the most recent push. The old approvals are not cancelled — they still
+  count toward the two — so you need one fresh approval, not two.
+- **An unresolved conversation.** Every review thread must be marked resolved.
+  Resolve the ones you answered; the reviewer resolves the ones they raised.
+- **A code owner hasn't approved yet.** `.github/CODEOWNERS` decides which team
+  is required per path. Four approvals from the wrong team is still zero.
+
 ---
 
 ## Tagging `@claude` on an issue or PR


### PR DESCRIPTION
## Summary

- `required_review_thread_resolution` was flipped to `true` on the `protect-main` ruleset. Three places still said it was `false`.
- Text only. The gate in `/review` §1 and the check in `senior-queue` are unchanged, and both are still needed: blocking *merge* does not stop a PR being *surfaced to a senior as ready*, which is the job those two checks do.

Tier: Trivial.

## Review guidance

**Start here:** `.claude/skills/review/SKILL.md` §1. The old sentence said stopping was necessary *because* nothing blocked merge; that reason is now wrong, but the instruction is not. The rewrite gives the real reason — not spending the scarcer reviewer on findings nobody has answered — and keeps the contrast that matters: an unresolved thread blocks merge, an outstanding changes-requested does not, so a reviewer checks both.

**Unsure about:** nothing.

## Plan

**Didn't change:** the §1 gate, the queue's readiness rules, and the ruleset.

**Acceptance check:** `grep -n "is false in the ruleset\|do not block merge\|neither blocks merge"` over both files returns nothing; the workflow still parses and `SELF` still equals the job name.

**Deviated from the plan:** Nothing.

## Test plan

- [x] YAML parses; embedded script parses; `SELF` matches the job name.
- [x] No stale claim left in either file.
- No suite touches these lines.

## Follow-on issues

None.