### PR TITLE
Stop the senior queue losing PRs to a re-run check and an unclicked Resolve

### DIFF
--- a/.github/tests/senior-queue-readiness.test.mjs
+++ b/.github/tests/senior-queue-readiness.test.mjs
@@ -1,0 +1,217 @@
+// Readiness truth table for senior-queue.yml's two decision rules.
+//
+// WHY THIS EXISTS. Both rules fail in the direction nothing complains about. A
+// PR that should be queued and is not looks exactly like a PR nobody has
+// approved yet — the job is green, the label is simply absent, and the only
+// detector is a senior noticing weeks later that their queue is short. Both
+// have already failed that way in production: PR #1523 sat out of both queues
+// on a `runlogs` check that had been re-run green 18 hours earlier, behind five
+// review threads its approver never went back to resolve.
+//
+// The functions are lifted out of the workflow rather than copied, so the two
+// cannot drift.
+//
+// WHAT IT CANNOT COVER. That `resolveReviewThread` is actually permitted to the
+// GITHUB_TOKEN, that a label write lands, or that the self-check filter excludes
+// the right runs — all three are only observable from a live run. Use the
+// `workflow_dispatch` dry run against a real approved PR.
+//
+// Run: node .github/tests/senior-queue-readiness.test.mjs
+import fs from 'node:fs';
+
+const WORKFLOW = '.github/workflows/senior-queue.yml';
+
+// Pull the `script: |` block scalar out of the raw YAML and dedent it.
+function scriptBody(path) {
+  const lines = fs.readFileSync(path, 'utf8').split('\n');
+  const start = lines.findIndex(l => /^\s*script: \|\s*$/.test(l));
+  if (start === -1) throw new Error(`${path}: no "script: |" block found`);
+  const indent = lines[start].match(/^\s*/)[0].length;
+  const out = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() !== '' && line.match(/^\s*/)[0].length <= indent) break;
+    out.push(line.slice(indent + 2));
+  }
+  return out.join('\n');
+}
+
+const body = scriptBody(WORKFLOW);
+const grab = (re, label) => {
+  const m = body.match(re);
+  if (!m) {
+    throw new Error(
+      `could not extract ${label} from ${WORKFLOW} — it was renamed or reformatted. ` +
+      `Update this regex, and re-check that this file still tests the real rule.`);
+  }
+  return m[0];
+};
+
+// scriptBody() dedents to column 0, so a top-level `}` in column 0 ends a function.
+const newestSrc = grab(/^function newestPerName\(runs\) \{[\s\S]*?\n\}/m, 'newestPerName');
+const supersededSrc = grab(/^function supersededThreads\(threads, approvals\) \{[\s\S]*?\n\}/m,
+  'supersededThreads');
+
+const { newestPerName, supersededThreads } = new Function(
+  `${newestSrc}\n${supersededSrc}\nreturn { newestPerName, supersededThreads };`)();
+
+let failures = 0;
+const fail = msg => { failures++; console.error(`FAIL  ${msg}`); };
+const eq = (got, want, label) => {
+  const g = JSON.stringify(got), w = JSON.stringify(want);
+  if (g !== w) fail(`${label}\n        got  ${g}\n        want ${w}`);
+};
+
+// ---------------------------------------------------------------------------
+// 1. newestPerName: one run per check name, newest wins.
+// ---------------------------------------------------------------------------
+const run = (name, conclusion, completed_at, extra = {}) =>
+  ({ name, status: 'completed', conclusion, completed_at, started_at: completed_at, ...extra });
+
+const NEWEST = [
+  {
+    label: 'a failure re-run green on the same sha no longer reads as failing (PR #1523)',
+    runs: [
+      run('runlogs', 'failure', '2026-08-10T16:05:01Z'),
+      run('runlogs', 'success', '2026-08-11T09:56:08Z'),
+      run('vitest', 'success', '2026-08-10T16:10:00Z'),
+    ],
+    want: [['runlogs', 'success'], ['vitest', 'success']],
+  },
+  {
+    label: 'the reverse — green then red — still reads as failing',
+    runs: [
+      run('runlogs', 'success', '2026-08-10T16:05:01Z'),
+      run('runlogs', 'failure', '2026-08-11T09:56:08Z'),
+    ],
+    want: [['runlogs', 'failure']],
+  },
+  {
+    label: 'a re-run still in progress supersedes the completed attempt it replaces',
+    runs: [
+      run('vitest', 'failure', '2026-08-10T16:05:01Z'),
+      { name: 'vitest', status: 'in_progress', conclusion: null,
+        completed_at: null, started_at: '2026-08-11T09:00:00Z' },
+    ],
+    want: [['vitest', null]],
+  },
+  {
+    label: 'a run with no timestamps at all never displaces a timestamped one',
+    runs: [
+      run('pytest', 'success', '2026-08-11T09:56:08Z'),
+      { name: 'pytest', status: 'completed', conclusion: 'failure',
+        completed_at: null, started_at: null },
+    ],
+    want: [['pytest', 'success']],
+  },
+  { label: 'no runs', runs: [], want: [] },
+];
+for (const { label, runs, want } of NEWEST) {
+  const got = newestPerName(runs)
+    .map(c => [c.name, c.conclusion])
+    .sort((a, b) => a[0].localeCompare(b[0]));
+  eq(got, want, `newestPerName: ${label}`);
+}
+
+// A single-element input must come back untouched, object identity included —
+// the dedupe must never rebuild or reorder what it keeps.
+const only = run('solo', 'success', '2026-08-11T00:00:00Z');
+if (newestPerName([only])[0] !== only) fail('newestPerName: rewrapped a lone check run');
+
+// ---------------------------------------------------------------------------
+// 2. supersededThreads: an approval closes its own author's earlier threads.
+// ---------------------------------------------------------------------------
+const T = (id, opener, times, opts = {}) => ({
+  id,
+  isResolved: opts.isResolved ?? false,
+  comments: {
+    pageInfo: { hasNextPage: opts.hasNextPage ?? false },
+    nodes: times.map(([login, createdAt]) =>
+      login === null ? { createdAt, author: null } : { createdAt, author: { login } }),
+  },
+  // `opener` is documentation for the reader; the rule reads comments[0].
+  opener,
+});
+
+const APPROVED_1700 = new Map([['chris', '2026-08-10T17:00:00Z']]);
+
+const SUPERSEDED = [
+  {
+    label: 'approval after the reviewer\'s only comment closes the thread (PR #1523)',
+    threads: [T('t1', 'chris', [['chris', '2026-08-10T12:43:00Z']])],
+    approvals: APPROVED_1700,
+    want: ['t1'],
+  },
+  {
+    label: 'approval BEFORE the reviewer\'s last comment leaves it open',
+    threads: [T('t1', 'chris', [
+      ['chris', '2026-08-10T12:43:00Z'],
+      ['chris', '2026-08-10T18:00:00Z'],
+    ])],
+    approvals: APPROVED_1700,
+    want: [],
+  },
+  {
+    label: 'the author replying after the approval does not reopen it',
+    threads: [T('t1', 'chris', [
+      ['chris', '2026-08-10T12:43:00Z'],
+      ['florence', '2026-08-10T19:00:00Z'],
+    ])],
+    approvals: APPROVED_1700,
+    want: ['t1'],
+  },
+  {
+    label: 'a thread opened by someone who has not approved keeps blocking',
+    threads: [T('t1', 'dallan', [['dallan', '2026-08-10T12:43:00Z']])],
+    approvals: APPROVED_1700,
+    want: [],
+  },
+  {
+    label: 'one reviewer\'s approval does not close another reviewer\'s thread',
+    threads: [
+      T('t1', 'chris', [['chris', '2026-08-10T12:00:00Z']]),
+      T('t2', 'dallan', [['dallan', '2026-08-10T12:00:00Z'], ['chris', '2026-08-10T12:30:00Z']]),
+    ],
+    approvals: APPROVED_1700,
+    want: ['t1'],
+  },
+  {
+    label: 'a reviewer whose latest standing is changes-requested closes nothing',
+    threads: [T('t1', 'chris', [['chris', '2026-08-10T12:43:00Z']])],
+    approvals: new Map(),   // evaluate() admits APPROVED standings only
+    want: [],
+  },
+  {
+    label: 'an already-resolved thread is not re-resolved',
+    threads: [T('t1', 'chris', [['chris', '2026-08-10T12:43:00Z']], { isResolved: true })],
+    approvals: APPROVED_1700,
+    want: [],
+  },
+  {
+    label: 'an unwalked comment page could hide a later reply, so leave it blocking',
+    threads: [T('t1', 'chris', [['chris', '2026-08-10T12:43:00Z']], { hasNextPage: true })],
+    approvals: APPROVED_1700,
+    want: [],
+  },
+  {
+    label: 'a deleted-account opener (author null) is not treated as an approver',
+    threads: [T('t1', null, [[null, '2026-08-10T12:43:00Z']])],
+    approvals: APPROVED_1700,
+    want: [],
+  },
+  {
+    label: 'an empty thread is skipped rather than crashing',
+    threads: [T('t1', 'chris', [])],
+    approvals: APPROVED_1700,
+    want: [],
+  },
+];
+for (const { label, threads, approvals, want } of SUPERSEDED) {
+  eq(supersededThreads(threads, approvals), want, `supersededThreads: ${label}`);
+}
+
+if (!failures) {
+  console.log(`ok    ${NEWEST.length + 1} newestPerName assertions`);
+  console.log(`ok    ${SUPERSEDED.length} supersededThreads assertions`);
+}
+console.log(failures ? `\n${failures} check(s) failed` : '\nall checks passed');
+process.exit(failures ? 1 : 0);

