### PR TITLE
Restore the research-plan annotation a rename merge left full of conflict markers

### DIFF
--- a/eval/runlogs/unit/research-plan/v1_2026-08-04_22-21-46.ann.json
+++ b/eval/runlogs/unit/research-plan/v1_2026-08-04_22-21-46.ann.json
@@ -1,11 +1,6 @@
 {
-<<<<<<<< HEAD:eval/runlogs/unit/research-plan/v1_2026-08-07_17-34-21.ann.json
-  "run_log": "v1_2026-08-07_17-34-21.json",
-  "annotator": "mercybocumy2000@gmail.com",
-========
   "run_log": "v1_2026-08-04_22-21-46.json",
   "annotator": "florencemashipei4@gmail.com",
->>>>>>>> origin/main:eval/runlogs/unit/research-plan/v1_2026-08-04_22-21-46.ann.json
   "corrections": [
     {
       "test_id": "ut_research_plan_006",
@@ -130,123 +125,7 @@
     {
       "test_id": "ut_research_plan_007",
       "dimension_source": "rubric",
-<<<<<<<< HEAD:eval/runlogs/unit/research-plan/v1_2026-08-07_17-34-21.ann.json
-      "dimension_name": "FAN approach and coverage",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_h4k",
-      "dimension_source": "base",
-      "dimension_name": "Correctness",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_h4k",
-      "dimension_source": "base",
-      "dimension_name": "Completeness",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_h4k",
-      "dimension_source": "base",
-      "dimension_name": "Tool Arguments",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_h4k",
-      "dimension_source": "rubric",
-      "dimension_name": "Record type selection",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_h4k",
-      "dimension_source": "rubric",
-      "dimension_name": "Sequencing logic",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_h4k",
-      "dimension_source": "rubric",
-      "dimension_name": "Jurisdiction accuracy",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_h4k",
-      "dimension_source": "rubric",
-      "dimension_name": "Plan mode and lifecycle",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_011",
-      "dimension_source": "base",
-      "dimension_name": "Correctness",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_011",
-      "dimension_source": "base",
-      "dimension_name": "Completeness",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_011",
-      "dimension_source": "base",
-      "dimension_name": "Tool Arguments",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_011",
-      "dimension_source": "rubric",
-      "dimension_name": "Record type selection",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_011",
-      "dimension_source": "rubric",
-      "dimension_name": "Sequencing logic",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_011",
-      "dimension_source": "rubric",
-      "dimension_name": "Jurisdiction accuracy",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_011",
-      "dimension_source": "rubric",
-      "dimension_name": "Plan mode and lifecycle",
-========
       "dimension_name": "FAN approach and pivot items",
->>>>>>>> origin/main:eval/runlogs/unit/research-plan/v1_2026-08-04_22-21-46.ann.json
       "llm_score": 3,
       "corrected_score": 3,
       "comment": null
@@ -605,8 +484,6 @@
     },
     {
       "test_id": "ut_research_plan_016",
-<<<<<<<< HEAD:eval/runlogs/unit/research-plan/v1_2026-08-07_17-34-21.ann.json
-========
       "dimension_source": "rubric",
       "dimension_name": "Jurisdiction accuracy",
       "llm_score": 3,
@@ -647,7 +524,6 @@
     },
     {
       "test_id": "ut_research_plan_016",
->>>>>>>> origin/main:eval/runlogs/unit/research-plan/v1_2026-08-04_22-21-46.ann.json
       "dimension_source": "base",
       "dimension_name": "Correctness",
       "llm_score": 3,
@@ -655,45 +531,15 @@
       "comment": null
     },
     {
-<<<<<<<< HEAD:eval/runlogs/unit/research-plan/v1_2026-08-07_17-34-21.ann.json
-      "test_id": "ut_research_plan_016",
-      "dimension_source": "base",
-      "dimension_name": "Completeness",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_016",
-      "dimension_source": "base",
-      "dimension_name": "Tool Arguments",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_016",
-      "dimension_source": "rubric",
-      "dimension_name": "Record type selection",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_016",
-      "dimension_source": "rubric",
-      "dimension_name": "Sequencing logic",
-========
       "test_id": "ut_research_plan_001",
       "dimension_source": "rubric",
       "dimension_name": "Plan mode and lifecycle",
->>>>>>>> origin/main:eval/runlogs/unit/research-plan/v1_2026-08-04_22-21-46.ann.json
       "llm_score": 3,
       "corrected_score": 3,
       "comment": null
     },
     {
-      "test_id": "ut_research_plan_016",
+      "test_id": "ut_research_plan_001",
       "dimension_source": "rubric",
       "dimension_name": "Jurisdiction accuracy",
       "llm_score": 3,
@@ -701,7 +547,7 @@
       "comment": null
     },
     {
-      "test_id": "ut_research_plan_016",
+      "test_id": "ut_research_plan_001",
       "dimension_source": "rubric",
       "dimension_name": "Sequencing logic",
       "llm_score": 3,
@@ -909,125 +755,12 @@
       "comment": null
     },
     {
-<<<<<<<< HEAD:eval/runlogs/unit/research-plan/v1_2026-08-07_17-34-21.ann.json
-      "test_id": "ut_research_plan_001",
-      "dimension_source": "base",
-      "dimension_name": "Completeness",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_001",
-      "dimension_source": "base",
-      "dimension_name": "Tool Arguments",
-      "llm_score": null,
-      "corrected_score": null,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_001",
-      "dimension_source": "rubric",
-      "dimension_name": "Record type selection",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_001",
-      "dimension_source": "rubric",
-      "dimension_name": "Sequencing logic",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_001",
-      "dimension_source": "rubric",
-      "dimension_name": "Jurisdiction accuracy",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_001",
-      "dimension_source": "rubric",
-      "dimension_name": "Plan mode and lifecycle",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_001",
-      "dimension_source": "base",
-      "dimension_name": "Correctness",
-      "llm_score": 2,
-      "corrected_score": 3,
-      "comment": "src_006 (1881 Thomas Flynn will, FamilySearch ARK) is confirmed present in this scenario's actual before-state, so this isn't a fabrication"
-    },
-    {
-      "test_id": "ut_research_plan_q7m",
-      "dimension_source": "base",
-      "dimension_name": "Tool Arguments",
-      "llm_score": 2,
-      "corrected_score": 2,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_q7m",
-      "dimension_source": "rubric",
-      "dimension_name": "Record type selection",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_q7m",
-      "dimension_source": "rubric",
-      "dimension_name": "Sequencing logic",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_q7m",
-      "dimension_source": "rubric",
-      "dimension_name": "Jurisdiction accuracy",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_q7m",
-      "dimension_source": "rubric",
-      "dimension_name": "Plan mode and lifecycle",
-      "llm_score": 3,
-      "corrected_score": 3,
-      "comment": null
-    },
-    {
-      "test_id": "ut_research_plan_q7m",
-      "dimension_source": "base",
-      "dimension_name": "Completeness",
-      "llm_score": 2,
-      "corrected_score": 3,
-      "comment": "The AI correctly proceeds to search_record without re-asking the user. "
-    },
-    {
-      "test_id": "ut_research_plan_q7m",
-      "dimension_source": "base",
-      "dimension_name": "Correctness",
-      "llm_score": 1,
-      "corrected_score": 3,
-      "comment": "The AI correctly proceeds to search_record without re-asking the user. "
-========
       "test_id": "ut_research_plan_010",
       "dimension_source": "rubric",
       "dimension_name": "Record type selection",
       "llm_score": 3,
       "corrected_score": 2,
       "comment": "Plan has no item targeting an associate/neighbor/witness every item targets Thomas Flynn directly. Judge rationale doesn't address the FAN requirement at all."
->>>>>>>> origin/main:eval/runlogs/unit/research-plan/v1_2026-08-04_22-21-46.ann.json
     }
   ]
 }


### PR DESCRIPTION
One committed annotation on main has carried unresolved git conflict markers
since 2026-08-08 and does not parse as JSON. This restores it. Annotations are
accumulated human genealogist judgment and cannot be regenerated, so nothing
here was invented, averaged, or paraphrased — the fix is a verbatim restore of
a pre-merge blob.

## What was broken

`eval/runlogs/unit/research-plan/v1_2026-08-04_22-21-46.ann.json` — five diff3
conflict hunks with eight-bracket markers, unparseable.

Merge `2747f9e6` ("Merge remote-tracking branch 'origin/main' into
exhaustive-research-feedback-fix", 2026-08-08) had a merge base holding neither
annotation file. Git therefore paired two independent additions as a single
rename and blended them line-by-line into the 08-04 path:

| Merge side | File it actually added | Annotator | Corrections |
|---|---|---|---|
| branch (`ba5a534d`) | `v1_2026-08-07_17-34-21.ann.json` | mercybocumy2000@gmail.com | 107 |
| main (`61eec452`) | `v1_2026-08-04_22-21-46.ann.json` | florencemashipei4@gmail.com | 95 |

## Which side was restored, and the evidence

**Restored the main side** — blob `179b74f6`, the file's content at `e1f1f29b`,
its last clean write before the merge — to
`eval/runlogs/unit/research-plan/v1_2026-08-04_22-21-46.ann.json`, byte for byte.

The evidence that this is the correct side:

- An annotation names the run log it annotates. Blob `179b74f6`'s `run_log`
  field is `"v1_2026-08-04_22-21-46.json"`, matching the filename stem it is
  being restored to. The other side's `run_log` is
  `"v1_2026-08-07_17-34-21.json"`, which is a different stem.
- Both run logs are committed on main, so both annotations have a live target:
  `v1_2026-08-04_22-21-46.json` and `v1_2026-08-07_17-34-21.json` are each
  present under `eval/runlogs/unit/research-plan/`.
- The graded test sets confirm it independently of that field. Florence's
  annotation grades exactly the 16 tests in the 08-04 run log — an exact set
  match, nothing extra, nothing unannotated. Mercy's grades exactly the 18 in
  the 08-07 run log, and two of those, `ut_research_plan_h4k` and
  `ut_research_plan_q7m`, **do not exist in the 08-04 run log at all**. So
  Mercy's annotation could not be the 08-04 one no matter what its `run_log`
  field said.
- The other side needed no repair. `v1_2026-08-07_17-34-21.ann.json` is already
  whole at its own path on main, byte-identical to its pre-merge blob
  `16c0dc35`. Mercy's annotation was never lost.

**No genealogist adjudication was required.** The two sides are not two gradings
of one run log — they grade two different run logs, proven by the test-set fit
above, and each has its own filename stem and its own committed run log to land
against. Restoring by matching `run_log` to the stem loses no human judgment and
puts no annotation where it does not belong.

Nothing unique was discarded either: all 1018 content lines of the blended file
were checked against the two clean sides, and every one appears in one of them.
The blend held no third content of its own.

## The second reported file no longer exists

`eval/runlogs/unit/search-records/v1_2026-08-06_01-03-04.ann.json` was corrupted
the same way, but it is not on main any more. Commit `e48d0dbf` (in PR #1225)
deleted it along with its run log `v1_2026-08-06_01-03-04.json` when
search-records was re-run. Nothing to restore. Per the brief, no run log was
added or deleted here.

## Parse count, before and after

A throwaway scan of every `.ann.json` under `eval/runlogs/`:

- before: 251 files, 250 parsed, **1 failed**
- after: 251 files, **251 parsed, 0 failed**

## Gate run

`eval/harness/scripts/check_runlogs.py`, invoked as
`.github/workflows/check-runlogs.yml` invokes it (`BASE_SHA`/`HEAD_SHA`/
`COSMETIC_SKIP=0`):

```
All runlog rules satisfied.
=== check_runlogs.py exit=0 ===
```

The workflow's four warn-only companions also ran and exited 0
(`check_tool_coverage`, `check_rubric_tool_drift`, `check_skill_frontmatter`,
`check_negative_reciprocity`); their warnings are pre-existing and unrelated to
this change. On the PR itself every check is green, with `claude-review` skipped.

Worth knowing why the gate stayed green through the corruption: its annotation
rule only reads the `.ann.json` of the **latest** run log per touched skill, and
the corrupt file was three run logs back.

## Scope

One file changed, content only — no reformatting, no key re-ordering, no
annotation edits.

Related to issue #1571, which reported this and owns the missing parse guard in
`check_runlogs.py`. **This PR does not add that guard and does not close the
issue** — it only repairs the corrupted data. Issue #1571 also names the
search-records file, which as described above is already gone from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
