### PR TITLE
Give the lead only the individual replies that matter

### DIFF
--- a/.claude/skills/triage-standup/SKILL.md
+++ b/.claude/skills/triage-standup/SKILL.md
@@ -294,14 +294,24 @@ Checks that have actually caught things:
 **Default to silence.** Would this person, or the repo, be measurably worse off
 if nobody said it? A nit or mild inefficiency is not a reply. **Anything true of
 several people is not a reply** — the lead broadcasts those himself; List 1 or
-nowhere. Nor is praise with no action attached; a numbering nit (an issue called
-a PR); a PR that merely needs review; a red check its author already knows
-about; a fact already in List 1 or List 3; a correction that changes nothing
-they do next. Two people needing the same fact get one reply naming both. Zero
-to four replies is a normal day; past four, the bar was too low — say so and
-cut. Never list who you skipped. **One or two sentences each. Name the one thing
-to do next and stop.** Lead with the correction where there is one. Write in the
-lead's voice: direct, no preamble, no praise sandwich.
+nowhere.
+
+Nor is any of these:
+
+- praise with no action attached
+- a numbering nit (an issue called a PR)
+- a PR that merely needs review
+- a red check its author already knows about
+- a fact already in List 1 or List 3
+- a correction that changes nothing they do next
+
+Two people needing the same fact get one reply naming both. Zero to four replies
+is a normal day; past four, the bar was too low — say so and cut. Never list who
+you skipped.
+
+**One or two sentences each. Name the one thing to do next and stop.** Short
+enough that the lead sends it without editing. Lead with the correction where
+there is one. Write in the lead's voice: direct, no preamble, no praise sandwich.
 
 Too long:
 

