### PR TITLE
Sort abandoned issues into their own board column instead of Done

### DIFF
--- a/.claude/skills/audit-board/SKILL.md
+++ b/.claude/skills/audit-board/SKILL.md
@@ -31,7 +31,7 @@ You have no `Edit` or `Write` tool on purpose.
 job and never yours.
 
 The one exception is **hygiene**: a closed issue stranded in an active column, an
-open issue sitting in `Done`, an issue on no column at all. Those are corrections,
+open issue sitting in `Done` or `Not planned`, an issue on no column at all. Those are corrections,
 not ranking, and fixing them needs `gh project item-edit` with the Status field id
 (`gh project field-list 1 --owner PioneerAIAcademy --format json`). Check the
 token first — `gh auth status` must list the `project` scope, or the write fails
@@ -580,7 +580,8 @@ for it in board['items']:
 print('closed but in an active column:',
       [n for n,s in onboard.items() if s in cols and n not in issues])
 print('open but on no column:', sorted(set(issues)-set(onboard)))
-print('open but in Done:', [n for n,s in onboard.items() if s=='Done' and n in issues])
+print('open but in a terminal column:',
+      [(n,s) for n,s in onboard.items() if s in ('Done','Not planned') and n in issues])
 print('unlabeled:', [n for n,s in onboard.items() if s in cols and n in issues
                      and not issues[n]['labels']])
 print('unassigned in Ready/In Progress/Review:',

--- a/.claude/skills/fill-ready/SKILL.md
+++ b/.claude/skills/fill-ready/SKILL.md
@@ -26,7 +26,8 @@ Repo `PioneerAIAcademy/cowork-genealogy`, project **1**.
 ```sh
 PROJ_ID="PVT_kwDOC-DkVc4BUEYb"
 STATUS_FIELD="PVTSSF_lADOC-DkVc4BUEYbzhBPBf8"
-# Backlog 0207fe08 / Ready f75ad846 / In Progress 47fc9ee4 / Review 4dc1cd86 / Done 98236657
+# Backlog 0207fe08 / Ready f75ad846 / In Progress 47fc9ee4 / Review 4dc1cd86
+# Done 98236657 / Not planned c44314b0 — both terminal, closed issues only; never promote out of one
 gh project item-list 1 --owner PioneerAIAcademy --format json --limit 1000
 ```
 

--- a/.github/tests/project-status-sync-routing.test.mjs
+++ b/.github/tests/project-status-sync-routing.test.mjs
@@ -1,0 +1,101 @@
+// Routing truth table for project-status-sync.yml.
+//
+// WHY THIS EXISTS. That workflow decides which column every card on the board
+// lands in, and until this file there was nothing between a typo in its branch
+// table and a silently mis-sorted board. The failure is invisible by
+// construction: a wrong column is still a valid column, the run goes green, and
+// the only symptom is a human eventually noticing Done looks wrong. Three
+// workflows in this repo have already gone green while doing nothing.
+//
+// WHAT IT COVERS, AND WHAT IT CANNOT. It extracts the two PURE decision
+// functions from the workflow's github-script body and runs them over every
+// input combination. It therefore checks the branch table and nothing else — it
+// does not and cannot check that the App token can write the board, that the
+// column names still exist on the live project, or that this workflow wins its
+// race with the built-in "Item closed" automation. Those need a live run; see
+// the ORDERING header note in the workflow.
+//
+// The extraction is deliberately dependency-free (no js-yaml): this runs on a
+// bare `node` with no install step. The cost is that it is coupled to the
+// workflow's text shape, so it fails loudly with "could not extract" if the
+// functions are renamed or reformatted rather than silently testing nothing.
+//
+// Run: node .github/tests/project-status-sync-routing.test.mjs
+import fs from 'node:fs';
+
+const WORKFLOW = '.github/workflows/project-status-sync.yml';
+
+// Pull the `script: |` block scalar out of the raw YAML and dedent it.
+function scriptBody(path) {
+  const lines = fs.readFileSync(path, 'utf8').split('\n');
+  const start = lines.findIndex(l => /^\s*script: \|\s*$/.test(l));
+  if (start === -1) throw new Error(`${path}: no "script: |" block found`);
+  const indent = lines[start].match(/^\s*/)[0].length;
+  const out = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() !== '' && line.match(/^\s*/)[0].length <= indent) break;
+    out.push(line.slice(indent + 2));
+  }
+  return out.join('\n');
+}
+
+const body = scriptBody(WORKFLOW);
+
+const grab = (re, label) => {
+  const m = body.match(re);
+  if (!m) {
+    throw new Error(
+      `could not extract ${label} from ${WORKFLOW} — it was renamed or reformatted. ` +
+      `Update this regex, and re-check that the truth table below still describes the rule.`);
+  }
+  return m[0];
+};
+
+// The columns the real script resolves off the live board, stubbed by name.
+const preamble = `
+  const DONE={name:'Done'}, NOT_PLANNED={name:'Not planned'}, REVIEW={name:'Review'},
+        IN_PROGRESS={name:'In Progress'}, BACKLOG={name:'Backlog'};
+  const TERMINAL=[DONE.name,NOT_PLANNED.name];
+`;
+const terminalForSrc = grab(/const terminalFor =[\s\S]*?: DONE;/, 'terminalFor');
+const desiredSrc     = grab(/function desiredStatus\(issue, pr\) \{[\s\S]*?\n\}/, 'desiredStatus');
+
+const { terminalFor, desiredStatus } = new Function(
+  `${preamble}${terminalForSrc}\n${desiredSrc}\nreturn { terminalFor, desiredStatus };`)();
+
+let failures = 0;
+const check = (got, want, label) => {
+  const g = got === null ? 'null' : got.name;
+  const ok = g === want;
+  if (!ok) failures++;
+  console.log(`${ok ? 'ok  ' : 'FAIL'}  ${label.padEnd(54)} -> ${g}${ok ? '' : `  (want ${want})`}`);
+};
+
+console.log('--- terminalFor: a close reason picks a terminal column ---');
+check(terminalFor('COMPLETED'),   'Done',        'COMPLETED');
+check(terminalFor('NOT_PLANNED'), 'Not planned', 'NOT_PLANNED');
+check(terminalFor('DUPLICATE'),   'Not planned', 'DUPLICATE is not delivered work');
+check(terminalFor(null),          'Done',        'null must NOT infer abandonment');
+check(terminalFor(undefined),     'Done',        'undefined must NOT infer abandonment');
+
+console.log('\n--- desiredStatus: an issue + a PR that links it ---');
+const openPr   = { state: 'OPEN',   isDraft: false };
+const draftPr  = { state: 'OPEN',   isDraft: true  };
+const mergedPr = { state: 'MERGED', isDraft: false };
+const open     = { state: 'OPEN',   stateReason: null };
+const done     = { state: 'CLOSED', stateReason: 'COMPLETED' };
+const dropped  = { state: 'CLOSED', stateReason: 'NOT_PLANNED' };
+
+check(desiredStatus(open,    openPr),   'Review',      'open issue + open PR');
+check(desiredStatus(open,    draftPr),  'In Progress', 'open issue + draft PR');
+check(desiredStatus(open,    mergedPr), 'null',        'open issue + merged PR (no opinion)');
+check(desiredStatus(done,    openPr),   'Done',        'completed issue cited by an open PR');
+check(desiredStatus(done,    mergedPr), 'Done',        'completed issue cited by a merged PR');
+// The regression this column exists to prevent: a later PR citing an abandoned
+// issue must not resurrect it into Done. Same shape as symptom 1, one over.
+check(desiredStatus(dropped, openPr),   'Not planned', 'ABANDONED issue cited by an open PR stays put');
+check(desiredStatus(dropped, draftPr),  'Not planned', 'abandoned issue cited by a draft PR stays put');
+check(desiredStatus(dropped, mergedPr), 'Not planned', 'abandoned issue cited by a merged PR stays put');
+
+console.log(failures ? `\n${failures} FAILING` : '\nall routing cases pass');
+process.exit(failures ? 1 : 0);

