### PR TITLE
Delete the 26 dead skill model: pins (ISSUES.md B2) — needs eval-cosmetic-skip

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -351,14 +351,15 @@ Per-step model routing exists **only through plugin agents.**
 | Surface | Honored where | Today |
 |---|---|---|
 | **Agent `model:`** | Cowork, hosted, both harnesses | `gps-mentor` → `claude-sonnet-5`; `image-reader-opus` → `claude-opus-4-8`; `record-extractor` + `image-reader` → `claude-sonnet-4-6` |
-| **Skill `model:`** | **the unit eval harness only** | 26 of 27 skills pin `claude-sonnet-4-6` — which *is* the harness default |
+| **Skill `model:`** | **the unit eval harness only** | no skill pins one |
 | **Reasoning effort** | session-wide; never set by `real_agent.build_options` | not a per-step lever |
 
-> **Direction (critique §2.4, §5.3).** The 26 skill `model:` pins are **dead
-> lines**, not a fidelity gap: they pin the value that is already the default, and
-> only the unit harness reads them. They are slated for deletion because they make
-> per-step routing look like it exists. **Do not add a `model:` pin to a new
-> skill.** To route a step to a different model, delegate it to a plugin agent.
+> **Do not add a `model:` pin to a new skill.** The mechanism still exists in the
+> unit harness (`harness/orchestrator.py` honours the field, falling back to
+> `DEFAULT_MODEL`), but nothing uses it: 26 skills pinned `claude-sonnet-4-6` —
+> the harness default — and were deleted, because a pin that changes nothing
+> makes per-step routing look like it exists. To route a step to a different
+> model, delegate it to a plugin agent.
 
 ### 3.6 The lane rule — classify a finding before you edit prose
 

--- a/packages/engine/mcp-server/tests/packaging/gps-terminology.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/gps-terminology.test.ts
@@ -101,15 +101,15 @@ function findMatchesInFile(abs: string, rel: string): Match[] {
 const ALLOWLIST: Array<{ relPath: string; lineNo: number; reason: string }> = [
   {
     relPath: "skills/citation/SKILL.md",
-    lineNo: 515,
+    lineNo: 514,
     reason:
       'terminology guardrail: quotes the user\'s "primary source"/"secondary source" phrasing back at them in order to correct it',
   },
   {
     relPath: "skills/citation/SKILL.md",
-    lineNo: 545,
+    lineNo: 544,
     reason:
-      "terminology guardrail decision-rule row: same correction context as line 515",
+      "terminology guardrail decision-rule row: same correction context as line 514",
   },
 ];
 

--- a/packages/engine/plugin/skills/check-warnings/SKILL.md
+++ b/packages/engine/plugin/skills/check-warnings/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: check-warnings
-model: claude-sonnet-4-6
 description: Genealogical data integrity guardrail — catches logical
   impossibilities in a person's data (impossible lifespans, events after death,
   child born after parent died, burial before death) and retrieves

--- a/packages/engine/plugin/skills/citation/SKILL.md
+++ b/packages/engine/plugin/skills/citation/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: citation
-model: claude-sonnet-4-6
 description: Refines source citations to Evidence Explained standards. Updates citation
   and citation_detail on existing source entries in research.json. GPS Step 2 — Complete and Accurate Source Citation. Use
   when the user says "cite this source", "fix citations", "format citation",

--- a/packages/engine/plugin/skills/conflict-resolution/SKILL.md
+++ b/packages/engine/plugin/skills/conflict-resolution/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: conflict-resolution
-model: claude-sonnet-4-6
 allowed-tools:
   - place_search
   - place_search_all

--- a/packages/engine/plugin/skills/convert-dates/SKILL.md
+++ b/packages/engine/plugin/skills/convert-dates/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: convert-dates
-model: claude-sonnet-4-6
 description: Use when a genealogist asks to convert a date "to the
   Gregorian calendar," asks what a Quaker numbered-month date means in
   modern terms, wonders if an unusual historical date is valid under the

