### PR TITLE
Size the image_transcribe OCR timeout from the measured corpus (90s -> 180s)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -679,8 +679,11 @@ Where to look first:
   `volume_search` hung for 236 minutes. Every tool that touches
   the network calls this instead of the global `fetch` directly; it is the
   only file allowed to (enforced by `tests/packaging/no-bare-fetch.test.ts`).
-  Default timeout 30s; pass a longer one as the third argument (90s for
-  `image_transcribe`'s OCR call and `fs-image-fetch.ts`'s multi-MB scan). The
+  Default timeout 30s; pass a longer one as the third argument (180s for
+  `image_transcribe`'s OCR call, 90s for `fs-image-fetch.ts`'s multi-MB scan,
+  60s for `wiki_search`, `collections_search` and `wikipedia_search`). Size a
+  raise from the measured e2e corpus, not by guessing — the worked method is in
+  `docs/specs/image-transcribe-tool-spec.md`. The
   budget covers headers **and** body — size it for the whole transfer, not the
   round-trip to first byte. A body still streaming when the clock fires is
   aborted mid-read, and the wrapper turns that into the same readable error,

--- a/docs/specs/collections-search-tool-spec.md
+++ b/docs/specs/collections-search-tool-spec.md
@@ -269,6 +269,18 @@ due to access restrictions).
 
 ---
 
+## Timeout
+
+`COLLECTIONS_TIMEOUT_MS` = **60s**, passed as `fetchWithTimeout`'s third
+argument, rather than the shared 30s default. The cold path is one un-retried
+`count=5000` request whose budget has to cover a large body streaming in full.
+Across the committed e2e run logs, 2 of 51 calls ran past 30s, at 33s and 36s —
+slow successes today, hard failures at the default. Re-measure rather than
+re-guess if the catalog grows; the method is in
+`image-transcribe-tool-spec.md`'s timeout-budget section.
+
+---
+
 ## Files
 
 ### `packages/engine/mcp-server/src/types/collection.ts`

--- a/docs/specs/image-transcribe-tool-spec.md
+++ b/docs/specs/image-transcribe-tool-spec.md
@@ -330,6 +330,39 @@ The tool **never fabricates** a transcription on failure. It throws; the
 caller (record-extraction) pivots to indexed records, exactly as the
 `image-reader` NOT-READ path prescribes today.
 
+### 5.7 Timeout budget
+
+Every network leg is bounded through `fetchWithTimeout` (`src/utils/http.ts`);
+Node's `fetch` has no timeout of its own and an unbounded OCR call is what hung
+a run for 605s. The legs are budgeted **separately**, and the budget covers
+headers and body together:
+
+| Leg | Constant | Budget |
+|---|---|---|
+| FS image download (and its fallback-URL retry) | `IMAGE_FETCH_TIMEOUT_MS` (`utils/fs-image-fetch.ts`) | 90s per attempt |
+| OpenRouter OCR | `OCR_TIMEOUT_MS` (`tools/image-transcribe.ts`) | 180s |
+
+Worst case for one `image_transcribe` is therefore 90 + 90 + 180 = **360s**,
+inside the e2e harness's 600s inactivity window — and a timeout returns as a
+`tool_result`, which re-arms that window.
+
+**Where 180s comes from.** Measured across every `image_transcribe` call in the
+committed e2e run logs (n=101, matched to its own `tool_result` in
+`usage.timeline`): p50 36s, p90 98s, p95 114s, max 316s. That tail is not the
+steady state — all five calls above 150s belong to the single run that hung
+(`pierre-tullier-son`, 2026-07-27). Excluding it: n=89, p90 79s, p95 98s, max
+167s. The download leg is small enough not to move the split — `image_read`
+runs the same fetch without OCR at a 7.2s maximum, though only 6 such calls
+exist in the corpus — so the tool distribution is the OCR distribution plus
+roughly 7s.
+
+180s therefore clears every genuine read observed, including the 167s one,
+while still cutting the 190s/208s/286s/316s calls of the run that hung. A 90s
+OCR budget would have failed 5 of the 89 healthy calls (~6%) — turning a slow
+page into a lost one mid-sweep. Re-measure before changing it: the analyzer is
+`eval/harness/e2e/latency_report.py`'s source data (`usage.timeline`), and a
+model change can move the whole distribution.
+
 ## 6. OpenRouter integration
 
 ### 6.1 Request