--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -24,6 +24,15 @@ name: project-status-sync
 #      by hand, and cards with a PR up for review sat in In Progress (#849,
 #      with PR #981 open and non-draft, was the live example).
 #
+#   3. ABANDONED WORK WAS INDISTINGUISHABLE FROM FINISHED WORK. Every closed
+#      issue landed in Done regardless of why it closed, so Done conflated
+#      "we shipped this" with "we decided not to". Measured 2026-08-09: of 62
+#      issues ever closed as not planned, 61 sat in Done, and 60 of those
+#      closures happened in the preceding two weeks — Done was ~40% pruning by
+#      volume in the week it was measured, which makes reading the board for
+#      what the team actually delivered actively misleading. Fixed by routing
+#      on the issue's close reason into a separate "Not planned" column.
+#
 # WHY NOT JUST DISABLE THE BUILT-IN. "Pull request linked to issue" is right
 # most of the time — an OPEN issue that gains a PR genuinely is in progress.
 # Its only defect is the missing closed-issue guard, and the Projects API has
@@ -32,6 +41,17 @@ name: project-status-sync
 # the same events and CORRECTS the result rather than racing to prevent it:
 # the built-in sets In Progress, this sets Done a moment later. The end state
 # is what matters, and it self-heals if the built-in is ever changed.
