### PR TITLE
CLAUDE.md: say why filing an issue is the last resort

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,17 @@ mocks (no E2B/Anthropic/OAuth needed).
 ## Work you find along the way
 
 Implementing one task always turns up others. **Filing an issue is the last
-resort, not the default.** Walk these in order and stop at the first that fits:
+resort, not the default.**
+
+**Why: an issue costs about four people.** Someone decides whether it is ready
+(`/review-ready`, which fans out a `task-reviewer` per candidate), someone
+implements it, and two review it (`/review` plus a human). So the test is not
+"is this issue justified?" — it is **"is the work big enough to carry
+four-person overhead?"** That is a ratio. A half-day genealogist deep dive
+carries it comfortably. A change of four functions in one file does not; build
+that one.
+
+Walk these in order and stop at the first that fits:
 
 1. **Fix it in the current PR.** The default, and the right answer about two
    times in three. You already have the context loaded; whoever picks up the
@@ -173,7 +183,10 @@ which of these is true:
 
 - the fix needs a different reviewer or skill — a code fix surfaced during a
   genealogist's fixture work, or vice versa;
-- it depends on a decision only the lead can make;
+- it depends on a decision only the lead can make — **and he is not reachable.**
+  A decision is a *question*, not work: filed, it costs triage every morning
+  until someone asks him anyway, and then costs the four people above on top. If
+  you can ask, ask;
 - it is a different skill's eval slot, and bundling it would force a second
   paid run;
 - it is too big for this PR — **and you have opened the call sites and counted.**


### PR DESCRIPTION
The rule said filing is the last resort and listed four exemptions, but never said what makes it expensive. Without the cost, "last resort" reads as a style preference and the exemptions read as boxes to tick — which is how I used them.

## What changes

Two edits to one section.

**Names the cost.** An issue commits about four people: someone decides whether it is ready (`/review-ready`, which fans out a `task-reviewer` per candidate), someone implements it, and two review it (`/review` plus a human). That turns the test into a **ratio** — is the work big enough to carry four-person overhead — rather than "is this issue justified?". A half-day genealogist deep dive carries it comfortably; a change of four functions in one file does not.

**Narrows the lead-decision exemption** to "and he is not reachable". A decision is a *question*, not work. Filed, it costs triage every morning until someone asks him anyway, and then costs the four people on top.

## Why now

I filed six issues off PR #1637 and named the required exemption in neither the PR body nor the issue bodies — "Deferred from PR #1637" restates the fact, it is not the reason.

Two of the six did not qualify at all, and I proved it myself: I filed the provenance check as too big for its PR, then built the whole thing in under an hour. Three more were decisions I raised as cards while in an active conversation with the person who owns them; he answered all three in one line, and two became immediate closes.

That is the failure this text is meant to prevent, and the missing piece was the arithmetic.

## Verification

`doc-links` passes (130 tests). No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)