### PR TITLE
Stop pulling a senior into documentation, styling, and dotfile PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,101 +3,43 @@
 # show this — after every edit here, check
 # `gh api /repos/{owner}/{repo}/codeowners/errors`.
 #
-# NOTHING MAY REST ON THE CATCH-ALL. Every tracked path must be claimed by a
-# rule that names it. A path nobody names still routes somewhere — it falls to
-# `*` below and lands on senior genealogists — so an unnamed file type is a
-# routing decision made by omission, which is how ~45 Windows batch wrappers and
-# the FastAPI pyproject.toml came to need genealogist review. The `*` line stays
-# as a floor, but `.github/tests/codeowners-routing.test.mjs` fails if it owns
-# anything.
+# Resolution is LAST MATCH WINS, so ordering is load-bearing: the genealogist
+# rules at the bottom override the developer rules above them.
 #
-# Resolution is LAST MATCH WINS, so ordering is load-bearing: the developer
-# block overrides the default, and the genealogist carve-outs at the bottom
-# override the developer block.
-#
-# Branch protection requires two approvals plus `require_code_owner_reviews`, so
-# a PR needs an approval from each team that owns any path in its diff, plus one
-# more from anyone with write access. A PR touching only developer-owned paths
-# does not need a senior genealogist.
+# THERE IS NO `*` DEFAULT, deliberately. Branch protection requires two
+# approvals from anyone with write access on every PR regardless; a rule here
+# adds the requirement that one of them come from a named senior team. A path
+# nobody names still gets two reviewers — it just does not pull a senior into a
+# CSS tweak, an icon, or a dotfile. Only claim a path when a senior's judgment
+# is what a review of it needs.
 
-# --- Default owner --------------------------------------------------------
-* @PioneerAIAcademy/senior-genealogists
+# --- Senior developer review: code and the infra that breaks silently ---
+# --- CODEOWNERS has no concept of PR labels, so this is scoped by file ---
+# --- type, not by the "developer" label.                              ---
 
-# --- Content whose default is deliberate, restated so the catch-all owns   ---
-# --- nothing. Prose is genealogist-reviewed wherever it lives; the         ---
-# --- developer block below still claims .github/ and docs/specs/schemas/.  ---
-
-*.md @PioneerAIAcademy/senior-genealogists
-*.pdf @PioneerAIAcademy/senior-genealogists
-LICENSE @PioneerAIAcademy/senior-genealogists
-
-# --- Developer infrastructure: senior-developer review required on code ---
-# --- and infra file types, repo-wide (last-match-wins means these       ---
-# --- extensions get ONLY senior-developers, not senior-genealogists     ---
-# --- too — see the carve-out block below for the exception).           ---
-# --- Intent: genealogists review skills and runlogs; developers review ---
-# --- infrastructure. CODEOWNERS has no concept of PR labels, so this   ---
-# --- is scoped by file type/path, not by the "developer" label.        ---
-
-# Source.
 *.ts @PioneerAIAcademy/senior-developers
 *.tsx @PioneerAIAcademy/senior-developers
 *.js @PioneerAIAcademy/senior-developers
 *.mjs @PioneerAIAcademy/senior-developers
 *.cjs @PioneerAIAcademy/senior-developers
 *.py @PioneerAIAcademy/senior-developers
-*.gs @PioneerAIAcademy/senior-developers
-
-# Data and config formats.
 *.json @PioneerAIAcademy/senior-developers
 *.yml @PioneerAIAcademy/senior-developers
 *.yaml @PioneerAIAcademy/senior-developers
 *.toml @PioneerAIAcademy/senior-developers
-*.lock @PioneerAIAcademy/senior-developers
-*.plist @PioneerAIAcademy/senior-developers
-
-# Web and Electron UI: markup, styles, and app assets.
-*.css @PioneerAIAcademy/senior-developers
-*.html @PioneerAIAcademy/senior-developers
-*.svg @PioneerAIAcademy/senior-developers
-*.png @PioneerAIAcademy/senior-developers
-*.ico @PioneerAIAcademy/senior-developers
-*.icns @PioneerAIAcademy/senior-developers
-
-# Build, run, and packaging entry points. The .bat wrappers are the Windows
-# genealogists' entry point but are developer-authored tooling, not content.
-Makefile @PioneerAIAcademy/senior-developers
-Dockerfile @PioneerAIAcademy/senior-developers
-*.Dockerfile @PioneerAIAcademy/senior-developers
-*.sh @PioneerAIAcademy/senior-developers
 *.bat @PioneerAIAcademy/senior-developers
-
-# Toolchain pins and per-tool ignore files.
+Makefile @PioneerAIAcademy/senior-developers
 .gitattributes @PioneerAIAcademy/senior-developers