+#
+# THE ORDERING THIS DEPENDS ON, STATED PLAINLY. Correcting rather than
+# preventing means last-writer-wins, and this workflow is only reliably last
+# because a built-in project automation lands in about a second while an
+# Actions run takes tens of seconds to schedule. That is an observation about
+# current timing, not a guarantee the API offers. If the built-in "Item closed"
+# ever wins the race, a not-planned issue lands in Done and stays there — the
+# same failure the Not planned column exists to prevent, just rarer. The
+# backstop is the dispatch sweep, which recomputes every closed card's column
+# from its live close reason; run it if the board looks wrong. Nothing here
+# detects the race on its own.
 #
 # WHAT IT WILL NOT DO. It acts only on issues a PR *links* — GitHub's
 # `closingIssuesReferences`, populated by a closing keyword ("Closes #123") or
@@ -75,6 +95,19 @@ on:
     # "Closes #123" to an existing PR body, which is how most links here are
     # created. `converted_to_draft` walks a card back from Review.
     types: [opened, reopened, edited, ready_for_review, converted_to_draft, closed]
+  issues:
+    # `closed` is the only moment the close REASON is knowable, and the reason
+    # is what separates Done from Not planned. Nothing else carries it: the
+    # built-in "Item closed" workflow fires on the same event and sets Done
+    # unconditionally, so this runs alongside it and corrects the result — the
+    # same correct-don't-race approach used for symptom 1 above.
+    #
+    # `reopened` is not optional once Not planned exists. Both terminal columns
+    # are dead ends — no other trigger moves a card out of one — so a revived
+    # issue would sit in a column meaning "abandoned" while being open and
+    # worked on, invisible to /fill-ready and /audit-board, which read only the
+    # four active columns. Reopening returns the card to Backlog for re-triage.
+    types: [closed, reopened]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -93,7 +126,13 @@ concurrency:
   # Per-PR events serialize per PR; every sweep shares one key. Two PRs
   # touching the same issue can still interleave, but each run recomputes the
   # desired status from live state, so the last writer is also the correct one.
-  group: project-status-sync-${{ github.event.pull_request.number || 'sweep' }}
+  #
+  # The event kind is part of the key on purpose: issues and PRs share one
+  # number sequence in this repo, so a bare number would make issue #1200 and
+  # PR #1200 contend for the same slot and serialize two unrelated runs.
+  group: >-
+    project-status-sync-${{ github.event_name }}-${{
+      github.event.pull_request.number || github.event.issue.number || 'sweep' }}
   cancel-in-progress: false
 
 jobs:
@@ -186,21 +225,46 @@ jobs:
             // Resolve every column this workflow can write, up front: a
             // renamed column should fail the run, not go silently unwritten.
             const DONE        = option('Done');
+            const NOT_PLANNED = option('Not planned');
             const REVIEW      = option('Review');
             const IN_PROGRESS = option('In Progress');
