### PR TITLE
Record built-in tool calls in the harness so a skipped Read is visible

### DIFF
--- a/docs/specs/schemas/run-log.schema.json
+++ b/docs/specs/schemas/run-log.schema.json
@@ -272,6 +272,19 @@
           "type": "array",
           "items": { "$ref": "#/$defs/tool_call" }
         },
+        "builtin_tool_calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["tool", "args"],
+            "additionalProperties": false,
+            "properties": {
+              "tool": { "type": "string" },
+              "args": { "type": "object" },
+              "agent_id": { "type": "string" }
+            }
+          }
+        },
         "files_created": {
           "type": "array",
           "items": { "type": "string" }

--- a/docs/specs/unit-test-spec.md
+++ b/docs/specs/unit-test-spec.md
@@ -1287,6 +1287,13 @@ A run log represents N runs of one test (N from `runs_per_test`, default 1). The
             "response_fixture": "string or null (fixture file name that provided the response, null when kind is `none`)"
           }
         ],
+        "builtin_tool_calls": [
+          {
+            "tool": "string (built-in tool name, e.g. Read, Write, Grep)",
+            "args": "object (the call's arguments, each value stringified and cut at 200 chars)",
+            "agent_id": "string (present only when the call came from inside a Task-spawned subagent)"
+          }
+        ],
         "files_created": ["string (paths of new files created, relative to cwd)"]
       },
 
@@ -1332,6 +1339,7 @@ A run log represents N runs of one test (N from `runs_per_test`, default 1). The
 - **`runs[].output.activated`** — derived boolean from Section 6's `activated` definition. Positive tests pass when `activated: true`; negative tests pass when `activated: false`. Having it as a derived field keeps Section 7's outcome formulas simple and prevents drift between activation logic and grading logic.
 - **`runs[].output.skills_invoked`** — the skill(s) Claude actually invoked. Combined with `activated`, drives the wrong-skill check for positive tests and the `correct_skill` array match for negative tests (Section 6).
 - **`runs[].output.tool_calls[].matched`** — distinguishes calls that hit a fixture (`kind: "predicate"`) from unmatched calls (`kind: "none"`, which returned a `fixture_not_found` error to the skill). Any unmatched call aborts the run with `aborted_reason: unmatched_tool_call` (Section 15) — the skill ran against an error response, so the run isn't scored.
+- **`runs[].output.builtin_tool_calls`** — every non-MCP tool call the run made (`Read`, `Write`, `Grep`, `Skill`, `Task`, …), in call order. Optional and **omitted entirely when the run made none**, so historical run logs stay valid and an unchanged run writes unchanged output. MCP calls are excluded — they are already in `tool_calls` and `attempted_mcp_calls`. `agent_id` is present only when the call came from inside a Task-spawned subagent and absent on the main thread, which is what distinguishes "the record-extractor agent read the reference file" from "the router read it". Argument values are stringified and truncated to 200 characters, so a `Write` cannot carry a whole file body into the committed corpus; the truncation is silent, with no marker. Telemetry only — nothing grades, gates, or aborts on it, and it does not count toward `max_tool_calls`.
 - **`runs[].output.tool_calls[].expected_args`** — the matched fixture's `args` block (the canonical expected args), copied so the trace view and judge prompt can render expected/actual side-by-side without re-reading the fixture file. Null when no fixture matched.
 - **`runs[].output.text_response`** — Claude's full response, not truncated. If a single run's text exceeds 100 KB, the harness writes it to a sidecar file (`runs/<run_id>.text.md`) and stores a reference (`{ "ref": "runs/<run_id>.text.md" }`) in the log instead, to keep the JSON tractable.
 - **`runs[].output.file_changes.diff`** — structured diff with full before/after values for modified fields. For a modified entry, fields that didn't exist on the `before` object are emitted as `{"before": null, "after": <value>}` (added field); fields removed from the `after` object are emitted as `{"before": <value>, "after": null}` (removed field). Use literal `null`, not absent keys, so the judge always sees a uniform shape. `deleted` should always be empty (no-delete enforcement); if it's not, the validator already caught it.