-.gitignore @PioneerAIAcademy/senior-developers
-.gitkeep @PioneerAIAcademy/senior-developers
-.dockerignore @PioneerAIAcademy/senior-developers
-.mcpbignore @PioneerAIAcademy/senior-developers
-.editorconfig @PioneerAIAcademy/senior-developers
-.prettierignore @PioneerAIAcademy/senior-developers
-.npmrc @PioneerAIAcademy/senior-developers
-.nvmrc @PioneerAIAcademy/senior-developers
-.python-version @PioneerAIAcademy/senior-developers
-.tool-versions @PioneerAIAcademy/senior-developers
-
-# Directories that are wholly developer-owned, which is also what claims the
-# extensionless files in them (scripts/git-hooks/post-checkout).
-/scripts/ @PioneerAIAcademy/senior-developers
-/.github/ @PioneerAIAcademy/senior-developers
 
 # --- Carve-out: genealogist-authored content that happens to live in   ---
-# --- .py/.json/.md files, re-asserted below the extension rules above  ---
-# --- so it stays senior-genealogists (last-match-wins). ---
+# --- .py/.json files, re-asserted below the extension rules above      ---
+# --- so it stays senior-genealogists (last-match-wins).                ---
 
 # Cowork plugin skills — SKILL.md prose, templates, references, and their
 # stdlib-only Python scripts (CLAUDE.md § "Skills") are genealogist-
 # reviewed content, not developer infrastructure, even though scripts/
-# holds .py files.
+# holds .py files. Scoped to the plugin: the process skills under
+# .claude/skills/ are the lead's, not genealogist content.
 /packages/engine/plugin/skills/ @PioneerAIAcademy/senior-genealogists
 
 # Cowork plugin agents — agent .md bodies are genealogist/doctrine prose.
@@ -111,11 +53,3 @@ Dockerfile @PioneerAIAcademy/senior-developers
 
 # Run logs and their .ann.json calibration annotations.
 /eval/runlogs/ @PioneerAIAcademy/senior-genealogists
-
-# docs/ prose, including specs — narrative and doctrine content. Schema
-# JSON Schema files under docs/specs/schemas/ are the one exception: they
-# are a code contract (validator.ts is generated/checked against them),
-# so they are deliberately NOT carved out here and stay under the *.json
-# rule above (senior-developers).
-/docs/ @PioneerAIAcademy/senior-genealogists
-/docs/specs/schemas/ @PioneerAIAcademy/senior-developers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,11 +3,33 @@
 # show this — after every edit here, check
 # `gh api /repos/{owner}/{repo}/codeowners/errors`.
 #
-# Every PR needs one approval from a senior genealogist (this team),
-# in addition to at least one more approval from anyone else with
-# write access. Enforced together with branch protection's
-# "required_approving_review_count: 2" + "require_code_owner_reviews".
+# NOTHING MAY REST ON THE CATCH-ALL. Every tracked path must be claimed by a
+# rule that names it. A path nobody names still routes somewhere — it falls to
+# `*` below and lands on senior genealogists — so an unnamed file type is a
+# routing decision made by omission, which is how ~45 Windows batch wrappers and
+# the FastAPI pyproject.toml came to need genealogist review. The `*` line stays
+# as a floor, but `.github/tests/codeowners-routing.test.mjs` fails if it owns
+# anything.
+#
+# Resolution is LAST MATCH WINS, so ordering is load-bearing: the developer
+# block overrides the default, and the genealogist carve-outs at the bottom
+# override the developer block.
+#
+# Branch protection requires two approvals plus `require_code_owner_reviews`, so
+# a PR needs an approval from each team that owns any path in its diff, plus one
+# more from anyone with write access. A PR touching only developer-owned paths
+# does not need a senior genealogist.
+
+# --- Default owner --------------------------------------------------------
 * @PioneerAIAcademy/senior-genealogists
+
+# --- Content whose default is deliberate, restated so the catch-all owns   ---
+# --- nothing. Prose is genealogist-reviewed wherever it lives; the         ---
+# --- developer block below still claims .github/ and docs/specs/schemas/.  ---
+
+*.md @PioneerAIAcademy/senior-genealogists
+*.pdf @PioneerAIAcademy/senior-genealogists
+LICENSE @PioneerAIAcademy/senior-genealogists
 
 # --- Developer infrastructure: senior-developer review required on code ---
 # --- and infra file types, repo-wide (last-match-wins means these       ---
@@ -17,15 +39,56 @@
 # --- infrastructure. CODEOWNERS has no concept of PR labels, so this   ---
 # --- is scoped by file type/path, not by the "developer" label.        ---
 
+# Source.
 *.ts @PioneerAIAcademy/senior-developers
 *.tsx @PioneerAIAcademy/senior-developers
 *.js @PioneerAIAcademy/senior-developers
 *.mjs @PioneerAIAcademy/senior-developers
 *.cjs @PioneerAIAcademy/senior-developers
 *.py @PioneerAIAcademy/senior-developers
+*.gs @PioneerAIAcademy/senior-developers
+
+# Data and config formats.
 *.json @PioneerAIAcademy/senior-developers
 *.yml @PioneerAIAcademy/senior-developers
 *.yaml @PioneerAIAcademy/senior-developers
