### PR TITLE
eval: retire a rubric dimension when a validator covers it (#1668)

### DIFF
--- a/docs/specs/unit-test-spec.md
+++ b/docs/specs/unit-test-spec.md
@@ -700,6 +700,29 @@ Two matcher modifiers keep the check both precise and non-flappy:
 
 **Deterministic-validator deference (grading).** When `test_expected_classifications` **passes**, the LLM judge's `Evidence type accuracy` and `Informant identification` dimensions cannot **FAIL** on the verified classifications — the harness floors a judge `1` to `2` (`orchestrator.apply_deterministic_deference`). A fuzzy re-grade must not override a deterministic check that already confirmed the classification (this retired the recurring census direct/indirect judge-inversion flap). Partial (`2`) is still permitted for a real issue on an *undeclared* assertion. Correctness likewise does not grade classification at all (base judge prompt) — evidence_type/proximity/quality are the classification dimensions' scope.
 
+**Validator coverage (`covered_by`).** A rubric dimension may declare a deterministic validator that decides it:
+
+```markdown
+## Evidence type accuracy
+
+Does the classification hold.
+
+- **pass:** …
+- **partial:** …
+- **fail:** …
+- **covered_by:** test_expected_classifications
+```
+
+When that validator **ran and passed**, the dimension is removed from the rubric the judge sees — the criteria never enter the prompt, so the tokens are not spent — and it is re-attached to the run log with `score: null` and a rationale beginning `[covered-by]`. No correction is owed for it (`check_runlogs` rule 3 skips it), so a genealogist is not asked to confirm what a validator already decided.
+
+When the validator **failed or did not run**, the dimension stays with the judge. A failing check did not answer the dimension, and retiring on a failure would convert a real defect into a silent null.
+
+Optional, and every rubric predates it: `pass`/`partial`/`fail` remain required.
+
+**Why it exists.** Adding a deterministic check did not previously retire the judge dimension it duplicated, so oracle coverage grew while grading cost stayed flat — `question-selection` carries 12 skill-specific validators *and* 7 of 7 dead judge dimensions grading the same axes. This is what makes a new check subtract cost rather than add it.
+
+**One interaction to preserve.** A `covered_by` null must not be read as the review sample's "rubric null on a positive test" signal (`review_sample.py`, targeted rule 1). That rule catches a null standing in for a 1, which records the run as a pass; a covered null is the opposite. Both readers key on the `[covered-by]` rationale prefix, which is why the prefix is a shared constant rather than a literal at each site.
+
 **Routing deference (grading).** On a **negative** test with a non-empty `correct_skill`, the outcome is decided by routing alone (§7) and the judge runs base-only and diagnostically. When the harness observes that the skill under test is absent from `skills_invoked` **and** an accepted skill fired, it floors a judge `1` on `Correctness` / `Completeness` to `2` (`orchestrator.apply_routing_deference`). A judge FAIL there is grading the routed-to skill's execution, which this test does not own. Partial (`2`) is still permitted. Excluded: `grade_on_invariant` negatives (they return before the routing branch), and out-of-scope negatives with `correct_skill: []`, whose base dimensions genuinely *do* gate the outcome.
 
 **Known limitation.** `activated` is False whenever the skill under test is absent from `skills_invoked`, and that list can be empty even when the skill ran (`runlog.derive_activated`). So a run where the skill carried out its own task inline *and* routed to an accepted skill is floored — even though `_negative_judge_context`'s third framing line correctly tells the judge to score that case `1`. There is no mechanical discriminator, so the pre-floor score and rationale are preserved in a `floored_routing_diagnostic_dimension` warning on the run entry rather than discarded, following the same reasoning as `coerced_tool_arguments_to_na`.

--- a/eval/harness/harness/orchestrator.py
+++ b/eval/harness/harness/orchestrator.py
@@ -33,7 +33,13 @@ from harness.judge import (
     grade,
 )
 from harness.loader import TestSpec
-from harness.rubric import Rubric, empty_rubric, parse_rubric_or_empty
+from harness.rubric import (
+    Rubric,
+    covered_dimension_entries,
+    empty_rubric,
+    parse_rubric_or_empty,
+    split_covered_dimensions,
+)
 from harness.runlog import (
     JudgeResult,
     SingleRun,
@@ -502,6 +508,7 @@ async def _execute_single_run(
                 before_snapshot=before_snapshot,
                 auth=auth,
                 judge_model=judge_model,
+                validator_results=validator_results,
             )
         except JudgeError as e:
             # Missing API key, model returned no tool_use, parse failure,
@@ -1130,6 +1137,7 @@ def _run_judge(
     before_snapshot: dict[str, Any] | None = None,
     auth: AuthConfig,
     judge_model: str,
+    validator_results=None,
 ) -> JudgeOutput:
     # Negative tests: the skill correctly declines, so there is no craft
     # output to grade against the skill's rubric. Spec §7 — "negative
@@ -1142,10 +1150,18 @@ def _run_judge(
     if spec.type == "negative":
         judge_rubric: Rubric = empty_rubric(spec.skill)
         judge_context = _negative_judge_context(spec)
+        retired = []
     else:
-        judge_rubric = rubric
+        # A rubric dimension whose `covered_by` validator ran and PASSED is not
+        # sent to the judge at all. Removing it (rather than grading it and
+        # overwriting) is what makes this a saving: the criteria never enter the
+        # prompt, so the tokens are not spent. The retired dimensions are
+        # re-attached below so the run log's dimension key set is unchanged.
+        judge_rubric, retired = split_covered_dimensions(
+            rubric, {r.name for r in (validator_results or []) if r.passed}
+        )
         judge_context = spec.judge_context
-    return grade(
+    out = grade(
         rubric=judge_rubric,
         judge_context=judge_context,
         scenario_readme=scenario_readme,

--- a/eval/harness/harness/review_sample.py
+++ b/eval/harness/harness/review_sample.py
@@ -35,6 +35,8 @@ from __future__ import annotations
 import random
 from typing import Any
 
+from harness.rubric import COVERED_BY_PREFIX
+
 
 N_ROTATION = 3
 N_TARGETED = 1
@@ -71,10 +73,22 @@ def zero_dimension_test_ids(tests: list[dict[str, Any]]) -> list[str]:
 
 
 def _has_rubric_null_on_positive(entry: dict[str, Any]) -> bool:
+    """A rubric dimension the judge returned `null` on a positive test.
+
+    Targeted rule 1 exists because a null standing in for a 1 records the run as
+    a pass — `_compute_outcome` gates on 1 and 2 and null is neither.
+
+    A **covered_by** null is the opposite of that: a deterministic validator ran,
+    passed, and answered the dimension, so the judge was never asked. Treating it
+    as the signal would hand the targeted slot to the very dimensions we retired
+    to save effort — on every run, in every suite that adopts `covered_by`.
+    """
     if entry.get("test_type") == "negative":
         return False
     return any(
-        d.get("source") != "base" and d.get("score") is None
+        d.get("source") != "base"
+        and d.get("score") is None
+        and not (d.get("rationale") or "").startswith(COVERED_BY_PREFIX)
         for d in _dimensions(entry)
     )
 

--- a/eval/harness/harness/rubric.py
+++ b/eval/harness/harness/rubric.py
@@ -20,6 +20,16 @@ import re
 from dataclasses import dataclass, field
 
 
+#: Prefix on the rationale of a dimension the judge did not grade because a
+#: `covered_by` validator already decided it. Load-bearing in three places, so
+#: it lives here rather than being spelled out at each: the run log stays
+#: auditable, `check_runlogs` skips the dimension when requiring corrections,
+#: and `review_sample` must NOT treat the resulting null as the
+#: "rubric null on a positive test" signal — that rule exists to catch a null
+#: standing in for a 1, and a covered null is the opposite of that.
+COVERED_BY_PREFIX = "[covered-by]"
+
+
 class InvalidRubricError(Exception):
     """Raised when a non-empty rubric.md file doesn't match the spec format."""
 
@@ -31,6 +41,13 @@ class RubricDimension:
     pass_criteria: str
     partial_criteria: str
     fail_criteria: str
+    #: Name of a deterministic validator that decides this dimension. When that
+    #: validator RAN and PASSED, the judge does not grade the dimension and the
+    #: annotator is not asked to confirm it — the mechanical check already
+    #: answered it, and asking twice is what let coverage grow while cost stayed
+    #: flat (`question-selection` has 12 validators and 7 of 7 dead dimensions
+    #: grading the same axes). Optional; None means the judge always grades it.
+    covered_by: str | None = None
 
 
 @dataclass
@@ -56,6 +73,14 @@ _H1 = re.compile(r"^# +(.+?)\s*$", re.MULTILINE)
 _H2 = re.compile(r"^## +(.+?)\s*$", re.MULTILINE)
 _BULLET = re.compile(
     r"^\s*-\s+\*\*(pass|partial|fail):\*\*\s+(.+?)\s*$", re.MULTILINE
+)
+
+# Optional per-dimension retirement declaration:
+#     - **covered_by:** test_expected_classifications
+# Deliberately a separate pattern from _BULLET: pass/partial/fail stay
+# REQUIRED (the parser is strict by design), and this one is not.
+_COVERED_BY = re.compile(
+    r"^\s*-\s+\*\*covered_by:\*\*\s+([A-Za-z_][A-Za-z0-9_]*)\s*$", re.MULTILINE
 )
 
 
@@ -110,6 +135,8 @@ def parse_rubric(text: str) -> Rubric:
                     f"dimension '{name}' is missing the **{required}** bullet"
                 )
 
+        covered = _COVERED_BY.search(section)
+
         # Description is everything before the first bullet.
         first_bullet_match = _BULLET.search(section)
         description = section[: first_bullet_match.start()].strip() if first_bullet_match else section.strip()
@@ -121,6 +148,7 @@ def parse_rubric(text: str) -> Rubric:
                 pass_criteria=bullets["pass"],
                 partial_criteria=bullets["partial"],
                 fail_criteria=bullets["fail"],
+                covered_by=covered.group(1) if covered else None,
             )
         )
 
@@ -146,3 +174,62 @@ def parse_rubric(text: str) -> Rubric:
 
 
 _MAX_DIMENSIONS = 5
+
+
+def split_covered_dimensions(
+    rubric: "Rubric", passed_validators: set[str]
+) -> tuple["Rubric", list["RubricDimension"]]:
+    """Split a rubric into (what the judge grades, what a validator retired).
+
+    A dimension is retired only when its `covered_by` validator both RAN and
+    PASSED. A failing or absent validator leaves the dimension with the judge:
+    the mechanical check did not answer it, so the fuzzy one still has to.
+
+    Retiring by removing the dimension from the judge's rubric — rather than
+    grading it and overwriting — is what makes this an actual saving. The judge
+    never sees the criteria, so the tokens are not spent and the score cannot
+    be argued with later.
+    """
+    if not rubric.dimensions:
+        return rubric, []
+    kept, retired = [], []
+    for d in rubric.dimensions:
+        if d.covered_by and d.covered_by in passed_validators:
+            retired.append(d)
+        else:
+            kept.append(d)
+    if not retired:
+        return rubric, []
+    judge_rubric = Rubric(
+        skill=rubric.skill,
+        preamble=rubric.preamble,
+        dimensions=kept,
+        content_hash=rubric.content_hash,
+        raw=rubric.raw,
+    )
+    return judge_rubric, retired
+
+
+def covered_dimension_entries(
+    retired: list["RubricDimension"],
+) -> list[dict]:
+    """Run-log entries for retired dimensions: `null`, with the marker.
+
+    They stay in `aggregated_dimensions` on purpose. Dropping them would make a
+    covered dimension indistinguishable from one nobody thought to grade, and
+    would silently change the dimension key set every reader keys on.
+    """
+    return [
+        {
+            "source": "rubric",
+            "name": d.name,
+            "score": None,
+            "rationale": (
+                f"{COVERED_BY_PREFIX} decided by the deterministic validator "
+                f"`{d.covered_by}`, which ran and passed — the judge was not "
+                f"asked to grade this dimension, and no correction is owed for "
+                f"it."
+            ),
+        }
+        for d in retired
+    ]

--- a/eval/harness/scripts/check_runlogs.py
+++ b/eval/harness/scripts/check_runlogs.py
@@ -45,6 +45,7 @@ from harness.snapshot import (  # noqa: E402
     hash_file,
 )
 from harness.review_sample import zero_dimension_test_ids  # noqa: E402
+from harness.rubric import COVERED_BY_PREFIX  # noqa: E402
 from harness.versioning import classify  # noqa: E402
 
 
@@ -524,6 +525,13 @@ def rule3_completeness(skill: str, log: dict, filename: str, skill_dir: Path) ->
         if required_test_ids is not None and t["test_id"] not in required_test_ids:
             continue
         for d in t.get("outcome_summary", {}).get("aggregated_dimensions") or []:
+            # A `covered_by` dimension was decided by a deterministic validator
+            # and never sent to the judge. Asking a genealogist to confirm it is
+            # the double-charge this mechanism exists to remove: without the
+            # skip, coverage grows and cost stays flat — which is exactly what
+            # happened to question-selection (12 validators, 7 of 7 dead dims).
+            if (d.get("rationale") or "").startswith(COVERED_BY_PREFIX):
+                continue
             key = (t["test_id"], d["source"], d["name"])
             if key not in have:
                 missing.append(key)

--- a/eval/harness/tests/unit/test_check_runlogs.py
+++ b/eval/harness/tests/unit/test_check_runlogs.py
@@ -967,3 +967,39 @@ def test_rule3_still_requires_a_comment_on_a_confirmed_partial(tmp_path, capsys)
     )
     assert check_runlogs.rule3_completeness("init-project", log, fn, skill_dir) == 1
     assert "no comment" in capsys.readouterr().out
+
+
+def test_rule3_does_not_require_a_correction_for_a_covered_dimension(tmp_path):
+    """The whole point of covered_by: a validator already decided it, so asking
+    a genealogist to confirm it is the double-charge this removes."""
+    from harness.rubric import COVERED_BY_PREFIX
+
+    skill_dir = tmp_path / "init-project"
+    skill_dir.mkdir()
+    sampled = ["ut_x_000"]
+    log = _multi_test_log(3, review_sample={"tests": sampled, "cursor": [], "seed": 0})
+    log["tests"][0]["outcome_summary"]["aggregated_dimensions"].append(
+        {
+            "source": "rubric",
+            "name": "Evidence type accuracy",
+            "score": None,
+            "rationale": f"{COVERED_BY_PREFIX} decided by test_expected_classifications",
+        }
+    )
+    # Corrections cover only the two base dimensions, not the covered one.
+    fn = _write_ann(skill_dir, "v1_2026-06-24_00-00-00.json", _corrections_for(sampled))
+    assert check_runlogs.rule3_completeness("init-project", log, fn, skill_dir) == 0
+
+
+def test_rule3_still_requires_an_ordinary_rubric_dimension(tmp_path, capsys):
+    """The skip keys on the marker, not on being a rubric dimension."""
+    skill_dir = tmp_path / "init-project"
+    skill_dir.mkdir()
+    sampled = ["ut_x_000"]
+    log = _multi_test_log(3, review_sample={"tests": sampled, "cursor": [], "seed": 0})
+    log["tests"][0]["outcome_summary"]["aggregated_dimensions"].append(
+        {"source": "rubric", "name": "Tier justification", "score": 3, "rationale": "ok"}
+    )
+    fn = _write_ann(skill_dir, "v1_2026-06-24_00-00-00.json", _corrections_for(sampled))
+    assert check_runlogs.rule3_completeness("init-project", log, fn, skill_dir) == 1
+    assert "unreviewed" in capsys.readouterr().out

--- a/eval/harness/tests/unit/test_review_sample.py
+++ b/eval/harness/tests/unit/test_review_sample.py
@@ -329,3 +329,40 @@ def test_released_runlog_outranks_a_superseded_candidate(tmp_path):
 
     got = _newest_releasable_runlog(d)
     assert got["review_sample"]["cursor"] == ["released"]
+
+
+# --- covered_by must not steal the targeted slot (issue #1668) -------------
+
+
+def test_a_covered_by_null_is_not_the_rubric_null_signal():
+    """Targeted rule 1 catches a null STANDING IN FOR A 1, which records the run
+    as a pass. A covered_by null is the opposite — a validator ran, passed, and
+    answered the dimension. Without this exclusion the slot would go to the very
+    dimensions we retired to save effort, on every run of every adopting suite.
+    """
+    from harness.rubric import COVERED_BY_PREFIX
+
+    tests = _suite(6, outcome="fail")  # every test matches rule 4
+    tests[5]["outcome_summary"]["aggregated_dimensions"] = [
+        _dim(),
+        _dim(
+            name="Evidence type accuracy",
+            score=None,
+            source="rubric",
+            rationale=f"{COVERED_BY_PREFIX} decided by test_expected_classifications",
+        ),
+    ]
+    out = select_review_sample(tests=tests, n_rotation=0, n_random=0)
+    # Rule 1 must not fire; rule 4 takes the slot, so the lowest matching id wins.
+    assert out["tests"] == ["ut_000"]
+
+
+def test_a_judge_emitted_null_still_wins_the_targeted_slot():
+    """The guard must not disarm rule 1 for ordinary nulls."""
+    tests = _suite(6, outcome="fail")
+    tests[5]["outcome_summary"]["aggregated_dimensions"] = [
+        _dim(),
+        _dim(name="Tier justification", score=None, source="rubric"),
+    ]
+    out = select_review_sample(tests=tests, n_rotation=0, n_random=0)
+    assert out["tests"] == ["ut_005"]

--- a/eval/harness/tests/unit/test_rubric.py
+++ b/eval/harness/tests/unit/test_rubric.py
@@ -196,3 +196,83 @@ def test_dimension_names_returns_case_sensitive_set():
 def test_dimension_names_empty_for_empty_rubric():
     r = empty_rubric("my-skill")
     assert r.dimension_names() == frozenset()
+
+
+# --- covered_by (issue #1668) ---------------------------------------------
+
+from harness.rubric import (  # noqa: E402
+    COVERED_BY_PREFIX,
+    covered_dimension_entries,
+    parse_rubric,
+    split_covered_dimensions,
+)
+
+
+def _rubric_text(covered: str | None = None) -> str:
+    line = f"\n- **covered_by:** {covered}" if covered else ""
+    return (
+        "# demo-skill\n\n"
+        "## Evidence type accuracy\n\n"
+        "Does the classification hold.\n\n"
+        "- **pass:** right\n"
+        "- **partial:** partly\n"
+        f"- **fail:** wrong{line}\n\n"
+        "## Narrative quality\n\n"
+        "Reads well.\n\n"
+        "- **pass:** yes\n"
+        "- **partial:** partly\n"
+        "- **fail:** no\n"
+    )
+
+
+def test_covered_by_is_parsed_when_present():
+    r = parse_rubric(_rubric_text("test_expected_classifications"))
+    assert r.dimensions[0].covered_by == "test_expected_classifications"
+
+
+def test_covered_by_is_none_when_absent():
+    r = parse_rubric(_rubric_text())
+    assert r.dimensions[0].covered_by is None
+    assert r.dimensions[1].covered_by is None
+
+
+def test_covered_by_is_optional_so_every_existing_rubric_still_parses():
+    """The pass/partial/fail bullets stay REQUIRED; this one does not. Every
+    rubric in the corpus predates it."""
+    r = parse_rubric(_rubric_text())
+    assert len(r.dimensions) == 2
+
+
+def test_split_retires_a_dimension_whose_validator_passed():
+    r = parse_rubric(_rubric_text("test_expected_classifications"))
+    judge_rubric, retired = split_covered_dimensions(
+        r, {"test_expected_classifications"}
+    )
+    assert [d.name for d in judge_rubric.dimensions] == ["Narrative quality"]
+    assert [d.name for d in retired] == ["Evidence type accuracy"]
+
+
+def test_split_keeps_the_dimension_when_its_validator_FAILED():
+    """A failing validator did not answer the dimension, so the judge still has
+    to. Retiring on a failure would convert a real defect into a silent null."""
+    r = parse_rubric(_rubric_text("test_expected_classifications"))
+    judge_rubric, retired = split_covered_dimensions(r, set())
+    assert len(judge_rubric.dimensions) == 2
+    assert retired == []
+
+
+def test_split_is_a_noop_without_any_covered_by():
+    r = parse_rubric(_rubric_text())
+    judge_rubric, retired = split_covered_dimensions(r, {"anything"})
+    assert judge_rubric is r
+    assert retired == []
+
+
+def test_retired_entries_are_null_and_carry_the_marker():
+    r = parse_rubric(_rubric_text("test_expected_classifications"))
+    _, retired = split_covered_dimensions(r, {"test_expected_classifications"})
+    entries = covered_dimension_entries(retired)
+    assert entries[0]["score"] is None
+    assert entries[0]["source"] == "rubric"
+    assert entries[0]["rationale"].startswith(COVERED_BY_PREFIX)
+    assert "test_expected_classifications" in entries[0]["rationale"]


### PR DESCRIPTION
eval-harness: retire a rubric dimension when a validator covers it (#1668)

Approved by the lead 2026-08-16. A rubric dimension may now declare the
deterministic validator that decides it:

    - **covered_by:** test_expected_classifications

When that validator RAN and PASSED, the dimension is removed from the rubric the
judge sees — the criteria never enter the prompt, so the tokens are not spent —
and re-attached to the run log with score: null and a rationale beginning
[covered-by]. Rule 3 owes no correction for it, so a genealogist is not asked to
confirm what a validator already decided.

When the validator FAILED or did not run, the dimension stays with the judge. A
failing check did not answer it, and retiring on a failure would convert a real
defect into a silent null.

**Why this and not more checks.** Adding a deterministic check did not previously
retire the judge dimension it duplicated, so oracle coverage grew while grading
cost stayed flat. question-selection is the worked example: 12 skill-specific
validators — including mechanical selection_basis checks — AND 7 of 7 dead judge
dimensions grading the same axes. 45 of 74 dead dimensions are fully
mechanizable, worth 1,984 graded cells, and none of that becomes a saving until
a covered dimension can stop being graded. This is the mechanism that makes
every future check subtract rather than add.

**One interaction, and it is the part most likely to have been silently wrong.**
PR #1637 made "a rubric null on a positive test" the TOP targeted rule of the
review sample, because a null standing in for a 1 records the run as a pass.
A covered_by null is the opposite of that — a validator ran, passed, and
answered the dimension. Without the exclusion the targeted slot would go to
exactly the dimensions we retired to save effort, on every run of every adopting
suite. Both readers key on the shared COVERED_BY_PREFIX constant rather than a
literal, so the two cannot drift apart.

Removing the dimension from the judge's rubric, rather than grading it and
overwriting the score, is what makes this a real saving and not a relabelling.

11 tests. Both interaction guards broken deliberately and watched to fail:
dropping the sampler exclusion reddens the covered-null test; dropping rule 3's
skip reddens the no-correction-owed test. Also pinned: a FAILING validator does
not retire its dimension, and covered_by is optional so every rubric in the
corpus still parses.

Nothing adopts covered_by yet — no rubric.md is touched here, so no skill's
snapshot moves and no eval re-run is owed. Design it against a real validator
first; `make provenance-report` (PR #1673) is the intended first candidate.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
