### PR TITLE
process: make folding and merging the path of least resistance for issue inflow

### DIFF
--- a/.claude/skills/audit-board/SKILL.md
+++ b/.claude/skills/audit-board/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-board
-description: Use when the lead wants the whole board looked at as a system rather than item by item — "audit the board", "review all the issues", "what should be merged", "are any issues stale", "where are the clusters", "weekly board review", or a bare "/audit-board". Run it weekly and BEFORE /fill-ready, since filers are told to file freely and let this pass judge fit. Reads every open issue in Backlog, Ready, In Progress and Review and answers four questions across the pool: which issues should be merged or closed into each other, which are obsolete against the current repo, where the clusters of related work are, and what cross-cutting handling would beat the per-issue plan each body carries. Maintains `cluster:*` labels and the standing per-skill `next run:` issues, and re-checks each cluster's named next action against the date it was named. Also reports board hygiene — closed issues in active columns, open issues on no column, unlabeled items, and stalled work. Verifies every claim against the repo before repeating it. Proposes first and applies only what the lead approves; never starts the work.
+description: Use when the lead wants the whole board looked at as a system rather than item by item — "audit the board", "review all the issues", "what should be merged", "are any issues stale", "where are the clusters", "weekly board review", or a bare "/audit-board". Run it weekly and BEFORE /fill-ready, since filers search once and then file, leaving this pass to judge fit across the pool. Sets its own merge-or-close target from the week's inflow and reports the gap when it falls short. Reads every open issue in Backlog, Ready, In Progress and Review and answers four questions across the pool: which issues should be merged or closed into each other, which are obsolete against the current repo, where the clusters of related work are, and what cross-cutting handling would beat the per-issue plan each body carries. Maintains `cluster:*` labels and the standing per-skill `next run:` issues, and re-checks each cluster's named next action against the date it was named. Also reports board hygiene — closed issues in active columns, open issues on no column, unlabeled items, and stalled work. Verifies every claim against the repo before repeating it. Proposes first and applies only what the lead approves; never starts the work.
 allowed-tools:
   - Read
   - Bash
@@ -17,11 +17,10 @@ the rot, the clusters, and the handling that no single body can propose because
 no single body can see the others.
 
 **Run it weekly, and run it before `/fill-ready`.** That ordering is the point:
-filers are told explicitly not to worry about how their issue fits the ~180
-already open, because that judgement needs the whole pool and cannot be made from
-inside one PR. This pass is where duplicates get merged, premises get corrected
-and dead items get dropped. `/fill-ready` then ranks a deduped Backlog. Run it the
-other way round and it ranks duplicates.
+filers search once and then file, because judging fit needs the whole pool and
+cannot be made from inside one PR. This pass is where duplicates get merged,
+premises get corrected and dead items get dropped. `/fill-ready` then ranks a
+deduped Backlog. Run it the other way round and it ranks duplicates.
 
 **You propose, then apply what is approved.** No branches, no PRs, no code edits.
 You have no `Edit` or `Write` tool on purpose.
@@ -52,10 +51,32 @@ most of them `Done`. A limit that clips the tail drops real Backlog and Ready
 items and every count downstream is wrong with no error. Confirm the returned
 count is below the limit you asked for before trusting anything.
 
-Join the two and keep only `Backlog`, `Ready`, `In Progress`, `Review`. Expect
-~180 items and ~430 KB of bodies. Read all of them — the whole yield of this
+Join the two and keep only `Backlog`, `Ready`, `In Progress`, `Review`. Take the
+size from what you pulled — `jq length /tmp/issues.json` — never from a number
+quoted here or in a body. Read all of them — the whole yield of this
 skill is in what one body says about another, and `updatedAt` does not tell you
 which pairs collide.
