### PR TITLE
Mark Pascal and Jude as senior developers in the roster

### DIFF
--- a/.claude/skills/triage-standup/references/roster.md
+++ b/.claude/skills/triage-standup/references/roster.md
@@ -33,7 +33,7 @@ the two who are not are listed under "Does not post standup" below.
 | florence | Florence Taburu | `florencemashipei` | genealogist | **senior** |
 | tife | Tife | `T-FEH` | developer | **senior** |
 | isaac | Isaac Boateng | `Paaboat` | genealogist | |
-| jude | Ebigide Jude | `jud-sdev` | developer | |
+| jude | Ebigide Jude | `jud-sdev` | developer | **senior** |
 | collins | Cia, Collins | `Cia-3` | genealogist | |
 | ernest | Ernest Jacob, Ernest | `aghadiayeamayanvboernest` | developer | |
 | solomon | Solomon Baidoo | `kofiatinka12` | genealogist | |
@@ -47,7 +47,7 @@ the two who are not are listed under "Does not post standup" below.
 | ikennaya | Ikennaya Mbadiwe | `Ikennaya1` | genealogist | |
 | precious | Precious Onotu | `clack391` | developer | **senior** |
 | edmund | Edmund Asante Oware | `EdmondOware` | genealogist | **senior** |
-| pascal | Pascal Okezie | `Gennecis` | developer | |
+| pascal | Pascal Okezie | `Gennecis` | developer | **senior** |
 | marc | Marc Mangum | `MMagnum` | developer | |
 | richard | Richard | `chesworthrm` | developer | **senior** |
 


### PR DESCRIPTION
Adds the **senior** marker to `pascal` (`Gennecis`) and `jude` (`jud-sdev`) in the standup roster, taking the senior developer count from four to six.

The Senior column mirrors GitHub team membership, which is what `.github/CODEOWNERS` routes review authority by. **The team write is already done** — both handles are `active` members of `PioneerAIAcademy/senior-developers` (now `DallanQ`, `chesworthrm`, `clack391`, `promise-emmanuel`, `T-FEH`, `Gennecis`, `jud-sdev`), so this file is catching up to the org, not getting ahead of it.

Nothing else in the repo lists senior developers by name — `senior-queue.yml` reads the team names out of CODEOWNERS at run time, so it needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)