+            const BACKLOG     = option('Backlog');
+
+            // Both columns that hold closed issues. A card in either is at rest:
+            // only reopening moves it out.
+            const TERMINAL = [DONE.name, NOT_PLANNED.name];
+
+            // ---- which terminal column a closed issue belongs in --------------
+            // GitHub's stateReason is COMPLETED | NOT_PLANNED | DUPLICATE |
+            // REOPENED, and is null on some issues closed before the field
+            // existed. Only COMPLETED is finished work, so everything else that
+            // is genuinely closed reads as not planned — a duplicate was not
+            // delivered either. Null is the one case that must NOT infer
+            // abandonment: it means "unknown", and Done is where those cards
+            // already sit, so treating it as completed changes nothing about
+            // today's board. Measured 2026-08-09 across all 467 closed issues:
+            // only COMPLETED and NOT_PLANNED occur, so the other branches are
+            // future-proofing, not current behavior.
+            const terminalFor = stateReason =>
+              (stateReason === 'NOT_PLANNED' || stateReason === 'DUPLICATE')
+                ? NOT_PLANNED
+                : DONE;
 
             // ---- the rule ----------------------------------------------------
             // Desired column for an issue, given a PR that links it. Returns
             // null for "this workflow has no opinion — leave the card alone".
             //
-            // A closed issue is Done no matter what the PR is doing: that is
-            // symptom 1's fix, and it must outrank every other branch.
+            // A closed issue is terminal no matter what the PR is doing: that is
+            // symptom 1's fix, and it must outrank every other branch. Routing
+            // through terminalFor rather than straight to Done is what stops a
+            // PR that merely cites an abandoned issue from resurrecting it into
+            // Done — the exact shape of symptom 1, one column over.
             // A merged PR is deliberately NOT its own rule — merging closes
             // the issue, which the built-in "Item closed" workflow already
             // handles, and a PR merged to a non-default branch leaves the
             // issue genuinely open and still in progress.