+*.toml @PioneerAIAcademy/senior-developers
+*.lock @PioneerAIAcademy/senior-developers
+*.plist @PioneerAIAcademy/senior-developers
+
+# Web and Electron UI: markup, styles, and app assets.
+*.css @PioneerAIAcademy/senior-developers
+*.html @PioneerAIAcademy/senior-developers
+*.svg @PioneerAIAcademy/senior-developers
+*.png @PioneerAIAcademy/senior-developers
+*.ico @PioneerAIAcademy/senior-developers
+*.icns @PioneerAIAcademy/senior-developers
+
+# Build, run, and packaging entry points. The .bat wrappers are the Windows
+# genealogists' entry point but are developer-authored tooling, not content.
+Makefile @PioneerAIAcademy/senior-developers
+Dockerfile @PioneerAIAcademy/senior-developers
+*.Dockerfile @PioneerAIAcademy/senior-developers
+*.sh @PioneerAIAcademy/senior-developers
+*.bat @PioneerAIAcademy/senior-developers
+
+# Toolchain pins and per-tool ignore files.
+.gitattributes @PioneerAIAcademy/senior-developers
+.gitignore @PioneerAIAcademy/senior-developers
+.gitkeep @PioneerAIAcademy/senior-developers
+.dockerignore @PioneerAIAcademy/senior-developers
+.mcpbignore @PioneerAIAcademy/senior-developers
+.editorconfig @PioneerAIAcademy/senior-developers
+.prettierignore @PioneerAIAcademy/senior-developers
+.npmrc @PioneerAIAcademy/senior-developers
+.nvmrc @PioneerAIAcademy/senior-developers
+.python-version @PioneerAIAcademy/senior-developers
+.tool-versions @PioneerAIAcademy/senior-developers
+
+# Directories that are wholly developer-owned, which is also what claims the
+# extensionless files in them (scripts/git-hooks/post-checkout).
+/scripts/ @PioneerAIAcademy/senior-developers
+/.github/ @PioneerAIAcademy/senior-developers
 
 # --- Carve-out: genealogist-authored content that happens to live in   ---
 # --- .py/.json/.md files, re-asserted below the extension rules above  ---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,12 +50,14 @@
 ## Test plan
 
 <!-- If this PR touches a code/infra file (.ts/.tsx/.js/.mjs/.cjs/.py/.json/
-     .yml/.yaml) outside packages/engine/plugin/skills/, packages/engine/
-     plugin/agents/, eval/fixtures/, eval/tests/, eval/runlogs/, or docs/,
-     a senior-developers approval is required by branch protection — see
-     .github/CODEOWNERS for the exact rule. Peer approval alone will not
-     unblock merge. This is a convenience note; GitHub's merge button is
-     the actual enforcement. -->
+     .yml/.yaml/.toml/.bat, Makefile, .gitattributes) outside
+     packages/engine/plugin/skills/, packages/engine/plugin/agents/,
+     eval/fixtures/, eval/tests/, or eval/runlogs/, a senior-developers
+     approval is required by branch protection — see .github/CODEOWNERS for
+     the exact rule. Peer approval alone will not unblock merge. Note that
+     docs/ is no longer an exclusion: prose there needs no senior, but a
+     schema or other code file under it does. This is a convenience note;
+     GitHub's merge button is the actual enforcement. -->
 
 - [ ] I ran `make test-all` (or `scripts/test.sh` — the same command) and it passed.
       <!-- No Windows equivalent exists (issue #1185): `eval\RunTests.bat` is the

--- a/.github/tests/codeowners-routing.test.mjs
+++ b/.github/tests/codeowners-routing.test.mjs
@@ -1,0 +1,156 @@
+// Review routing truth table for .github/CODEOWNERS.
+//
+// WHY THIS EXISTS. CODEOWNERS routes every path to a reviewing team, and a path
+// nobody named still routes somewhere: it falls to the `*` catch-all and lands
+// on senior genealogists. That is invisible from the file — you have to resolve
+// a real path against every rule to see it. It went unnoticed until a Windows
+// batch-file PR and a pyproject PR both asked genealogists to review build
+// tooling.
+//
+// THE INVARIANT. No tracked file may be owned by the `*` catch-all alone. Every
+// path must be claimed by a rule that names it, so a new file type forces a
+// deliberate routing decision at the moment it is added instead of silently
+// inheriting the default. The catch-all stays as a floor — a repo with no owner
+// for some path is worse — but nothing may rest on it.
+//
+// It also resolves paths through senior-queue.yml's OWN CODEOWNERS parser,
+// which understands only three pattern shapes and skips the rest with a
+// warning. A pattern GitHub honours but that parser cannot read enforces the
+// merge correctly while routing the review queue to the wrong team, and the
+// only signal is a warning nobody reads.
+//
+// WHAT IT CANNOT COVER. That the named teams exist. A rule naming a nonexistent
+// team is silently dropped by GitHub and this file cannot see it — check
+// `gh api /repos/{owner}/{repo}/codeowners/errors` after editing CODEOWNERS.
+//
+// Run: node .github/tests/codeowners-routing.test.mjs
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const CODEOWNERS = '.github/CODEOWNERS';
+const WORKFLOW = '.github/workflows/senior-queue.yml';
+
+// Pull the `script: |` block scalar out of the raw YAML and dedent it.
+function scriptBody(path) {
+  const lines = fs.readFileSync(path, 'utf8').split('\n');
+  const start = lines.findIndex(l => /^\s*script: \|\s*$/.test(l));
+  if (start === -1) throw new Error(`${path}: no "script: |" block found`);
+  const indent = lines[start].match(/^\s*/)[0].length;
+  const out = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() !== '' && line.match(/^\s*/)[0].length <= indent) break;
+    out.push(line.slice(indent + 2));
+  }
+  return out.join('\n');
+}
+
+const body = scriptBody(WORKFLOW);
+const grab = (re, label) => {
+  const m = body.match(re);
+  if (!m) {
+    throw new Error(
+      `could not extract ${label} from ${WORKFLOW} — it was renamed or reformatted. ` +
+      `Update this regex, and re-check that this file still tests the real parser.`);
+  }
+  return m[0];
+};
+
+// The two pure functions the workflow uses to route a PR, lifted verbatim so
+// this test fails when they drift rather than testing a copy of them.
+// scriptBody() dedents to column 0, so a top-level `}` in column 0 ends a function.
+const loadSrc = grab(/async function loadCodeowners\(\) \{[\s\S]*?\n\}/, 'loadCodeowners');
+const ownersSrc = grab(/^function ownersOf\(file, rules\) \{[\s\S]*?\n\}/m, 'ownersOf');
+
+// loadCodeowners() reads the default branch over the API; here it reads disk.
+const stubGithub = `
+  const github = { rest: {
+    repos: {
+      get: async () => ({ data: { default_branch: 'main' } }),
+      getContent: async () => ({ data: {
+        content: Buffer.from(require('fs').readFileSync(${JSON.stringify(CODEOWNERS)}, 'utf8')).toString('base64'),
+      } }),
+    },
+  } };
+  const owner = 'o', repo = 'r';
+`;
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const { loadCodeowners, ownersOf } = await new AsyncFunction('require',
+  `${stubGithub}${loadSrc}\n${ownersSrc}\nreturn { loadCodeowners, ownersOf };`)(
+  (await import('node:module')).createRequire(import.meta.url));
+
+const { rules, unknown } = await loadCodeowners();
+
+let failures = 0;
+const fail = msg => { failures++; console.error(`FAIL  ${msg}`); };
+
+// 1. Every pattern must be one senior-queue.yml can resolve.
+if (unknown.length) {
+  fail(`${CODEOWNERS} patterns senior-queue.yml cannot match, so it routes those ` +
+       `paths to the wrong review queue: ${unknown.join(', ')}\n` +
+       `      Teach loadCodeowners() the shape rather than dropping the pattern.`);
+} else {
+  console.log(`ok    all ${rules.length} CODEOWNERS rules are shapes senior-queue.yml can resolve`);
+}
+
+// 2. The `*` catch-all must own nothing.
+const catchAll = rules.find(r => r.pattern === '*');
+if (!catchAll) fail(`${CODEOWNERS} has no \`*\` rule — every unclaimed path would be unowned`);
+
+const files = execSync('git ls-files', { encoding: 'utf8' }).trim().split('\n').filter(Boolean);
+const unclaimed = files.filter(f => {
+  let last = null;
+  for (const r of rules) if (r.test(f)) last = r;
+  return last === null || last.pattern === '*';
+});
+
+if (unclaimed.length) {
+  // Group by the shape a fix would take, so the message names the rule to add.
+  const groups = new Map();
+  for (const f of unclaimed) {
+    const base = f.split('/').pop();
+    const ext = base.includes('.') && !base.startsWith('.') ? `*${base.slice(base.lastIndexOf('.'))}` : base;
+    if (!groups.has(ext)) groups.set(ext, []);
+    groups.get(ext).push(f);
+  }
+  const lines = [...groups].sort((a, b) => b[1].length - a[1].length).map(
+    ([k, v]) => `        ${k.padEnd(18)} ${String(v.length).padStart(4)} file(s), e.g. ${v[0]}`);
+  fail(`${unclaimed.length} tracked file(s) are owned only by the \`*\` catch-all, so they\n` +
+       `      route to senior genealogists by default rather than by decision:\n` +
+       lines.join('\n') + `\n` +
+       `      Add a rule naming each — to senior-developers if it is infrastructure, or\n` +
+       `      to senior-genealogists to state that the default is intended.`);
+} else {
+  console.log(`ok    all ${files.length} tracked files are claimed by an explicit rule`);
+}
+
+// 3. The routing the two teams actually care about, stated as a table so a
+//    reordering that inverts last-match-wins fails here rather than in review.
+const D = 'senior-developers', G = 'senior-genealogists';
+const TABLE = [
+  // Infrastructure — the class this file was written for.
+  ['Makefile', D], ['scripts/mcpb.bat', D], ['scripts/test.sh', D],
+  ['apps/server/pyproject.toml', D], ['.gitattributes', D], ['deploy/fly.toml', D],
+  ['deploy/Dockerfile', D], ['apps/server/sandbox/e2b.Dockerfile', D],
+  ['scripts/git-hooks/post-checkout', D], ['apps/web/src/styles.css', D],
+  ['packages/engine/mcp-server/src/index.ts', D],
+  // Genealogist content that lives in developer-looking files — the carve-outs.
+  ['packages/engine/plugin/skills/citation/SKILL.md', G],
+  ['packages/engine/plugin/skills/timeline/scripts/build.py', G],
+  ['packages/engine/plugin/agents/gps-mentor.md', G],
+  ['eval/fixtures/scenarios/x/research.json', G],
+  ['eval/tests/e2e/x/fixture.json', G],
+  ['eval/runlogs/unit/citation/run.json', G],
+  ['docs/specs/research-schema-spec.md', G],
+  // ...and the one carve-out from the carve-out.
+  ['docs/specs/schemas/research.schema.json', D],
+];
+for (const [file, want] of TABLE) {
+  const got = ownersOf(file, rules);
+  if (got.length !== 1 || got[0] !== want) {
+    fail(`${file} routes to [${got.join(', ') || 'nobody'}], expected ${want}`);
+  }
+}
+if (!failures) console.log(`ok    ${TABLE.length} routing assertions`);
+
+console.log(failures ? `\n${failures} check(s) failed` : '\nall checks passed');
+process.exit(failures ? 1 : 0);