--- a/packages/engine/plugin/skills/historical-context/SKILL.md
+++ b/packages/engine/plugin/skills/historical-context/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: historical-context
-model: claude-sonnet-4-6
 description: Provides historical context for genealogy research — boundary changes, naming conventions, migration patterns, record availability by era, cultural practices, and historical events that affect records. Outputs narrative context to the user; does not modify project files. Use
   when the user says "what was happening in [place] in [year]?", "boundary
   changes", "naming conventions", "why would [thing] appear in a record?",

--- a/packages/engine/plugin/skills/hypothesis-tracking/SKILL.md
+++ b/packages/engine/plugin/skills/hypothesis-tracking/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: hypothesis-tracking
-model: claude-sonnet-4-6
 description: >-
   Creates, updates, and reviews hypotheses about person identity, parentage,
   and relationships. Links supporting and contradicting assertions, manages

--- a/packages/engine/plugin/skills/init-project/SKILL.md
+++ b/packages/engine/plugin/skills/init-project/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: init-project
-model: claude-sonnet-4-6
 description: Initializes a new genealogy research project with GPS-conformant
   file structures. Creates research.json (GPS audit trail) and
   tree.gedcomx.json (simplified GedcomX deliverable) from a FamilySearch

--- a/packages/engine/plugin/skills/locality-guide/SKILL.md
+++ b/packages/engine/plugin/skills/locality-guide/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: locality-guide
-model: claude-sonnet-4-6
 description: >-
   Produces a locality research guide for a place and time period — what
   genealogical records exist, where they're held, jurisdictional history, and

--- a/packages/engine/plugin/skills/person-evidence/SKILL.md
+++ b/packages/engine/plugin/skills/person-evidence/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: person-evidence
-model: claude-sonnet-4-6
 description: >-
   Links assertions to GedcomX persons — identity resolution. Evaluates whether
   a record's person matches a tree person, creates person_evidence entries with

--- a/packages/engine/plugin/skills/project-status/SKILL.md
+++ b/packages/engine/plugin/skills/project-status/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: project-status
-model: claude-sonnet-4-6
 description: Reads the current state of a genealogy research project and
   produces two summaries — a detailed GPS-state summary for experienced
   genealogists and a user-friendly narrative for casual users. Detects

--- a/packages/engine/plugin/skills/proof-conclusion/SKILL.md
+++ b/packages/engine/plugin/skills/proof-conclusion/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: proof-conclusion
-model: claude-sonnet-4-6
 description: Writes GPS-conformant proof conclusions — selects the tier
   (Proved/Probable/Possible/Not Proved/Disproved), chooses the form
   (Statement/Summary/Argument), and writes a self-contained narrative

--- a/packages/engine/plugin/skills/question-selection/SKILL.md
+++ b/packages/engine/plugin/skills/question-selection/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: question-selection
-model: claude-sonnet-4-6
 description: Selects the next research question (writing it to research.json) based on current project
   state — timeline gaps, unresolved conflicts, hypothesis tests, or
   exhausted direct evidence requiring FAN pivot. Also derives the first