--- a/.github/workflows/senior-queue.yml
+++ b/.github/workflows/senior-queue.yml
@@ -18,6 +18,14 @@ name: senior-queue
 # changes-requested, and neither of them keeps a PR out of a review QUEUE —
 # so without these two rules a PR is surfaced to a senior with round one open.
 #
+# AN APPROVAL ANSWERS THE APPROVER'S OWN THREADS. Reviewers here routinely
+# re-review, approve, and never go back to click Resolve, so requiring the click
+# made the queue lag the review indefinitely and blocked the merge besides. A
+# thread is treated as closed — and resolved for real, so the merge gate agrees —
+# once the reviewer who OPENED it submits an approval later than their own last
+# comment on it. Threads opened by anyone who has not approved keep blocking, and
+# a fresh changes-requested puts every one of that reviewer's threads back.
+#
 # WHY A LABEL AND NOT THE REVIEW REQUEST. CODEOWNERS makes GitHub request the
 # owning team the instant a matching PR opens, when CI is usually red and nobody
 # has read it — accurate as "a PR exists", useless as "this needs you". The
@@ -43,8 +51,8 @@ name: senior-queue
 # ADD-ONLY. Once labelled a PR stays labelled, even if it later goes red.
 # Demotion would make PRs flicker out of the queue mid-review.
 #
