### PR TITLE
Narrow the lead-decision exemption in the gate prompt and DEVELOPMENT.md too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,8 +157,8 @@ resort, not the default.**
 
 **Why: an issue costs about four people.** Someone decides whether it is ready
 (`/review-ready`, which fans out a `task-reviewer` per candidate), someone
-implements it, and two review it (`/review` plus a human). So the test is not
-"is this issue justified?" — it is **"is the work big enough to carry
+implements it, and two review it — the branch needs two approvals. So the test
+is not "is this issue justified?" — it is **"is the work big enough to carry
 four-person overhead?"** That is a ratio. A half-day genealogist deep dive
 carries it comfortably. A change of four functions in one file does not; build
 that one.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -146,7 +146,8 @@ issue is easy to create and easy to forget; a PR that closes the gap it found
 needs nothing else to remember it. File a new issue instead of fixing it here
 only when at least one of these holds, and say which in the PR description:
 the fix needs a different reviewer or skill (a code fix found during fixture
-work, or vice versa); it depends on a decision only the lead can make; it's
+work, or vice versa); it depends on a decision only the lead can make and he
+is not reachable — a decision is a question, so if you can ask, ask; it's
 a different skill's eval slot and bundling it would force a second paid run;
 or it is too big for this PR — **and you have opened the call sites and
 counted**, and can say how many files and roughly how many lines. "It feels

--- a/scripts/claude-hooks/gate-issue-create.py
+++ b/scripts/claude-hooks/gate-issue-create.py
@@ -34,7 +34,8 @@ and stop at the first that fits:
   2. Drop it. A nit costs triage every morning for as long as it stays open.
   3. Comment on the issue that already covers it (one search, then stop).
   4. File -- only by naming which exemption applies: different reviewer/skill;
-     a decision only the lead can make; a different skill's paid eval slot; or
+     a decision only the lead can make AND he is not reachable (a decision is a
+     question -- if you can ask, ask); a different skill's paid eval slot; or
      too big for this PR AFTER opening the call sites and counting files/lines.
 
 "I noticed it in passing" and "I'm not sure if this is in scope" are not


### PR DESCRIPTION
## Summary

Trivial tier. Follow-up to PR #1674, which merged before these could be folded into it.

- PR #1674 narrowed the lead-decision exemption to "and he is not reachable" in CLAUDE.md only. Two other texts carry the same exemption list and still granted it unconditionally: the gate hook's prompt (`scripts/claude-hooks/gate-issue-create.py`) and DEVELOPMENT.md. Both now say the same thing CLAUDE.md does.
- The hook matters most. It is the text a filer reads at the moment of filing, ADR-0011 names it as the write boundary for this rule, and its own docstring says restating the rule in prose does not bind. Narrowing the prose and leaving the prompt unnarrowed means the old rule is what gets read at the only moment it counts.
- DEVELOPMENT.md matters because CLAUDE.md points at its "Follow-on work you find along the way" section as the owner of these rules, so the owner was contradicting the pointer.
- Also replaced "(`/review` plus a human)" in the new CLAUDE.md paragraph with "the branch needs two approvals". The old phrasing reads as one agent plus one person, which makes the count three against a headline of four. The `protect-main` ruleset sets `required_approving_review_count` to 2, so two humans really do review it and four is right.

## Review guidance

**Start here:** `scripts/claude-hooks/gate-issue-create.py`, the `REASON` string. Check that the narrowed clause reads the same as CLAUDE.md's and that the ASCII `--` convention is preserved — that string is printed in a terminal, so it deliberately avoids em-dashes. Nothing asserts on its content, so the test suite will not catch a wording slip here.

**Unsure about:** There is no acceptance check for this, and that is the honest state. No test compares the three copies of the exemption list, so nothing on main fails today and nothing would fail if they drift apart again tomorrow. A lint is awkward because the three are worded differently on purpose. Your call whether that gap is worth closing — I did not want to expand a text fix into a new check without asking.

Separately, and left alone: `docs/task-lifecycle.md` step 7 still tells a junior "Everything you decided not to do becomes a GitHub issue, in this PR", with no exemption test at all. That is the instruction they actually follow in the workflow, and it is more permissive than either version of the rule. It predates PR #1674, so it is not drift this introduced, but it will keep undoing what that PR was trying to establish. Not touched here because rewriting a workflow step is a bigger decision than syncing three copies of one clause.

## Test plan

- [x] I ran `make test-all` and it passed. 2125 passed, 2 skipped.

Also ran, since the suite does not reach either:

- `python3 scripts/claude-hooks/test-gate-issue-create.py` — 12/12. The hook still fires on all four filing shapes and stays quiet on `gh issue list`, `gh pr create`, malformed input, and empty stdin.
- `doc-links` and `adr-links` — 155/155.

The two eval boxes do not apply: no skill directory, agent body, unit test, or fixture is touched, so no run-log snapshot changed and no skill `description` or DO NOT clause moved.

Note for whoever picks this up: touching a `.py` file pulls in the `*.py @PioneerAIAcademy/senior-developers` rule in CODEOWNERS, so this needs a senior developer's approval where PR #1674 needed none.

## Follow-on issues

**Folded in / filed instead:** All three findings folded in; nothing filed. They were found while reviewing PR #1674, which merged mid-review, so this branch is where they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