+
+### The week's arithmetic sets this run's target
+
+Compute inflow and closure for the last seven days before reading any body:
+
+```sh
+d=$(date -v-7d +%Y-%m-%d)
+echo "filed:  $(gh issue list --repo PioneerAIAcademy/cowork-genealogy --state all \
+  --limit 500 --search "created:>=$d" --json number -q 'length')"
+echo "closed: $(gh issue list --repo PioneerAIAcademy/cowork-genealogy --state closed \
+  --limit 500 --search "closed:>=$d" --json number -q 'length')"
+```
+
+**This run's merge-or-close target is at least the week's inflow** — merges,
+absorbs, closes and obsoletes combined.
+
+If you cannot reach it, **say so at the top of the output**: the number you
+propose, the target, and the gap. Four merges against a week of two hundred
+filings is not a successful audit; the shortfall is the finding, and burying it
+under the merges you did find misreports the week. The lead still approves every
+item — the target binds what you propose, not what he accepts.
 
 ## 1. Merges
 
@@ -82,14 +103,18 @@ unassignable. Say "same week, two people" and leave both open.
 Search for merge candidates **by fix site, not by topic**. Issues that collide
 here almost never share a title; they want different lines in one file.
 
+**Two issues wanting different lines in the same file default to one issue.**
+Keeping them apart needs a stated reason — different lane, different reviewer, or
+a paid-run slot they cannot share. Absent one, merge.
+
 Bodies filed from 2026-08-04 open with a `**Touches:**` line — the instruction
 lives in `CLAUDE.md`'s `gh issue create` recipe, and essentially every issue in
 this repo is filed by Claude reading that file, so coverage on new issues should
 be high. Read it first.
 
-Still treat a missing line as **unknown**, never as "touches nothing": ~180 issues
-predate the convention, and a `CLAUDE.md` rule can be evicted from context late in
-a long session. The fallback grep is what carries the older half of the pool:
+Still treat a missing line as **unknown**, never as "touches nothing": much of the
+pool predates the convention, and a `CLAUDE.md` rule can be evicted from context
+late in a long session. The fallback grep carries the older half of the pool:
 
 ```sh
 grep -ho '\(docs\|eval\|packages\|apps\|scripts\)/[A-Za-z0-9._/-]*\.\(py\|ts\|tsx\|md\|json\)' \
@@ -505,7 +530,9 @@ confidence.
 
 ## Output shape
 
-Lead with the two or three things that change what happens this week. Then:
+Open with the week's arithmetic (§0) — filed, closed, and whether this run's
+proposals meet the target, naming the gap when they do not. Then the two or three
+things that change what happens this week. Then:
 
 1. **Merge and close** — the duplicates and absorbs, with the evidence for each
    and the exact `gh` command. Then the batch-together and schedule-together

--- a/.claude/skills/fill-ready/SKILL.md
+++ b/.claude/skills/fill-ready/SKILL.md
@@ -674,6 +674,10 @@ verdict, not a promotion.
 Same read, nearly free. Cap it at about **eight** proposals — a grooming list
 longer than the promotion list means the day's output was grooming.
 
+**The cap lifts when §1's "Arrival vs. closure" shows arrival leading for three
+consecutive weeks.** Then grooming *is* the day's output: propose as many closes
+and merges as the read supports, and say that is what you did.
+
 Candidates: empty-bodied issues months old; issues superseded by a newer, better
 one; issues whose premise the team has since abandoned; duplicates. Give one
 line of reasoning each, and a verdict — **close / rewrite / delete / leave**.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -85,3 +85,5 @@
 ## Follow-on issues
 
 <!-- Numbers filed for work you deferred. DEVELOPMENT.md § "Follow-on work". -->
+
+**Folded in / filed instead:** <!-- Follow-on work found during this PR: what you folded in, and for anything filed rather than folded, which of the four reasons applied. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,8 +142,18 @@ mocks (no E2B/Anthropic/OAuth needed).
   not sure if this is in scope" are not reasons — they're the two most common
   ways a foldable fix turns into an orphaned ticket. When genuinely unsure,
   ask rather than defaulting to filing.
-- **Deferring work creates an issue, not a file entry.** In the same PR that
-  defers something, file it — one command, no board write:
+- **Deferring work creates an issue, not a file entry.** Filing is the last
+  resort, not the default. Stop at the first of these that fits:
+
+  1. **Fold it into the current PR** — the rule above. Default.
+  2. **Comment on an existing issue that covers it.** Search before filing:
+     `gh issue list --state open --search "<path or symbol>"`, and grep the
+     `**Touches:**` lines. Adding to the issue that already owns the file beats
+     opening a second one against it.
+  3. **File with `--label icebox`** when no decision sits behind it.
+  4. **File as normal work.**
+
+  When you do file — in the same PR that defers it — one command, no board write:
 
   ```sh
   gh issue create --label developer|genealogist [--label icebox] \
