### PR TITLE
A blank rubric.md is an error, not an opt-out

### DIFF
--- a/docs/specs/unit-test-spec-v2.md
+++ b/docs/specs/unit-test-spec-v2.md
@@ -26,8 +26,10 @@ sources:
 - **base** — always: `Correctness`, `Completeness`. Defined in
   `eval/harness/judge/prompt.md`.
 - **rubric** — opt-in, per-skill: dimensions in
-  `eval/tests/unit/<skill>/rubric.md`. A skill with no `rubric.md`,
-  or with an empty one, is graded on base only.
+  `eval/tests/unit/<skill>/rubric.md`. A skill with no `rubric.md` is
+  graded on base only. Opting out means **deleting** the file: a
+  present-but-blank one is a runnability failure, since the CRUD UI's
+  parser rejects it.
 
 There is **no `criteria` source.** Per-test `judge_context[]` (formerly
 `additional_criteria[]`) is still rendered into the judge prompt as

--- a/eval/app/components/forms/TestForm.tsx
+++ b/eval/app/components/forms/TestForm.tsx
@@ -468,6 +468,13 @@ export function TestForm({ mode, initialValues, onSaved }: TestFormProps) {
                   <Text size="sm" c="dimmed">
                     Pick a skill to see its rubric dimensions.
                   </Text>
+                ) : selectedSkill.rubricError ? (
+                  <Text size="sm" c="red">
+                    {selectedSkill.name}&apos;s rubric.md could not be read, so
+                    its dimensions are missing here and every test for this
+                    skill will be blocked until it is fixed.{' '}
+                    {selectedSkill.rubricError}
+                  </Text>
                 ) : selectedSkill.rubricDimensions.length === 0 ? (
                   <Text size="sm" c="dimmed">
                     No rubric.md found for {selectedSkill.name}.

--- a/eval/app/lib/skills.ts
+++ b/eval/app/lib/skills.ts
@@ -7,9 +7,10 @@
  *   dimensions per unit-test-spec.md §7.
  *
  * No caching: the scan is sub-millisecond, and dev edits to
- * `rubric.md` show up without a server restart. Malformed rubrics
- * throw with a path pointer — surfaces as a clean 500 from the first
- * request that hits the bad file.
+ * `rubric.md` show up without a server restart. A rubric that fails to
+ * parse is reported on its own skill as `rubricError` and takes only
+ * that skill's dimensions down — one bad file used to throw out of
+ * `listSkills` and 500 the whole picker for every skill.
  */
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -109,6 +110,14 @@ function parseAllowedTools(raw: SkillFrontmatter['allowed-tools']): string[] {
  * Throws on malformed input with a file-path pointer.
  */
 export function parseRubric(content: string, filePath: string): SkillRubricDimension[] {
+  // Blank gets its own message. It is the one malformed shape with an
+  // obvious fix, and "no H2 dimension headings found" does not name it.
+  // Matches parse_rubric_or_empty in eval/harness/harness/rubric.py.
+  if (content.trim() === '') {
+    throw new Error(
+      `Malformed rubric: ${filePath} is blank. To grade a skill on the base dimensions only, delete the file.`,
+    );
+  }
   const lines = content.split(/\r?\n/);
   const dimensions: SkillRubricDimension[] = [];
 
@@ -172,15 +181,32 @@ async function readSkillMd(skillName: string): Promise<{ frontmatter: SkillFront
   }
 }
 
-async function readRubricFor(skillName: string): Promise<SkillRubricDimension[]> {
+/**
+ * A skill's rubric dimensions, plus why they are missing when they are.
+ *
+ * `error` is null both when the file parsed and when there is no file at
+ * all — absent is the supported opt-out, so it is not an error. Only a
+ * parse failure fills it in, and only a parse failure is caught: any
+ * other read failure (EACCES, EISDIR) is a broken checkout rather than
+ * bad content, and still throws.
+ */
+async function readRubricFor(
+  skillName: string,
+): Promise<{ dimensions: SkillRubricDimension[]; error: string | null }> {
   const rubricPath = path.join(testsUnitDir(), skillName, 'rubric.md');
+  let content: string;
   try {
-    const content = await fs.readFile(rubricPath, 'utf8');
-    return parseRubric(content, rubricPath);
+    content = await fs.readFile(rubricPath, 'utf8');
   } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === 'ENOENT') return [];
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { dimensions: [], error: null };
+    }
     throw err;
+  }
+  try {
+    return { dimensions: parseRubric(content, rubricPath), error: null };
+  } catch (err) {
+    return { dimensions: [], error: (err as Error).message };
   }
 }
 