--- a/.github/tests/codeowners-routing.test.mjs
+++ b/.github/tests/codeowners-routing.test.mjs
@@ -1,23 +1,12 @@
 // Review routing truth table for .github/CODEOWNERS.
 //
-// WHY THIS EXISTS. CODEOWNERS routes every path to a reviewing team, and a path
-// nobody named still routes somewhere: it falls to the `*` catch-all and lands
-// on senior genealogists. That is invisible from the file — you have to resolve
-// a real path against every rule to see it. It went unnoticed until a Windows
-// batch-file PR and a pyproject PR both asked genealogists to review build
-// tooling.
-//
-// THE INVARIANT. No tracked file may be owned by the `*` catch-all alone. Every
-// path must be claimed by a rule that names it, so a new file type forces a
-// deliberate routing decision at the moment it is added instead of silently
-// inheriting the default. The catch-all stays as a floor — a repo with no owner
-// for some path is worse — but nothing may rest on it.
-//
-// It also resolves paths through senior-queue.yml's OWN CODEOWNERS parser,
-// which understands only three pattern shapes and skips the rest with a
-// warning. A pattern GitHub honours but that parser cannot read enforces the
-// merge correctly while routing the review queue to the wrong team, and the
-// only signal is a warning nobody reads.
+// WHY THIS EXISTS. senior-queue.yml resolves CODEOWNERS itself to decide which
+// senior team's queue a PR lands in, and its parser understands only a few
+// pattern shapes — anything else it drops with a warning nobody reads. A
+// pattern GitHub honours but that parser cannot read enforces the merge
+// correctly while routing the review to the wrong team, with no visible
+// symptom. This file resolves paths through that same parser, lifted out of the
+// workflow rather than copied, so the two cannot drift.
 //
 // WHAT IT CANNOT COVER. That the named teams exist. A rule naming a nonexistent
 // team is silently dropped by GitHub and this file cannot see it — check
