### PR TITLE
fill-ready: gate every developer issue through review-ready, not just the junior shortlist

### DIFF
--- a/.claude/skills/fill-ready/SKILL.md
+++ b/.claude/skills/fill-ready/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fill-ready
-description: Use when the lead wants the day's work chosen off the cowork-genealogy kanban board — "what should the team work on today", "fill the Ready column", "review the backlog", "groom the board", "what should I take on", or a bare "/fill-ready". The follow-on to triage-standup, which files new issues into Backlog; this skill decides which of them the team starts. Ranks the Backlog against the two committed milestones and holds Ready at two standing depths — ~10 unassigned developer tasks and ~10 unassigned genealogist tasks — promoting only what is unblocked and swapping a lower-ranked item back when a pool is at target. Routes by seniority before priority: every developer takes from the junior pool, and the lead takes no issues at all. Work above the junior pools splits three ways and the split decides who can start — `needs-decision` (one answer from the lead unblocks it, and the work behind it is often junior), `senior` (hard regardless, assigned to a senior in the developer or genealogist lane), and logistics (unlabelled, anyone once cleared). The one thing that arrives pre-assigned is a `cross-cutting` item, which the lead hands to a named person and which counts toward no pool target. Holds each skill's eval slot to one item at a time, since two changes to one skill's snapshot cannot share a paid run. Gates the developer shortlist through review-ready before promoting. Labels, splits, and grooms; verifies claims against the repo first. Proposes, then applies only what the lead approves; never starts the work.
+description: Use when the lead wants the day's work chosen off the cowork-genealogy kanban board — "what should the team work on today", "fill the Ready column", "review the backlog", "groom the board", "what should I take on", or a bare "/fill-ready". The follow-on to triage-standup, which files new issues into Backlog; this skill decides which of them the team starts. Ranks the Backlog against the two committed milestones and holds Ready at two standing depths — ~10 unassigned developer tasks and ~10 unassigned genealogist tasks — promoting only what is unblocked and swapping a lower-ranked item back when a pool is at target. Routes by seniority before priority: every developer takes from the junior pool, and the lead takes no issues at all. Work above the junior pools splits three ways and the split decides who can start — `needs-decision` (one answer from the lead unblocks it, and the work behind it is often junior), `senior` (hard regardless, assigned to a senior in the developer or genealogist lane), and logistics (unlabelled, anyone once cleared). The one thing that arrives pre-assigned is a `cross-cutting` item, which the lead hands to a named person and which counts toward no pool target. Holds each skill's eval slot to one item at a time, since two changes to one skill's snapshot cannot share a paid run. Gates every developer issue it moves through review-ready before promoting. Labels, splits, and grooms; verifies claims against the repo first. Proposes, then applies only what the lead approves; never starts the work.
 allowed-tools:
   - Read
   - Bash
@@ -634,20 +634,29 @@ auto-add workflow that sets nothing else — a freshly filed issue that belongs 
 Ready still needs this move. (The exception is a `feedback` item, which the same
 workflow files directly into Ready and which you never move at all.)
 
-**Gate the unassigned `developer` shortlist through `/review-ready` before you
-promote it.** Your seniority test (§1) is a pre-filter read off the issue body;
-that skill fans out one agent per item to check the same call against the cited
-code, the architecture guide's site list, and the board's what-nothing-checks
-issues —
-which is where a "junior-safe" item turns out to hide an open API decision.
+**Gate every `developer` issue you are moving into Ready through `/review-ready`
+before you promote it — not just the ones you rank as junior.** Your seniority
+test (§1) is a pre-filter read off the issue body; that skill fans out one agent
+per item to check the same call against the cited code, the architecture guide's
+site list, and the board's what-nothing-checks issues — which is where a
+"junior-safe" item turns out to hide an open API decision.
+
+**"Every" means every one you move, including a `senior`-labeled item.** A senior
+item's body is stale in exactly the ways a junior item's is, and it is the more
+expensive one to hand out wrong. The only issue that skips the gate is one that
+already carries the `reviewed` label from a previous pass **and** has not been
+edited since — check `updatedAt` against the reviewed marker's date. Re-running
+the gate on an unchanged issue pays for the same deep read twice
+(`docs/specs/task-review-spec.md` §2); skipping it on a changed one is how a
+refuted premise reaches a junior.
 
 Promote what comes back `ready` or `ready-after-edit`. A `senior` or
