### PR TITLE
Say who a post-push approval has to come from, and that CODEOWNERS requests go stale

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -332,11 +332,18 @@ Two ruleset settings decide what a stale approval is worth here, and they pull
 in opposite directions. `dismiss_stale_reviews_on_push: false` means a push does
 **not** clear existing approvals — they keep counting toward the two required,
 and nothing re-requests review. But `require_last_push_approval: true` means at
-least one approval must land **after** the most recent push. So an old approval
-is neither void nor sufficient: a PR approved twice and then pushed to still
-needs a fresh approval, while both old ones still count. Do not tell an author
-their approvals were reset, and do not treat a pre-push approval as clearing the
-gate.
+least one approval must land **after** the most recent push **and come from
+someone other than whoever pushed it**. So an old approval is neither void nor
+sufficient: a PR approved twice and then pushed to still needs a fresh approval,
+while both old ones still count. Do not tell an author their approvals were
+reset, and do not treat a pre-push approval as clearing the gate.
+
+**If you push the fix yourself, your own approval will not clear it.** Pushing a
+minor correction instead of asking the author for it is fine, but it makes you
+the pusher, so the merge now needs a click from a *third* person. Either ask
+whoever already approved to re-approve, or send the fix as a suggested change
+and approve after the author commits it — that second route keeps it to the two
+people already on the PR.
 
 ## 8. Write the edits — don't make them
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -338,12 +338,11 @@ sufficient: a PR approved twice and then pushed to still needs a fresh approval,
 while both old ones still count. Do not tell an author their approvals were
 reset, and do not treat a pre-push approval as clearing the gate.
 
-**If you push the fix yourself, your own approval will not clear it.** Pushing a
-minor correction instead of asking the author for it is fine, but it makes you
-the pusher, so the merge now needs a click from a *third* person. Either ask
-whoever already approved to re-approve, or send the fix as a suggested change
-and approve after the author commits it — that second route keeps it to the two
-people already on the PR.
+**Senior developers are exempt.** Pushing a small fix rather than asking the
+author for it is the fast path, and it stays fast: the `last-push-approval`
+ruleset lists `senior-developers` as a bypass actor, so a senior who pushes the
+last commit can still merge. Anyone else who pushes needs an approval from
+someone who didn't.
 
 ## 8. Write the edits — don't make them
 

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -321,15 +321,25 @@ returns as an input to your review, never as your review.
 
 ### "It says approved, but it won't merge"
 
-Three rules can each hold a green, approved PR. Check them in this order:
+Four rules can each hold a green, approved PR. Check them in this order:
 
 - **Someone pushed after the approvals.** At least one approval has to land
-  *after* the most recent push. The old approvals are not cancelled — they still
-  count toward the two — so you need one fresh approval, not two.
+  *after* the most recent push, from someone other than whoever pushed it. The
+  old approvals are not cancelled — they still count toward the two — so you
+  need one fresh approval, not two. This catches reviewers too: a senior who
+  pushes a minor fix rather than asking for it becomes the pusher, and their own
+  approval will not clear the gate. Ask whoever already approved to re-approve,
+  or send the fix as a suggested change and approve after the author commits it.
 - **An unresolved conversation.** Every review thread must be marked resolved.
   Resolve the ones you answered; the reviewer resolves the ones they raised.
 - **A code owner hasn't approved yet.** `.github/CODEOWNERS` decides which team
   is required per path. Four approvals from the wrong team is still zero.
+- **A review request left over from an older CODEOWNERS.** Owners are computed
+  when the PR opens; editing `.github/CODEOWNERS` later never re-runs against an
+  open PR, and GitHub never withdraws a request it has already made. So a PR can
+  sit showing a team that owns none of its files. Check the current file before
+  believing the request, and clear a dead one with
+  `gh api -X DELETE /repos/{owner}/{repo}/pulls/{n}/requested_reviewers -f 'team_reviewers[]=<team>'`.
 
 ---
 

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -326,10 +326,9 @@ Four rules can each hold a green, approved PR. Check them in this order:
 - **Someone pushed after the approvals.** At least one approval has to land
   *after* the most recent push, from someone other than whoever pushed it. The
   old approvals are not cancelled — they still count toward the two — so you
-  need one fresh approval, not two. This catches reviewers too: a senior who
-  pushes a minor fix rather than asking for it becomes the pusher, and their own
-  approval will not clear the gate. Ask whoever already approved to re-approve,
-  or send the fix as a suggested change and approve after the author commits it.
+  need one fresh approval, not two. **Senior developers are exempt**, so a
+  senior who pushes a small fix rather than asking the author for it can still
+  merge it themselves.
 - **An unresolved conversation.** Every review thread must be marked resolved.
   Resolve the ones you answered; the reviewer resolves the ones they raised.
 - **A code owner hasn't approved yet.** `.github/CODEOWNERS` decides which team


### PR DESCRIPTION
## Summary

- Trivial tier. Prose only — two markdown files, no code.
- Documents the new rule: **a senior developer who pushes a small fix can merge
  it themselves.** The `last-push-approval` ruleset lists `senior-developers` as
  a bypass actor, so pushing a correction rather than asking the author for it
  no longer costs a round-trip. Anyone else who pushes still needs an approval
  from someone who didn't.
- Adds a fourth cause to the "It says approved, but it won't merge" list: code
  owners are worked out when a PR opens, editing `.github/CODEOWNERS` later
  never re-runs against an open PR, and GitHub never withdraws a request it has
  already made — so a PR can sit showing a team that owns none of its files.

The second gap is why PR #1438 sat blocked for two days while reading as
approved by two senior developers. It was carrying a `senior-genealogists`
request created when it opened on 2026-08-07, under the blanket `*` rule that
was removed four hours later. Clearing that request was the whole fix — it
merged shortly after, before any ruleset change.

## Review guidance

**Start here:** the "It says approved, but it won't merge" list in
`docs/task-lifecycle.md`. Check that the new fourth bullet tells you what to
actually *do* when you hit it — it carries the `gh` command to clear a dead
request, because reading the current CODEOWNERS is not enough to tell you the
request is dead.

**Unsure about:** nothing.

## Plan

**Didn't change:** nothing relevant. The matching ruleset change — moving
`require_last_push_approval` out of `protect-main` into a `last-push-approval`
ruleset that `senior-developers` bypasses — is applied outside git, since branch
protection does not live in the repo.

**Acceptance check:** none, honestly — this is prose, and no test distinguishes
this branch from `main`. The two suites that do read these files,
`doc-links.test.ts` and `adr-links.test.ts`, pass (155 tests), and `make
test-all` passes (1956 tests).

**Deviated from the plan:** nothing.

## Test plan

- [x] I ran `make test-all` and it passed (1956 passed in 13.37s).
- [x] No skill run-log snapshot changed. `.claude/skills/review/` is a process
      skill for this repo, not a shipped plugin skill under
      `packages/engine/plugin/skills/`, so no eval slot is involved.
- [x] No skill `description` frontmatter or DO NOT clause changed.

## Follow-on issues

**Folded in / filed instead:** Nothing filed. Nine open PRs were found carrying
the same stale `senior-genealogists` request — PRs #1438, #1538, #1502, #1453,
#1437, #1428, #1419, #1408 and #1251. All nine were cleared directly rather than
filed, since the fix is one API call per PR and the context was already loaded.
