### PR TITLE
Measurement provenance in issue bodies, and a front door for task-reviewer

### DIFF
--- a/.claude/agents/task-reviewer.md
+++ b/.claude/agents/task-reviewer.md
@@ -155,6 +155,13 @@ Rationale, contracts and rejected alternatives: `docs/specs/task-review-spec.md`
 it goes. This covers only what is true whichever way the decisions below go.
 Omit the section when the verdict needs no edit.
 
+Every number you put in a body edit carries the command that reproduces it.
+Prefer naming the command to pasting its output — `make e2e-nudges SINCE=all`
+stays true, a pasted count does not. When a number must be inline, stamp it
+`measured <date>, <command>` and say what would move it. An unstamped
+measurement is quoted forward as settled fact and cannot be re-checked; that is
+how issue bodies come to carry figures that do not survive a re-run.
+
 **For the lead** — one block per genuinely open decision, to the contract below.
 Omit when there are none.
 

--- a/.claude/commands/review-task.md
+++ b/.claude/commands/review-task.md
@@ -1,0 +1,98 @@
+---
+description: Vet ONE issue before handing it to a junior developer. Dispatches to the read-only task-reviewer agent; never edits the issue, a label, or the board without approval.
+argument-hint: <issue-number>
+---
+
+Run the **`task-reviewer`** agent against the issue named in `$ARGUMENTS`.
+
+For a whole shortlist, use `/review-ready` instead — it fans out one agent per
+issue in parallel and collates the verdicts. This command is the single-issue
+door to the same agent, for when one task needs vetting and a fan-out is
+overkill. Rationale and contracts:
+[`docs/specs/task-review-spec.md`](../../docs/specs/task-review-spec.md).
+
+## Step 1 — Resolve the issue, and check it needs reviewing
+
+`$ARGUMENTS` must name one issue number. Empty, or more than one → say so and
+stop; a fan-out is `/review-ready`'s job.
+
+Then read it and skip in two cases, saying which:
+
+- **It already carries `reviewed`.** Re-reviewing costs ~110k tokens and
+  produces the same verdict. Only re-run when the user explicitly asks, or when
+  the body has changed since — check `updatedAt` against the review.
+- **The body is empty or a single line.** There is nothing to review. That is a
+  `/fill-ready` rewrite verdict: ask the filer for a scope line instead.
+
+## Step 2 — Dispatch
+
+Call the Agent tool with `subagent_type: "task-reviewer"` and exactly this:
+
+```
+Review issue #<N> in PioneerAIAcademy/cowork-genealogy for handoff to a junior
+developer working with Claude Code. Follow your instructions exactly and return
+your report in the specified format.
+```
+
+**Pass nothing else.** Not your opinion of the issue, not its board rank, not
+what you suspect is wrong with it. An agent told what to expect finds it, and
+the value here is a read that owes nothing to yours.
+
+## Step 3 — Relay, and verify before acting
+
+Print the verdict, the body edit and the `Checked` lines substantially intact.
+
+**Then check the findings before acting on them.** Open the file, run the
+command, confirm the claim — proposals as much as criticisms. A suggested
+command or file name relayed without checking reads like an established thing to
+whoever picks the issue up. Say what you rejected and why, alongside what you
+accepted.
+
+If the agent returns a **For the lead** block, put it to the lead with
+`AskUserQuestion`, passing each option through **verbatim** — the agent read the
+spec, the ADRs and the code, and you did not.
+
+## Step 4 — Apply what is approved
+
+Every verdict has a write; a verdict you cannot act on does nothing.
+
+| Verdict | Write |
+|---|---|
+| `ready` | `reviewed` label only |
+| `ready-after-edit` | Prepend the agent's text, then `reviewed` |
+| `needs-a-decision` | `needs-decision` label — **not** `senior`. One answer unblocks it and the work behind it is often junior |
+| `senior` | `senior` label, no assignee. Keep the `developer`/`genealogist` label: it picks the lane, and CODEOWNERS routes the review by it |
+| `stale-rewrite` | Replace the ask, keeping the original under an `## Original issue` heading |
+| `close` | `gh issue close --reason "not planned"` with the reason |
+
+Four rules on the writes:
+
+- **Edit the body, not a comment.** The junior reads the body; a finding in a
+  comment thread evaporates.
+- **Prepend, never replace** — except `stale-rewrite`, where the premise moved
+  and the ask is now wrong.
+- **Open the body with the marker**, for whoever picks it up:
+
+  ```
+  > **Reviewed <YYYY-MM-DD> before junior handoff.** <one clause: decision
+  > settled / no decision needed / premise was false>; the original body follows
+  > under "Original issue".
+  ```
+
+- **`reviewed` goes on last**, after the body write lands. Labelling first and
+  failing on the body leaves an issue that looks vetted and is not.
+
+**Never apply both `senior` and `needs-decision`.** They are different states
+with different remedies — one wants a person, the other wants an answer — and an
+issue carrying both tells the board neither.
+
+**If the lead answers a fork while you have him**, that issue never gets
+`needs-decision`. Comment the answer opening `**Ruling:**`, splice in the chosen
+option's pre-written body text, and apply `reviewed`. Handing him an answered
+item on tomorrow's waiting list is the failure this avoids.
+
+## Step 5 — Do not move the board
+
+Promotion and demotion belong to `/fill-ready`. A `senior` or
+`needs-a-decision` verdict means the issue stays where it is, out of the junior
+pool; report it so the next fill can swap it. Do not start the work either.