--- a/docs/specs/wiki-search-tool-spec.md
+++ b/docs/specs/wiki-search-tool-spec.md
@@ -82,6 +82,17 @@ Example:
 Match the LLM-instruction error pattern used by `getValidToken()` in
 `src/auth/refresh.ts` — error messages must tell Claude what to do next.
 
+### Timeout
+
+`WIKI_SEARCH_TIMEOUT_MS` = **60s**, passed as `fetchWithTimeout`'s third
+argument, rather than the shared 30s default. RAG retrieval over the wiki
+corpus is slower than a plain JSON read, and this is a single un-retried
+request — a slow success becomes a hard failure at the default with nothing
+behind it. Across the committed e2e run logs, 5 of 47 calls ran past 30s, the
+slowest at 56s. Re-measure rather than re-guess if the sidecar's retrieval
+changes; the method is in `image-transcribe-tool-spec.md`'s timeout-budget
+section.
+
 ---
 
 ## wiki-query-api Endpoint Reference

--- a/docs/specs/wikipedia-search-tool-spec.md
+++ b/docs/specs/wikipedia-search-tool-spec.md
@@ -45,6 +45,15 @@ Example:
 | Article not found (404) | Throw error: `"No Wikipedia article found for '{query}'"` |
 | Other API errors | Throw error: `"Wikipedia API error: {status}"` |
 
+### Timeout
+
+`WIKIPEDIA_TIMEOUT_MS` = **60s**, passed as `fetchWithTimeout`'s third
+argument, rather than the shared 30s default. This is a single un-retried
+summary fetch, so a slow success becomes a hard failure at the default with
+nothing behind it. Across the committed e2e run logs, 2 of 19 calls ran past
+30s, at 33.7s and 35.2s. Re-measure rather than re-guess; the method is in
+`image-transcribe-tool-spec.md`'s timeout-budget section.
+
 ---
 
 ## Wikipedia API Reference