--- a/.claude/skills/triage-standup/SKILL.md
+++ b/.claude/skills/triage-standup/SKILL.md
@@ -212,15 +212,14 @@ findings fail that bar. Before a finding earns a row, it must clear both:
 - **Is there implementation work here that doesn't already exist?** Check
   §3's duplicate search first. A finding that only confirms or corrects an
   *existing* issue (a stale claim, a wrong attribution, a "this already
-  shipped") is not a new task — surface it as a comment on that issue, or in
-  List 4, not as a second card competing with the first.
+  shipped") is not a new task — surface it as a comment on that issue, not as a
+  second card competing with the first.
 
 A finding can be real, verified, and still not worth a card. "Worth mentioning"
-(List 1, List 4, or a direct comment on an existing issue) and "worth a card"
-(List 2) are different bars, and the second is higher. When in doubt, mention
-it and don't file it — a missed mention costs a sentence next time; an
-over-filed card sits in Backlog until someone spends triage time re-discovering
-it's not actionable.
+(List 1 or a direct comment on an existing issue) and "worth a card" (List 2) are
+different bars, and the second is higher. When in doubt, mention it and don't
+file it — a missed mention costs a sentence next time; an over-filed card sits in
+Backlog until someone spends triage time re-discovering it's not actionable.
 
 What survives: implementation work, not yet tracked anywhere, that genuinely
 needs a separate session to pick up. For each surviving row, a table for the
@@ -247,9 +246,10 @@ Also flag, per row:
   it silently joins every morning's ranking.
 - **What you deliberately did NOT file, and where it went instead.** Over-filing
   is its own failure; a Backlog nobody can read is the same as no Backlog. Don't
-  just say "not filing" — say whether it moved to List 1, List 4, a comment on
-  an existing issue, or was handled directly (and how). A rejected candidate
-  with nowhere named is a finding quietly dropped, not a finding triaged.
+  just say "not filing" — say whether it moved to List 1, List 4, a comment on an
+  existing issue, was handled directly (and how), or was dropped as below every
+  bar. A rejected candidate with nowhere named is a finding quietly dropped, not
+  a finding triaged.
 
 ### List 3 — Problematic PRs
 
@@ -291,14 +291,17 @@ Checks that have actually caught things:
 
 ### List 4 — Individual replies
 
-**One or two sentences each. Name the one thing to do next and stop.**
-
-These are messages the lead pastes to a person, not a briefing about them. He
-already read your other lists, so the reply does not need to re-explain the
-finding, recap what they said, or justify itself — it needs to be short enough
-that he sends it without editing.
-
-Skip anyone who needs nothing, and just say who you skipped.
+**Default to silence.** Would this person, or the repo, be measurably worse off
+if nobody said it? A nit or mild inefficiency is not a reply. **Anything true of
+several people is not a reply** — the lead broadcasts those himself; List 1 or
+nowhere. Nor is praise with no action attached; a numbering nit (an issue called
+a PR); a PR that merely needs review; a red check its author already knows
+about; a fact already in List 1 or List 3; a correction that changes nothing
+they do next. Two people needing the same fact get one reply naming both. Zero
+to four replies is a normal day; past four, the bar was too low — say so and
+cut. Never list who you skipped. **One or two sentences each. Name the one thing
+to do next and stop.** Lead with the correction where there is one. Write in the
+lead's voice: direct, no preamble, no praise sandwich.
 
 Too long:
 
@@ -312,10 +315,6 @@ Right:
 
 > **Ruth** — #964 merged with your approval and no ark cited. Can you get the ark
 > from Solomon, or flip it to changes-requested?
-
-Lead with the correction where there is one. Route overlaps in a clause, not a
-paragraph ("read #942 and #963 first — same problem"). Write in the lead's voice:
-direct, no preamble, no praise sandwich.
 
 ## 5. File the approved tasks
 


### PR DESCRIPTION
Today's triage run produced **fourteen** individual replies. The reason for this change, in the lead's words:

> Many (most) of these replies are unnecessary. I reached out to everyone that we have too many PRs that are more than 24 hours old. I don't want to send individual messages too. Give me just the *important* replies.

Two things in the old text produced the roster:

- **No bar.** The only filter was "Skip anyone who needs nothing, and just say who you skipped," which reads as "cover everyone unless they're idle."
- **It did not know the lead broadcasts.** He messages the whole team himself about anything general — stale PRs, review latency, a convention people are drifting on. A reply about something true of six people is a second message he now has to send on a topic he already covered.

## What the section now says

It opens with **Default to silence** and the test — would this person, or the repo, be measurably worse off if nobody said it? A nit or mild inefficiency is not a reply, and neither is anything true of several people, because the lead broadcasts those himself: List 1 or nowhere.

Then the six non-qualifiers, as a bulleted checklist rather than a comma-run, so they can actually be checked off on a fresh read: praise with no action attached; a numbering nit (an issue called a PR); a PR that merely needs review; a red check its author already knows about; a fact already in List 1 or List 3; a correction that changes nothing they do next.

Then the volume and folding rules: two people needing the same fact get one reply naming both; zero to four replies is a normal day, and past four the bar was too low — say so and cut; never list who you skipped.

The craft rules close the block: one or two sentences each, name the one thing to do next and stop, short enough that the lead sends it without editing, lead with the correction where there is one, and write in the lead's voice — direct, no preamble, no praise sandwich.

The `### List 4 — Individual replies` heading is unchanged, so the cross-references from the other sections still resolve. The too-long/right worked example pair is byte-identical to main (488 bytes, verified).

**Section: 27 lines on main, 36 here. File: 444 lines on main, 453 here.** A deliberate trade — this is a `.claude/` skill read once per invocation, not a shipped plugin body under the prompt-token rule, and a criteria list that can be checked is worth more than the nine lines.

## Knock-on references I changed

Three places routed leftovers into List 4 as though it were the low-bar bucket:

- The List 2 filter for a finding that only corrects an existing issue said "surface it as a comment on that issue, **or in List 4**" — a correction that changes nothing is now explicitly not a reply, so that clause is gone; the comment on the issue is the whole route.
- "'Worth mentioning' (List 1, **List 4**, or a direct comment on an existing issue) … different bars, and the second is higher" made List 4 the *lowest* bar in the file. List 4 is out of that parenthetical.
- The "what you deliberately did NOT file" rule demanded a named destination for every rejected finding, which conflicts with "List 1 or nowhere." It now accepts "dropped as below every bar" as a named destination, so a deliberate drop still reads as triage rather than as a finding quietly lost.

Left alone after reading: the "close this issue / add a comment / tell so-and-so" route into List 1/List 4 (naming a person a real action still clears the new bar), the four-list structure, the roll call, and the Output shape section — "the four lists in order" and "most consequential item first rather than ordering by author" already read correctly against a high bar. `references/roster.md` and `references/daily-summary-format.md` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