@@ -25,7 +14,6 @@
 //
 // Run: node .github/tests/codeowners-routing.test.mjs
 import fs from 'node:fs';
-import { execSync } from 'node:child_process';
 
 const CODEOWNERS = '.github/CODEOWNERS';
 const WORKFLOW = '.github/workflows/senior-queue.yml';
@@ -55,8 +43,6 @@ const grab = (re, label) => {
   return m[0];
 };
 
-// The two pure functions the workflow uses to route a PR, lifted verbatim so
-// this test fails when they drift rather than testing a copy of them.
 // scriptBody() dedents to column 0, so a top-level `}` in column 0 ends a function.
 const loadSrc = grab(/async function loadCodeowners\(\) \{[\s\S]*?\n\}/, 'loadCodeowners');
 const ownersSrc = grab(/^function ownersOf\(file, rules\) \{[\s\S]*?\n\}/m, 'ownersOf');
@@ -92,63 +78,43 @@ if (unknown.length) {
   console.log(`ok    all ${rules.length} CODEOWNERS rules are shapes senior-queue.yml can resolve`);
 }
 
-// 2. The `*` catch-all must own nothing.
-const catchAll = rules.find(r => r.pattern === '*');
-if (!catchAll) fail(`${CODEOWNERS} has no \`*\` rule — every unclaimed path would be unowned`);
-
-const files = execSync('git ls-files', { encoding: 'utf8' }).trim().split('\n').filter(Boolean);
-const unclaimed = files.filter(f => {
-  let last = null;
-  for (const r of rules) if (r.test(f)) last = r;
-  return last === null || last.pattern === '*';
-});
-
-if (unclaimed.length) {
-  // Group by the shape a fix would take, so the message names the rule to add.
-  const groups = new Map();
-  for (const f of unclaimed) {
-    const base = f.split('/').pop();
-    const ext = base.includes('.') && !base.startsWith('.') ? `*${base.slice(base.lastIndexOf('.'))}` : base;
-    if (!groups.has(ext)) groups.set(ext, []);
-    groups.get(ext).push(f);
-  }
-  const lines = [...groups].sort((a, b) => b[1].length - a[1].length).map(
-    ([k, v]) => `        ${k.padEnd(18)} ${String(v.length).padStart(4)} file(s), e.g. ${v[0]}`);
-  fail(`${unclaimed.length} tracked file(s) are owned only by the \`*\` catch-all, so they\n` +
-       `      route to senior genealogists by default rather than by decision:\n` +
-       lines.join('\n') + `\n` +
-       `      Add a rule naming each — to senior-developers if it is infrastructure, or\n` +
-       `      to senior-genealogists to state that the default is intended.`);
-} else {
-  console.log(`ok    all ${files.length} tracked files are claimed by an explicit rule`);
-}
-
-// 3. The routing the two teams actually care about, stated as a table so a
-//    reordering that inverts last-match-wins fails here rather than in review.
+// 2. Who reviews what, stated as a table so a reordering that inverts
+//    last-match-wins fails here rather than in review. `null` means no senior
+//    team is required — the two ordinary approvals still are.
 const D = 'senior-developers', G = 'senior-genealogists';
 const TABLE = [
-  // Infrastructure — the class this file was written for.
-  ['Makefile', D], ['scripts/mcpb.bat', D], ['scripts/test.sh', D],
-  ['apps/server/pyproject.toml', D], ['.gitattributes', D], ['deploy/fly.toml', D],
-  ['deploy/Dockerfile', D], ['apps/server/sandbox/e2b.Dockerfile', D],
-  ['scripts/git-hooks/post-checkout', D], ['apps/web/src/styles.css', D],
+  // Code and the infra that breaks silently.
   ['packages/engine/mcp-server/src/index.ts', D],
-  // Genealogist content that lives in developer-looking files — the carve-outs.
+  ['apps/server/app/main.py', D],
+  ['apps/server/pyproject.toml', D],
+  ['.github/workflows/js-tests.yml', D],
+  ['scripts/mcpb.bat', D],
+  ['Makefile', D],
+  ['apps/electron/Makefile', D],
+  ['.gitattributes', D],
+  ['docs/specs/schemas/research.schema.json', D],
+  // Genealogist content, including where it lives in developer-looking files.
   ['packages/engine/plugin/skills/citation/SKILL.md', G],
   ['packages/engine/plugin/skills/timeline/scripts/build.py', G],
   ['packages/engine/plugin/agents/gps-mentor.md', G],
   ['eval/fixtures/scenarios/x/research.json', G],
   ['eval/tests/e2e/x/fixture.json', G],
   ['eval/runlogs/unit/citation/run.json', G],
-  ['docs/specs/research-schema-spec.md', G],
-  // ...and the one carve-out from the carve-out.
-  ['docs/specs/schemas/research.schema.json', D],
+  // Documentation and incidental files need no senior. Losing these to a team
+  // is the regression this table is here to catch.
+  ['README.md', null],
+  ['docs/architecture.md', null],
+  ['docs/specs/research-schema-spec.md', null],
+  ['.claude/skills/fill-ready/SKILL.md', null],
+  ['apps/web/src/styles.css', null],
+  ['apps/web/public/favicon.svg', null],
+  ['.gitignore', null],
+  ['scripts/test.sh', null],
 ];
 for (const [file, want] of TABLE) {
   const got = ownersOf(file, rules);
-  if (got.length !== 1 || got[0] !== want) {
-    fail(`${file} routes to [${got.join(', ') || 'nobody'}], expected ${want}`);
-  }
+  const ok = want === null ? got.length === 0 : got.length === 1 && got[0] === want;
+  if (!ok) fail(`${file} routes to [${got.join(', ') || 'no senior team'}], expected ${want ?? 'no senior team'}`);
 }
 if (!failures) console.log(`ok    ${TABLE.length} routing assertions`);
 

