### PR TITLE
Name the four task-lifecycle commands that ship with this repo, not just two

### DIFF
--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -52,10 +52,9 @@ other four ship with this repo, so cloning is the whole install —
 in [`.claude/skills/`](../.claude/skills/). Nothing here needs a plugin you have
 to install.
 
-If you have a personal plugin that defines one of these names, **yours wins**.
-That matters most for `/review`: another toolchain's version reads neither this
-repo's test suites nor the human reviews on the PR, and your teammates don't
-have it. Make sure the one you run is the repo's.
+If you have a personal plugin that defines one of these names, yours wins. Most
+people don't — but if `/review` ever behaves unlike what's described here,
+that's the first thing to check.
 
 ---
 

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -45,13 +45,17 @@ Two things worth knowing:
 
 ## The commands in this document
 
-Every slash command below ships with Claude Code, except `/critique-plan` and
-`/check-drift`, which live in this repo at
-[`.claude/commands/`](../.claude/commands/). Nothing here needs a plugin you
-have to install.
+Two of them ship with Claude Code: `/code-review` and `/security-review`. The
+other four ship with this repo, so cloning is the whole install —
+`/critique-plan` and `/check-drift` in
+[`.claude/commands/`](../.claude/commands/), `/review` and `/audit-merged-prs`
+in [`.claude/skills/`](../.claude/skills/). Nothing here needs a plugin you have
+to install.
 
-If you have a personal plugin that defines one of these names, **yours wins** —
-which is worth knowing before you wonder why `/review` did something else.
+If you have a personal plugin that defines one of these names, **yours wins**.
+That matters most for `/review`: another toolchain's version reads neither this
+repo's test suites nor the human reviews on the PR, and your teammates don't
+have it. Make sure the one you run is the repo's.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Trivial.** `docs/task-lifecycle.md`'s "The commands in this document"
  section said every command in it ships with Claude Code except
  `/critique-plan` and `/check-drift`. `/review` and `/audit-merged-prs` ship
  with this repo too, in `.claude/skills/`.
- Only `/code-review` and `/security-review` are built-ins. The section now
  names all four repo-shipped commands and where each lives.
- Reworded the follow-up paragraph about a personal plugin shadowing one of
  these names, so it points a reader at the right first thing to check without
  implying most people need to.

## Review guidance

**Start here:** the bulleted list of where each command lives. That list is the
whole point of the change — check it against `.claude/commands/` and
`.claude/skills/`. The paragraph below it is just wording.

**Unsure about:** nothing.

## Test plan

- [x] I ran `make test-all` (or `scripts/test.sh` — the same command) and it passed.
      1843 passed in 11.35s.

- [x] For every skill whose **run-log snapshot** I changed — none. Docs-only
      diff; no skill dir, agent, unit test, or fixture touched.

- [x] If I changed a skill's `description` frontmatter or its DO NOT clauses —
      not applicable, no skill frontmatter in this diff.

## Follow-on issues

**Folded in / filed instead:** nothing filed. The inaccuracy was found while
answering a question about this file and fixed in place.
