### PR TITLE
Catch a byte-order mark before it costs an eval run

### DIFF
--- a/eval/fixtures/scenarios/person-a-death-cert-not-indexed/README.md
+++ b/eval/fixtures/scenarios/person-a-death-cert-not-indexed/README.md
@@ -1,4 +1,4 @@
-﻿# Scenario: person-a-death-cert-not-indexed
+# Scenario: person-a-death-cert-not-indexed
 
 proof-conclusion is ready to conclude a **death** question where the specifically
 requested record type (a state death certificate) was **searched but not found** in

--- a/packages/engine/mcp-server/tests/packaging/no-bom.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/no-bom.test.ts
@@ -1,47 +1,41 @@
 import { describe, it, expect } from "vitest";
-import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// A UTF-8 BOM sits before the first character of a file, and is invisible in an
-// editor and in a diff. Before a SKILL.md's opening `---` it stops the YAML
-// frontmatter parsing, so the skill loads with no allowed-tools; the eval
-// harness then denies every genealogy tool it didn't grant, and the run
-// completes having made zero tool calls while reporting that its tools are
-// gated (PR #1461). In a JSON fixture it breaks json.loads the same way.
-// A Windows "UTF-8 with BOM" save is all it takes, and the whole genealogist
-// team is on Windows.
+// A UTF-8 BOM sits before the opening `---` of the frontmatter, so the
+// frontmatter stops parsing: no name, no description, no allowed-tools. The
+// eval harness derives its allowlist from allowed-tools and denies every
+// genealogy tool it didn't grant, so the run completes, makes zero tool calls,
+// and reports that its tools are gated. Invisible in an editor and in a diff —
+// a Windows "UTF-8 with BOM" save is all it takes (PR #1461).
 //
-// Compared as bytes, not as a "﻿" string literal, so this file cannot carry
-// an invisible copy of the character it checks for.
+// Frontmatter only, on purpose. A BOM in a JSON fixture or a .bat announces
+// itself with a parse error the first time anything reads it; this is the one
+// place it fails silently and costs a paid run to find.
+//
+// Compared as bytes, not as a "﻿" string literal, so this file cannot
+// carry an invisible copy of the character it is checking for.
 const BOM = Buffer.from([0xef, 0xbb, 0xbf]);
 
 const here = dirname(fileURLToPath(import.meta.url));
-const projectRoot = join(here, "..", "..", "..", "..", "..");
+const pluginRoot = join(here, "..", "..", "..", "plugin");
 
-// Tracked files only: `git ls-files` already excludes node_modules, build
-// output, and other worktrees, so this needs no skip list of its own. A new
-// file is checked from the moment it is `git add`ed.
-const files = execFileSync("git", ["ls-files", "-z"], {
-  cwd: projectRoot,
-  maxBuffer: 64 * 1024 * 1024,
-})
-  .toString("utf8")
-  .split("\0")
-  .filter(Boolean);
+const files = [
+  ...readdirSync(join(pluginRoot, "skills"), { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => join("skills", e.name, "SKILL.md")),
+  ...readdirSync(join(pluginRoot, "agents"))
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => join("agents", f)),
+];
 
