### PR TITLE
Mark Mercy as a senior genealogist in the roster

### DIFF
--- a/.claude/skills/triage-standup/references/roster.md
+++ b/.claude/skills/triage-standup/references/roster.md
@@ -28,7 +28,7 @@ the two who are not are listed under "Does not post standup" below.
 | Key | Posts as | GitHub | Role | Senior |
 |---|---|---|---|---|
 | christopher | Christopher Edeson | `chrisedeson` | developer | |
-| mercy | Mercy Okum | `mercyokum` | genealogist | |
+| mercy | Mercy Okum | `mercyokum` | genealogist | **senior** |
 | israel | Israel, Israel Ayomikun Asimi | `Asimi1234` | developer | |
 | florence | Florence Taburu | `florencemashipei` | genealogist | **senior** |
 | tife | Tife | `T-FEH` | developer | **senior** |
@@ -70,10 +70,11 @@ roster gap.
 ## What a senior genealogist's approval means
 
 **It is a genealogical-quality signal, not just a process step.** When a fixture
-or adjudication PR carries an approval from any of the five — Clorinda,
-Shaunese, Florence, John, or Edmund — that is a stronger claim than an ordinary
-teammate's. It cuts both ways: when one of them approves something that turns
-out wrong, that is a finding about the doctrine, not just about the author.
+or adjudication PR carries an approval from any of the six — Clorinda,
+Shaunese, Florence, John, Edmund, or Mercy — that is a stronger claim than an
+ordinary teammate's. It cuts both ways: when one of them approves something
+that turns out wrong, that is a finding about the doctrine, not just about the
+author.
 
 ## Known identity quirks
 


### PR DESCRIPTION
Adds the **senior** marker to mercy (`mercyokum`), taking the senior
genealogist count from five to six, and adds her to the list of names in
"What a senior genealogist's approval means".

## This PR does not grant anything on its own

The Senior column mirrors GitHub team membership, which is what CODEOWNERS
routes review authority by. **The matching add to the
`PioneerAIAcademy/senior-genealogists` team has to be made separately** —
until that happens, Mercy's approval still will not satisfy the senior
requirement on skills, agents, or eval fixtures/tests/runlogs, and the
senior-queue workflow will keep routing past her.

## Why Mercy

She already reviews at this level. 12 reviews across 9 different authors —
more breadth than any other non-senior genealogist — and her catches are
about whether the committed evidence supports the claim:

- Held back Isaac's Mary McAndrew fixture because neither committed run
  reached the conclusion the PR claimed: one "passed" only because the MCP
  server never connected, the other reached the opposite answer. She also
  caught the body saying three runs when there were two.
- Caught a README on Solomon's Gertrudis Hoffmans fixture citing a duplicate
  register as corroboration when the run's own proof critique says no
  independent second record exists.
- Caught two annotations on Isaac's Micaela Salgado runs carrying the same
  note but scored 3 and 2.

Her own PRs are in the senior lane too — tiering documented-negative death
conclusions, and the research-plan/search-records breadth self-check.

## Acceptance check

`grep "mercy" .claude/skills/triage-standup/references/roster.md` shows
`**senior**`, and the six names in "What a senior genealogist's approval
means" match the four genealogists marked senior in the table plus Clorinda
and Shaunese from "Does not post standup".

## Follow-on

Nothing filed. The team add is a console action, not a code change.