--- a/.claude/skills/fill-ready/SKILL.md
+++ b/.claude/skills/fill-ready/SKILL.md
@@ -820,6 +820,14 @@ it in one sentence and move on. When it refutes the *issue*, say so in the issue
 — a stale body left unannotated will mislead the next reader exactly as it
 misled you.
 
+Every number you write **into an issue** — a body you edit, an issue you file, a
+ruling you comment — carries the command that reproduces it. Prefer naming the
+command to pasting its output: `make e2e-nudges SINCE=all` stays true, a pasted
+count does not. When a number must be inline, stamp it
+`measured <date>, <command>` and say what would move it. An unstamped
+measurement is quoted forward as settled fact and cannot be re-checked; that is
+how issue bodies come to carry figures that do not survive a re-run.
+
 ## Repo-specific costs to respect
 
 **A paid eval run is the hidden price of most eval fixes.** Editing a skill body,


### PR DESCRIPTION
Three files, all prompt text. No code, no behaviour change.

## 1. A measurement written into an issue carries the command that reproduces it

Reviewing the whole `needs-decision` queue today, **every issue body had at least one number that did not survive a re-run.** Not drift — wrong when checked:

| Issue | The claim | What checking found |
|---|---|---|
| #290 | `hosted_config()` gives an operator no override; redirecting needs an engine rebuild | The override shipped — `Settings` fields, two call sites, refreshed on connect, 10 tests. What is true is narrower: nothing *sets* it |
| #1104 | Max 9 nudges observed, so a cap of 10 or 20 binds on nothing | A run hit 20 of 20. The dominant seam had also inverted, and "more than half named the next step" was down to 13 of 45 |
| #1485 | 139 of 171 rubric dimensions are non-discriminating | Reproduces as 130 under one reading of "which run log", 77 under the other. Never 139 |
| #1484 | Verification pinned to the default 14-day window | The window slides; three days later stored equals recomputed and the defect is invisible |
| #1189 | Prose was tried twice on this fixture and failed | No such commits. The two traceable ones target other fixtures |

Every one of those numbers came from a command that still exists. A body saying *run `make e2e-nudges SINCE=all`* cannot go stale; a body saying *45 nudges across 11 runs* is wrong within days.

Added to the two places that write measurements into issues:

- **`task-reviewer`** — supplies the exact replacement text a caller pastes into a body.
- **`fill-ready`** — writes reciprocal notes, files split issues, comments rulings. Three write paths, none governed.
- **`review-ready`** — deliberately unchanged. Every body write it makes is a verbatim splice of `task-reviewer`'s text (it is told four separate times not to compose its own), so it inherits this for free. Adding the paragraph there would be dead prose.

**This cannot be linted.** Issues do not live in the repo, so no check can fail — and by this repo's own rule a check that cannot fail is worse than none. Convention only, with `task-reviewer` as the sole detector on the issues that reach it.

## 2. A front door for `task-reviewer`

It was the only agent in `.claude/agents/` with no command dispatching to it — `plan-critic`, `drift-critic`, `rubric-critic` and `skill-improver` each have one. Reachable only by `/review-ready` fanning it out over a shortlist, so vetting a single issue meant running the whole fan-out or nothing. That is also why it is easy to forget it exists.

`/review-task <issue-number>` carries the parts of `/review-ready`'s contract a single-issue run still needs: skip an issue already labelled `reviewed` or one with no body; pass the dispatch prompt with nothing added, because an agent told what to expect finds it; and the per-verdict write table — including that `senior` and `needs-decision` are different states that must never both be applied, and that `reviewed` goes on last so a failed body write cannot leave an issue looking vetted.

## Verification

`doc-links` covers `.claude/commands`, and it was **proven to see the new file** rather than assumed to: breaking the spec citation fails the test by name —

```
× .claude/commands/review-task.md cites only paths that still exist
AssertionError: … cites paths that no longer exist: docs/specs/no-such-spec.md
```

— and restoring it passes 130/130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)