@@ -207,12 +233,13 @@ export async function listSkills(): Promise<SkillInfo[]> {
     if (!stat?.isDirectory()) continue;
     const parsed = await readSkillMd(name);
     const allowedTools = parseAllowedTools(parsed?.frontmatter['allowed-tools']);
-    const rubricDimensions = await readRubricFor(name);
+    const rubric = await readRubricFor(name);
     out.push({
       name,
       description: parsed?.frontmatter.description?.trim() ?? null,
       allowedTools,
-      rubricDimensions,
+      rubricDimensions: rubric.dimensions,
+      rubricError: rubric.error,
       stateless: isStateless(allowedTools),
     });
   }
@@ -226,12 +253,13 @@ export async function readSkill(name: string): Promise<SkillInfo | null> {
   if (!stat?.isDirectory()) return null;
   const parsed = await readSkillMd(name);
   const allowedTools = parseAllowedTools(parsed?.frontmatter['allowed-tools']);
-  const rubricDimensions = await readRubricFor(name);
+  const rubric = await readRubricFor(name);
   return {
     name,
     description: parsed?.frontmatter.description?.trim() ?? null,
     allowedTools,
-    rubricDimensions,
+    rubricDimensions: rubric.dimensions,
+    rubricError: rubric.error,
     stateless: isStateless(allowedTools),
   };
 }

--- a/eval/app/lib/types.ts
+++ b/eval/app/lib/types.ts
@@ -401,6 +401,14 @@ export interface SkillInfo {
   description: string | null;
   allowedTools: string[];
   rubricDimensions: SkillRubricDimension[];
+  /**
+   * Why `rubricDimensions` is empty, when the rubric failed to parse.
+   * Null when the rubric parsed AND when there is no rubric.md at all —
+   * an absent file is the supported opt-out, not a failure. Empty
+   * dimensions alone can't tell those apart, which is the distinction
+   * the harness enforces (eval/harness/harness/rubric.py).
+   */
+  rubricError: string | null;
   stateless: boolean;
 }
 

--- a/eval/app/tests/fs/skills.test.ts
+++ b/eval/app/tests/fs/skills.test.ts
@@ -85,6 +85,63 @@ describe('skills — happy parse', () => {
     expect(init.allowedTools).toEqual([]);
     expect(init.stateless).toBe(true);
     expect(init.rubricDimensions).toEqual([]);
+    // No rubric.md at all is the supported opt-out, not a failure.
+    expect(init.rubricError).toBeNull();
+  });
+
+  it('reports no error for a rubric that parses', async () => {
+    const skills = await listSkills();
+    expect(skills.find((s) => s.name === 'locality-guide')!.rubricError).toBeNull();
+  });
+});
+
+describe('skills — one unparseable rubric does not take down the list', () => {
+  let handle: FixtureTreeHandle;
+
+  // A blank rubric.md is the shape this guards against: the harness
+  // blocks it, but nothing stops someone emptying the file locally
+  // between edits. Before rubricError existed, readRubricFor rethrew and
+  // the throw escaped listSkills, so GET /api/skills 500'd and the picker
+  // died for EVERY skill rather than the one bad file's.
+  beforeEach(async () => {
+    handle = await makeFixtureTree({
+      skills: [
+        { name: 'locality-guide', skillMd: SKILL_MD_LOCALITY, rubricMd: RUBRIC_LOCALITY },
+        { name: 'init-project', skillMd: SKILL_MD_INIT, rubricMd: '' },
+      ],
+    });
+    process.env.EVAL_DIR = handle.root;
+  });
+
+  afterEach(async () => {
+    delete process.env.EVAL_DIR;
+    await handle.cleanup();
+  });
+
+  it('still lists every skill', async () => {
+    const skills = await listSkills();
+    expect(skills.map((s) => s.name)).toEqual(['init-project', 'locality-guide']);
+  });
+
+  it('leaves the healthy skill dimensions intact', async () => {
+    const skills = await listSkills();
+    const locality = skills.find((s) => s.name === 'locality-guide')!;
+    expect(locality.rubricDimensions.map((d) => d.name)).toEqual([
+      'Jurisdiction accuracy',
+      'Record availability',
+    ]);
+    expect(locality.rubricError).toBeNull();
+  });
+
+  it('names the bad file and the fix on the skill that owns it', async () => {
+    const skills = await listSkills();
+    const init = skills.find((s) => s.name === 'init-project')!;
+    expect(init.rubricDimensions).toEqual([]);
+    // Not null — this is what separates "blank file" from "no file", which
+    // empty dimensions alone cannot express.
+    expect(init.rubricError).toContain('is blank');
+    expect(init.rubricError).toContain('delete the file');
+    expect(init.rubricError).toContain('init-project');
   });
 });
 