-# TWO TRAPS THIS FILE HAS HIT BEFORE, both of which made the job go green while
-# doing nothing:
+# THREE TRAPS THIS FILE HAS HIT BEFORE, each of which made the job go green
+# while doing nothing:
 #
 #   1. SELF must equal the JOB's name, because that is what a check run is named.
 #      Setting it to the workflow's name matched nothing, so every run counted
@@ -53,10 +61,16 @@ name: senior-queue
 #   2. The label write was wrapped in a try/catch that downgraded failure to a
 #      warning, and the API then no-op'd with HTTP 200. There is no catch around
 #      the write, and the label is read back to confirm it landed.
+#   3. Every check run ever attached to a sha comes back from `listForRef`, so a
+#      failure that was later re-run green still read as "CI failing" and the PR
+#      could never enter a queue again. See newestPerName().
 #
 # When changing the readiness rules, verify against a real approved PR. A
 # `workflow_dispatch` dry run does not exercise the self-filter at all: a
 # dispatch's check run lands on the default branch's sha, not on any PR's head.
+# It DOES exercise everything else, including both rules below, and it makes no
+# writes — so a dispatch dry run is the way to check a readiness change against
+# the live board before letting it label or resolve anything.
 #
 # THE EVENTS ALONE CANNOT KEEP THE QUEUE CURRENT. `check_suite` never fires here
 # (see the trigger below), so nothing observes CI turning green; a PR approved
