### PR TITLE
audit-board: stop folding independent work into one tracker issue

### DIFF
--- a/.claude/skills/audit-board/SKILL.md
+++ b/.claude/skills/audit-board/SKILL.md
@@ -126,6 +126,40 @@ valuable. See §4.
 different labor — a `developer` lint and a `genealogist` audit. Merging makes it
 unassignable. Say "same week, two people" and leave both open.
 
+### Never replace N issues with one issue holding N rows
+
+There is no fifth verdict. Do **not** close a set of issues into a "batch
+tracker", "umbrella", or "index" issue whose body is a table of the work — one
+row per item, each with a **Who** column to claim. It reads like tidying and it
+destroys the thing the board is for.
+
+A row cannot be assigned, cannot sit in a column, cannot be closed, and does not
+appear in anyone's queue. One card that is done when twenty independent
+adjudications are done is a card nobody can finish, and the twenty become
+invisible the moment the tracker scrolls.
+
+**The merge test is whether the WORK is the same, never whether the TEXT is.**
+Ask: does one person, doing this once, finish all of it? If no, they are
+separate issues no matter how alike the bodies read.
+
+Template-filled bodies are the trap, because a fleet of them looks like mass
+duplication at a glance. This happened, and cost real data: on 2026-08-04 this
+skill closed twenty `test <slug>` record-hint adjudications into one tracker,
+justifying it as "byte-identical bodies differing only in a name and two URLs".
+They were not duplicates in any sense — twenty different people, twenty
+different records, four different countries — and the shared text was the
+`/resolve-record-hint` boilerplate every one of them carries. The tracker then
+asserted three things that were false within days: that eighteen fixtures were
+still draft (ten were), that the unlisted ones had no card (three did, all
+assigned), and it dropped one fixture's hint ark entirely, pointing at a README
+that did not contain it. All four were reopened 2026-08-10 and the tracker
+deleted.
+
+If a set genuinely wants shared coordination, the tools for that are the
+`cluster:*` label and §4's batching, which keep every issue open and assignable.
+A standing `next run:` issue is the one legitimate umbrella, and it schedules
+work rather than containing it.
+
 Search for merge candidates **by fix site, not by topic**. Issues that collide
 here almost never share a title; they want different lines in one file.
 
@@ -495,6 +529,16 @@ Merge when the issues share a lane — the same doctrine question, the same test
 files, the same agent body. Do not merge across lanes to save a run: a
 `developer` harness fix and a `genealogist` fixture adjudication in one issue is
 unassignable, which costs more than the run saved.
+
+**Sharing a lane is necessary and not sufficient.** The run being paid once is
+what makes a merge pay, so this only applies where a single run covers the
+merged work — one snapshot, one suite, one annotation pass. It does **not**
+apply to N independent pieces of research that merely happen to be filed by the
+same lane against the same directory. Twenty record-hint adjudications are
+twenty separate investigations of twenty different people; merging them buys no
+run at all, because each still costs its own. Same-lane plus same-directory is
+where this rule has misfired — apply the "does one person finish all of it in
+one sitting?" test from §1 before merging on lane alone.
 
 Do **not** reach for `eval-cosmetic-skip` to squeeze a second edit past the gate.
 It is for behavior-neutral changes only, and a gate too expensive to satisfy


### PR DESCRIPTION
## What happened

On 2026-08-04 this skill closed twenty `test <slug>` record-hint adjudications into a single tracker issue whose body was a table of rows, justifying it as "byte-identical bodies differing only in a name and two URLs".

They were not duplicates in any sense — twenty different people, twenty different records, four different countries. The shared text was the `/resolve-record-hint` boilerplate every one of them carries.

## Why it matters

A table row cannot be assigned, cannot sit in a column, cannot be closed, and appears in nobody's queue. One card that is done when twenty independent adjudications are done is a card nobody can finish, and the twenty become invisible the moment the tracker scrolls.

The tracker also asserted three things that were false within days:

- eighteen fixtures still draft — ten were
- the unlisted ones had no card of their own — three did, all assigned
- one fixture's hint ark was dropped entirely, with the row pointing at a README that does not contain it, so the only surviving record of that ark was the issue the fold had closed

## The fix — two edits, one per rule that allowed it

**The merge verdicts gain an explicit prohibition.** There is no fifth verdict: do not close a set of issues into a batch tracker, umbrella, or index issue. The test is whether the **work** is the same, never whether the **text** is — does one person, doing this once, finish all of it? Template-filled bodies are called out as the specific trap, since a fleet of them reads as mass duplication at a glance. The legitimate tools for shared coordination are named: the `cluster:*` label, the batching rule, and the standing `next run:` issue, all of which keep every issue open and assignable.

**The queue-shortening rule said to merge issues that share a lane.** That is necessary but not sufficient — a merge pays only when one run covers the merged work. N independent investigations filed by one lane against one directory each still cost their own run, so nothing is saved. Same-lane plus same-directory is exactly where this misfired.

## Already applied outside this PR

- #875, #876, #878, #882 reopened and returned to Backlog, with #882 carrying a comment recording its hint ark (`1:1:QPR9-YLYV`), which existed nowhere else.
- The tracker issue was deleted. No file in the repo referenced it, and one closed issue mentioned it in passing.
- Verified no other skill teaches this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
