### PR TITLE
Make the two schema specs readable on their own, for a genealogist review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,8 +472,8 @@ change, with different (and easy-to-undercount) site lists:
   `EvaluationVerdict`, `ExperienceLevel`, `Subscription` — which the generator
   cannot see and which stay hand-written in `packages/schema/src/index.ts` until
   they move. Worked blast-radius and
-  rationale: `docs/specs/research-schema-spec.md`, the `no_evidence` note under
-  the `evidence_type` row.
+  rationale: `docs/specs/research-schema-spec.md`, the `no_evidence` note in
+  the enum section.
 - **Tree-schema (simplified-GedcomX) change** — a new/renamed field on tree
   persons, names, facts, relationships, or sources: in addition to the spec
   (`docs/specs/simplified-gedcomx-spec.md`) and the schema mirrors above, the

--- a/docs/specs/research-schema-spec.md
+++ b/docs/specs/research-schema-spec.md
@@ -47,17 +47,36 @@ A project often starts with a question about a person who does not yet exist in 
 ```
 
 All arrays start empty. The file is created at project initialization.
-`researcher_profile` is optional and populated by `init-project` from a
-short two-question interview. `known_holdings` is optional and populated
-by `init-project` from the holdings survey (what the researcher already
-has — documents, prior research, living-relative knowledge — before any
-new research begins).
+
+**Twelve of these fifteen keys must be present**, even when their array is
+empty: `project`, `questions`, `plans`, `log`, `sources`, `assertions`,
+`person_evidence`, `conflicts`, `hypotheses`, `timelines`,
+`proof_summaries`, `evaluations`. Omitting one is a validation failure, not
+a shorthand for "empty". The other three are optional and may be absent
+entirely:
+
+- `researcher_profile` — written by `init-project` from a short two-question
+  interview (Section 5.1.1).
+- `known_holdings` — written by `init-project` from the holdings survey: what
+  the researcher already has (documents, prior research, living-relative
+  knowledge) before any new research begins (Section 5.1.2).
+- `localities` — written by `locality-guide`; absent on projects that predate
+  it (Section 5.13).
+
+**No other top-level key is permitted.** Every object in this file is
+closed: the JSON Schema sets `additionalProperties: false` on the document
+and on every nested object, so a field not named in the tables of Section 5
+is rejected rather than ignored. Proposing a new field means adding it to
+the schema, not just writing it.
 
 ---
 
 ## 2. Status Enums
 
-All enums are defined here once and referenced by section schemas. Skills must use these exact values.
+Every controlled vocabulary in `research.json` is listed here and referenced
+by the section schemas in Section 5. Skills must use these exact values: an
+unlisted value in a closed enum is **rejected** at write time, not stored and
+flagged. (One row below is the exception, and says so.)
 
 | Enum name | Values | Used by |
 |-----------|--------|---------|
@@ -65,24 +84,10 @@ All enums are defined here once and referenced by section schemas. Skills must u
 | `plan_status` | `active`, `completed`, `superseded` | plans |
 | `plan_item_status` | `planned`, `in_progress`, `completed`, `skipped` | plan items |
 | `log_outcome` | `positive`, `negative`, `partial`, `error` | log |
+| `external_site` | `ancestry`, `myheritage`, `findmypast`, `familysearch_web`, `findagrave`, `newspapers` | log entries' `external_site.site` — the sites supported by the generate-click-capture-analyze workflow (Section 5.4) |
 | `source_classification` | `original`, `derivative`, `authored` | sources |
 | `information_quality` | `primary`, `secondary`, `indeterminate` | assertions |
 | `evidence_type` | `direct`, `indirect`, `negative` | assertions |
-
-> **`no_evidence` was considered and rejected (2026-06-21).** The model reaches
-> for it when a record simply does not speak to the question, and the instinct is
-> GPS-correct — but a *scalar* `evidence_type` cannot represent "no evidence"
-> honestly, and a bare enum add buys that honesty at the cost of new exclusion
-> logic in four consumers, none of it validator-caught, plus an under-specified
-> value. The retry loop it was meant to fix was closed instead by a
-> lower-blast-radius prose pin (#433: state the valid values inline, plus
-> "there is no `no_evidence`; keep best-effort `indirect`"). If the honesty is
-> ever judged worth it, do it deliberately, not as a quick fix: settle the
-> scalar-vs-structural mismatch first, define the structural convention + eval
-> invariant + re-classification trigger, then land all ~6 definition sites, both
-> skills, and the eval rubrics/goldens **in one PR**. This is also the worked
-> example of a closed-enum change's blast radius — see CLAUDE.md's schema-change
-> site list.
 | `conflict_type` | `fact`, `identity` | conflicts |
 | `conflict_status` | `unresolved`, `resolved`, `moot` | conflicts |
 | `hypothesis_status` | `active`, `supported`, `ruled_out` | hypotheses |
@@ -95,8 +100,38 @@ All enums are defined here once and referenced by section schemas. Skills must u
 | `informant_proximity` | `self`, `witness`, `household_member`, `family_not_present`, `researcher`, `official_duty`, `unknown` | assertions |
 | `date_certainty` | `exact`, `approximate`, `estimated`, `calculated`, `before`, `after`, `between` | assertions |
 | `date_certainty_timeline` | `exact`, `approximate`, `estimated`, `calculated` | timeline events (subset of date_certainty — directional qualifiers like before/after don't apply to timeline positioning) |
+| `severity` | `high`, `medium`, `low` | timeline gaps (Section 5.10) |
 | `holding_type` | `document`, `prior_research`, `oral_knowledge`, `gedcom`, `photo`, `artifact`, `other` | known_holdings |
 | `holding_confidence` | `confident`, `unsure` | known_holdings — how settled the researcher is about the item, so research prioritizes shaky holdings over settled ones |
+| `experience_level` | `novice`, `intermediate`, `experienced`, `professional` | researcher_profile (Section 5.1.1) |
+| `subscriptions` | `Ancestry`, `MyHeritage`, `FindMyPast`, `Newspapers.com`, `GenealogyBank`, `FindAGrave-Plus`, `other`, `none` | researcher_profile. Note the mixed casing: these are site brand names, not the lowercase_with_underscores used elsewhere |
+| `evaluation_focus` | `pre-exhaustiveness`, `conclusion-readiness`, `proof-critique`, `on-demand` | evaluations (Section 5.12). Note the hyphens — this is the one enum in the file that does not use underscores |
+| `evaluation_target_type` | `question`, `proof_summary`, `project` | evaluations |
+| `evaluation_verdict` | `looks_solid`, `consider_addressing`, `address_first`, `refused` | evaluations |
+| `locality_page_section` | `home`, `getting_started`, `online_records`, `research_tips` | localities' `pages_read[].section` (Section 5.13) — the four FamilySearch Research Wiki place-page sections. **The one closed enum `validate_research_schema` does not check**: it does not descend into a locality's nested objects, so a misspelled section reaches disk and only the JSON Schema catches it |
+
+**Where these live in the machine-readable schemas.** Most are shared with
+`tree.gedcomx.json` and live in `enums.schema.json`. The last six rows above
+(`experience_level` through `locality_page_section`) are defined inline in
+`research.schema.json` instead, so their names are this document's; a
+developer changing one edits `research.schema.json` rather than
+`enums.schema.json`. The blast radius of a change either way is in CLAUDE.md's
+schema-change site list.
+
+> **`no_evidence` was considered and rejected as an `evidence_type` value
+> (2026-06-21).** The model reaches for it when a record simply does not speak
+> to the question, and the instinct is GPS-correct — but a *scalar*
+> `evidence_type` cannot represent "no evidence" honestly, and a bare enum add
+> buys that honesty at the cost of new exclusion logic in four consumers, none
+> of it validator-caught, plus an under-specified value. The retry loop it was
+> meant to fix was closed instead by a lower-blast-radius prose pin (issue #433:
+> state the valid values inline, plus "there is no `no_evidence`; keep
+> best-effort `indirect`"). If the honesty is ever judged worth it, do it
+> deliberately, not as a quick fix: settle the scalar-vs-structural mismatch
+> first, define the structural convention + eval invariant + re-classification
+> trigger, then land all ~6 definition sites, both skills, and the eval
+> rubrics/goldens **in one PR**. This is also the worked example of a
+> closed-enum change's blast radius — see CLAUDE.md's schema-change site list.
 
 The following are **open enums** — recommended values that skills should prefer, but new values may be added when existing values don't fit. Document new values in the assertion/plan/timeline entry's notes.
 
@@ -114,7 +149,11 @@ The following are **open enums** — recommended values that skills should prefe
 
 ## 3. ID Conventions
 
-All IDs are strings with a prefix indicating the section. IDs are immutable once created and never reused.
+All IDs are strings with a prefix indicating the section. IDs are immutable
+once created and never reused. **The prefixes are enforced, not advisory** —
+every id field and every field that references one is validated against its
+prefix, so an assertion id of `assert_001` or a `plan_item_id` holding a `q_`
+value is rejected at write time.
 
 | Prefix | Section | Example |
 |--------|---------|---------|
@@ -134,7 +173,40 @@ All IDs are strings with a prefix indicating the section. IDs are immutable once
 | `ev_` | evaluations | `ev_001` |
 | `loc_` | localities | `loc_001` |
 
+The digits after the prefix are a convention, not a constraint — `q_flynn-1850`
+is as valid as `q_002` — with one exception: an `ev_` id must be the prefix
+followed by digits only (`ev_001`, `ev_17`).
+
 GedcomX IDs (person IDs like `I1`, source description IDs like `S1`) use their own conventions from `tree.gedcomx.json` and are referenced as foreign keys.
+
+### Date and timestamp formats
+
+Two distinct formats appear in this file, and the distinction is enforced.
+
+| Format | Fields | Shape |
+|--------|--------|-------|
+| **Date** | `project.created`, `project.updated`, `known_holdings[].created`, `questions[].created`, `questions[].resolved`, `plans[].created`, `sources[].access_date`, `person_evidence[].created`, `localities[].created`, `localities[].updated` | `YYYY-MM-DD` exactly — `2026-05-01`. No time part, no month- or year-only form. Enforced by both validators |
+| **Timestamp** | `log[].performed`, `timelines[].generated`, `evaluations[].timestamp` | ISO 8601 date-time **with an explicit timezone** — `2026-05-01T10:15:00Z` or `2026-05-01T10:15:00+01:00` |
+
+Write the colon form with a `Z` or a numeric offset and both validators accept
+it. Two footnotes for anyone reading a file rather than writing one:
+
+- For `log[].performed` and `timelines[].generated` the time part may also use
+  dashes instead of colons (`2026-05-01T10-15-00Z`), with optional fractional
+  seconds after either a dot or a dash. That tolerance exists so a timestamp can
+  double as a filename on filesystems that disallow colons. Nothing in the
+  corpus writes that form today.
+- `evaluations[].timestamp` is the one timestamp the two gates disagree on. The
+  JSON Schema types it as a plain `date-time` rather than the pattern above, and
+  `validate_research_schema` only checks that it parses as a date at all — so a
+  naive local time with no offset slips through there while an equivalent value
+  in `performed` does not. Section 5.12 requires UTC; treat that as the rule.
+
+These formats govern the *bookkeeping* fields above. They do **not** govern
+`assertions[].date` or `timelines[].events[].date`, which hold genealogical
+dates as encountered in records and are deliberately free-form — see
+Sections 5.6 and 5.10, and `simplified-gedcomx-spec.md` Section 4.5 for the
+date patterns the standardizer recognizes.
 
 ---
 
@@ -597,7 +669,7 @@ Array of evaluation pointer records — a lightweight index of mentor reviews pe
 | `verdict` | `evaluation_verdict` | yes | Result of the evaluation: `looks_solid`, `consider_addressing`, `address_first`, or `refused` |
 | `file_path` | string | yes | Path to the JSON verdict file, relative to the project folder (e.g. `evaluations/pre-exhaustiveness-q_001-2026-06-02T14-30-00.json`) |
 | `timestamp` | string | yes | UTC ISO 8601 timestamp of when the evaluation was written |
-| `superseded_by` | string \| null | yes | `ev_` ID of a later evaluation for the same `focus` + `target_id` combination, or null when this entry is the latest |
+| `superseded_by` | string or null | yes | `ev_` ID of a later evaluation for the same `focus` + `target_id` combination, or null when this entry is the latest |
 
 **Append-only ownership.** The `gps-mentor` agent is the sole writer of this array. Entries are never deleted. When a re-evaluation runs for the same `focus` + `target_id`, the prior entry's `superseded_by` field is updated to point at the new entry's `id`, and the new entry is appended with `superseded_by: null`. This preserves the full audit trail without overwriting history. No other skill should mutate `evaluations`, and `gps-mentor` itself never modifies any other section of `research.json`.
 
@@ -620,15 +692,16 @@ researches; it accumulates across the project's questions (reused, not per-quest
 |-------|------|----------|-------------|
 | `id` | string | yes | `loc_` prefix |
 | `place` | string | yes | Standardized jurisdiction the guide covers (usually country or US-state / Canadian-province — the wiki corpus granularity) |
-| `for_place` | string \| null | no | The specific place of interest that prompted it, when narrower than `place` |
-| `time_period` | string \| null | no | Era the guide was scoped to |
+| `for_place` | string or null | no | The specific place of interest that prompted it, when narrower than `place` |
+| `time_period` | string or null | no | Era the guide was scoped to |
 | `jurisdictions` | array | no | Border/name succession from `place_search_all`: `{ name, date_range? }` |
 | `collections` | array | no | Record sets covering the place from `collections_search`: `{ id, title, date_range? }` |
 | `quirks` | string[] | no | Short, actionable gotchas (e.g. "indexed only at county level") |
-| `guide_markdown` | string \| null | no | The distilled research guide (from the wiki place pages) — what the viewer renders |
-| `pages_read` | array | yes | Provenance: which wiki sections were fetched — `{ section, url?, found }`, `section` ∈ `home` / `getting_started` / `online_records` / `research_tips`. Makes read-coverage checkable |
+| `guide_markdown` | string or null | no | The distilled research guide (from the wiki place pages) — what the viewer renders |
+| `pages_read` | array | yes | Provenance: which wiki sections were fetched — `{ section, url?, found }`, `section` ∈ `home` / `getting_started` / `online_records` / `research_tips` (the `locality_page_section` enum). Makes read-coverage checkable |
 | `source` | string | yes | Always `"locality-guide"` |
-| `created` / `updated` | date | `created` yes | Tool-stamped `YYYY-MM-DD` |
+| `created` | string | yes | Tool-stamped ISO 8601 date |
+| `updated` | string | no | Tool-stamped ISO 8601 date; absent until the entry is first refreshed |
 
 **Applied facts live in `plan_item.rationale`.** `localities` is the knowledge base;
 the per-search decision (e.g. "search Oppland, not Ringebu — see `loc_001`") is
@@ -819,7 +892,7 @@ Research objective: Identify the parents of Patrick Flynn, born ~1845 in Pennsyl
       "child": "I1",
       "sources": [
         { "ref": "S1", "page": "1850 Census, Schuylkill Co., dwelling 84", "quality": 2 },
-        { "ref": "S2", "page": "1860 Census, Schuylkill Co., dwelling 112", "quality": 3 },
+        { "ref": "S2", "page": "1860 Census, Schuylkill Co., dwelling 112", "quality": 2 },
         { "ref": "S3", "page": "Death cert. no. 4521", "quality": 2 }
       ]
     }
@@ -1146,7 +1219,7 @@ Research objective: Identify the parents of Patrick Flynn, born ~1845 in Pennsyl
       "information_quality": "indeterminate",
       "informant": "Unknown household member reporting to census enumerator",
       "informant_proximity": "household_member",
-      "informant_bias_notes": "Census enumerator is the recorder, not the informant. The household member who provided the name is unknown. Proximity is 'unknown' rather than 'household_member' because for names specifically, the enumerator may have read a sign, heard a neighbor, or made an assumption — the name fact doesn't necessarily require active reporting the way age/birthplace does.",
+      "informant_bias_notes": "Census enumerator is the recorder, not the informant. Everything on this line came from whoever answered the door, so proximity is 'household_member'; which member is unrecorded, and the 1850 census names no informant.",
       "evidence_type": "direct",
       "log_entry_id": "log_001",
       "extracted_for_question_ids": ["q_002"]
@@ -1274,7 +1347,7 @@ Research objective: Identify the parents of Patrick Flynn, born ~1845 in Pennsyl
       "information_quality": "indeterminate",
       "informant": "Unknown household member reporting to census enumerator",
       "informant_proximity": "household_member",
-      "informant_bias_notes": "Census enumerator is the recorder, not the informant. Proximity is 'unknown' for names (same reasoning as a_001 — name facts don't necessarily require active reporting).",
+      "informant_bias_notes": "Census enumerator is the recorder, not the informant. Proximity is 'household_member' (same reasoning as a_001).",
       "evidence_type": "direct",
       "log_entry_id": "log_004",
       "extracted_for_question_ids": ["q_001"]
@@ -1310,8 +1383,8 @@ Research objective: Identify the parents of Patrick Flynn, born ~1845 in Pennsyl
       "place": "Schuylkill County, Pennsylvania",
       "information_quality": "indeterminate",
       "informant": "Inferred from household structure — no explicit informant for relationships in 1860 census",
-      "informant_proximity": "unknown",
-      "informant_bias_notes": "1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname. The relationship column was not introduced until the 1880 census.",
+      "informant_proximity": "researcher",
+      "informant_bias_notes": "1860 census does not state relationships; like the 1850 census, this assertion is inferred from household position, age, and shared surname, so the researcher is the source of the claim rather than any record informant. The relationship column was not introduced until the 1880 census.",
       "evidence_type": "indirect",
       "log_entry_id": "log_004",
       "extracted_for_question_ids": ["q_001"]
@@ -1531,9 +1604,38 @@ Research objective: Identify the parents of Patrick Flynn, born ~1845 in Pennsyl
       "exhaustive_search_summary": "Searched 1850 census (FamilySearch, Ancestry, MyHeritage — log_001, log_002, log_003), 1860 census (FamilySearch — log_004), and death certificate (FamilySearch — log_005). Probate search in progress. 1870, 1880, and 1900 censuses not yet searched.",
       "narrative_markdown": "## Parentage of Patrick Flynn (ca. 1845–1908)\n\nPatrick Flynn is **Probably** the son of Thomas Flynn of Schuylkill County, Pennsylvania.\n\n### Evidence Summary\n\nThree independent lines of evidence support this conclusion:\n\n1. **1850 U.S. Census** (Original Source). Patrick Flynn, age 5, born Ireland, appears in the household of Thomas Flynn, age 32, born Ireland, in Schuylkill County, Pennsylvania (dwelling 84, family 91). The 1850 census does not state relationships, but Patrick's position in the household and shared surname are consistent with a parent-child relationship. The informant is indeterminate but likely a household member. This constitutes indirect evidence of parentage.\n\n2. **1860 U.S. Census** (Original Source). Patrick Flynn, age 15, born Ireland, appears in the household of Thomas Flynn in Schuylkill County (dwelling 112, family 119). Like the 1850 census, the 1860 census does not state relationships explicitly (the relationship column was not introduced until 1880). Patrick's position in the household, shared surname, and age consistent with the 1850 enumeration support a parent-child relationship. This constitutes indirect evidence of parentage.\n\n3. **1908 Death Certificate** (Original Source). Patrick Flynn's death certificate (no. 4521, Pennsylvania Department of Health) names \"Thomas Flynn\" as his father. The informant was James Brown, identified as Patrick's son-in-law. As a son-in-law reporting his father-in-law's parentage, Brown is a secondary informant for this fact — he was not a witness to Patrick's birth and is reporting what he was told. Nevertheless, this is direct evidence naming the father.\n\n### Conflict Resolution\n\nA birthplace conflict exists: the 1850 and 1860 censuses list Patrick's birthplace as Ireland, while the 1908 death certificate states Pennsylvania. The two census records are contemporary recordings with informants likely present in the household, while the death certificate was created 63 years after Patrick's birth by a son-in-law with no firsthand knowledge of the event. Per the GPS preponderance hierarchy, contemporary recordings by closer informants outweigh later recollections by secondary informants. Ireland is accepted as the birthplace; the death certificate entry is attributed to informant error.\n\n### Assessment\n\nThe conclusion is rated **Probable** rather than **Proved** because: (a) both census sources (1850 and 1860) provide only indirect evidence of parentage (relationships not stated — the relationship column was not introduced until 1880), (b) the death certificate informant is secondary, and (c) research is not yet exhaustive — the 1870, 1880, and 1900 censuses have not been searched, and Thomas Flynn's probate records have not been located. If Thomas Flynn's will names Patrick as a son, or if additional census records confirm the relationship, the conclusion would advance to **Proved**.\n\n### Citations\n\n1. 1850 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 84, family 91, Thomas Flynn household; NARA microfilm publication M432, roll 810; digital image, FamilySearch.org, accessed 1 May 2026.\n2. 1860 U.S. Census, Schuylkill County, Pennsylvania, population schedule, dwelling 112, family 119, Thomas Flynn household; NARA microfilm publication M653, roll 1141; digital image, FamilySearch.org, accessed 2 May 2026.\n3. Pennsylvania Department of Health, death certificate no. 4521 (1908), Patrick Flynn; Pennsylvania State Archives, Harrisburg; digital image, FamilySearch.org, accessed 3 May 2026."
     }
+  ],
+
+  "evaluations": [
+    {
+      "id": "ev_001",
+      "focus": "proof-critique",
+      "target_id": "ps_001",
+      "target_type": "proof_summary",
+      "verdict": "consider_addressing",
+      "file_path": "evaluations/proof-critique-ps_001-2026-05-04T09-15-00.json",
+      "timestamp": "2026-05-04T09:15:00Z",
+      "superseded_by": null
+    }
   ]
 }
 ```