@@ -102,7 +116,8 @@ permissions:
   # `issues: write` is what authorizes labelling (labels live on the issues API
   # even for PRs); `pull-requests: write` is granted alongside it because the
   # mapping between the two is inconsistent enough that relying on one alone has
-  # bitten other repos.
+  # bitten other repos. `pull-requests: write` is also what authorizes the
+  # `resolveReviewThread` mutation.
   issues: write
   pull-requests: write
   checks: read
@@ -196,6 +211,75 @@ jobs:
               return teams;
             }
 
+            // ---- the two decision rules, kept pure and testable ---------------
+            // Both are lifted out of this file verbatim by
+            // .github/tests/senior-queue-readiness.test.mjs, so they must stay
+            // top-level `function` declarations that close on a column-0 brace.
+
+            // A sha keeps EVERY check run ever attached to it, and
+            // `checks.listForRef`'s default `latest` filter dedupes per check
+            // SUITE, not per check NAME. Re-triggering a workflow on the same
+            // commit — which is exactly what applying `eval-cosmetic-skip` does —
+            // opens a second suite, so the first run's `failure` stays visible
+            // forever and this workflow reads the sha as failing however many
+            // times CI is re-run green. Add-only labelling means nothing ever
+            // recovers such a PR: it cannot reach a queue until someone pushes a
+            // new commit. PR #1523 sat out of both queues on a `runlogs` failure
+            // that had been re-run green 18 hours earlier.
+            //
+            // Keeping only the newest run per name is how branch protection
+            // resolves a required check. It does mean two DIFFERENT workflows
+            // sharing one job name collapse into one — but such a pair is already
+            // ambiguous to branch protection, so rename one rather than key this
+            // on the workflow.
+            function newestPerName(runs) {
+              const newest = new Map();
+              for (const c of runs) {
+                // A still-running attempt has no completed_at, and its started_at
+                // is later than the completed_at of the run it supersedes.
+                const at = Date.parse(c.completed_at || c.started_at || '') || 0;
+                const prev = newest.get(c.name);
+                if (!prev || at >= prev.at) newest.set(c.name, { at, run: c });
+              }
+              return [...newest.values()].map(v => v.run);
+            }
+
+            // An approval submitted after the reviewer's own last word in a
+            // thread IS their answer to it — they read the reply, or decided it
+            // no longer matters, and said so in the only way that carries weight.
+            // Holding the PR out of the senior queue until they also click
+            // Resolve makes the queue lag the review by however long that takes,
+            // and the same threads block the merge, so nothing downstream catches
+            // it either. These get resolved for real (see resolveSuperseded) so
+            // the merge gate agrees with the queue.
+            //
+            // Scoped per thread by its OPENER: an approval from one reviewer says
+            // nothing about a thread another reviewer opened, and those keep
+            // blocking. `approvals` holds only reviewers whose LATEST standing is
+            // APPROVED, so a re-requested change re-blocks every thread — and it
+            // is built from a map the PR's own author is already excluded from,
+            // so nobody can clear their own threads by approving their own PR.
+            function supersededThreads(threads, approvals) {
+              const superseded = [];
+              for (const t of threads) {
+                if (t.isResolved) continue;
+                const comments = t.comments.nodes;
+                if (!comments.length) continue;
+                const opener = comments[0].author && comments[0].author.login;
+                const approvedAt = opener && approvals.get(opener);
+                if (!approvedAt) continue;
+                // An unwalked page could hold a later comment from the opener,
+                // which would make the approval look like the last word when it
+                // is not. Leave the thread blocking rather than guess.
+                if (t.comments.pageInfo.hasNextPage) continue;
+                const lastWord = comments
+                  .filter(c => c.author && c.author.login === opener)
+                  .reduce((max, c) => Math.max(max, Date.parse(c.createdAt) || 0), 0);
+                if (Date.parse(approvedAt) > lastWord) superseded.push(t.id);
+              }
+              return superseded;
+            }
+
             const { rules, unknown } = await loadCodeowners();
             if (!rules.length) {
               core.setFailed('parsed 0 rules out of .github/CODEOWNERS — refusing to label ' +
@@ -234,7 +318,7 @@ jobs:
             async function evaluate(number) {
               const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: number });
               const labels = pr.labels.map(l => l.name);
-              const blank = { pr, labels, wanted: [], ready: false };
+              const blank = { pr, labels, wanted: [], ready: false, toResolve: [] };
 
               if (pr.state !== 'open') return { ...blank, reasons: ['not open'] };
               if (pr.draft)            return { ...blank, reasons: ['draft'] };
@@ -248,9 +332,15 @@ jobs:
               for (const r of reviews) {
                 if (!r.user || r.user.login === pr.user.login) continue;
                 if (r.state === 'COMMENTED') continue;
-                latest.set(r.user.login, r.state);
+                latest.set(r.user.login, { state: r.state, at: r.submitted_at });
               }
-              const standings = [...latest.values()];
+              const standings = [...latest.values()].map(s => s.state);
+              // When a reviewer's latest standing is APPROVED, that approval is
+              // their answer to every thread they opened before it — see
+              // supersededThreads().
+              const approvals = new Map([...latest]
+                .filter(([, s]) => s.state === 'APPROVED')
+                .map(([login, s]) => [login, s.at]));
 
               const [checks, status, files, threads] = await Promise.all([
                 github.paginate(github.rest.checks.listForRef,
@@ -268,7 +358,14 @@ jobs:
                       pullRequest(number:$number) {
                         reviewThreads(first:100) {
                           pageInfo { hasNextPage }
-                          nodes { isResolved }
+                          nodes {
+                            id
+                            isResolved
+                            comments(first:100) {
+                              pageInfo { hasNextPage }
+                              nodes { createdAt author { login } }
+                            }
+                          }
                         } } } }`,
                   { owner, repo, number }),
               ]);
@@ -280,9 +377,11 @@ jobs:
               const isSelf = c =>
                 (c.details_url || '').includes(`/actions/runs/${context.runId}/`)
                 || (c.name || '').startsWith(SELF);
-              const others   = checks.filter(c => !isSelf(c));
-              const failed   = others.filter(c => BAD.has(c.conclusion));
-              const running  = others.filter(c => PENDING.has(c.status));
+              // newestPerName drops superseded attempts — without it a failure
+              // that was later re-run green locks the PR out permanently.
+              const current  = newestPerName(checks.filter(c => !isSelf(c)));
+              const failed   = current.filter(c => BAD.has(c.conclusion));
+              const running  = current.filter(c => PENDING.has(c.status));
               const statuses = status.data.statuses || [];
               const statusFailed = statuses.filter(s => s.state === 'failure' || s.state === 'error');
 
@@ -296,7 +395,12 @@ jobs:
               // A page-2 unresolved thread would otherwise read as "all resolved",
               // so an un-walked page is reported rather than assumed clean.
               const rt = threads.repository.pullRequest.reviewThreads;
-              const unresolved = rt.nodes.filter(t => !t.isResolved).length;
+              // Threads an approval has already answered are counted as closed
+              // here and resolved for real in act(), so the queue and the merge
+              // gate cannot disagree about them.
+              const toResolve = supersededThreads(rt.nodes, approvals);
+              const unresolved =
+                rt.nodes.filter(t => !t.isResolved).length - toResolve.length;
 
               const reasons = [];
               if (!standings.includes('APPROVED'))         reasons.push('no peer approval');
@@ -307,12 +411,12 @@ jobs:
               if (failed.length)       reasons.push(`CI failing: ${failed.map(c => c.name).join(', ')}`);
               if (statusFailed.length) reasons.push(`status failing: ${statusFailed.map(s => s.context).join(', ')}`);
               if (running.length)      reasons.push(`CI still running (${running.length})`);
-              if (others.length === 0 && statuses.length === 0) reasons.push('no CI has reported');
+              if (current.length === 0 && statuses.length === 0) reasons.push('no CI has reported');
               // A PR owned by no senior team needs no senior review, so there is
               // nothing to queue — distinct from "not ready".
               if (!wanted.length)      reasons.push('no senior-owned path');
 
-              return { pr, labels, wanted, ready: reasons.length === 0, reasons };
+              return { pr, labels, wanted, ready: reasons.length === 0, reasons, toResolve };
             }
 
             // ---- label bootstrap --------------------------------------------
@@ -330,14 +434,50 @@ jobs:
             }
             await ensureLabels();
 
+            // Resolve the threads an approval already answered. This is the one
+            // place this workflow changes anything other than a label, and it is
+            // deliberate: leaving them open would block the MERGE on comments the
+            // reviewer has signed off, which no amount of labelling fixes.
+            //
+            // The mutation returns the thread, so success is read back off the
+            // response rather than off the HTTP status — the same rule the label
+            // write follows, for the same reason. A refusal here is a permissions
+            // change, not a transient error, so it throws: the sweep records it
+            // per-PR and fails the job, and the PR is left unlabelled with its
+            // threads still blocking, which is the honest state.
+            async function resolveSuperseded(ids) {
+              for (const id of ids) {
+                const res = await github.graphql(`
+                  mutation($id:ID!) {
+                    resolveReviewThread(input:{threadId:$id}) {
+                      thread { id isResolved }
+                    } }`, { id });
+                if (!res.resolveReviewThread.thread.isResolved) {
+                  throw new Error(
+                    `resolveReviewThread(${id}) returned success but the thread is still ` +
+                    `unresolved. Treat this as a permissions or API-behaviour change.`);
+                }
+              }
+              return ids.length;
+            }
+
             // ---- act ---------------------------------------------------------
             // No try/catch around the write, and the labels are read back: an
             // earlier version downgraded a failed write to a warning and the API
             // then no-op'd with HTTP 200, so the job went green having done nothing.
             async function act(n) {
-              const { pr, labels, wanted, ready, reasons } = await evaluate(n);
+              const { pr, labels, wanted, ready, reasons, toResolve } = await evaluate(n);
               const missing = wanted.filter(l => !labels.includes(l));
               let action;
+
+              // Independent of readiness: an approval answers its author's own
+              // threads whether or not CI is green.
+              if (toResolve.length && dryRun) {
+                core.info(`#${n} WOULD resolve ${toResolve.length} thread(s) superseded by an approval`);
+              } else if (toResolve.length) {
+                core.info(`#${n} resolved ${await resolveSuperseded(toResolve)} thread(s) ` +
+                          `superseded by an approval`);
+              }
 
               if (ready && !missing.length) {
                 action = 'already queued';

--- a/.github/workflows/workflow-logic-tests.yml
+++ b/.github/workflows/workflow-logic-tests.yml
@@ -7,9 +7,11 @@ name: workflow-logic-tests
 # nothing downstream complains. project-status-sync.yml picks a column and a
 # wrong column is still a column; senior-queue.yml picks a review queue off
 # CODEOWNERS, and a pattern its parser cannot read routes the PR to the wrong
-# team while the merge gate still enforces correctly. The run goes green, the
-# board or the review queue is quietly wrong, and the only detector is a human
-# noticing weeks later. Nothing else in CI reads either file — the JS suite
+# team while the merge gate still enforces correctly. It also decides WHEN a PR
+# is ready, and a PR wrongly held back is indistinguishable from one nobody has
+# approved yet — an absent label looks the same either way. The run goes green,
+# the board or the review queue is quietly wrong, and the only detector is a
+# human noticing weeks later. Nothing else in CI reads either file — the JS suite
 # (`make test-js`) covers web, electron, viewer-ui and schema, and neither a
 # workflow branch table nor a CODEOWNERS resolution belongs in any of those
 # packages.
@@ -60,3 +62,13 @@ jobs:
         with:
           node-version: '22'
       - run: node .github/tests/codeowners-routing.test.mjs
+
+  readiness:
+    name: senior-queue readiness rules
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - run: node .github/tests/senior-queue-readiness.test.mjs


### PR DESCRIPTION
Two ways a PR that is ready for senior review never gets its label. Both leave
`senior-queue` green and the PR silently missing from the queue, which looks
exactly like a PR nobody has approved yet. PR #1523 hit both at once and sat
unqueued for a day.

## A check run that was re-run green still reads as failing

Every check run ever attached to a commit comes back from `checks.listForRef` —
its default `latest` filter dedupes per check *suite*, not per check *name* — so
re-triggering a workflow on the same commit leaves the earlier failure visible
forever.

Applying `eval-cosmetic-skip` does exactly that, because `check-runlogs.yml`
triggers on `labeled`. On PR #1523 the `runlogs` check failed, the label
re-triggered it, it passed 18 hours later, and `senior-queue` still read the
commit as failing:

```
runlogs | failure | run=31407025015 | Check runlog discipline
runlogs | success | run=31479910012 | Check runlog discipline
```

Labelling is add-only, so nothing recovered it short of pushing a new commit.
`newestPerName()` now keeps only the newest run per name, which is how branch
protection resolves a required check.

## An approval no longer waits on the Resolve click

Reviewers here re-review, approve, and never go back to resolve the threads from
round one. That held the PR out of the queue for as long as it took someone to
click, and blocked the merge besides, since the ruleset requires thread
resolution.

A thread whose opener later approves is now treated as answered — and resolved
for real via `resolveReviewThread`, not just ignored, so the merge gate agrees
with the queue. Guards:

- scoped by thread opener, so another reviewer's threads keep blocking;
- only reviewers whose *latest* standing is approval count, so a fresh
  changes-requested puts all of that reviewer's threads back;
- the approval must postdate the reviewer's own last comment in the thread;
- the PR author was already excluded from the review map, so nobody can clear
  their own threads by approving their own PR.

## How this was verified

Both rules are pure functions with a new
`.github/tests/senior-queue-readiness.test.mjs` (16 assertions), lifted out of
the YAML the way the CODEOWNERS routing test already does so the two cannot
drift. It runs as a third job in `workflow-logic-tests.yml`.

Each rule was broken and watched to fail rather than assumed covered:

| Break | Result |
|---|---|
| `newestPerName` returns its input unchanged (old behaviour) | 4 assertions fail |
| thread rule ignores who opened the thread | 3 fail |
| thread rule drops the approval-is-later check | 1 fails |
| rename `newestPerName` | extractor throws instead of passing green |

Then PR #1523's real API responses were replayed through both the old and the
new script:

```
old:  #1523 not ready — 5 unresolved review thread(s); CI failing: runlogs
new:  #1523 WOULD resolve 5 thread(s) superseded by an approval
      #1523 WOULD add ready-for-senior-developer, ready-for-senior-genealogist
```

The old one reproduces the live sweep's output verbatim, which is what makes the
new one's result trustworthy.

## One thing that can only be checked live

That `GITHUB_TOKEN` with `pull-requests: write` is permitted to call
`resolveReviewThread`. If it is refused, the mutation throws: the sweep records
it per PR, finishes the others, and fails the job loudly rather than labelling a
PR whose threads still block. Worth a `workflow_dispatch` dry run against PR
#1523 once this is on main — the dry run exercises both rules and writes
nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
