### PR TITLE
CLAUDE.md: say that the fetch timeout covers the body, not just the headers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -665,9 +665,12 @@ Where to look first:
   `volume_search` hung for 236 minutes. Every tool that touches
   the network calls this instead of the global `fetch` directly; it is the
   only file allowed to (enforced by `tests/packaging/no-bare-fetch.test.ts`).
-  Default timeout 30s; pass a longer one (e.g. `image_transcribe`'s OCR call,
-  `fs-image-fetch.ts`'s multi-MB body read) as the third argument when 30s
-  doesn't fit the call's own budget.
+  Default timeout 30s; pass a longer one as the third argument (90s for
+  `image_transcribe`'s OCR call and `fs-image-fetch.ts`'s multi-MB scan). The
+  budget covers headers **and** body — size it for the whole transfer, not the
+  round-trip to first byte. A body still streaming when the clock fires is
+  aborted mid-read, and the wrapper turns that into the same readable error,
+  so call sites never handle it themselves.
 - **`src/utils/place-resolver.ts`** — the shared resolver between a
   `standardPlace` name and FamilySearch IDs: `resolveStandardPlace`,
   `standardPlaceToRepId`, `repIdToStandardPlace`, `standardPlaceToPlaceId`


### PR DESCRIPTION
## Start here
`CLAUDE.md`, the `src/utils/http.ts` bullet under "Code reuse → Where to look first". One paragraph, no code.

## Summary
PR #1373 landed `fetchWithTimeout` and this entry describing it, then changed the behavior in its last commit without updating the entry. As merged, the line gives the default and how to override it, but not the fact that decides which number to pick: **the clock starts at the request and keeps running while the response streams.** A 30s budget on a multi-MB download is 30s for the whole transfer, not 30s to first byte. Not knowing that is exactly what left `image_read` / `image_transcribe` on a budget too small for their payload.

Also records that a mid-body abort is translated inside the wrapper, so no call site needs its own `try`/`catch` around `.json()` / `.text()` / `.arrayBuffer()` — there were 40 such reads across 24 files and the point of putting it in one place is that nobody writes the 41st.

## Didn't change
No code. The behavior this describes is already on `main`; this only makes the entry match it.

## Acceptance check
`npx vitest run tests/packaging/` — 384 passed, 16 files. That is the suite that reads `CLAUDE.md` (the ADR- and doc-link checks); nothing else in the repo reads this paragraph, so there is no stronger check available than "the doc lints still pass and the text now matches `http.ts`."

## Unsure about
Nothing blocking. The one judgement call is length: this is prompt context on every session, so I kept the addition to three lines and dropped the "confirmed live when volume_search hung" framing rather than adding to it.