--- a/.github/workflows/senior-queue.yml
+++ b/.github/workflows/senior-queue.yml
@@ -175,9 +175,14 @@ jobs:
                 // a mis-parsed rule would route a PR to the wrong queue with no sign.
                 let test;
                 if (pattern === '*')                      test = () => true;
-                else if (/^\*\.[A-Za-z0-9]+$/.test(pattern))
+                else if (/^\*\.[A-Za-z0-9.]+$/.test(pattern))
                                                           test = f => f.endsWith(pattern.slice(1));
                 else if (/^\/.*\/$/.test(pattern))        test = f => f.startsWith(pattern.slice(1));
+                // A bare filename (Makefile, .gitattributes) matches that
+                // basename at any depth, which is how GitHub resolves a
+                // slash-free pattern.
+                else if (/^[A-Za-z0-9._-]+$/.test(pattern))
+                                                          test = f => f.split('/').pop() === pattern;
                 else { unknown.push(pattern); continue; }
                 rules.push({ pattern, test, teams });
               }

--- a/.github/workflows/workflow-logic-tests.yml
+++ b/.github/workflows/workflow-logic-tests.yml
@@ -1,13 +1,17 @@
 name: workflow-logic-tests
 
-# Runs the pure-logic tests for the workflows that write the kanban board.
+# Runs the pure-logic tests for the repo-governance files that route work:
+# which board column a card lands in, and which team reviews a path.
 #