@@ -156,8 +166,9 @@ mocks (no E2B/Anthropic/OAuth needed).
   change, when you know them. Overlap between issues here is almost never
   same-title — it is two issues wanting different lines in one file — and that
   line is what makes it greppable. Best guess is fine; the weekly `/audit-board`
-  pass reads it, no gate does. **File even when you suspect a duplicate**: judging
-  fit against ~180 open issues is that pass's job, not the filer's.
+  pass reads it, no gate does. One search is the whole obligation — do not agonise
+  past it. `/audit-board` judges fit across the whole open pool, which is the only
+  vantage point that sees every collision.
 
   | Label | Use for |
   |---|---|

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -165,12 +165,18 @@ gh issue create --label developer --title "…" --body "…"
 - **Mention the number in your PR description** so the reviewer can see what you
   chose not to do.
 
-**File it even if you think it might be a duplicate.** Deciding how a new issue
-fits against the ~180 already open is not your job and cannot be done well from
-inside one PR — the overlap is usually at a line number, not a title. File it;
-the lead's weekly `/audit-board` pass merges, rewrites and drops issues across the
-whole pool, which is the only vantage point from which duplicates are visible. A
-duplicate costs one comment to close. An unfiled finding costs a rediscovery.
+**Search once before you file, then stop.** Filing is the last resort in a
+four-step order: fold it into this PR; comment on an existing issue that covers
+it; file with `--label icebox` when no decision sits behind it; file as normal
+work. The search is one command — `gh issue list --state open --search "<path or
+symbol>"`, plus a grep of the `**Touches:**` lines — because the overlap is
+usually at a line number, not a title, and a comment on the issue that already
+owns the file beats a second issue against it.
+
+Do not agonise past that one search. `/audit-board` merges, rewrites and drops
+issues across the whole pool weekly, which is the only vantage point from which
+every duplicate is visible. A duplicate costs one comment to close; an unfiled
+finding costs a rediscovery.
 
 **Do not park these in a to-do file, under any name.** That was tried:
 `docs/TODOs.md`, retired 2026-08-02 as issues #1117–#1157. Its exit event — "an


### PR DESCRIPTION
## Summary

- Four process edits so the lead's four inflow levers are the path of least resistance, not the harder path.
- **Tier: Normal.** Prose/config only — no code, no schema, no skill under `packages/engine/plugin/skills/**` (the run-log gate is untouched).

### The measured problem

Re-measured today with `gh issue list --state all --search "created:…"` / `"closed:…"`:

| Window | Filed | Closed | Net |
|---|---|---|---|
| 2026-07-12..19 | 35 | 19 | +16 |
| 2026-07-19..26 | 72 | 19 | +53 |
| 2026-07-26..08-02 | 135 | 80 | +55 |
| 2026-08-02..09 | **236** | 118 | **+118** |

**235 open right now.** Arrival has led closure for four consecutive weeks and the gap is widening.

### The four levers, mapped