--- a/packages/engine/mcp-server/src/tools/collections-search.ts
+++ b/packages/engine/mcp-server/src/tools/collections-search.ts
@@ -14,6 +14,12 @@ const FS_COLLECTIONS_URL =
   "https://www.familysearch.org/service/search/hr/v2/collections";
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
+// One un-retried request for the whole catalog (count=5000), so the budget
+// covers a large body streaming in full. Cold calls have been measured at 33s
+// and 36s, above the 30s default — those are slow successes today and a hard
+// failure at the default, with no second attempt behind them.
+const COLLECTIONS_TIMEOUT_MS = 60_000;
+
 // Module-level cache for the full collections response
 let cache: {
   token: string;
@@ -100,13 +106,17 @@ export async function fetchAllCollections(
 
   const url = `${FS_COLLECTIONS_URL}?count=5000&offset=0&facets=OFF`;
 
-  const response = await fetchWithTimeout(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-      "User-Agent": BROWSER_USER_AGENT,
+  const response = await fetchWithTimeout(
+    url,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "User-Agent": BROWSER_USER_AGENT,
+      },
     },
-  });
+    COLLECTIONS_TIMEOUT_MS
+  );
 
   if (!response.ok) {
     throw new Error(

--- a/packages/engine/mcp-server/src/tools/image-transcribe.ts
+++ b/packages/engine/mcp-server/src/tools/image-transcribe.ts
@@ -13,9 +13,13 @@ import type {
 
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 
-// VLM OCR on a full page scan can legitimately take longer than a typical
-// JSON API call — give it more headroom than the default fetch timeout.
-const OCR_TIMEOUT_MS = 90_000;
+// VLM OCR on a full page scan is the slowest call this server makes, and the
+// budget has to clear a slow-but-genuine read without waiting out a hung one.
+// Across the committed e2e corpus a healthy transcription runs p90 79s / p95
+// 98s with a 167s maximum, and the image download it follows adds ~7s — so
+// 180s clears every real read with margin while still cutting the 190–316s
+// calls of the one run that hung. Sized in the spec, not guessed.
+const OCR_TIMEOUT_MS = 180_000;
 
 // OpenRouter attribution headers (recommended, not required). Stable app id.
 const APP_REFERER = "https://github.com/PioneerAIAcademy/cowork-genealogy";

--- a/packages/engine/mcp-server/src/tools/wiki-search.ts
+++ b/packages/engine/mcp-server/src/tools/wiki-search.ts
@@ -5,6 +5,11 @@ import type {
   WikiSearchResult,
 } from "../types/wiki-search.js";
 
+// One un-retried RAG request against the sidecar, and retrieval over the wiki
+// corpus is slower than a plain JSON read: calls have been measured up to 56s,
+// with 5 of 47 above the 30s default. Nothing retries behind this one.
+const WIKI_SEARCH_TIMEOUT_MS = 60_000;
+
 export interface WikiSearchInput {
   query: string;
 }
@@ -17,14 +22,18 @@ export async function wikiSearch(
 
   let response: Response;
   try {
-    response = await fetchWithTimeout(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "User-Agent": "genealogy-mcp-server/0.0.1",
+    response = await fetchWithTimeout(
+      url,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "User-Agent": "genealogy-mcp-server/0.0.1",
+        },
+        body: JSON.stringify({ query: input.query }),
       },
-      body: JSON.stringify({ query: input.query }),
-    });
+      WIKI_SEARCH_TIMEOUT_MS
+    );
   } catch (error) {
     const cause = error instanceof Error ? error.message : String(error);
     throw new Error(

--- a/packages/engine/mcp-server/src/tools/wikipedia.ts
+++ b/packages/engine/mcp-server/src/tools/wikipedia.ts
@@ -6,6 +6,11 @@ import type {
 
 const WIKIPEDIA_API_BASE = "https://en.wikipedia.org/api/rest_v1/page/summary";
 
+// One un-retried summary fetch, so a slow success today is a hard failure at
+// the 30s default with nothing behind it. Measured at 33.7s and 35.2s (2 of 19)
+// across the committed e2e run logs.
+const WIKIPEDIA_TIMEOUT_MS = 60_000;
+
 export interface WikipediaSearchInput {
   query: string;
 }
@@ -15,11 +20,15 @@ export async function wikipediaSearch(
 ): Promise<WikipediaSearchResult> {
   const url = `${WIKIPEDIA_API_BASE}/${encodeURIComponent(input.query)}`;
 
-  const response = await fetchWithTimeout(url, {
-    headers: {
-      "User-Agent": "genealogy-mcp-server/0.0.1",
+  const response = await fetchWithTimeout(
+    url,
+    {
+      headers: {
+        "User-Agent": "genealogy-mcp-server/0.0.1",
+      },
     },
-  });
+    WIKIPEDIA_TIMEOUT_MS
+  );
 
   if (!response.ok) {
     if (response.status === 404) {

--- a/packages/engine/mcp-server/src/utils/fs-image-fetch.ts
+++ b/packages/engine/mcp-server/src/utils/fs-image-fetch.ts
@@ -11,8 +11,9 @@ import { toArk, arkToUrl } from "./ark.js";
 
 // fetchWithTimeout's budget covers headers and body together, and a full-size
 // page scan at typical throughput needs more than the 30s default to finish
-// streaming. Give it the same 90s as the OCR call it feeds
-// (image-transcribe.ts's OCR_TIMEOUT_MS).
+// streaming. A measured download of one takes ~7s, so 90s is deliberate
+// headroom — this is the download leg only, and it is budgeted separately
+// from the OCR call it feeds (image-transcribe.ts's OCR_TIMEOUT_MS).
 const IMAGE_FETCH_TIMEOUT_MS = 90_000;
 
 // An imageId is a digitized-image identifier of the form NUMBER_NUMBER


### PR DESCRIPTION
## Summary

The bounded-fetch work merged with PR #1373 gave the OpenRouter OCR call a 90s budget with nothing measured behind it — the code comment said only that OCR "can take longer than a typical JSON API call." The analysis on issue #916 asked that PR to justify 90s or raise it; the ask was written after the PR's only review and never reached it, so the value merged unchanged.

Measured it. Across every `image_transcribe` call in the committed e2e run logs, matched to its own `tool_result`: **n=101, p50 36s, p90 98s, p95 114s, max 316s.**

Two things that distribution alone doesn't say:

- **The fat tail is the pathology, not the steady state.** All five calls above 150s come from the single run that hung (`pierre-tullier-son`, 2026-07-27 — the run issue #916 is about). Excluding it: **n=89, p90 79s, p95 98s, max 167s.**
- **The leg split doesn't rescue 90s.** PR #1373 budgets the image download and the OCR call separately, so a 114s round-trip might have fit. It doesn't: `image_read` runs the same download without OCR at a 7.2s maximum, so the tool distribution is the OCR distribution plus roughly 7s.

At 90s, 5 of the 89 healthy calls would have failed — a slow but genuine page becomes a lost one in the middle of an exhaustive-negative sweep. **180s** clears every real read observed (including the 167s one) and still cuts the 190s/208s/286s/316s calls of the run that hung, turning that silent stall into tool errors. Worst case for one transcription is now 90 (download) + 90 (fallback download) + 180 (OCR) = **360s**, inside the harness's 600s inactivity window — and a timeout comes back as a `tool_result`, which re-arms that window.

The download leg stays at 90s: already 12× its measured maximum.

## Three other tools sitting inside the 30s default's tail

Same measurement, different finding — these three make a **single un-retried request**, so a slow success today is a hard failure at the default with nothing behind it. All three get 60s:

| Tool | Request | Measured |
|---|---|---|
| `collections_search` | one `count=5000` catalog fetch | 33s and 36s (2 of 51) |
| `wiki_search` | one RAG request to the sidecar | 5 of 47 above 30s, max 56s |
| `wikipedia_search` | one article-summary fetch | 33.7s and 35.2s (2 of 19) |

The multi-fetch tools that also show 30s+ round-trips — `wiki_place_page`, `volume_search`, `external_links_search` — are deliberately left alone: their round-trip spans several sequential requests, so it says nothing about any single budget.

Most of the slow calls cluster in four runs, so this is degraded-network behaviour rather than the norm. That's the case for raising these three rather than the shared 30s default, which stays as-is for the other 21 files.

## Where the numbers live

`docs/specs/image-transcribe-tool-spec.md` gains a timeout-budget section: the per-leg table, the worst case against the inactivity window, the distribution, and a note to re-measure rather than re-guess if the OCR model changes. The spec documented no timeout at all before this.

The three 60s values get the same treatment, one short section each, in `wiki-search-tool-spec.md`, `collections-search-tool-spec.md` and `wikipedia-search-tool-spec.md` — a number that lives only in a code comment is a number the next reader re-guesses.

`CLAUDE.md` told every session in this repo that the OCR call gets 90s, naming the exact constant this branch changes. Updated, along with the other three.

## Test plan

- [x] engine `tsc --noEmit` clean
- [x] `npm run build` clean, and confirmed the new value compiled into `build/tools/image-transcribe.js`
- [x] engine vitest — 2104 passed, 88 files
- [x] packaging suite re-run after the spec edit — 384 passed, 16 files

No new test asserts the constants: `AbortSignal.timeout` doesn't expose its duration, so anything here would be a change-detector on a number the spec already states.

## Follow-up

None. Issue #916 is closed — the timeout half landed in PR #1373, and by its own analysis the harness-watchdog half has no motivating failure left in the corpus.