-# WHY. project-status-sync.yml decides which column every card lands in, and a
-# wrong column is still a valid column: the run goes green, the board is quietly
-# wrong, and the only detector is a human noticing weeks later. Nothing else in
-# CI reads that file — the JS suite (`make test-js`) covers web, electron,
-# viewer-ui and schema, and a GitHub-workflow branch table belongs in none of
-# those packages.
+# WHY. Both decide something where a wrong answer is still a VALID answer, so
+# nothing downstream complains. project-status-sync.yml picks a column and a
+# wrong column is still a column; CODEOWNERS picks a reviewing team and an
+# unclaimed path still routes somewhere — to whoever the `*` catch-all names.
+# The run goes green, the board or the review queue is quietly wrong, and the
+# only detector is a human noticing weeks later. Nothing else in CI reads either
+# file — the JS suite (`make test-js`) covers web, electron, viewer-ui and
+# schema, and neither a workflow branch table nor a CODEOWNERS resolution
+# belongs in any of those packages.
 #
 # WHAT THIS DOES NOT COVER. Only the pure decision functions. A green run here
 # says nothing about whether the App token can still write the board, whether
@@ -19,18 +23,16 @@ name: workflow-logic-tests
 # No install step and no dependencies on purpose: the test extracts the script
 # block from the raw YAML itself, so this job is `checkout` + `node`.
 
+# NO `paths:` FILTER, deliberately. The CODEOWNERS job's invariant is about the
+# repo's FILE SET — that no tracked path falls through to the `*` catch-all — so
+# the PR that breaks it is the one ADDING a file of a type nobody has claimed,
+# which touches none of the paths a filter could name. Both jobs are
+# `checkout` + `node` with no install step, so running them on every PR costs
+# seconds. Do not add a filter back without moving that job to its own workflow.
 on:
   pull_request:
-    paths:
-      - '.github/workflows/project-status-sync.yml'
-      - '.github/workflows/workflow-logic-tests.yml'
-      - '.github/tests/**'
   push:
     branches: [main]
-    paths:
-      - '.github/workflows/project-status-sync.yml'
-      - '.github/workflows/workflow-logic-tests.yml'
-      - '.github/tests/**'
   workflow_dispatch:
 
 permissions:
@@ -46,3 +48,13 @@ jobs:
         with:
           node-version: '22'
       - run: node .github/tests/project-status-sync-routing.test.mjs
+
+  codeowners:
+    name: CODEOWNERS review routing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - run: node .github/tests/codeowners-routing.test.mjs

--- a/.github/workflows/workflow-logic-tests.yml
+++ b/.github/workflows/workflow-logic-tests.yml
@@ -5,13 +5,14 @@ name: workflow-logic-tests
 #
 # WHY. Both decide something where a wrong answer is still a VALID answer, so
 # nothing downstream complains. project-status-sync.yml picks a column and a
-# wrong column is still a column; CODEOWNERS picks a reviewing team and an
-# unclaimed path still routes somewhere — to whoever the `*` catch-all names.
-# The run goes green, the board or the review queue is quietly wrong, and the
-# only detector is a human noticing weeks later. Nothing else in CI reads either
-# file — the JS suite (`make test-js`) covers web, electron, viewer-ui and
-# schema, and neither a workflow branch table nor a CODEOWNERS resolution
-# belongs in any of those packages.
+# wrong column is still a column; senior-queue.yml picks a review queue off
+# CODEOWNERS, and a pattern its parser cannot read routes the PR to the wrong
+# team while the merge gate still enforces correctly. The run goes green, the
+# board or the review queue is quietly wrong, and the only detector is a human
+# noticing weeks later. Nothing else in CI reads either file — the JS suite
+# (`make test-js`) covers web, electron, viewer-ui and schema, and neither a
+# workflow branch table nor a CODEOWNERS resolution belongs in any of those
+# packages.
 #
 # WHAT THIS DOES NOT COVER. Only the pure decision functions. A green run here
 # says nothing about whether the App token can still write the board, whether
@@ -23,16 +24,17 @@ name: workflow-logic-tests
 # No install step and no dependencies on purpose: the test extracts the script
 # block from the raw YAML itself, so this job is `checkout` + `node`.
 
-# NO `paths:` FILTER, deliberately. The CODEOWNERS job's invariant is about the
-# repo's FILE SET — that no tracked path falls through to the `*` catch-all — so
-# the PR that breaks it is the one ADDING a file of a type nobody has claimed,
-# which touches none of the paths a filter could name. Both jobs are
-# `checkout` + `node` with no install step, so running them on every PR costs
-# seconds. Do not add a filter back without moving that job to its own workflow.
 on:
   pull_request:
+    paths: &paths
+      - '.github/CODEOWNERS'
+      - '.github/workflows/project-status-sync.yml'
+      - '.github/workflows/senior-queue.yml'
+      - '.github/workflows/workflow-logic-tests.yml'
+      - '.github/tests/**'
   push:
     branches: [main]
+    paths: *paths
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- CODEOWNERS defaulted every unnamed path to senior genealogists, so anything the file did not list inherited that — the Windows batch wrappers and `pyproject.toml` that prompted this, but also all 106 files under `docs/`, README, CONTRIBUTING and every `.claude/` prose file. Over the last six months, 266 commits needed a senior genealogist approval for `docs/` and nothing else.
- Drops that default and adds the four types that genuinely warrant a senior developer: `.toml`, `.bat`, `Makefile`, `.gitattributes`. Net effect is 257 files that no longer require a senior at all, 29 that move to senior developers, and none that move to genealogists.
- Tier: Normal.

## Review guidance

**Start here:** `.github/CODEOWNERS`, and specifically the decision to remove the `*` default rather than repoint it. Branch protection requires two approvals from anyone with write access on every PR independently of code-owner review (`required_approving_review_count: 2`), so a rule in this file only adds the requirement that one of those approvals come from a named senior team. Removing the default therefore does not reduce any PR below two reviewers — it stops a senior being pulled into a CSS tweak, an icon, or a `.gitignore` edit. Please check that reading of the branch protection settings, because everything else follows from it.

The four added types were chosen by measurement, not judgement. For each candidate rule I counted, across 2236 commits since February, how often it was the *only* reason a senior of that team was required. `.toml`, `.bat`, `Makefile` and `.gitattributes` scored between 1 and 5. CSS, HTML, SVG and icon files, shell scripts, lockfiles and ten toolchain dotfiles scored zero — every commit touching them also touched a `.ts` or a `.py`, so a rule for them would never once have changed who reviewed anything. Those get no rule.

**Unsure about:** two things, both flagged rather than decided.

`docs/specs/` is now unowned, including the per-tool specs and `research-schema-spec.md`. That follows from the instruction that only SKILL.md should pull in a genealogist, but those specs are the source of truth an implementation gets checked against. Say the word and they come back.

`eval/runlogs/` is now the largest single senior-genealogist gate — 379 commits in six months where it was the sole reason one was needed, more than `docs/` was. Run logs are largely written by the harness rather than by hand. It may be the next thing to cut, but it is a genealogist-lane call and was not part of this ask, so it is untouched here.

## Plan

**Didn't change:** the genealogist carve-outs for plugin skills, plugin agents, `eval/fixtures/` and `eval/tests/` — those are genuinely genealogist-authored and all four still resolve to that team. Also left `eval/runlogs/` alone despite the number above. The skills rule stays scoped to `packages/engine/plugin/skills/` rather than becoming a bare `SKILL.md` pattern, because the process skills under `.claude/skills/` are the lead's, not genealogist content, and a bare pattern would sweep them in.

**Acceptance check:** `node .github/tests/codeowners-routing.test.mjs`, wired into the `workflow-logic-tests` workflow as a second job. It fails on `main` and passes here. I broke it three ways to confirm it can fail rather than merely pass: adding a pattern shape the queue workflow cannot parse, letting genealogists reclaim `docs/`, and re-appending a `*.py` rule below the carve-outs to invert last-match-wins. Each produced the specific failure it should.

**Deviated from the plan:** yes, substantially, and the first two commits show it. The first pass claimed every unclaimed file type — 48 rules — on the theory that nothing should rest on the default. Review feedback was that this was overbuilt and that documentation must not route to genealogists. Measuring which rules were ever load-bearing is what produced the current 18. The intermediate commit is left in history because the measurement is the argument for the final shape.

## Test plan

- [x] I ran `make test-all` and it passed (1852 passed in 11s).
- [x] `gh api /repos/PioneerAIAcademy/cowork-genealogy/codeowners/errors?ref=worktree-codeowners-infra` returns zero errors, so every rule parses and both teams exist. Reading the file cannot show this — a rule naming a nonexistent team is dropped silently.

No skill run-log snapshot changed, so no paid eval run applies.

## Follow-on issues

**Folded in / filed instead:** two things folded in, nothing filed.

`senior-queue.yml` resolves CODEOWNERS itself to decide which senior team's queue a PR lands in, and its parser understood only three pattern shapes, dropping anything else with a warning. `Makefile` and `.gitattributes` are a fourth shape it could not read, so without this it would have routed those PRs to the genealogist queue while the merge gate correctly demanded a developer — green, silent, and wrong. It now reads bare filenames, and the new check resolves paths through that same parser lifted out of the workflow rather than a copy of it, so the two cannot drift apart.

The PR template's note about which paths need a senior-developer approval listed `docs/` as an exclusion, which this change makes wrong. Corrected in the same PR.

Prompted by PR #1502 and PR #1437, both of which hit this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