--- a/eval/harness/harness/orchestrator.py
+++ b/eval/harness/harness/orchestrator.py
@@ -594,6 +594,14 @@ async def _execute_single_run(
                 for c in result.tool_calls
             ],
             "files_created": files_created,
+            # Omitted when empty so a run that called no built-in tool writes
+            # the same run_output it always has — this field appearing is
+            # itself the signal that something was read.
+            **(
+                {"builtin_tool_calls": result.builtin_tool_calls}
+                if result.builtin_tool_calls
+                else {}
+            ),
             **({"file_changes": file_changes} if file_changes else {}),
             **(
                 {"warnings": warnings}

--- a/eval/harness/harness/skill_runner.py
+++ b/eval/harness/harness/skill_runner.py
@@ -205,6 +205,48 @@ def read_skill_tool_input(tool_input: dict[str, Any]) -> tuple[str | None, list[
     return None, sorted(tool_input)
 
 
+# Longest argument value kept per built-in tool call. Run logs are committed,
+# and an untruncated Write/Edit argument would carry whole file bodies into
+# the corpus. 200 chars keeps the diagnostic part of every argument we care
+# about (a Read `file_path`, a Skill name, a Grep pattern) and bounds the rest.
+BUILTIN_ARG_TRUNCATE = 200
+
+
+def builtin_call_record(
+    tool_name: str, input_data: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Return a run-log record for one **built-in** tool call, or None for MCP.
+
+    The harness records MCP calls two ways (`tool_calls` from the mock,
+    `attempted_mcp_calls` off the message stream) and Skill calls a third
+    (`skills_invoked`), but nothing recorded plain built-ins. A subagent told
+    to `Read` a reference file therefore left no trace whether it read the
+    file, skipped it, or read the wrong one — the run only differed in its
+    assertion values, so the failure had to be diagnosed by hand. This closes
+    that blind spot at the one site that sees every call, including calls made
+    inside a Task-spawned subagent.
+
+    `agent_id` is present only when the hook fires inside a subagent (see
+    context_policy), so it is the field that distinguishes "the extractor
+    agent read it" from "the main thread read it" — the exact question a
+    delegated-reference design has to answer.
+    """
+    if tool_name.startswith("mcp__"):
+        return None
+    tool_input = input_data.get("tool_input") or {}
+    record: dict[str, Any] = {
+        "tool": tool_name,
+        "args": {
+            key: str(value)[:BUILTIN_ARG_TRUNCATE]
+            for key, value in tool_input.items()
+        },
+    }
+    agent_id = input_data.get("agent_id")
+    if agent_id:
+        record["agent_id"] = agent_id
+    return record
+
+
 @dataclass
 class SkillRunResult:
     text_response: str
@@ -241,6 +283,10 @@ class SkillRunResult:
     # this harness reads, holding that input's actual keys. Non-empty means the
     # SDK's Skill-tool contract moved and `skills_invoked` is undercounting.
     unread_skill_calls: list[list[str]] = field(default_factory=list)
+    # Every built-in (non-MCP) tool call the run emitted, as
+    # {"tool", "args", "agent_id"?} — see builtin_call_record for why this
+    # exists. Telemetry only: nothing reads it to gate, grade, or abort.
+    builtin_tool_calls: list[dict[str, Any]] = field(default_factory=list)
 
 
 async def run_skill(
@@ -327,9 +373,17 @@ async def run_skill(
     blocked_context_calls: list[dict[str, Any]] = []
     # Skill calls whose name we couldn't read (see read_skill_tool_input).
     unread_skill_calls: list[list[str]] = []
+    # Every built-in (non-MCP) tool call, for telemetry only — see
+    # builtin_call_record. Collected in the hook rather than off the message
+    # stream because the hook is the only site that sees calls made inside a
+    # Task-spawned subagent, which is where reference reads actually happen.
+    builtin_tool_calls: list[dict[str, Any]] = []
 
     async def pretool_hook(input_data, tool_use_id, ctx):
         tool_name = input_data.get("tool_name", "")
+        # Telemetry only — never gates, denies, or counts toward any limit.
+        if (builtin_record := builtin_call_record(tool_name, input_data)):
+            builtin_tool_calls.append(builtin_record)
         # Track skill invocations so we can populate skills_invoked.
         if tool_name == "Skill":
             tool_input = input_data.get("tool_input", {}) or {}
@@ -575,4 +629,5 @@ async def run_skill(
         blocked_context_calls=blocked_context_calls,
         registered_mcp_tools=set(tools_by_name.keys()),
         unread_skill_calls=unread_skill_calls,
+        builtin_tool_calls=builtin_tool_calls,
     )

--- a/eval/harness/tests/unit/test_skill_runner.py
+++ b/eval/harness/tests/unit/test_skill_runner.py
@@ -80,6 +80,63 @@ def test_skill_run_result_shape():
     # field for free, and the orchestrator's uncovered-call gate reads it.
     assert r.attempted_mcp_calls == []
     assert r.unread_skill_calls == []
+    assert r.builtin_tool_calls == []
+
+
+def test_builtin_call_record_captures_a_read():
+    """The blind spot this closes: a Read left no trace anywhere, so a
+    subagent that skipped its reference file looked identical to one that
+    read it (issue #702)."""
+    from harness.skill_runner import builtin_call_record
+
+    record = builtin_call_record(
+        "Read", {"tool_input": {"file_path": "/p/references/probate.md"}}
+    )
+    assert record == {
+        "tool": "Read",
+        "args": {"file_path": "/p/references/probate.md"},
+    }
+
+
+def test_builtin_call_record_ignores_mcp_calls():
+    """MCP calls are already recorded twice (tool_calls, attempted_mcp_calls);
+    recording them a third time would double-count the uncovered-call gate."""
+    from harness.skill_runner import builtin_call_record
+
+    assert builtin_call_record(
+        "mcp__genealogy__record_read", {"tool_input": {"recordId": "x"}}
+    ) is None
+
+
+def test_builtin_call_record_keeps_agent_id_when_inside_a_subagent():
+    """`agent_id` is present only inside a Task-spawned subagent, so it is
+    what distinguishes the extractor agent reading a file from the main
+    thread reading it — the question a delegated-reference design asks."""
+    from harness.skill_runner import builtin_call_record
+
+    record = builtin_call_record(
+        "Read",
+        {
+            "tool_input": {"file_path": "/p/x.md"},
+            "agent_id": "record-extractor-1",
+        },
+    )
+    assert record["agent_id"] == "record-extractor-1"
+    # Main-thread calls carry no agent_id, and the key is omitted rather
+    # than set to None so the schema can forbid unknown/null shapes.
+    main = builtin_call_record("Read", {"tool_input": {"file_path": "/p/x.md"}})
+    assert "agent_id" not in main
+
+
+def test_builtin_call_record_truncates_long_arguments():
+    """Run logs are committed; an untruncated Write argument would carry a
+    whole file body into the corpus."""
+    from harness.skill_runner import builtin_call_record, BUILTIN_ARG_TRUNCATE
+
+    record = builtin_call_record(
+        "Write", {"tool_input": {"content": "x" * 5000}}
+    )
+    assert len(record["args"]["content"]) == BUILTIN_ARG_TRUNCATE
 
 
 def test_read_skill_tool_input_reads_the_documented_key():

--- a/eval/harness/tests/unit/test_skill_runner.py
+++ b/eval/harness/tests/unit/test_skill_runner.py
@@ -139,6 +139,113 @@ def test_builtin_call_record_truncates_long_arguments():
     assert len(record["args"]["content"]) == BUILTIN_ARG_TRUNCATE
 
 
+class _HookDrivingStream:
+    """An async message stream that first drives the registered PreToolUse hook
+    with scripted inputs, then yields its messages so run_skill completes."""
+
+    def __init__(self, hook, hook_inputs, messages):
+        self._hook = hook
+        self._hook_inputs = hook_inputs
+        self._messages = messages
+        self._started = False
+        self._i = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._started:
+            self._started = True
+            for inp in self._hook_inputs:
+                await self._hook(inp, "tool-use-id", None)
+        if self._i >= len(self._messages):
+            raise StopAsyncIteration
+        msg = self._messages[self._i]
+        self._i += 1
+        return msg
+
+    async def aclose(self):
+        return None
+
+
+def test_run_skill_collects_builtin_calls_through_the_real_hook(tmp_path, monkeypatch):
+    """The tests above prove the RECORD; this proves the WIRING.
+
+    Deleting the hook's two collection lines leaves every other test green
+    while `builtin_tool_calls` stays empty — and because run_output omits the
+    field when empty, a broken collector writes byte-identical output to a run
+    that genuinely called no built-in tool. That is the exact ambiguity this
+    field exists to remove, so the collection needs a test that fails when it
+    is gone.
+
+    The orchestrator's `run_output` spread stays covered-by-inspection, as
+    `file_changes` and `warnings` already are — same boundary
+    test_e2e_context_block.py draws around the `blocked_context_calls=` kwarg.
+    """
+    import asyncio
+
+    from claude_agent_sdk import ResultMessage
+
+    from harness import skill_runner as sr
+    from harness.auth import AuthConfig
+
+    def fake_query(**kw):
+        hook = kw["options"].hooks["PreToolUse"][0].hooks[0]
+        return _HookDrivingStream(
+            hook,
+            [
+                # Inside the extractor subagent — carries agent_id.
+                {
+                    "tool_name": "Read",
+                    "tool_input": {"file_path": "/p/references/probate.md"},
+                    "agent_id": "agent-record-extractor",
+                },
+                # Main thread — the SDK omits agent_id entirely.
+                {
+                    "tool_name": "Read",
+                    "tool_input": {"file_path": "/p/research.json"},
+                },
+                # MCP calls are recorded elsewhere and must not land here.
+                {
+                    "tool_name": "mcp__genealogy__record_read",
+                    "tool_input": {"recordId": "x"},
+                },
+            ],
+            [
+                ResultMessage(
+                    subtype="result",
+                    duration_ms=1,
+                    duration_api_ms=1,
+                    is_error=False,
+                    num_turns=1,
+                    session_id="S1",
+                )
+            ],
+        )
+
+    monkeypatch.setattr(sr, "query", fake_query)
+    result = asyncio.run(
+        sr.run_skill(
+            user_message="go",
+            workspace=tmp_path,
+            fixture_names=[],
+            fixtures_dir=tmp_path,
+            auth=AuthConfig(
+                skill_runner_mode="api_key", api_key="x", detail="stub"
+            ),
+        )
+    )
+
+    assert result.builtin_tool_calls == [
+        {
+            "tool": "Read",
+            "args": {"file_path": "/p/references/probate.md"},
+            "agent_id": "agent-record-extractor",
+        },
+        {"tool": "Read", "args": {"file_path": "/p/research.json"}},
+    ]
+
+
 def test_read_skill_tool_input_reads_the_documented_key():
     """"skill" is the claude-agent-sdk 0.1.81 contract."""
     from harness.skill_runner import read_skill_tool_input

--- a/packages/schema/schemas/run-log.schema.json
+++ b/packages/schema/schemas/run-log.schema.json
@@ -272,6 +272,19 @@
           "type": "array",
           "items": { "$ref": "#/$defs/tool_call" }
         },
+        "builtin_tool_calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["tool", "args"],
+            "additionalProperties": false,
+            "properties": {
+              "tool": { "type": "string" },
+              "args": { "type": "object" },
+              "agent_id": { "type": "string" }
+            }
+          }
+        },
         "files_created": {
           "type": "array",
           "items": { "type": "string" }


### PR DESCRIPTION
## What

The eval harness records MCP tool calls two ways and `Skill` calls a third, but
recorded plain built-ins nowhere. A subagent told to `Read` a reference file left
no trace whether it read the file, skipped it, or read the wrong one.

That is why the reference-file experiment in issue #702 had to be diagnosed by
reading assertion values: its three failure modes — silent skip, silent
over-application, load-on-some-tests-not-others — were indistinguishable in the
run log. The harness measured the *outcome* and never the *cause*.

This collects every non-MCP tool call in the `PreToolUse` hook and surfaces it on
the run log as `builtin_tool_calls`.

## Why the hook, and not the message stream

The message-consuming loop reads `AssistantMessage` blocks from the main thread.
The hook is the only site that also sees calls made **inside a Task-spawned
subagent** — which is where reference reads actually happen. Each record carries
`tool`, truncated `args`, and `agent_id` when present. `agent_id` appears only
inside a subagent, so it is the field that separates "the extractor agent read it"
from "the main thread read it".

## Telemetry only — nothing changes behavior

Deliberate, because the failure this instruments was expensive and I did not want
the instrument to have its own blast radius:

- **`max_tool_calls` still counts MCP calls only.** Folding built-ins in would
  change every test's effective budget and could newly abort runs that pass today.
- **`attempted_mcp_calls` is untouched.** It feeds the uncovered-tool-call abort
  gate and its warning, both of which compare attempted calls against fixture
  matches. Built-ins have no fixtures, so folding them in would have produced
  false Type-1 `unmatched_tool_call` aborts.
- **`run_output` omits the field when empty**, so a run that called no built-in
  writes byte-identical output to what it writes today. The field appearing is
  itself the signal.
- Args truncate at 200 chars: run logs are committed, and an untruncated `Write`
  argument would carry whole file bodies into a corpus that has already hit
  205 MB.

## Verification

- `make harness-test` — 2080 passed, 2 skipped.
- `make harness-lint` — clean.
- **The four new tests were proven to fail against the pre-change source** before
  landing (`git stash` the module, run the file: 5 failures — `ImportError` on the
  helper, `AttributeError` on the dataclass field). A test that cannot fail reads
  as coverage and is worse than none.
- Both run-log schema mirrors edited and confirmed byte-identical.

`builtin_call_record` is a module-level pure helper mirroring
`read_skill_tool_input`, so the hook's logic is unit-testable without the SDK.

### Follow-on commit, from review

Those four tests covered the helper but not the collection: deleting the hook's
two collection lines, or the orchestrator's emit block, left the suite green
either way (measured, both mutations). Combined with omitting the field when
empty, a broken collector would write byte-identical output to a run that
genuinely called no built-in tool — the ambiguity this field exists to remove.

A fifth test now drives the real `pretool_hook` closure through a mocked
`query` and asserts the subagent read is attributed, the main-thread read is
not, and the MCP call stays out. Proven to fail against three mutations:
dropping the collection, dropping the MCP filter, and always setting
`agent_id`. The orchestrator's `run_output` spread stays covered-by-inspection,
as `file_changes` and `warnings` already are.

Also reviewed and **rejected**: swapping the `agent_id` truthiness check for
`context_policy.is_subagent_call`. They look like rival predicates, but the SDK
types `agent_id` as `NotRequired[str]` on `PreToolUseHookInput` — absent, or a
non-empty id, never None and never empty — so they cannot disagree, and the
guard covering the difference is one nothing can reach.

## Schema

`builtin_tool_calls` added as an **optional** `run_output` property in both
`docs/specs/schemas/run-log.schema.json` and
`packages/schema/schemas/run-log.schema.json` — that object is
`additionalProperties: false`, so the field could not be emitted without the edit.
Optional keeps every historical run log valid, matching how the timing fields
landed. The follow-on commit adds it to the `output` block in
`docs/specs/unit-test-spec.md` too — the JSON Schema cannot say that an absent
`agent_id` means the main thread, or that the truncation is silent.

No skill body, unit test, or plugin agent changed, so no skill is marked touched
and no re-run or annotation is owed.

## What this unblocks

It is the measuring instrument for the reference-loading question, whichever way
that goes. Today no option in that space can be evaluated, because the harness
cannot see a load happen or fail to happen. Notably it can now answer the question
the original experiment could not: *did the agent load the probate reference on the
probate cases and not on the others?*

## Follow-on work deferred, with the exemption named

Two false statements in `record-extractor.md`, found while verifying an unrelated
research question. Filed rather than fixed here under **"the fix needs a different
reviewer or skill"**: both are edits to a shipped agent body — one to the
`description` field the Cowork orchestrator matches on — which is a genealogist-lane
prose change carrying an eval consideration, not a mechanical harness edit. Bundling
them into this Python-only PR would drag an eval gate onto a change that currently
owes none.

- issue #1635 — the agent is instructed to recover deferred tools via
  `ToolSearch`, which appears in zero agent `tools:` lists. `tools:` is an
  allowlist, so the recovery path is dead in every environment.
- issue #1636 — the description asserts "agents cannot nest agents" as a
  general rule; the docs put default subagent spawn depth at 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