-`needs-a-decision` verdict is a §1 miss caught in time — it stays in Backlog and
-never enters the junior pool. **The two get different labels** (`senior` vs
-`needs-decision`, §6), and the verdict tells you which: `needs-a-decision` means
-one answer unblocks it, `senior` means it is hard regardless. Running the gate
-after promotion instead works, but pays for the same deep read twice — see
-`docs/specs/task-review-spec.md` §2.
+`needs-a-decision` verdict on an item you had ranked junior is a §1 miss caught
+in time — it stays in Backlog and never enters the junior pool. **The two get
+different labels** (`senior` vs `needs-decision`, §6), and the verdict tells you
+which: `needs-a-decision` means one answer unblocks it, `senior` means it is hard
+regardless. Running the gate after promotion instead works, but pays for the same
+deep read twice.
 
 ## 6. Above the junior pools — three states, not one
 

--- a/.claude/skills/fill-ready/SKILL.md
+++ b/.claude/skills/fill-ready/SKILL.md
@@ -701,14 +701,27 @@ report; the genealogist one is newer and easier to forget.
 ### Reporting — your job is the arithmetic, not the routing
 
 ```sh
-# `needs-decision`, split by whether a ruling has been recorded. A ruling is an
-# issue comment carrying a bold `**Ruling` marker (the convention
-# `/find-big-wins` owns). Match the marker anywhere in the body, not just at
-# character zero: real ruling comments put a heading above it and number it
-# (`## Lead rulings` … `**Ruling 1 — …`), which an exact-prefix test misses.
+# `needs-decision`, split by whether a ruling has been recorded.
+#
+# MATCH BOTH WORDS, AND BOTH MARKUPS. We are instructed to write `**Ruling:**`,
+# but this query does not read what we wrote — it reads what the LEAD wrote, and
+# he writes `## Decision:` and `**Decision (lead, <date>)`. A `**Ruling`-only
+# test called two answered items WAITING on 2026-08-13 (issues #1331 and #1394,
+# both ruled that afternoon), which is the exact inverse of the defect this
+# split exists to catch: it hides a dropped item by reporting the lead as the
+# bottleneck. Bold marker or ATX heading, "Ruling" or "Decision".
+#
+# Match anywhere in the body, not at character zero: real ruling comments put a
+# heading above the marker and number it (`## Lead rulings` … `**Ruling 1 — …`),
+# which an exact-prefix test misses.
+#
+# Prove it before trusting a change to this pattern — run it against a known
+# answered issue and a known waiting one and watch the two land in different
+# buckets. A pattern that matches nothing reports a clean board forever.
 gh issue list --repo PioneerAIAcademy/cowork-genealogy --state open --limit 200 \
   --label needs-decision --json number,title,updatedAt,comments \
-  -q '.[] | (if ([.comments[].body | test("\\*\\*Ruling")] | any)
+  -q '.[] | (if ([.comments[].body
+                 | test("(?m)^#{1,4} +(Ruling|Decision)\\b|\\*\\*(Ruling|Decision)\\b")] | any)
              then "ANSWERED" else "WAITING" end) as $s
       | "\(.updatedAt[0:10])\t\($s)\t#\(.number)\t\(.title)"' | sort
 gh issue list --repo PioneerAIAcademy/cowork-genealogy --state open --limit 200 \

--- a/.claude/skills/fill-ready/SKILL.md
+++ b/.claude/skills/fill-ready/SKILL.md
@@ -34,6 +34,15 @@ gh project item-list 1 --owner PioneerAIAcademy --format json --limit 1000
 Each item carries `id` (the item id you need to move it), `content.number`,
 `status`, `assignees`, `title`, `labels`.
 
+**A closed issue counts for nothing, whatever column its card is in.** It fills
+no pool, holds no eval slot (Gate 4), loses no swap, and is never a blocker.
+`gh project item-list` reports the *column*, and the column follows the issue's
+state only when `.github/workflows/project-status-sync.yml` gets to it — so a
+just-closed card can still read `Review` for a while. Ready / In Progress /
+Review are the three active columns; **Done and Not planned are the terminal
+ones, and "outside Backlog" is never the test for anything**, because it counts
+them too.
+
 **Re-read the board immediately before you apply anything.** The lead edits it
 while you work — in one session nine items moved to Ready and 23 assignments
 were cleared between the opening read and the write-back. A snapshot taken at
@@ -500,9 +509,27 @@ Then say it in your report as well, so the lead can hand both to one person.
 
 ### Gate 4 — the skill's eval slot is already taken
 