@@ -126,6 +183,15 @@ describe('skills — malformed rubric throws with path pointer', () => {
 Description only, no bullets.
 `;
     expect(() => parseRubric(bad, '/path/to/eval/tests/unit/foo/rubric.md')).toThrow(/rubric.md/);
+  });
+
+  it('names the file and the fix when the rubric is blank', () => {
+    expect(() => parseRubric('', '/path/to/eval/tests/unit/foo/rubric.md')).toThrow(
+      /is blank.*delete the file/s,
+    );
+    expect(() => parseRubric('   \n\n  ', '/path/to/eval/tests/unit/foo/rubric.md')).toThrow(
+      /is blank/,
+    );
   });
 
   it('throws when there are no dimensions at all', () => {

--- a/eval/harness/harness/rubric.py
+++ b/eval/harness/harness/rubric.py
@@ -85,8 +85,7 @@ def parse_rubric_or_empty(skill: str, text: str | None) -> Rubric:
         raise InvalidRubricError(
             f"'{skill}' has a blank rubric.md. To grade a skill on the base "
             "dimensions only, delete the file — the CRUD UI's parser rejects "
-            "a blank one, so leaving it in place breaks the skills list while "
-            "the harness reads it as an opt-out."
+            "a blank one, so leaving it in place breaks the skills list."
         )
     return parse_rubric(text)
 

--- a/eval/harness/harness/rubric.py
+++ b/eval/harness/harness/rubric.py
@@ -6,11 +6,14 @@ Conventions enforced when a rubric is present and non-empty:
 - each H2 section MUST contain three bullets: pass, partial, fail
 - no other H2-level structure (the parser is strict by design)
 
-The rubric layer is **opt-in**. A skill with no `rubric.md`, or with a
-present-but-empty file, is graded on the base dimensions only. Use
-`parse_rubric_or_empty(skill_name, text)` to opt into the empty-rubric
-path; `parse_rubric(text)` retains the strict contract for callers
-that want to validate a non-empty file directly.
+The rubric layer is **opt-in**, and there is exactly one way to opt out:
+delete `rubric.md`. A skill with no file is graded on the base dimensions
+only; a present-but-empty file is malformed, not an opt-out, because the
+CRUD UI's own parser rejects it (`eval/app/lib/skills.ts::parseRubric`)
+and a state the two halves disagree about is worse than either answer.
+Use `parse_rubric_or_empty(skill_name, text)` when the file may be
+absent; `parse_rubric(text)` retains the strict contract for callers
+that want to validate a file's content directly.
 """
 
 from __future__ import annotations
@@ -21,7 +24,8 @@ from dataclasses import dataclass, field
 
 
 class InvalidRubricError(Exception):
-    """Raised when a non-empty rubric.md file doesn't match the spec format."""
+    """Raised when a present rubric.md doesn't match the spec format —
+    including a blank one, which must be deleted rather than emptied."""
 
 
 @dataclass
@@ -72,10 +76,18 @@ def empty_rubric(skill: str) -> Rubric:
 
 
 def parse_rubric_or_empty(skill: str, text: str | None) -> Rubric:
-    """Opt-in entry point. text=None (file missing) or text.strip()==""
-    (present-but-empty) → empty rubric. Otherwise parse strictly."""
-    if text is None or not text.strip():
+    """Opt-in entry point. text=None (file missing) → empty rubric.
+    Otherwise parse strictly — including text.strip()=="", which is a
+    blanked file, not an opt-out."""
+    if text is None:
         return empty_rubric(skill)
+    if not text.strip():
+        raise InvalidRubricError(
+            f"'{skill}' has a blank rubric.md. To grade a skill on the base "
+            "dimensions only, delete the file — the CRUD UI's parser rejects "
+            "a blank one, so leaving it in place breaks the skills list while "
+            "the harness reads it as an opt-out."
+        )
     return parse_rubric(text)
 
 

--- a/eval/harness/harness/runnability.py
+++ b/eval/harness/harness/runnability.py
@@ -260,10 +260,10 @@ def check_runnable(
                 )
 
     rubric_path = Path(tests_dir) / spec.skill / "rubric.md"
-    # Rubric is opt-in per unit-test-spec-v2.md: a missing or empty file
-    # is fine — the skill is graded on base dimensions only. A present-
-    # but-malformed file is still a runnability failure (it's a typo,
-    # not an opt-out).
+    # Rubric is opt-in per unit-test-spec-v2.md: a missing file is fine —
+    # the skill is graded on base dimensions only. A present-but-malformed
+    # file is a runnability failure (it's a typo, not an opt-out), and so
+    # is a blank one — opting out means deleting the file.
     try:
         parse_rubric_or_empty(
             spec.skill,

--- a/eval/harness/tests/unit/test_rubric.py
+++ b/eval/harness/tests/unit/test_rubric.py
@@ -14,9 +14,8 @@ from harness.rubric import (
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
-# Use citation/ as the real-rubric fixture. search-familysearch-wiki's rubric is
-# being deleted as part of the criteria-demotion rollout; citation
-# stays because it encodes Evidence Explained craft.
+# Use citation/ as the real-rubric fixture — it encodes Evidence Explained
+# craft, so it is the least likely rubric in the corpus to be retired.
 CITATION_RUBRIC = REPO_ROOT / "eval/tests/unit/citation/rubric.md"
 
 
@@ -78,6 +77,29 @@ def test_parse_real_citation_rubric():
         assert d.fail_criteria
 
 
+def test_every_committed_rubric_parses():
+    """Every rubric.md in the corpus must parse, blank ones included.
+
+    The runnability gate rejects a blank rubric.md, but it only runs when
+    someone spends a paid harness run. Nothing else reads these files
+    strictly — test_judge's corpus loop swallows InvalidRubricError on
+    purpose — so a blanked rubric could be committed with CI green and
+    then 500 `GET /api/skills` for every skill, because the CRUD UI's
+    parser refuses it (eval/app/lib/skills.ts::parseRubric catches only
+    ENOENT). This is the commit-time half of that gate."""
+    rubrics = sorted((REPO_ROOT / "eval/tests/unit").glob("*/rubric.md"))
+    assert len(rubrics) > 10, (
+        f"sanity check: expected a substantial rubric corpus, found "
+        f"{len(rubrics)} under {REPO_ROOT / 'eval/tests/unit'}"
+    )
+    for path in rubrics:
+        skill = path.parent.name
+        try:
+            parse_rubric_or_empty(skill, path.read_text(encoding="utf-8"))
+        except InvalidRubricError as e:
+            raise AssertionError(f"{path.relative_to(REPO_ROOT)}: {e}") from e
+
+
 def test_empty_rubric_helper():
     r = empty_rubric("my-skill")
     assert r.skill == "my-skill"
@@ -91,9 +113,14 @@ def test_parse_or_empty_handles_missing_file():
     assert r.skill == "my-skill"
 
 
-def test_parse_or_empty_handles_whitespace_only_file():
-    r = parse_rubric_or_empty("my-skill", "   \n\n  ")
-    assert r.dimensions == []
+@pytest.mark.parametrize("blank", ["", "   \n\n  "])
+def test_parse_or_empty_rejects_blank_file(blank):
+    """A blank rubric.md is malformed, not an opt-out. Opting out means
+    deleting the file — the CRUD UI's parser rejects a blank one, so
+    accepting it here would leave the two halves disagreeing."""
+    with pytest.raises(InvalidRubricError) as exc:
+        parse_rubric_or_empty("my-skill", blank)
+    assert "delete the file" in str(exc.value)
 
 
 def test_parse_or_empty_delegates_to_strict_parser_when_populated():

--- a/eval/harness/tests/unit/test_runnability.py
+++ b/eval/harness/tests/unit/test_runnability.py
@@ -125,14 +125,18 @@ def test_runnable_when_rubric_missing(tmp_path):
     assert result.runnable is True
 
 
-def test_runnable_when_rubric_empty(tmp_path):
-    """An empty rubric.md is equivalent to a missing one — base dims only."""
+def test_blocks_when_rubric_empty(tmp_path):
+    """A blank rubric.md is NOT equivalent to a missing one. Opting out of
+    rubric grading means deleting the file; a blank one is rejected by the
+    CRUD UI's parser, so letting it through here would grade the run on base
+    dimensions while breaking the skills list the annotator needs."""
     fake_tests = tmp_path / "tests"
     (fake_tests / "search-wikipedia").mkdir(parents=True)
     (fake_tests / "search-wikipedia" / "rubric.md").write_text("", encoding="utf-8")
     spec = load_test_from_dict(_runnable_test_dict())
     result = check_runnable(spec, scenarios_dir=SCENARIOS, fixtures_dir=FIXTURES, skills_dir=SKILLS, tests_dir=fake_tests)
-    assert result.runnable is True
+    assert result.runnable is False
+    assert "delete the file" in (result.reason or "")
 
 
 def test_blocks_when_rubric_malformed(tmp_path):

--- a/eval/harness/validators/test_search_wikipedia.py
+++ b/eval/harness/validators/test_search_wikipedia.py
@@ -1,8 +1,7 @@
 """Skill-specific validators for the search-wikipedia skill.
 
-search-wikipedia has no `rubric.md` (deleted in the criteria-demotion
-rollout). All mechanical
-checks live here; narrative judgment lands on the base Correctness +
+Mechanical checks live here; narrative judgment lands on the
+search-wikipedia `rubric.md` dimensions plus the base Correctness +
 Completeness dimensions in the LLM judge.
 
 See test_universal.py module docstring for the full validator

--- a/eval/harness/validators/test_validate_schema.py
+++ b/eval/harness/validators/test_validate_schema.py
@@ -1,10 +1,8 @@
 """Skill-specific validators for the validate-schema skill.
 
-validate-schema has no `rubric.md` (deleted in the criteria-demotion
-rollout). All
-mechanical checks live here; narrative judgment about validation
-reporting lands on the base Correctness + Completeness dimensions in
-the LLM judge.
+Mechanical checks live here; narrative judgment about validation
+reporting lands on the validate-schema `rubric.md` dimensions plus the
+base Correctness + Completeness dimensions in the LLM judge.
 
 The skill is read-only: it calls the validate_research_schema MCP tool
 and reports findings, but never edits research.json or tree.gedcomx.json.


### PR DESCRIPTION
## Summary

- There were two ways to say "this skill has no rubric", and the two halves of the eval system disagreed about the second one. The harness read a blank `rubric.md` as equivalent to no file — runnable, graded on base dimensions only. The CRUD UI refuses it: `readRubricFor` swallowed only `ENOENT`, so the throw escaped `listSkills()` and `GET /api/skills` 500s, breaking the skill picker for every skill rather than just the blanked one.
- The rubric audit now tells a reviewer to **delete** `rubric.md` when a skill's last dimension is retired (PR #1678, PR #1680), so a blank file is never a legitimate state. This makes the harness say so: `parse_rubric_or_empty` raises on blank text, and the runnability gate turns that into a blocked test whose reason names the fix. One spelling for "no rubric": no file.
- That gate only fires when someone spends a paid harness run, so `test_every_committed_rubric_parses` is the commit-time half. Nothing else read these files strictly — `test_judge`'s corpus loop swallows the error on purpose — so without it a blanked rubric reaches `main` with CI green and breaks the UI for whoever opens it next.
- The UI half is fixed too. `readRubricFor` now reports a parse failure on the skill that owns it, as `SkillInfo.rubricError`, so one bad file costs that skill's dimensions instead of the whole picker, and the test form's rubric sidebar says what happened. `rubricError` stays null for an absent `rubric.md` — that is the opt-out, and empty dimensions alone cannot tell it from a blank file. Only a parse failure is caught; `EACCES` and friends still throw, because a broken checkout is not bad content. `parseRubric` also gives a blank file its own message naming the fix, matching the harness side.

Tier: Normal.

This is not issue #1668's pilot. It came out of scoping that pilot, and the pilot itself — delete `question-selection`'s rubric, re-run, annotate, write the call on base-dimension-only grading — is untouched here and still open.

## Review guidance

**Start here:** `parse_rubric_or_empty` in `eval/harness/harness/rubric.py`. The decision is that `text is None` (file absent) and `text.strip() == ""` (file blanked) now mean different things — the first is the opt-out, the second is malformed. Worth checking that the two production callers are the only ones affected: `runnability.py` already caught `InvalidRubricError`, and `orchestrator.py`'s call is unguarded but unreachable because the gate returns an aborted entry first. `test_judge.py`'s `_rubric_for_snapshot` also parses snapshot text and already falls back to the on-disk rubric on that error, so historical run logs still replay.

**Then `readRubricFor` in `eval/app/lib/skills.ts`.** The call worth checking is the narrow catch: only `parseRubric` is wrapped, not the `readFile`, so a permissions or wrong-type failure still surfaces instead of being reported as a content problem.

**Unsure about:** nothing outstanding.

## Plan

**Didn't change:** `question-selection`'s rubric — deleting it is issue #1668's pilot and wants its own paid run plus a genealogist's annotation wave.

**Acceptance check:** `test_blocks_when_rubric_empty` in `eval/harness/tests/unit/test_runnability.py` and `test_parse_or_empty_rejects_blank_file` in `eval/harness/tests/unit/test_rubric.py` both fail on `main` — I reverted the two source files and watched them go red on `assert True is False` — and pass here. For `test_every_committed_rubric_parses` I blanked `eval/tests/unit/timeline/rubric.md` and confirmed it fails naming that file, then restored it; that blank is the only failure in the whole 2160-test harness suite, which is the evidence that nothing else read these files strictly. I also ran the gate against a real committed spec (`first-question-from-objective.json`): blank gives `runnable=False` with a reason naming deletion, deleting the file gives `runnable=True`, so the real opt-out still works.

On the UI half, the three new `eval/app/tests/fs/skills.test.ts` cases were watched failing twice: with the catch in `readRubricFor` reverted to a rethrow, all three fail with the throw escaping `listSkills` — the 500 path; with the blank-specific message removed from `parseRubric`, the two that assert on it fail. `npm test` is 168 passing and `npm run typecheck` is clean.

**Deviated from the plan:** three things. Two after round 1 of `/critique-plan`: the parser test is parametrized over `""` as well as whitespace — the old test covered whitespace only, so the case that actually happens was untested; and `test_every_committed_rubric_parses` was not in the plan at all, without which the change makes the two halves agree but still lets the motivating failure reach `main`. The third is the UI fix, added in review: the commit-time gate keeps a blank file out of `main` but not out of a working tree, which is where a genealogist actually hits it — blank the file mid-edit, open the eval app, and the picker dies for all 25 skills with nothing naming the cause.

## Test plan

- [x] I ran `make test-all` (or `scripts/test.sh` — the same command) and it passed.

- [ ] For every skill whose **run-log snapshot** I changed (anything under its
      skill dir, an agent it delegates to, its `eval/tests/unit/<skill>/`, or a
      scenario/fixture it references), I ran `make eval-skill SKILL=<name>` —
      Windows: `RunTests.bat` — and committed the run log **and its
      `.ann.json`** under `eval/runlogs/unit/<skill>/`.

      No skill's snapshot changed — the diff is `eval/harness/**`, `eval/app/**` and `docs/`, and no file under any `eval/tests/unit/<skill>/` was modified. No paid run is owed.

- [ ] If I changed a skill's `description` frontmatter or its DO NOT clauses, I
      added or refreshed the negative test on **both** sides of every routing
      pair I touched — not just the direction I was fixing.

      No skill bodies touched.

## Follow-on issues

None filed.

**Folded in / filed instead:** Three stale claims that a skill has no `rubric.md` — in the `search-wikipedia` and `validate-schema` validators and in `test_rubric.py`'s fixture comment. All three rubrics exist on disk. Only `validate-schema`'s was ever deleted by the criteria-demotion rollout those lines cite, and it came back in `073c8ec3`; the other two were never deleted at all. Two lines each, same subject as this diff, context already loaded — folded in rather than filed. The CRUD UI fix was folded in for the same reason: four files in one tree, same reviewing team, no paid run.
