### PR TITLE
Delete rubric dimensions that never discriminate, rather than rewriting them

### DIFF
--- a/.claude/agents/rubric-critic.md
+++ b/.claude/agents/rubric-critic.md
@@ -41,10 +41,20 @@ For skill `<X>` (paths relative to repo root):
 ## What to flag
 
 1. **Non-discriminating dimension** — scores (nearly) the same across every
-   test and version: all `3`, or all `1`. A dimension that never varies isn't
-   separating good from bad — likely too easy, too vague, or mis-scoped.
-   (skill-creator's analyzer: "always passes → may not differentiate value";
-   "always fails → may be broken or beyond capability".)
+   test and version. Split by direction:
+   - **All `3`** — the dimension separates nothing. **Recommend deleting it,
+     not rewriting it.** A rubric is capped at 5 dimensions, so one that grades
+     nothing holds a slot a discriminating dimension could take, and every kept
+     dimension is a cell a human reviews in the CRUD UI on every annotated run.
+     An empty `rubric.md` is a supported end state: the skill is then graded on
+     the base dimensions only. Before recommending a delete, name what would
+     still catch a regression on that axis — a validator in
+     `eval/harness/validators/test_<X>.py`, or a base dimension. Where nothing
+     would, recommend rewriting the dimension so it can fail instead. Say in the
+     report that deleting steps the skill's weighted mean, which drops the
+     deleted dimension's scores from the denominator.
+   - **All `1`** — broken, mis-scoped, or beyond current capability. Never
+     recommend deleting one; that hides a real failure.
 2. **Flaky / high-variance dimension** — `flaky: true` recurs, or a dimension's
    score swings across runs/versions with no code change. Flag as
    non-deterministic; the improver must not chase it.

--- a/docs/skill-lifecycle.md
+++ b/docs/skill-lifecycle.md
@@ -352,9 +352,11 @@ Run the rubric audit first — it's a health check on the *grading*, so you're
 not chasing a score that was wrong to begin with. The **rubric-critic** agent
 reads the skill's run logs, your corrections and its `rubric.md`, and flags
 dimensions that never discriminate (always pass or always fail), flaky ones,
-and ones no test exercises. Then **skill-improver** reads the annotated run log
-and proposes an evidence-cited diff. Both are read-only: they propose, **you**
-apply the edits.
+and ones no test exercises. Delete a dimension that always passes rather than
+rewriting it — a rubric may legitimately end up empty, and the skill is then
+graded on the base dimensions alone. Then **skill-improver** reads the
+annotated run log and proposes an evidence-cited diff. Both are read-only: they
+propose, **you** apply the edits.
 
 #### The lane rule — classify every finding before touching skill prose
 


### PR DESCRIPTION
Closes the first half of issue #1668.

## What changed

`rubric-critic`'s first finding type — the non-discriminating dimension — now
splits by direction and says what to do:

- **All `3`** → recommend **deleting** the dimension, not rewriting it, after
  naming what else would still catch a regression on that axis (a validator in
  `eval/harness/validators/test_<skill>.py`, or a base dimension). An empty
  `rubric.md` is called out as a supported end state — the skill is then graded
  on the base dimensions alone.
- **All `1`** → never delete. That case is broken, mis-scoped, or beyond current
  capability, and deleting it hides a real failure.

`docs/skill-lifecycle.md` gets one sentence in the improve step, so whoever runs
a deep dive sees the rule without reading the agent body.

## Why

Measured across the latest run log for all 25 skills:

- 78 of 94 rubric dimensions scored the same on every test. Sixteen skills have
  no dimension that discriminates at all.
- A run log cannot be released until every dimension of every test has a
  correction entry, so a genealogist reviews 861 dead cells per full annotation
  wave. Each dead dimension also holds one of the five rubric slots.
- Judging costs $3.64 against $79.43 for the skill runs — 4.4% of eval spend.
  The saving here is a person's time, not tokens, which is why this rides the
  deep dives instead of becoming a sweep.

The detection already existed and `/audit-rubric` already runs before
`/improve-skill`. Only the verdict changes, so this needs no new field, parser,
script, or process step.

## Verification

Prose-only change to a Claude Code subagent and a team doc. No eval files
changed, so no run-log snapshot went stale and `check-runlogs` is unaffected;
nothing in CI reads either file.

Second half of issue #1668 — the `question-selection` pilot, where all four flat
dimensions get deleted and the suite re-run — is not in this PR. It needs a paid
run and an annotation pass, and belongs with that skill's deep dive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