| Lever (lead's words) | Edit |
|---|---|
| fold follow-on tasks into the current PR | `CLAUDE.md` + `DEVELOPMENT.md`: fold is step 1 of an explicit four-step order |
| merge new issues into existing issues | same order, step 2 — comment on the issue that already owns the file, search first |
| merging issues | `audit-board`: merge-or-close target ≥ the week's inflow; same-file collisions default to one issue |
| not filing unimportant issues / label icebox | same order, steps 3–4; `fill-ready` grooming cap lifts while arrival leads |

### What changed

**1. `CLAUDE.md` — precedence flipped.** The load-bearing sentence was *"**File even when you suspect a duplicate**: judging fit against ~180 open issues is that pass's job, not the filer's."* That read as blanket permission overriding the fold-first rule immediately above it. Replaced with a numbered order — fold → comment on an existing issue (search first) → file as `icebox` → file as normal work — and the duplicate tolerance kept as *"One search is the whole obligation — do not agonise past it."*

**2. `DEVELOPMENT.md` — folded in, not filed.** That file's § "Follow-on work you find along the way" declares itself *"the owner of these rules"* and carried the same blanket-permission paragraph plus the same stale `~180`. Editing `CLAUDE.md` alone would have left the owning doc contradicting it. Matched to the same four-step order.

**3. `.claude/skills/audit-board/SKILL.md` — a volume obligation.** The pass previously had none: it could return four merges against a week of 236 filings and read as a successful audit. Added, right after the pool is pulled, a merge-or-close target of **at least the week's inflow** computed from live `gh` counts, and a requirement to state the number/target/gap at the top of the output when it falls short. Merge bias strengthened — two issues wanting different lines in one file now default to one issue, and keeping them apart needs a stated reason. Three stale `~180` literals replaced with the counts the skill already measures (`jq length /tmp/issues.json`), so no count can be quoted stale again.

**4. `.claude/skills/fill-ready/SKILL.md` — cap lifts under sustained inflow.** The ~eight grooming cap was a hard ceiling on closure set below inflow. It now lifts when the skill's own § "Arrival vs. closure — the trend that outranks the day's move" shows arrival leading for three consecutive weeks (true now, for four), and grooming becomes the day's output.

**5. `.github/pull_request_template.md`** — one line under "Follow-on issues" asking what was folded in, and for anything filed instead, which of the four reasons applied.

### This changes defaults and reporting, not authority

`audit-board` and `fill-ready` still **propose**; the lead still approves every merge, close and promotion. The target binds what the pass proposes, not what he accepts. No skill's decision criteria changed — the only new obligation is that an under-delivery must be *stated* rather than silently reported as success.

Two counts are deliberately **not** hardcoded. The brief's "~180 → 224" was already stale when I measured (236 filed / 235 open), which is the failure mode itself, so `CLAUDE.md` now says "the whole open pool" with no literal and `audit-board` computes its own.

## Review guidance

**Start here:** the four-step order in `CLAUDE.md` (§ "Deferring work creates an issue") and its twin in `DEVELOPMENT.md` — they must not drift apart, since `CLAUDE.md` points at `DEVELOPMENT.md` as the owner. Check the order reads the same in both.

**Unsure about:** whether `audit-board`'s target should be inflow (what I used) or inflow-plus-a-drawdown. Inflow-parity only stops the board growing; it does not shrink the 235.

## Plan

**Didn't change:** nothing under `packages/engine/plugin/skills/**` or `agents/**` — no run-log snapshot flips, no paid eval run needed. `triage-standup` and `review-icebox` also file/handle issues but neither was named in the brief.

**Acceptance check:** `make test-all` passes (1793 pytest + 148 vitest). `doc-links.test.ts` lints `.claude/{agents,commands,skills}`; I verified it actually fails rather than trusting the green — appending a bogus `docs/specs/no-such-spec-xyz.md` and `/no-such-command-xyz` to `audit-board/SKILL.md` failed exactly two assertions, then reverted.

**Deviated from the plan:** two additions beyond the four named edits, both folded in per the rule this PR strengthens — the `DEVELOPMENT.md` twin (#2 above), and `audit-board`'s `description` frontmatter, which still said filers *"are told to file freely and let this pass judge fit"* and would have contradicted the new order at the routing surface.

## Test plan

- [x] I ran `make test-all` and it passed.
- [x] No skill run-log snapshot changed — `.claude/skills/` is Claude Code tooling, not the shipped plugin, so no `make eval-skill` run is required.
- [x] No `description` change on a shipped plugin skill, so no negative-reciprocity routing tests apply. The one frontmatter edit is on a `.claude/` tooling skill.

## Follow-on issues

None filed.

**Folded in / filed instead:** folded in the `DEVELOPMENT.md` twin paragraph and the `audit-board` description clause — both were the same stale rule this PR exists to fix, and filing them would have been the exact behaviour being corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
