### PR TITLE
docs: write down four traps that only lived in an agent's memory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,8 @@
+# A rule naming a team that does not exist is SILENTLY DROPPED: the file still
+# parses, and reviews for those paths route to nobody. Reading the file cannot
+# show this — after every edit here, check
+# `gh api /repos/{owner}/{repo}/codeowners/errors`.
+#
 # Every PR needs one approval from a senior genealogist (this team),
 # in addition to at least one more approval from anyone else with
 # write access. Enforced together with branch protection's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -614,6 +614,11 @@ The `description` in SKILL.md frontmatter is critical — it determines
 when Claude triggers the skill. Be specific about what kinds of user
 requests should activate it.
 
+**No explanatory prose in a `SKILL.md` or an agent `.md`.** Every line in those
+files is a billed prompt token on every invocation. No comments, no rationale,
+no note of what was tried before. Write the instruction; the reasoning behind it
+goes in the skill's spec or its rubric.
+
 **Lane rule for skill findings.** Before editing any SKILL.md (or plugin
 agent body) to fix an e2e/eval/user finding, classify the finding:
 (1) tooling defect → MCP tool PR; (2) eval defect (judge/rubric/fixture
@@ -622,6 +627,14 @@ playbook/table; (4) core doctrine → the stewarded prose edit, gated by
 the unit suite. Most findings are lanes 1–2; prose edits never
 compensate for a tool or eval bug. Full version:
 `docs/skill-lifecycle.md` §5.
+
+### A new lint must be proven to fail
+
+Before committing a lint, validator, or CI check, break the repo so the check
+fires and watch it fail. A check that cannot fail reads as coverage and is worse
+than no check at all. The three ways one silently passes here: a grep whose
+pattern excludes its own tree, a `git grep` that skips untracked files, and a
+field-name match that collides with an unrelated key.
 
 ### Python file I/O: always pass `encoding="utf-8"`
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,6 +44,13 @@ that re-runs the tracked hook, so editing anything under `scripts/git-hooks/`
 takes effect immediately — there's nothing to reinstall after a pull. Rerun the
 installer only when a *new* hook is added to the list.
 
+The one thing the hook does **not** set up is the compiled engine
+(`packages/engine/mcp-server/build/`). Run the Python suites through
+`make harness-test`, which builds the engine first; a bare `pytest` in a fresh
+worktree fails on the missing build and looks like a regression. Do not symlink
+`build/` into a worktree — a worktree on an engine branch would then silently
+test `main`'s compiled output.
+
 ## Smoke-test tools against live APIs
 
 Bypass the MCP harness to debug a tool in isolation:


### PR DESCRIPTION
Four traps that had bitten someone but were only recorded in one agent's
private memory, so no teammate could find them. Each is written as a rule at
the place you'd be standing when it bites you. No behavior changes.

**A fresh worktree has no compiled engine** — `DEVELOPMENT.md`, git-hooks
section. That section told you what the post-checkout hook sets up and said
nothing about the one thing it skips, so a bare `pytest` in a new worktree
fails on a missing build and reads as a regression. Adds: run the Python
suites through `make harness-test`, and never symlink `build/` in (a worktree
on an engine branch would then test `main`'s compiled output).

**A CODEOWNERS rule naming a team that doesn't exist is silently dropped** —
comment at the top of `.github/CODEOWNERS`. The file still parses and those
paths route to nobody. You cannot see it by reading the file, so the comment
names the endpoint that shows it: `gh api /repos/{owner}/{repo}/codeowners/errors`.

**A lint nobody has watched fail may not be able to fail** — `CLAUDE.md`,
under the conventions. Break the repo and watch the check fire before you
commit it. Lists the three ways one has silently passed here: a grep whose
pattern excludes its own tree, a `git grep` that skips untracked files, and a
field-name match that collides with an unrelated key.

**No comments or rationale in a SKILL.md or agent body** — `CLAUDE.md`, skills
section. Those lines are billed prompt tokens on every invocation. The
neighbouring rule about agent playbook files was already written down; this one
wasn't. Reasoning goes in the skill's spec or rubric.

All 384 packaging tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
