### PR TITLE
docs(feedback): spec §6 — thinking blocks are kept, not stripped (#1122)

### DIFF
--- a/apps/electron/docs/feedback-json-spec.md
+++ b/apps/electron/docs/feedback-json-spec.md
@@ -220,9 +220,11 @@ consuming skills can rely on it:
   the same filtering `feedback.ts` already does today. System
   messages, hook outputs, and other SDK-internal entries are
   excluded.
-- **Thinking blocks are stripped** from assistant messages before
-  writing. The skill that summarizes the transcript should not see
-  the model's internal reasoning.
+- **Thinking blocks are kept** in assistant messages. The agent's
+  internal reasoning is the highest-value signal for triage and exists
+  nowhere in the persisted project files, so it is retained rather than
+  stripped (`feedback.ts` and `feedback.py` both keep it; pinned by
+  `test_session_log_keeps_thinking_and_filters_non_conversation`).
 - **Entries are filtered to the submitting project's `cwd`** —
   multi-project sessions get one log per submission, scoped to
   the failing project only.


### PR DESCRIPTION
## Summary

- `apps/electron/docs/feedback-json-spec.md` §6 said thinking blocks are **stripped** from the session log. Both bundlers deliberately **keep** them (`feedback.ts:195`, `feedback.py:209-213`), and `test_session_log_keeps_thinking_and_filters_non_conversation` pins it. Fixed the spec to match the code (per the issue: fix the spec, not the code).
- This spec is cited as "the authority" by `feedback-case-spec.md:14`, so the contradiction misled every downstream reader.
- Tier: **Trivial** (documentation, one line, no behavior change).

## Review guidance

**Start here:** the one changed bullet. Verify the direction against `feedback.ts:195` ("Retain thinking blocks…") and `feedback.py:209-213` ("Thinking blocks are **kept**…") — the code is the source of truth; the spec was the stale side.

**Unsure about:** nothing.

## Not batched with #1480 (deliberate)

Dallan asked to batch this with #1480 (`agent_should_have` marked `required: yes`) as a second one-line spec fix. On checking, **#1480 is not a spec fix**: in this table `required: yes` means "always present in the JSON, empty string when blank" (same convention as `notes` / `correct_answer`), and the bundler always writes `agent_should_have` (`feedback.ts:251`) — so the line is correct, and flipping it would contradict the code (the exact bug this PR fixes). The real #1480 defect is the form gate at `FeedbackDialog.tsx:106` (`agentShouldHave.trim().length > 0`), which is a code/validation fix needing a developer's review — raised with Dallan separately.

## Test plan

- [x] No code changed — documentation only. `feedback-json-spec.md` now matches `feedback.ts` / `feedback.py` and the pinning test `test_session_log_keeps_thinking_and_filters_non_conversation`. No suite exercises this doc line, so there's no fail-then-pass check to cite; correctness is the spec-vs-code agreement above.
- [x] N/A — no skill run-log snapshot changed.

Closes #1122.
