### PR TITLE
Tell the rubric audit to delete rubric.md, not empty it

### DIFF
--- a/.claude/agents/rubric-critic.md
+++ b/.claude/agents/rubric-critic.md
@@ -46,8 +46,9 @@ For skill `<X>` (paths relative to repo root):
      not rewriting it.** A rubric is capped at 5 dimensions, so one that grades
      nothing holds a slot a discriminating dimension could take, and every kept
      dimension is a cell a human reviews in the CRUD UI on every annotated run.
-     An empty `rubric.md` is a supported end state: the skill is then graded on
-     the base dimensions only. Before recommending a delete, name what would
+     Deleting every dimension is a supported end state — delete the `rubric.md`
+     file rather than leaving it empty, and the skill is graded on the base
+     dimensions only. Before recommending a delete, name what would
      still catch a regression on that axis — a validator in
      `eval/harness/validators/test_<X>.py`, or a base dimension. Where nothing
      would, recommend rewriting the dimension so it can fail instead. Say in the

--- a/docs/skill-lifecycle.md
+++ b/docs/skill-lifecycle.md
@@ -353,8 +353,9 @@ not chasing a score that was wrong to begin with. The **rubric-critic** agent
 reads the skill's run logs, your corrections and its `rubric.md`, and flags
 dimensions that never discriminate (always pass or always fail), flaky ones,
 and ones no test exercises. Delete a dimension that always passes rather than
-rewriting it — a rubric may legitimately end up empty, and the skill is then
-graded on the base dimensions alone. Then **skill-improver** reads the
+rewriting it — a skill may legitimately end up with no dimensions left, in
+which case delete its `rubric.md` file and the skill is graded on the base
+dimensions alone. Then **skill-improver** reads the
 annotated run log and proposes an evidence-cited diff. Both are read-only: they
 propose, **you** apply the edits.
 


### PR DESCRIPTION
## Summary

- **Trivial.** Follow-up to PR #1678, which merged while it was being reviewed.
- That PR told the rubric audit that "an empty `rubric.md` is a supported end
  state", and added the same sentence to the skill-lifecycle doc. The eval
  harness does accept a blank file, but the grading UI does not — so a
  genealogist who follows the advice breaks the tool they need to finish the
  annotation the advice exists to shorten.
- Both places now say to delete the file instead. No code change; deleting
  already works on both paths.

## Review guidance

**Start here:** the "All `3`" bullet in `.claude/agents/rubric-critic.md`. The
thing to check is that "delete the file" really is safe where "empty the file"
was not.

It is, on both readers. The harness treats a missing file and a blank file the
same — `parse_rubric_or_empty` maps either to an empty rubric, and there is a
test pinning it. The grading UI does not: its rubric reader swallows only a
missing-file error, so a file that exists with no `##` headings throws, and the
throw escapes `listSkills()`, which has no guard. That makes `GET /api/skills`
fail for **every** skill, not just the one whose rubric was emptied.

Running the UI's parser on the three ways a rubric ends up blank:

```
completely empty file:            THROWS -> Malformed rubric: no H2 dimension headings found
whitespace only:                  THROWS -> Malformed rubric: no H2 dimension headings found
H1 kept, all dimensions deleted:  THROWS -> Malformed rubric: no H2 dimension headings found
one real dimension (control):     OK -> 1 dims
```

The third row is the likely one — deleting dimensions in an editor leaves the
`# <Skill> Rubric` heading behind.

**Unsure about:** Nothing.

## Test plan

- [x] I ran `make test-all` and it passed (2142 passed, 2 skipped, "All checks
      passed").

- [ ] N/A — no skill's run-log snapshot changed. A snapshot covers the skill
      dir, its unit tests, and the fixtures it references; `.claude/agents/` is
      a Claude Code subagent used by developers, not a plugin agent a skill
      delegates to, so no paid re-run is owed.

- [ ] N/A — no skill `description` frontmatter or DO NOT clause changed.

There is no automated check behind this one either way: nothing in CI reads
either file. The reproduction above is the evidence.

## Follow-on issues

**Folded in / filed instead:** Nothing filed. Issue #1668 carried the same
"empty `rubric.md`" wording in the section describing what to do; its body is
corrected alongside this PR, since the `question-selection` pilot that issue
still tracks is exactly where someone deletes every dimension and hits this.