-            function desiredStatus(issueState, pr) {
-              if (issueState === 'CLOSED')          return DONE;
+            function desiredStatus(issue, pr) {
+              if (issue.state === 'CLOSED')         return terminalFor(issue.stateReason);
               if (pr.state !== 'OPEN')              return null;
               if (pr.isDraft)                       return IN_PROGRESS;
               return REVIEW;
@@ -246,7 +310,7 @@ jobs:
             // No try/catch: a write that throws must fail the job. Three
             // workflows in this repo have gone green while doing nothing.
             async function reconcile(issue, pr) {
-              const want = desiredStatus(issue.state, pr);
+              const want = desiredStatus(issue, pr);
               if (!want) {
                 return [`#${issue.number}`, 'no opinion', `PR #${pr.number} ${pr.state.toLowerCase()}`];
               }
@@ -270,7 +334,7 @@ jobs:
 
             const LINKED = `
               closingIssuesReferences(first: 20) {
-                nodes { id number state title }
+                nodes { id number state stateReason title }
               }`;
 
             const rows = [];
@@ -282,7 +346,11 @@ jobs:
               // PR that caused it may be long merged); Review drift is only
               // visible from the open PR list.
 
-              // Pass 1: every card whose issue is closed belongs in Done.
+              // Pass 1: every card whose issue is closed belongs in the terminal
+              // column its close reason selects. This pass is also the backfill:
+              // the first live sweep after "Not planned" was added is what moves
+              // the historical not-planned cards out of Done, and it stays
+              // correct to re-run because it compares against current state.
               let cursor = null;
               for (;;) {
                 const page = await github.graphql(`
@@ -296,7 +364,7 @@ jobs:
                             fieldValueByName(name: "${STATUS_FIELD}") {
                               ... on ProjectV2ItemFieldSingleSelectValue { name }
                             }
-                            content { ... on Issue { number state } }
+                            content { ... on Issue { number state stateReason } }
                           }
                         }
                       }
@@ -307,13 +375,15 @@ jobs:
                   const c = item.content;
                   if (!c || c.state !== 'CLOSED') continue;
                   const status = item.fieldValueByName?.name || null;
-                  if (status === DONE.name) continue;
+                  const want = terminalFor(c.stateReason);
+                  if (status === want.name) continue;
+                  const why = `closed: ${(c.stateReason || 'unknown').toLowerCase()}`;
                   if (dryRun) {
-                    rows.push([`#${c.number}`, `WOULD move ${status || '(none)'} -> Done`, 'closed issue']);
+                    rows.push([`#${c.number}`, `WOULD move ${status || '(none)'} -> ${want.name}`, why]);
                     continue;
                   }
-                  await move(item.id, DONE);
-                  rows.push([`#${c.number}`, `moved ${status || '(none)'} -> Done`, 'closed issue']);
+                  await move(item.id, want);
+                  rows.push([`#${c.number}`, `moved ${status || '(none)'} -> ${want.name}`, why]);
                 }
                 if (!items.pageInfo.hasNextPage) break;
                 cursor = items.pageInfo.endCursor;
@@ -339,6 +409,58 @@ jobs:
                 }
                 if (!prs.pageInfo.hasNextPage) break;
                 prCursor = prs.pageInfo.endCursor;
+              }
+            } else if (context.eventName === 'issues') {
+              // ---- event: one issue closed or reopened ----------------------
+              // No PR is involved, so this path does not use desiredStatus.
+              // The close reason is read back from the API rather than taken
+              // from context.payload.issue.state_reason: the payload spells it
+              // lowercase while every other read here is the GraphQL enum, and
+              // one spelling for one concept is worth the extra call.
+              //
+              // On repoGraphql (GITHUB_TOKEN), not the App token, per the
+              // two-token note above: this is a repo read, and keeping the App
+              // to board reads and writes is what lets it stay Issues:
+              // Read-only-and-nothing-more.
+              const issueNodeId = context.payload.issue.node_id;
+              const number      = context.payload.issue.number;
+              const action      = context.payload.action;
+              const q = await repoGraphql(`
+                query($id: ID!) {
+                  node(id: $id) { ... on Issue { state stateReason } }
+                }`, { id: issueNodeId });
+              const { state, stateReason } = q.node;
+
+              const before = await card(issueNodeId);
+              if (!before) {
+                // add-to-project.yml owns putting cards on the board. It runs on
+                // `reopened` too, so a reopened issue with no card gets one from
+                // that workflow; racing it here would create a second write to
+                // the same field for no gain.
+                rows.push([`#${number}`, 'not on board', `issue ${action}`]);
+              } else {
+                // A reopened issue is out of both terminal columns and back for
+                // re-triage. Anything already in an active column was moved
+                // there deliberately (by the lead, or by the PR path) and is
+                // left alone — this must not demote work in flight.
+                const want = state === 'CLOSED'
+                  ? terminalFor(stateReason)
+                  : (TERMINAL.includes(before.status) ? BACKLOG : null);
+                const why = state === 'CLOSED'
+                  ? `closed: ${(stateReason || 'unknown').toLowerCase()}`
+                  : 'reopened';
+                if (!want) {
+                  rows.push([`#${number}`, `left in ${before.status || '(none)'}`, why]);
+                } else if (before.status === want.name) {
+                  rows.push([`#${number}`, `already ${want.name}`, why]);
+                } else if (dryRun) {
+                  rows.push([`#${number}`,
+                             `WOULD move ${before.status || '(none)'} -> ${want.name}`, why]);
+                } else {
+                  await move(before.id, want);
+                  rows.push([`#${number}`,
+                             `moved ${before.status || '(none)'} -> ${want.name}`, why]);
+                }
               }
             } else {
               // ---- event: just this PR's linked issues ----------------------

--- a/.github/workflows/workflow-logic-tests.yml
+++ b/.github/workflows/workflow-logic-tests.yml
@@ -1,0 +1,48 @@
+name: workflow-logic-tests
+
+# Runs the pure-logic tests for the workflows that write the kanban board.
+#
+# WHY. project-status-sync.yml decides which column every card lands in, and a
+# wrong column is still a valid column: the run goes green, the board is quietly
+# wrong, and the only detector is a human noticing weeks later. Nothing else in
+# CI reads that file — the JS suite (`make test-js`) covers web, electron,
+# viewer-ui and schema, and a GitHub-workflow branch table belongs in none of
+# those packages.
+#
+# WHAT THIS DOES NOT COVER. Only the pure decision functions. A green run here
+# says nothing about whether the App token can still write the board, whether
+# the column names still exist on the live project, or whether the workflow wins
+# its race with the built-in "Item closed" automation. Those are only observable
+# from a live run — see the ORDERING note in project-status-sync.yml. Do not
+# read this job as end-to-end coverage of the board automation.
+#
+# No install step and no dependencies on purpose: the test extracts the script
+# block from the raw YAML itself, so this job is `checkout` + `node`.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/project-status-sync.yml'
+      - '.github/workflows/workflow-logic-tests.yml'
+      - '.github/tests/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/project-status-sync.yml'
+      - '.github/workflows/workflow-logic-tests.yml'
+      - '.github/tests/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  routing:
+    name: project-status-sync routing table
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - run: node .github/tests/project-status-sync-routing.test.mjs


### PR DESCRIPTION
## What

Every closed issue lands in `Done` regardless of why it closed, so the column conflates "we shipped this" with "we decided not to".

Measured 2026-08-09: of the 62 issues ever closed as not planned, **61 sat in `Done`**, and 60 of those closures happened in the preceding two weeks. `Done` was about 40% pruning by volume that week. Reading the board for what the team actually delivered is misleading, and getting more so as the audit skills prune harder.

This adds a **Not planned** column and routes on the issue's close reason.

The column already exists on the board — I added it to the Status field before writing this, and confirmed no existing card lost its value (every card kept its column). The workflow change is what keeps it correct from here.

## Why GitHub can't do this on its own

The built-in "Item closed" project workflow sets `Done` unconditionally, and the Projects API offers no way to reconfigure it — only `deleteProjectV2Workflow`, which is irreversible. So `project-status-sync` grows an `issues:` trigger and corrects the result a moment later. That is the same correct-don't-race approach it already uses for cards that a linked PR drags back to `In Progress`.

## The routing rules

Each is a case that would otherwise strand a card:

| Event | Result |
|---|---|
| Closed as not planned, or as duplicate | → `Not planned` |
| Closed as completed | → `Done` (unchanged) |
| Closed with no reason recorded | → `Done` — never infers abandonment, so no existing card moves on a guess |
| A PR merely *cites* an abandoned issue | stays in `Not planned`, no longer resurrected into `Done` |
| Reopened from either terminal column | → `Backlog` for re-triage |

That last rule is not optional once a second terminal column exists. Both terminal columns are dead ends — nothing else moves a card out of one — so a revived issue would sit in a column meaning "abandoned" while being actively worked, invisible to the skills that pick up work, since they read only the four active columns. It also fixes the same pre-existing stranding for `Done`.

## Backfill

The dispatch sweep is the backfill. It now recomputes each closed card's column from its live close reason instead of forcing `Done`, so running it moves the historical cards, and it stays correct to re-run because it compares against current state.

**After merge:** run `project-status-sync` via workflow dispatch with `dry_run: true`, read the table it prints, then re-run with `dry_run: false`.

## What now checks this

Nothing in CI read this workflow before. A wrong column is still a valid column, so the run goes green and the board is quietly wrong — the same silent-green failure the file's own header documents three times.

Adds a routing truth table under `.github/tests/`, run by a new `workflow-logic-tests` job on any change to the workflow. Dependency-free: it extracts the script block from the raw YAML, so the job is checkout + node with no install step.

Both failure modes were verified by breaking them rather than assumed:

- flipping a branch in the routing rule → 4 tests fail with an explicit `want` diff
- renaming `desiredStatus` → the test **refuses to run** with "could not extract", rather than silently testing nothing

It covers the pure decision functions only. It cannot tell you the App token still writes the board, that the column names still exist upstream, or that this workflow wins its race with the built-in automation.

## The limitation worth knowing

Correcting rather than preventing means last-writer-wins, and this workflow is only reliably last because a built-in project automation lands in about a second while an Actions run takes tens of seconds to schedule. That is an observation about current timing, not a guarantee. If the built-in ever wins, a not-planned issue lands in `Done` and stays there until the next sweep. Nothing detects that on its own — it is written into the workflow header rather than left implicit.

A scheduled sweep would make this self-healing. I left it out: the same race already applies to the existing closed-issue guard, so it is a pre-existing gap rather than one this PR introduces, and adding a weekly automated board write is a separate call.

## Also

Two skills name columns and needed updating: the board-audit hygiene check now treats both terminal columns as places an open issue should not be, and the ready-queue skill carries the new option id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