-**At most one item touching a given skill's eval snapshot may be outside Backlog
-at a time.** If one is already in Ready, In Progress or Review, the next one is
-not Ready — leave it in Backlog and name the holder.
+**At most one item touching a given skill's eval snapshot may be in an active
+column at a time** — Ready, In Progress, or Review. If one is already there, the
+next one is not Ready — leave it in Backlog and name the holder.
+
+**Only an open issue in one of those three columns holds a slot.** Never
+"outside Backlog", which is what this rule used to say and which is wrong in
+both terminal directions: Done and Not planned are outside Backlog too. A closed
+issue holds nothing. Whatever it was going to change, it is not going to change
+it, so nothing is waiting on it and the next item can go.
+
+**When the column and the issue's state disagree, the state wins.** Closing an
+issue does not move its card — `.github/workflows/project-status-sync.yml` does,
+and it is a workflow, not an atomic write. So a card can sit in Review for a
+while after its issue closed, and a pass that reads the column alone will hold a
+whole skill shut on an issue nobody is working. Check `state` on any holder
+before you believe it, and say so when you find one:
+
+```sh
+gh issue view <holder> --repo PioneerAIAcademy/cowork-genealogy \
+  --json number,state,stateReason,title
+```
 
 *Why it is hard rather than soft.* A skill's run log goes inactive the moment any
 file under its snapshot changes, so two such items cannot share a run however they
@@ -907,10 +934,13 @@ list it does not appear in. Add state when it matters.
 6a. **Cross-cutting** — one line per active `cross-cutting` item: who holds it,
    days since it last moved, and any person holding two. Flag any unassigned one
    as a mis-file. Skip the heading when there are none.
-6b. **Skill slots** — one line per skill with anything in flight: the holder, its
-   idle days, and how many are queued behind it. Flag a holder idle ~10 days as a
-   reclaim proposal, and a queue three or more deep as a merge candidate for
-   `/audit-board`. Skip the heading when every slot is free.
+6b. **Skill slots** — one line per skill whose slot is held by an **open** issue
+   in Ready, In Progress or Review: the holder, its idle days, and how many are
+   queued behind it. Flag a holder idle ~10 days as a reclaim proposal, and a
+   queue three or more deep as a merge candidate for `/audit-board`. A holder
+   whose issue has closed frees the slot immediately — report it as freed, name
+   what is now promotable behind it, and do not wait for the card to move. Skip
+   the heading when every slot is free.
 7. **Grooming** — capped, with verdicts.
 
 Then stop and wait for approval. Apply only what he approves, re-reading the

--- a/.claude/skills/find-big-wins/SKILL.md
+++ b/.claude/skills/find-big-wins/SKILL.md
@@ -264,11 +264,19 @@ finding, and finding them is the *first* thing a `decisions` run does:
 ```sh
 # answered, never closed out. Should be EMPTY. Anything here is a session that
 # heard an answer and walked away — fix it now, before preparing new questions.
+#
 # `test` and not `startswith`: a real ruling comment carries a heading above the
 # marker and a number after it, so an exact-prefix match reports zero forever.
+#
+# BOTH WORDS, BOTH MARKUPS. This reads what the LEAD wrote, not what we were
+# told to write. We write `**Ruling:**`; he writes `## Decision:` and
+# `**Decision (lead, <date>)`. A `**Ruling`-only test missed two real rulings on
+# 2026-08-13 (issues #1331, #1394) — and here a miss is silent, because this
+# query reports emptiness as health.
 gh issue list --repo PioneerAIAcademy/cowork-genealogy --state open --limit 200 \
   --label needs-decision --json number,title,comments \
