### PR TITLE
Reviewers can push a fix without costing an approval

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -328,21 +328,17 @@ A review's `commit_id` is the commit it read. **Compare it to `headRefOid`.** If
 they differ, say which commit the approval read and re-check each note against
 the code as it stands now.
 
-Two ruleset settings decide what a stale approval is worth here, and they pull
-in opposite directions. `dismiss_stale_reviews_on_push: false` means a push does
-**not** clear existing approvals — they keep counting toward the two required,
-and nothing re-requests review. But `require_last_push_approval: true` means at
-least one approval must land **after** the most recent push **and come from
-someone other than whoever pushed it**. So an old approval is neither void nor
-sufficient: a PR approved twice and then pushed to still needs a fresh approval,
-while both old ones still count. Do not tell an author their approvals were
-reset, and do not treat a pre-push approval as clearing the gate.
+One ruleset setting decides what a stale approval is worth here, and it is
+permissive. `dismiss_stale_reviews_on_push: false` means a push does **not**
+clear existing approvals — they keep counting toward the two required, and
+nothing re-requests review. **Nothing takes their place.** An approval that read
+a commit three pushes ago still clears the merge gate, and the merge box says
+approved.
 
-**Senior developers are exempt.** Pushing a small fix rather than asking the
-author for it is the fast path, and it stays fast: the `last-push-approval`
-ruleset lists `senior-developers` as a bypass actor, so a senior who pushes the
-last commit can still merge. Anyone else who pushes needs an approval from
-someone who didn't.
+So the `commit_id` check above is the only thing standing between a stale
+approval and main. Run it on every approval on the PR, not just the ones you
+doubt, and report each one whose commit is not `headRefOid` — naming what
+landed after it that nobody has read.
 
 ## 8. Write the edits — don't make them
 

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -318,17 +318,16 @@ returns as an input to your review, never as your review.
    whatever the code looks like. And check `.github/CODEOWNERS`: on the paths it
    lists, your approval doesn't unblock merge. Say which is still owed rather
    than leaving the author to discover it at the merge button.
+5. **Pushing a small fix to their branch is fine.** It costs nobody a
+   reapproval: a push doesn't clear the approvals already on the PR, and nothing
+   is required after it. That cuts both ways — whatever you push merges unread,
+   so push only what you'd approve on sight, and leave anything bigger to the
+   author.
 
 ### "It says approved, but it won't merge"
 
-Four rules can each hold a green, approved PR. Check them in this order:
+Three rules can each hold a green, approved PR. Check them in this order:
 
-- **Someone pushed after the approvals.** At least one approval has to land
-  *after* the most recent push, from someone other than whoever pushed it. The
-  old approvals are not cancelled — they still count toward the two — so you
-  need one fresh approval, not two. **Senior developers are exempt**, so a
-  senior who pushes a small fix rather than asking the author for it can still
-  merge it themselves.
 - **An unresolved conversation.** Every review thread must be marked resolved.
   Resolve the ones you answered; the reviewer resolves the ones they raised.
 - **A code owner hasn't approved yet.** `.github/CODEOWNERS` decides which team


### PR DESCRIPTION
## Summary

- Trivial. Docs only.
- The `last-push-approval` branch ruleset is deleted, so a push no longer holds an approved PR. Both docs described it as live.
- `.claude/skills/review/SKILL.md` and `docs/task-lifecycle.md` also claimed senior developers were exempt from it. They never were — T-FEH pushed a one-line test fix to PR #1570, approved it, and still could not merge.

## Review guidance

**Start here:** the replacement paragraph in `.claude/skills/review/SKILL.md`. Deleting this rule takes away the only thing that forced *someone* to look at a PR after its last push. `dismiss_stale_reviews_on_push` is still false, so an approval that read a three-day-old commit counts exactly as much as one that read HEAD. The paragraph now says that plainly and hands the job to the `commit_id` vs `headRefOid` comparison in the paragraph above it. Check that it actually reads as an instruction and not as trivia — that check is advisory, run by whoever happens to invoke the skill, and it is now the whole guard.

**Unsure about:** whether the new item 5 in `docs/task-lifecycle.md` ("push only what you'd approve on sight") is strong enough. It is the only thing telling a reviewer that what they push merges unread.

## Test plan

- [x] I ran `make test-all` and it passed. 2061 passed, 2 skipped.

Docs only — no `.ts`/`.py`/`.json`/`.yml` files touched, and no skill under `packages/engine/plugin/skills/`, so no eval run and no senior-developers approval is required by CODEOWNERS.

## Follow-on issues

**Folded in / filed instead:** Nothing filed. Both files were the whole blast radius — `grep` for `last-push`, `last_push`, `reapprov`, `last pusher`, `most recent push`, and `Senior developers are exempt` across every `.md`, `.yml`, and `.yaml` in the repo returns only these two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)