+
+### Notes on the example
+
+- **`evaluations` holds a pointer, not the review.** `ev_001` records that
+  `gps-mentor` critiqued proof summary ps_001 and returned
+  `consider_addressing`. The mentor's actual reasoning lives in the file named
+  by `file_path`, not in `research.json`. See Section 5.12.
+- **`researcher_profile`, `known_holdings`, and `localities` are absent.** All
+  three are optional (Section 1); a project that skipped the holdings survey
+  and has done no locality research legitimately has none of them. The other
+  twelve keys are all present. On a younger project several of them would be
+  present but empty, which is required; omitting them is not.
+- **The tree above and this file are consistent by design.** `subject_person_ids`
+  names `I1`; `sources[].gedcomx_source_description_id` values (`S1`–`S3`) name
+  source descriptions in the tree; `person_evidence[].person_id` values name
+  tree persons. Those three are the only links between the files (Section 1).
 
 ---
 

--- a/docs/specs/simplified-gedcomx-spec.md
+++ b/docs/specs/simplified-gedcomx-spec.md
@@ -45,6 +45,16 @@ gates' agreement. **Never use the JSON Schema alone as a validity gate.**
 }
 ```
 
+**All three keys must be present, and no fourth key is permitted.** An empty
+array is written as `[]`, never omitted. Every object in the file is likewise
+closed: the field tables in Section 4 are exhaustive, and a field not listed
+there is rejected rather than ignored — by the JSON Schema
+(`additionalProperties: false` throughout) and by the runtime validator, which
+enforces the same per-object field lists. Adding a field to the tree means
+changing the schema and the validator, not just writing it. (One narrow
+exception, for documents written before a field set was closed: see "Legacy
+documents are healed at read" in Section 4.3.)
+
 ---
 
 ## 2. Simplification Rules
@@ -165,6 +175,12 @@ Array of relationship objects.
 | `notes` | string[] | no | Free-text notes attached to this relationship. Each entry is the text of one note |
 | `sources` | object[] | no | Source references |
 
+A ParentChild relationship has **no `facts` array** in this format — only
+Couple does. An adoption or a guardianship is carried by `subtype` instead
+(conversion re-expands it into a relationship fact on the full-GedcomX side,
+see Section 5), and a dated event that merely involves a parent and a child —
+a christening, say — is a fact on the *person*.
+
 **Couple:**
 
 | Field | Type | Required | Description |
@@ -230,7 +246,7 @@ link an assertion to a source description with a locator.
 |-------|------|----------|-------------|
 | `ref` | string | yes | The `id` of a source in the top-level `sources` array |
 | `page` | string | no | Specific locator within the source (page, entry, certificate number, dwelling number). Corresponds to Evidence Explained's "where-within" |
-| `quality` | number | no | Source quality score mimicking GEDCOM's QUAY: `0` = unreliable, `1` = questionable, `2` = secondary evidence, `3` = direct and primary evidence. See design decision below for usage guidance |
+| `quality` | integer | no | Source quality score mimicking GEDCOM's QUAY, and the only numeric field in the format: `0` = unreliable, `1` = questionable, `2` = secondary evidence, `3` = direct and primary evidence. Whole numbers 0–3 only — `2.5` is rejected, and there is no value for "better than 3". See design decision below for usage guidance |
 
 ### 4.5 Date Strings
 
@@ -283,20 +299,34 @@ round-trip. See §7 below.
 
 ## 5. Enums
 
+These are the tree's own controlled vocabularies. They are **not** the ones in
+`research-schema-spec.md` Section 2, even where a name looks the same: the
+tree's fact types are PascalCase (`Birth`), `research.json`'s are
+lowercase_with_underscores (`birth`). See "Casing convention" below.
+
 ### Closed enums
 
-| Enum | Values | Used by |
-|------|--------|---------|
-| `gender` | `Male`, `Female`, `Unknown` | persons |
-| `relationship_type` | `ParentChild`, `Couple` | relationships |
+| Enum | Schema name | Values | Used by |
+|------|-------------|--------|---------|
+| `gender` | `gender` | `Male`, `Female`, `Unknown` | persons |
+| `relationship_type` | `relationship_type` | `ParentChild`, `Couple` | relationships |
 
 ### Open enums (recommended values)
 
-| Enum | Recommended values | Used by |
-|------|-------------------|---------|
-| `fact_type` | See table below | person facts, relationship facts |
-| `name_type` | `BirthName`, `MarriedName`, `AlsoKnownAs`, `Nickname`, `Formal`, `Religious` | names |
-| `parent_subtype` | `Biological`, `Adoptive`, `Step`, `Foster`, `Guardian` | ParentChild relationships |
+An open enum accepts values beyond those listed; the recommended set is what
+tools emit and what skills should prefer. `fact_type` carries one hard
+constraint anyway — see the casing note below.
+
+| Enum | Schema name | Recommended values | Used by |
+|------|-------------|-------------------|---------|
+| `fact_type` | `gedcomx_fact_type_recommended` | See table below | person facts, relationship facts |
+| `name_type` | `gedcomx_name_type_recommended` | `BirthName`, `MarriedName`, `AlsoKnownAs`, `Nickname`, `Formal`, `Religious` | names |
+| `parent_subtype` | `parent_subtype_recommended` | `Biological`, `Adoptive`, `Step`, `Foster`, `Guardian` | ParentChild relationships |
+
+The "Schema name" column is the `$defs` key in
+[`schemas/enums.schema.json`](schemas/enums.schema.json), where all five are
+defined; the short names are what this document and the field tables in
+Section 4 call them.
 
 **Parent subtype values and GedcomX compatibility:**
 
@@ -334,6 +364,15 @@ The `Parent` suffix is dropped in the simplified format because the parent-child
 | `Probate` | **no** | Extension. No standard GedcomX type. Same caveat as Property |
 
 **Casing convention:** Fact and name types use PascalCase (matching GedcomX conventions with URI prefixes dropped). This contrasts with `research.json` which uses lowercase_with_underscores. When mapping between the two files, convert case: `birth` ↔ `Birth`, `military_service` ↔ `Military`, `residence` ↔ `Residence`. The research.json types `name`, `relationship`, and `other` are research-only and do not appear as GedcomX fact types.
+
+**The initial capital on a fact type is enforced, and it is the one part of an
+open enum that is.** A fact `type` must begin with an uppercase letter; the
+rest of the value is unconstrained, so a type outside the table above is
+accepted so long as it is capitalized. This exists because the failure it
+catches is otherwise invisible: a lowercase `birth` copied across from
+`research.json` looks like a plausible value, passes every enum check that
+treats the list as open, and then hard-fails `tree_edit` mid-run. Name types
+carry no such constraint, but should follow the same PascalCase convention.
 
 ---
 


### PR DESCRIPTION
You asked whether a professional genealogist could review our data model by reading only the two prose specs, never the JSON Schema files. Two answers, then what this PR changes.

## Are the specs in sync with the schemas?

**Yes, on substance, both of them.** I checked mechanically rather than by eye:

- Every property in `research.schema.json` and `tree-gedcomx.schema.json` has a table row in its spec. No field is undocumented.
- The specs' Required columns agree with the schemas' `required` arrays on all 29 object types.
- Every enum value list matches exactly — fact types 21/21 on the research side, 18/18 on the tree side, name types 6/6, parent subtypes 5/5, and so on.
- The three schema files under `docs/specs/schemas/` are byte-identical to the `packages/schema/` mirror.

## Do they contain everything the schemas contain?

**Not quite.** The gap was never a missing field — it was everything the schemas *enforce* that the prose never claimed, plus one bug that hid a chunk of the doc.

## What this PR fixes

**The enum catalogue was silently broken.** The `no_evidence` note sat in the middle of the closed-enum table, which terminates a table in GitHub-flavored Markdown. Fourteen rows — `conflict_type` through `holding_confidence` — rendered as literal pipe-delimited text on GitHub, not as a table. That is more than half the closed enums, invisible to anyone reading the rendered page. I moved the note below the table and verified both states through GitHub's own markdown API.

**Six controlled vocabularies were absent from the enum section entirely** — `external_site`, `severity`, `experience_level`, `subscriptions`, the three evaluation enums, and the locality wiki-section enum. Their values existed only inside whichever field description happened to use them, so a reviewer scanning the enum section for "what values are legal" would not find them.

**Nothing said what is enforced.** Added, in both specs: which top-level keys are required and that an empty array must still be written; that every object is closed to unlisted fields; that the id prefixes are validated rather than conventional; and — the one most likely to bite a genealogist — that PascalCase on tree fact types is enforced, so a lowercase `birth` copied across from research.json passes every open-enum check and then fails `tree_edit` mid-run. The spec had called that a casing convention.

**Added a date-and-timestamp reference** to the research spec: which fields are `YYYY-MM-DD`, which are timestamps needing an explicit timezone, and the fact that neither governs `assertions[].date`, which is deliberately free-form. Also flagged the two places the gates disagree — `evaluations[].timestamp` is checked more loosely than the other timestamps, and a locality's `pages_read[].section` is the one closed enum `validate_research_schema` never descends far enough to check.

**Smaller readability fixes:** the tree spec now names the `enums.schema.json` key beside each enum, so a reader can map its `fact_type` to `gedcomx_fact_type_recommended` and tell it apart from research.json's own `fact_type`; `quality` is an integer 0-3, not a "number"; ParentChild carries no facts array, only Couple does; and the locality table no longer crams `created` and `updated` into one row with "`created` yes" in the Required column.

## Worked-example corrections

These matter more than they sound — the worked example is what a genealogist reads most closely.

- **The research.json example failed validation against our own schema.** It was missing the required `evaluations` key. I added an entry showing the section's pointer shape rather than an empty array, plus notes on what is present and what is legitimately absent.
- **The 1860 census source reference on R1 carried `quality: 3`** — "direct and primary evidence" — while both specs' prose calls that census indirect evidence, and the same example in the tree spec gives it `2`. The two docs disagreed about the same example. Now 2 in both.
- **Two assertions set `informant_proximity: "household_member"` while their own bias notes argued for `unknown`.** Rewrote the notes to match the values.
- **a_010 used `unknown` for a relationship inferred from household structure.** The field's own definition assigns `researcher` to exactly that case, which is what the identical 1850 assertion (a_004) already used.

## Verification

No schema, code, or behavior change — docs only, plus one CLAUDE.md pointer that named the `no_evidence` note by its old position.

- Both worked examples validate against the schemas (the research one did not before).
- All 14 orphaned enum rows now render as table rows; zero rows render as literal text in either spec.
- Every property still has a table row; required/optional still agrees everywhere.
- `tests/packaging` passes, 384 tests, including the doc-link lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)