-  -q '.[] | select([.comments[].body | test("\\*\\*Ruling")] | any)
+  -q '.[] | select([.comments[].body
+                   | test("(?m)^#{1,4} +(Ruling|Decision)\\b|\\*\\*(Ruling|Decision)\\b")] | any)
       | "#\(.number)  \(.title)"'
 ```
 

--- a/.claude/skills/triage-standup/references/roster.md
+++ b/.claude/skills/triage-standup/references/roster.md
@@ -18,9 +18,16 @@ routes review authority by: `senior-genealogists` owns skills, agents, eval
 fixtures/tests/runlogs and `docs/`; `senior-developers` owns the code and
 infrastructure paths.
 
-**It is review authority only — never an assignment tier.** A senior developer
-still takes work from the junior pool and works with Claude Code. The lead is
-the only person `fill-ready` assigns senior-required *work* to.
+**The `Senior` column is review authority.** A senior developer still takes work
+from the junior pool and works with Claude Code, so being on the list is not a
+promotion out of that pool.
+
+**It is also who a `senior`-labeled issue goes to.** The lead takes no issues at
+all, so senior-required work is handed to a senior in its own lane — a
+`developer`+`senior` issue to a `senior-developers` member, a
+`genealogist`+`senior` issue to a `senior-genealogists` member. `fill-ready`
+labels those and reports the queue; it sets no assignee on anything, and the lead
+hands them out at standup.
 
 Everyone in this table is expected to post a standup update, seniors included —
 the two who are not are listed under "Does not post standup" below.


### PR DESCRIPTION
## What changed

The `/fill-ready` gate step said *"Gate the unassigned `developer` shortlist through
`/review-ready` before you promote it."* Read literally, that covers only the items
`fill-ready` ranked as junior — so a `senior`-labeled developer issue could be moved into
Ready on the strength of its own body, ungated.

That happened in today's fill: issue #1572 went to Ready without the gate because it was
already `senior`. It happened to carry a `reviewed` marker from 2026-08-12, so no harm —
but nothing in the skill made that the reason.

The rule is now: **every `developer` issue you move into Ready goes through
`/review-ready` first, whatever its label.** A senior item's body goes stale in exactly
the ways a junior item's does, and it is the more expensive one to hand out wrong.

One exemption, stated so it cannot be stretched: an issue that already carries `reviewed`
**and** has not been edited since that marker's date. Re-reviewing an unchanged issue
costs about 110k tokens for nothing; skipping the gate on a changed one is how a refuted
premise reaches a junior. Check `updatedAt` against the marker, don't just look for the
label.

## The contradiction this surfaced

`.claude/skills/triage-standup/references/roster.md` still said:

> The lead is the only person `fill-ready` assigns senior-required *work* to.

Both halves are now false. The lead takes no issues, and `fill-ready` sets no assignee on
anything at all. A `senior` issue goes to a senior in its own lane — `developer`+`senior`
to a `senior-developers` member, `genealogist`+`senior` to a `senior-genealogists` member
— and the lead hands it out at standup. Left as it was, the roster told a reader the
opposite of the skill that reads it. Fixed here rather than filed, since it is two
sentences in a file this change is already about.

## What is not in scope

Extending the gate to the `genealogist` pool. That stays opt-in (`--all`), and the
rationale is measured, not a preference: `docs/specs/task-review-spec.md` records that
pointed at fixture-adjudication work the three passes mostly return "checked, clean" at
full token cost. The genealogist lane's one expensive failure mode — two items contending
for a skill's eval snapshot, at $8–12 and 45–65 minutes per wasted paid run — wants a
much shorter purpose-built agent, which that spec already names and which does not exist
yet. Flipping this flag would not build it.

## Verifying

Prose-only, in `.claude/` — no code path, no test, no CI job reads either file. The check
is the next `/fill-ready` run: every developer issue in its promote list should appear in
a `/review-ready` fan-out first, and a `senior`-labeled one should no longer be exempt
from it.

---

## Second commit: the ruling detector was reading the wrong word

Both `fill-ready` and `find-big-wins` split the `needs-decision` queue on whether a
ruling has been recorded, and both tested for `**Ruling` only. We are *told* to write
`**Ruling:**` — but the query does not read what we wrote, it reads what the lead wrote,
and he writes `## Decision:` and `**Decision (lead, <date>)`.

Proven to miss on real data before changing anything: issues #1331 and #1394 were both
ruled on 2026-08-13 and both tested **WAITING** under the old pattern.

That is the inverse of the defect the split exists to catch. A dropped item reads as the
lead being the bottleneck, so the morning report blames him for an answer he already
gave. In `find-big-wins` it is worse — that query reports emptiness as health, so a
pattern matching nothing says the board is clean forever.

Now matches either word under either markup, bold marker or ATX heading. Verified through
the verbatim queries, both branches: issues #1331 and #1394 report ANSWERED, issue #1136
(genuinely unanswered) reports WAITING.

The *writing* convention is unchanged — we still write `**Ruling:**`. Only the reader
got permissive, which is the right asymmetry: we control what we write and cannot control
what the lead types.

---

## Third commit: a closed issue was holding an eval slot forever

Gate 4 read *"at most one item touching a skill's eval snapshot may be **outside
Backlog** at a time"*. Done and Not planned are outside Backlog. So a closed issue held
its skill's slot permanently, jamming everything queued behind it.

Live case, today: issue #1392 closed `not planned` — it was the **only** holder of
`proof-conclusion`, with issues #1183 and #1399 queued. Under the old wording that slot
would have stayed shut indefinitely.

The rule now names the three active columns positively — Ready, In Progress, Review — and
a slot is held only by an **open** issue in one of them. Whatever a closed issue was going
to change, it is not going to change it, so nothing is waiting on it.

**Plus the tiebreaker that makes the rule usable:** when the column and the issue's state
disagree, the state wins. Closing an issue does not move its card —
`.github/workflows/project-status-sync.yml` does, and it is a workflow, not an atomic
write. A card can read `Review` for a while after its issue closed, and a pass reading
the column alone holds a whole skill shut on work nobody is doing.

Stated once up front in the board-facts block as well, because it binds on pool counts and
swaps too, not only on Gate 4 — "outside Backlog" is never the right test for anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