--- a/packages/engine/plugin/skills/record-extraction/SKILL.md
+++ b/packages/engine/plugin/skills/record-extraction/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: record-extraction
-model: claude-sonnet-4-6
 description: >-
   Extracts GPS-conformant assertions from genealogical records and owns
   their evidence classifications. Acquires and triages the record (search

--- a/packages/engine/plugin/skills/research-exhaustiveness/SKILL.md
+++ b/packages/engine/plugin/skills/research-exhaustiveness/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: research-exhaustiveness
-model: claude-sonnet-4-6
 description: Evaluates whether research on a question is reasonably
   exhaustive — applies the five threshold questions and the 7-point
   stop criteria, then either writes the exhaustive_declaration on the

--- a/packages/engine/plugin/skills/research-plan/SKILL.md
+++ b/packages/engine/plugin/skills/research-plan/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: research-plan
-model: claude-sonnet-4-6
 description: Creates, reviews, and revises a sequenced research plan (in research.json)
   for a genealogy question — which record sets to search, in what order, from which
   repositories, with fallbacks. GPS Step 1; BCG Standards 9-18. Use to create a plan

--- a/packages/engine/plugin/skills/research/SKILL.md
+++ b/packages/engine/plugin/skills/research/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: research
-model: claude-sonnet-4-6
 description: >-
   Drives the full GPS research workflow on a research objective, invoking the
   right sub-skills in the right order based on current research.json state.

--- a/packages/engine/plugin/skills/search-external-sites/SKILL.md
+++ b/packages/engine/plugin/skills/search-external-sites/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: search-external-sites
-model: claude-sonnet-4-6
 description: Generates search URLs for external genealogy sites (Ancestry,
   MyHeritage, FindMyPast, FindAGrave, Newspapers.com) and walks the user
   through the click-capture-analyze workflow. Logs each search to research.json (including nil results) and

--- a/packages/engine/plugin/skills/search-familysearch-wiki/SKILL.md
+++ b/packages/engine/plugin/skills/search-familysearch-wiki/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: search-familysearch-wiki
-model: claude-sonnet-4-6
 description: >-
   Search the FamilySearch Research Wiki for genealogy research guidance and
   save the findings as a markdown file in the user's working folder. Use when

--- a/packages/engine/plugin/skills/search-full-text/SKILL.md
+++ b/packages/engine/plugin/skills/search-full-text/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: search-full-text
-model: claude-sonnet-4-6
 description: Invoke for FamilySearch full-text search (FTS) — immediately
   when the user says "full-text search", "FTS", "search document
   transcripts", or "construct a full-text query". Use this skill to find a

--- a/packages/engine/plugin/skills/search-images/SKILL.md
+++ b/packages/engine/plugin/skills/search-images/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: search-images
-model: claude-sonnet-4-6
 description: Invoke for browsing FamilySearch digitized image volumes
   page-by-page — immediately when the user says "browse the images", "browse
   a volume", "page through", "look through the film/roll", "go through the

--- a/packages/engine/plugin/skills/search-records/SKILL.md
+++ b/packages/engine/plugin/skills/search-records/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: search-records
-model: claude-sonnet-4-6
 description: Executes searches against FamilySearch historical records per
   the research plan. Routes to the correct MCP search tool based on record
   type, triages results using match scoring, logs every search including nil

--- a/packages/engine/plugin/skills/search-wikipedia/SKILL.md
+++ b/packages/engine/plugin/skills/search-wikipedia/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: search-wikipedia
-model: claude-sonnet-4-6
 description: Look up a topic on Wikipedia — the general-purpose encyclopedia — and save the summary as a markdown file in the user's working folder. Use when the user explicitly names Wikipedia, or asks to look up or save general background on a topic, person, place, or historical event. Do NOT use when the user names the FamilySearch Research Wiki or "FamilySearch wiki" (use search-familysearch-wiki), wants a locality records-availability guide — what records exist for a place and where they are held (use locality-guide), or wants narrative genealogical history such as migration patterns or boundary changes (use historical-context).
 allowed-tools:
   - wikipedia_search

--- a/packages/engine/plugin/skills/timeline/SKILL.md
+++ b/packages/engine/plugin/skills/timeline/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: timeline
-model: claude-sonnet-4-6
 description: Builds candidate timelines (written to research.json) from assertions, surfaces gaps,
   and supports identity-testing by checking whether records cohere into one
   life. Logical-impossibility checks (events after death, impossible ages)

--- a/packages/engine/plugin/skills/translation/SKILL.md
+++ b/packages/engine/plugin/skills/translation/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: translation
-model: claude-sonnet-4-6
 description: Genealogy-specific translation and paleography assistance for
   historical records in German, French, Spanish, Italian, Dutch, Latin, and
   Portuguese. Covers period handwriting (Kurrentschrift, Sütterlin), Latin

--- a/packages/engine/plugin/skills/tree-edit/SKILL.md
+++ b/packages/engine/plugin/skills/tree-edit/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: tree-edit
-model: claude-sonnet-4-6
 description: Direct edits to tree.gedcomx.json — add fact, correct value,
   create person, add relationship, merge two persons (confirmed
   identical via proof-conclusion), verify the tree already reflects a

--- a/packages/engine/plugin/skills/validate-schema/SKILL.md
+++ b/packages/engine/plugin/skills/validate-schema/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: validate-schema
-model: claude-sonnet-4-6
 allowed-tools:
   - validate_research_schema
 description: Validates genealogy project files (research.json and


### PR DESCRIPTION
> ## Needs `eval-cosmetic-skip` from a senior — applied **after** the final push
>
> This touches `packages/engine/plugin/skills/**`, which invalidates the run-log snapshot for all 26 skills and arms `check-runlogs.yml` rule 2 across every one of them. The change is behaviour-neutral, so a re-run and re-grade of 26 skills would buy nothing.
>
> **The label is stripped on every push** (`cosmetic-skip-strip.yml`), and rule 2's expiry is decided from the `synchronize` event rather than from the label, so re-applying it before a later push does not survive. Please apply it **after** the last commit lands.
>
> **Why behaviour-neutral, in one line:** the pins name the value that is already the default, and only the unit harness reads them — so deleting them changes nothing, anywhere. The detail is below.

---

Item **B2** from `ISSUES.md` § B. Separate from the other seven fixes (PR #1496) precisely because it arms the run-log gate.

`make test-all` passes.

### What was verified before deleting anything

| Claim | Verified |
|---|---|
| All 26 pin the same value | Yes — every one is exactly `model: claude-sonnet-4-6`. The script asserted the literal string per file and refused to touch a line that differed; none did. |
| That value is the harness default | Yes — `DEFAULT_MODEL = "claude-sonnet-4-6"`, `eval/harness/harness/skill_runner.py:57` |
| The unit harness is the only reader | Yes — `eval/harness/harness/orchestrator.py:209` is the sole read of a skill's `model:` frontmatter |
| It falls back to the default when absent | Yes — same site: the field is used only `if isinstance(skill_model, str) and skill_model.strip()`, otherwise the CLI `model` arg stands, which defaults to `DEFAULT_MODEL` |
| Nothing else reads it | Yes — the **e2e** harness's `model:` handling (`e2e/orchestrator.py:473,508`) rewrites a staged plugin **agent's** frontmatter from `fixture.json`, not a skill's; the eval CRUD UI only reads the `model` field recorded on the run-log envelope; Cowork and the hosted path ignore skill `model:` entirely |
| 26 of 27, not 27 | Yes — `forget-and-rederive` never carried one |

So the pins are dead lines whose only effect is to make per-step model routing look like it exists.

### The four plugin agent pins are untouched

`gps-mentor` → `claude-sonnet-5`, `image-reader-opus` → `claude-opus-4-8`, `record-extractor` and `image-reader` → `claude-sonnet-4-6`. Those are real, differentiated, and honored in every environment — they are the *only* per-step routing lever the system has, which is exactly why the skill-level lookalikes are worth removing.

### Also in this PR

- **`docs/architecture.md` §3.5** — the Direction callout said the pins were "slated for deletion", which is now stale. The guidance itself stays: adding a `model:` pin to a new skill is still the wrong move, and the mechanism still exists in the unit harness. Only the claim about pending work goes.
- **`gps-terminology.test.ts`** — its allow-list pins two `citation/SKILL.md` line numbers, and removing a frontmatter line shifted them by one. Retargeted 515/545 → 514/544. Caught by `make test-all`, not by inspection.

---

### CI state, and one thing to know before applying the label

Everything is green except **`runlogs`**, which fails on rule 2 for **25 skills** (the 26th, `research`, is in `RUNLOG_GATE_EXEMPT_SKILLS`). That is the expected and intended failure — it is what the label exists to clear.

**Worth knowing before you sign it:** several of those 25 report snapshot drift in files **this PR does not touch**. Their run logs were already inactive on `main`; this PR is simply the first change to those skill paths since, so it is the first PR whose scope step makes `check-runlogs` look. The label would wave these through too:

- 12 `eval/fixtures/scenarios/*/research.json` (the `flynn-*` and `mid-research-flynn*` family)
- `eval/tests/unit/person-evidence/low-score-strong-correlation-still-links.json`
- `packages/engine/plugin/agents/image-reader.md`, `image-reader-opus.md`

I have not touched any of them and make no claim about whether those divergences are behaviour-neutral — only the 26 frontmatter deletions are mine. If you would rather that backlog were dealt with on its own terms, this PR is not the place it has to happen, but applying the label here does suppress the signal for one cycle.

---

**Not merging this myself** — over to you, after the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
