### PR TITLE
docs: correct the description-cap provenance in §3.2

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -276,16 +276,29 @@ turns from the right skill.
   `eval/harness/scripts/check_skill_frontmatter.py` (CI **and** the plugin
   packaging script, checking the *folded* value so a long multi-line description
   cannot escape to install time) and
-  `tests/packaging/skill-description-length.test.ts`. **1024 is a house
-  standard, not a runtime limit.** Measured 2026-08-09 against CLI 2.1.226:
-  descriptions of 1,105 and 2,000 characters register intact — full text, no
-  truncation, no error — under **both** load paths, `setting_sources=["project"]`
-  (what both harnesses stage into) and `plugins=[{"type": "local", …}]` (what the
-  hosted control plane passes). The repo corroborates it: five `.claude/skills/`
-  descriptions run 1028–1197 characters and load every session. Only Cowork's
-  own install-time validator is untested, and it is the reason to keep the cap —
-  that plus attention: every description is resident in the orchestrator's
-  context on every turn. **Keep the lint. Do not restate it as an SDK limit.**
+  `tests/packaging/skill-description-length.test.ts`.
+  **The cap binds where the Agent SDK loads the file** —
+  `packages/engine/plugin/skills/*/SKILL.md` and
+  `packages/engine/plugin/agents/*.md` (both harnesses stage them, the hosted
+  control plane passes `plugins=[{"type": "local", …}]`, Cowork loads the
+  plugin). It does **not** apply to this repo's own `.claude/skills/`, which a
+  Claude Code session reads directly and nothing stages into an SDK run — two
+  have sat over the cap for months, and a proposal to widen the lint to them was
+  closed invalid for exactly that reason. **They are not evidence about the SDK
+  path in either direction; do not cite them as such.**
+  **Treat 1024 as hard — the mechanism is unproven and three sources disagree.**
+  The PR that added the lint (2026-07-18) trimmed `proof-conclusion` from 1,220
+  characters after an observed failure, with eleven other descriptions within
+  ~25 of the cap; the
+  vendored `improve_description.py` says an over-length description is
+  *truncated*, not dropped; and a 2026-08-09 probe against CLI 2.1.226 saw 1,105
+  and 2,000 characters register **intact** under both load paths. Those three
+  cannot all be right, and no one has reconciled them — the SDK's behaviour may
+  simply have changed since July. Cowork's own install-time validator is
+  untested by all three. **Keep the lint regardless**: truncated-vs-dropped
+  changes what an over-cap description does to triggering, nobody knows which it
+  is, and 1024 characters is enough — a description is resident in the
+  orchestrator's context on every turn.
 - **Descriptions are tuned empirically, not by taste.** `eval/triggering/` holds
   the vendored description optimizer; `docs/skill-lifecycle.md` owns the
   workflow.


### PR DESCRIPTION
## What

PR #1498 landed **"1024 is a house standard, not a runtime limit"** on the strength of a single probe. The lead supplied the history that contradicts it. This corrects the claim without losing the measurement.

## Two problems with the merged text

**1. The corroborating evidence was invalid.** It cited five `.claude/skills/` descriptions running 1028–1197 characters and loading fine. Those are read directly by a Claude Code session and are **never staged into an Agent SDK run** — they sit on the other side of the load-path seam and say nothing about where the cap binds. A proposal to widen the lint to them was closed invalid for exactly that reason.

**2. The conclusion outran the evidence.** Three sources disagree, and none is decisive:

| Source | Says |
|---|---|
| The PR that added the lint (2026-07-18) | Trimmed `proof-conclusion` from **1,220** chars after an observed failure; eleven others sat within ~25 of the cap |
| Vendored `improve_description.py` | Over-length descriptions are **truncated**, not dropped |
| Probe, 2026-08-09, CLI 2.1.226 | 1,105 and 2,000 chars register **intact** under both load paths |

They cannot all be right. The SDK's behaviour may simply have changed since July. **Truncated-vs-dropped changes what an over-cap description does to triggering** — one is a load failure, the other is silent degradation that looks like a routing bug.

## What this PR says instead

- **Where the cap binds:** `packages/engine/plugin/skills/*/SKILL.md` and `packages/engine/plugin/agents/*.md` — the Agent SDK path (both harnesses stage them, hosted passes `plugins=[{"type": "local", …}]`, Cowork loads the plugin).
- **Where it does not:** this repo's own `.claude/skills/`, by load path — and those are not evidence in either direction.
- **Treat 1024 as hard**, mechanism unproven, sources named so the next reader does not re-derive it.
- **Keep the lint.** 1024 characters is enough, and every description is resident in the orchestrator's context on every turn.

No further investigation is proposed — the lead's call is that the cap is worth keeping whether or not it binds.

## Verification

`make test-all` green. Note the **issue-reference ratchet caught a first draft** of this change: `doc-links.test.ts` pins `docs/architecture.md` at 24 refs and failed when I cited the two issue numbers inline. Rewritten to state the fact rather than the ticket, which is that lint's documented intent — a live demonstration that it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)