-describe("no UTF-8 BOM in tracked files", () => {
-  // A walk that matches nothing would pass forever and read as coverage.
-  it("finds the repo's files to check", () => {
-    expect(files.length).toBeGreaterThan(500);
-    expect(files).toContain("packages/engine/plugin/skills/search-records/SKILL.md");
+describe("no UTF-8 BOM in plugin markdown", () => {
+  it("finds skills and agents to check", () => {
+    expect(files.length).toBeGreaterThan(20);
   });
 
-  it("finds no file starting with a BOM", () => {
-    const offenders = files.filter((f) =>
-      readFileSync(join(projectRoot, f)).subarray(0, 3).equals(BOM),
-    );
-    expect(offenders).toEqual([]);
+  it.each(files)("%s starts with its frontmatter, not a BOM", (rel) => {
+    expect(readFileSync(join(pluginRoot, rel)).subarray(0, 3).equals(BOM)).toBe(false);
   });
 });

--- a/packages/engine/mcp-server/tests/packaging/no-bom.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/no-bom.test.ts
@@ -1,37 +1,47 @@
 import { describe, it, expect } from "vitest";
-import { readFileSync, readdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// A UTF-8 BOM sits before the opening `---` of the frontmatter, so the
-// frontmatter stops parsing: no name, no description, no allowed-tools. The
-// eval harness derives its allowlist from allowed-tools and denies every
-// genealogy tool it didn't grant, so the run completes, makes zero tool calls,
-// and reports that its tools are gated. Invisible in an editor and in a diff —
-// a Windows "UTF-8 with BOM" save is all it takes (PR #1461).
+// A UTF-8 BOM sits before the first character of a file, and is invisible in an
+// editor and in a diff. Before a SKILL.md's opening `---` it stops the YAML
+// frontmatter parsing, so the skill loads with no allowed-tools; the eval
+// harness then denies every genealogy tool it didn't grant, and the run
+// completes having made zero tool calls while reporting that its tools are
+// gated (PR #1461). In a JSON fixture it breaks json.loads the same way.
+// A Windows "UTF-8 with BOM" save is all it takes, and the whole genealogist
+// team is on Windows.
 //
-// Compared as bytes, not as a "﻿" string literal, so this file cannot
-// carry an invisible copy of the character it is checking for.
+// Compared as bytes, not as a "﻿" string literal, so this file cannot carry
+// an invisible copy of the character it checks for.
 const BOM = Buffer.from([0xef, 0xbb, 0xbf]);
 
 const here = dirname(fileURLToPath(import.meta.url));
-const pluginRoot = join(here, "..", "..", "..", "plugin");
+const projectRoot = join(here, "..", "..", "..", "..", "..");
 
-const files = [
-  ...readdirSync(join(pluginRoot, "skills"), { withFileTypes: true })
-    .filter((e) => e.isDirectory())
-    .map((e) => join("skills", e.name, "SKILL.md")),
-  ...readdirSync(join(pluginRoot, "agents"))
-    .filter((f) => f.endsWith(".md"))
-    .map((f) => join("agents", f)),
-];
+// Tracked files only: `git ls-files` already excludes node_modules, build
+// output, and other worktrees, so this needs no skip list of its own. A new
+// file is checked from the moment it is `git add`ed.
+const files = execFileSync("git", ["ls-files", "-z"], {
+  cwd: projectRoot,
+  maxBuffer: 64 * 1024 * 1024,
+})
+  .toString("utf8")
+  .split("\0")
+  .filter(Boolean);
 
-describe("no UTF-8 BOM in plugin markdown", () => {
-  it("finds skills and agents to check", () => {
-    expect(files.length).toBeGreaterThan(20);
+describe("no UTF-8 BOM in tracked files", () => {
+  // A walk that matches nothing would pass forever and read as coverage.
+  it("finds the repo's files to check", () => {
+    expect(files.length).toBeGreaterThan(500);
+    expect(files).toContain("packages/engine/plugin/skills/search-records/SKILL.md");
   });
 
-  it.each(files)("%s starts with its frontmatter, not a BOM", (rel) => {
-    expect(readFileSync(join(pluginRoot, rel)).subarray(0, 3).equals(BOM)).toBe(false);
+  it("finds no file starting with a BOM", () => {
+    const offenders = files.filter((f) =>
+      readFileSync(join(projectRoot, f)).subarray(0, 3).equals(BOM),
+    );
+    expect(offenders).toEqual([]);
   });
 });

--- a/packages/engine/mcp-server/tests/packaging/no-bom.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/no-bom.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// A UTF-8 BOM sits before the opening `---` of the frontmatter, so the
+// frontmatter stops parsing: no name, no description, no allowed-tools. The
+// eval harness derives its allowlist from allowed-tools and denies every
+// genealogy tool it didn't grant, so the run completes, makes zero tool calls,
+// and reports that its tools are gated. Invisible in an editor and in a diff —
+// a Windows "UTF-8 with BOM" save is all it takes (PR #1461).
+//
+// Compared as bytes, not as a "﻿" string literal, so this file cannot
+// carry an invisible copy of the character it is checking for.
+const BOM = Buffer.from([0xef, 0xbb, 0xbf]);
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pluginRoot = join(here, "..", "..", "..", "plugin");
+
+const files = [
+  ...readdirSync(join(pluginRoot, "skills"), { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => join("skills", e.name, "SKILL.md")),
+  ...readdirSync(join(pluginRoot, "agents"))
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => join("agents", f)),
+];
+
+describe("no UTF-8 BOM in plugin markdown", () => {
+  it("finds skills and agents to check", () => {
+    expect(files.length).toBeGreaterThan(20);
+  });
+
+  it.each(files)("%s starts with its frontmatter, not a BOM", (rel) => {
+    expect(readFileSync(join(pluginRoot, rel)).subarray(0, 3).equals(BOM)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What happened

PR #1461 saved two SKILL.md files with a UTF-8 byte-order mark — three bytes (`EF BB BF`) in front of the opening `---`. A Windows editor set to "UTF-8 with BOM" is all it takes, and the character is invisible in an editor and in the GitHub diff.

Those three bytes stop the YAML frontmatter parsing, so the skill loads with no `name`, no `description`, and no `allowed-tools`. The eval harness builds each run's tool allowlist from `allowed-tools`, then explicitly denies every genealogy tool it did not grant. The run does not error. It completes, makes zero tool calls, and reports that its tools are blocked by a permissions gate.

Two full paid suite runs were spent on that before anyone looked at the first three bytes. It was diagnosed as a concurrency race, which it was not — the same tests failed in both runs, and a race scatters.

CI did go red, but only in `skill-description-length`, with `description is within 1024 characters`. That is true, useless, and points at the wrong file.

## What this adds

One test file in `tests/packaging/`, checking the first three bytes of the 31 shipped SKILL.md and agent `.md` files. 9ms. The failing test names the file:

```
× agents/record-extractor.md starts with its frontmatter, not a BOM
```

**No new CI check.** It joins the packaging suite the `vitest` check already runs, and that check's path filter already includes `packages/engine/plugin/`, so every PR that edits a skill triggers it.

**Frontmatter only, deliberately.** A repo-wide version was tried and dropped: it cost ~600ms over ~4k tracked files to protect cases that already fail loudly, since a BOM in a JSON fixture or a `.bat` throws a parse error the first time anything reads it. Frontmatter is the one place it fails silently, which is the whole reason this incident was expensive.

## Also in this diff

`eval/fixtures/scenarios/person-a-death-cert-not-indexed/README.md` had carried a BOM for a while — found by the repo-wide version before it was dropped. Nothing parses that file, so it was harmless and this check no longer requires it to be clean, but it was a real BOM and it is stripped here. One-byte-run change.

## Verified to fail

Adding a BOM to `citation/SKILL.md`, and separately to `agents/record-extractor.md`, reds the test and names the file. Reverted both. Full packaging suite green afterwards: 426 tests across 17 files.

Does not fix PR #1461 — that branch still needs the BOM stripped from its two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)