### PR TITLE
Let a senior of either team approve any senior-owned path

### DIFF
--- a/.claude/skills/audit-merged-prs/SKILL.md
+++ b/.claude/skills/audit-merged-prs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-merged-prs
-description: Use when the lead wants a weekly sample of recently-merged developer PRs that did not require senior review — "audit merged PRs", "spot-check last week's merges", "sample the peer-reviewed PRs", "weekly PR audit", or a bare "/audit-merged-prs". Pulls every developer-labeled PR merged in the last 7 days whose diff touched no `senior-developers`-owned path in `.github/CODEOWNERS`, samples a subset, and runs `/review` against each merge commit to surface what peer review may have missed: design drift, a missed multi-site edit, a check that cannot fail, cost regressions. Reports findings and any pattern worth turning into a new CODEOWNERS path or a `/review` checklist addition. Do NOT use to review a PR before merge (that is `/review`), to decide what the team works on next (`fill-ready`), or to audit the issue board (`audit-board`).
+description: Use when the lead wants a weekly sample of recently-merged developer PRs that did not require senior review — "audit merged PRs", "spot-check last week's merges", "sample the peer-reviewed PRs", "weekly PR audit", or a bare "/audit-merged-prs". Pulls every developer-labeled PR merged in the last 7 days whose diff matched no rule in `.github/CODEOWNERS`, so no senior approval was required, samples a subset, and runs `/review` against each merge commit to surface what peer review may have missed: design drift, a missed multi-site edit, a check that cannot fail, cost regressions. Reports findings and any pattern worth turning into a new CODEOWNERS path or a `/review` checklist addition. Do NOT use to review a PR before merge (that is `/review`), to decide what the team works on next (`fill-ready`), or to audit the issue board (`audit-board`).
 allowed-tools:
   - Read
   - Bash
@@ -10,18 +10,18 @@ allowed-tools:
 
 # Audit merged PRs
 
-`docs/task-lifecycle.md` step 9 requires a `senior-developers` approval only
-on code/infrastructure file types — `.github/CODEOWNERS` routes
-`.ts`/`.js`/`.py`/`.json`/`.yml` and similar to `senior-developers`
-repo-wide, carving genealogist-authored content (plugin skills, plugin
-agents, eval fixtures/tests, run logs, docs) back out even where it's one
-of those extensions. Everything without a `senior-developers` match merges
-on a peer approval alone — which is the point, since one senior cannot
-review every PR for 10+ developers and also do strategic work. But a peer
-approval is not a senior's judgment, and CODEOWNERS only routes by file
-type *in advance*. It cannot catch a wrong abstraction, an architectural
-drift, or a "peer approved it without reading it closely" pattern in code
-a senior never saw.
+`docs/task-lifecycle.md` step 9 requires a senior approval only on the paths
+`.github/CODEOWNERS` claims — code/infrastructure file types
+(`.ts`/`.js`/`.py`/`.json`/`.yml` and similar, repo-wide) plus the
+genealogist-authored trees (plugin skills, plugin agents, eval
+fixtures/tests, run logs). Every rule names both senior teams, so either
+one's approval satisfies it; the team named first only decides which review
+queue the PR is labelled for. **A file matching no rule at all** merges on a
+peer approval alone — which is the point, since one senior cannot review
+every PR for 10+ developers and also do strategic work. But a peer approval
+is not a senior's judgment, and CODEOWNERS only claims paths *in advance*.
+It cannot catch a wrong abstraction, an architectural drift, or a "peer
+approved it without reading it closely" pattern in code a senior never saw.
 
 This skill is that compensating control: the senior's one weekly touchpoint
 on the PRs they did not personally gate. Sampling **after** merge, not
@@ -55,14 +55,15 @@ skill runs in may differ from the lead's shell.)
 
 Read `.github/CODEOWNERS` fresh every run — **do not hardcode its path list
 in this skill file.** CODEOWNERS is the single source of truth for which
-paths are `senior-developers`-owned (`docs/task-lifecycle.md` step 9 says
-the same); a copy here would drift the moment someone edits the real file.
+paths need a senior (`docs/task-lifecycle.md` step 9 says the same); a copy
+here would drift the moment someone edits the real file.
 
 For each PR in the pool from §0, check whether any file in `.files[].path`
-falls under a `senior-developers`-owned path. If yes, drop it — that PR
-already got a senior's eyes at merge time via branch protection, and
-auditing it again duplicates work rather than covering a gap. Keep only
-PRs where **no** file matched a `senior-developers` path.
+matches **any** rule in CODEOWNERS — which team the rule names does not
+matter, since every rule names both and any senior's approval satisfies it.
+If one does, drop the PR: it already got a senior's eyes at merge time via
+branch protection, and auditing it again duplicates work rather than
+covering a gap. Keep only PRs where **no** file matched **any** rule.
 
 **Also check `.reviews` for evidence of an actual senior approval**, not
 just CODEOWNERS ownership — the bypass-actor pattern documented in this

--- a/.claude/skills/fill-ready/SKILL.md
+++ b/.claude/skills/fill-ready/SKILL.md
@@ -731,8 +731,9 @@ when the item would still be hard *after* every open question is answered.
 
 `senior` items carry `developer` or `genealogist` exactly as the junior pools do,
 and the lane decides the reviewer as much as the doer — `.github/CODEOWNERS`
-routes `.ts`/`.py`/`.json` to `senior-developers` and the skill, agent, eval and
-docs trees to `senior-genealogists`.
+queues `.ts`/`.py`/`.json` to `senior-developers` and the skill, agent and eval
+trees to `senior-genealogists`. Either team's approval unblocks the merge; the
+lane is who the work is routed to, not who is permitted to sign it off.
 
 **A `genealogist`-lane senior item is not a lesser one.** Doctrine adjudication
 across drifted skill copies, deciding whether a compliance rate is acceptable,

--- a/.claude/skills/triage-standup/references/roster.md
+++ b/.claude/skills/triage-standup/references/roster.md
@@ -13,9 +13,10 @@ people as missing, which is worse than not checking at all.
 `developer`-labeled issue must not be assigned to a genealogist, and vice versa.
 
 **Senior is a separate axis from role, and from standup attendance.** The
-`Senior` column marks GitHub team membership, which is what `.github/CODEOWNERS`
-routes review authority by: `senior-genealogists` owns skills, agents, eval
-fixtures/tests/runlogs and `docs/`; `senior-developers` owns the code and
+`Senior` column marks GitHub team membership. `.github/CODEOWNERS` names both
+teams on every rule, so either can approve any senior-owned path; the team it
+names first is who the review is queued to — `senior-genealogists` for skills,
+agents and eval fixtures/tests/runlogs, `senior-developers` for the code and
 infrastructure paths.
 
 **The `Senior` column is review authority.** A senior developer still takes work

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,58 +3,64 @@
 # show this — after every edit here, check
 # `gh api /repos/{owner}/{repo}/codeowners/errors`.
 #
-# Resolution is LAST MATCH WINS, so ordering is load-bearing: the genealogist
-# rules at the bottom override the developer rules above them.
+# EVERY RULE NAMES BOTH SENIOR TEAMS, and a rule's owners are an OR: one
+# approval from either team satisfies it. The team listed first is the one whose
+# judgment the path normally wants; the second is there so a senior of either
+# kind can unblock a PR that spans both. Keep both on every line you add.
+#
+# Resolution is LAST MATCH WINS. Because every rule carries the same two teams,
+# ordering does not currently change who may approve — it would again the moment
+# any line names a different set.
 #
 # THERE IS NO `*` DEFAULT, deliberately. Branch protection requires two
 # approvals from anyone with write access on every PR regardless; a rule here
-# adds the requirement that one of them come from a named senior team. A path
-# nobody names still gets two reviewers — it just does not pull a senior into a
-# CSS tweak, an icon, or a dotfile. Only claim a path when a senior's judgment
-# is what a review of it needs.
+# adds the requirement that one of them come from a senior. A path nobody names
+# still gets two reviewers — it just does not pull a senior into a CSS tweak, an
+# icon, or a dotfile. Only claim a path when a senior's judgment is what a
+# review of it needs.
 
 # --- Senior developer review: code and the infra that breaks silently ---
 # --- CODEOWNERS has no concept of PR labels, so this is scoped by file ---
 # --- type, not by the "developer" label.                              ---
 
-*.ts @PioneerAIAcademy/senior-developers
-*.tsx @PioneerAIAcademy/senior-developers
-*.js @PioneerAIAcademy/senior-developers
-*.mjs @PioneerAIAcademy/senior-developers
-*.cjs @PioneerAIAcademy/senior-developers
-*.py @PioneerAIAcademy/senior-developers
-*.json @PioneerAIAcademy/senior-developers
-*.yml @PioneerAIAcademy/senior-developers
-*.yaml @PioneerAIAcademy/senior-developers
-*.toml @PioneerAIAcademy/senior-developers
-*.bat @PioneerAIAcademy/senior-developers
-Makefile @PioneerAIAcademy/senior-developers
-.gitattributes @PioneerAIAcademy/senior-developers
+*.ts @PioneerAIAcademy/senior-developers @PioneerAIAcademy/senior-genealogists
+*.tsx @PioneerAIAcademy/senior-developers @PioneerAIAcademy/senior-genealogists
+*.js @PioneerAIAcademy/senior-developers @PioneerAIAcademy/senior-genealogists
+*.mjs @PioneerAIAcademy/senior-developers @PioneerAIAcademy/senior-genealogists
+*.cjs @PioneerAIAcademy/senior-developers @PioneerAIAcademy/senior-genealogists
+*.py @PioneerAIAcademy/senior-developers @PioneerAIAcademy/senior-genealogists
+*.json @PioneerAIAcademy/senior-developers @PioneerAIAcademy/senior-genealogists
+*.yml @PioneerAIAcademy/senior-developers @PioneerAIAcademy/senior-genealogists
+*.yaml @PioneerAIAcademy/senior-developers @PioneerAIAcademy/senior-genealogists
+*.toml @PioneerAIAcademy/senior-developers @PioneerAIAcademy/senior-genealogists
+*.bat @PioneerAIAcademy/senior-developers @PioneerAIAcademy/senior-genealogists
+Makefile @PioneerAIAcademy/senior-developers @PioneerAIAcademy/senior-genealogists
+.gitattributes @PioneerAIAcademy/senior-developers @PioneerAIAcademy/senior-genealogists
 
-# --- Carve-out: genealogist-authored content that happens to live in   ---
-# --- .py/.json files, re-asserted below the extension rules above      ---
-# --- so it stays senior-genealogists (last-match-wins).                ---
+# --- Genealogist-authored content, including the pieces that happen to  ---
+# --- live in .py/.json files and so need re-asserting below the         ---
+# --- extension rules above.                                            ---
 
 # Cowork plugin skills — SKILL.md prose, templates, references, and their
 # stdlib-only Python scripts (CLAUDE.md § "Skills") are genealogist-
 # reviewed content, not developer infrastructure, even though scripts/
 # holds .py files. Scoped to the plugin: the process skills under
 # .claude/skills/ are the lead's, not genealogist content.
-/packages/engine/plugin/skills/ @PioneerAIAcademy/senior-genealogists
+/packages/engine/plugin/skills/ @PioneerAIAcademy/senior-genealogists @PioneerAIAcademy/senior-developers
 
 # Cowork plugin agents — agent .md bodies are genealogist/doctrine prose.
-/packages/engine/plugin/agents/ @PioneerAIAcademy/senior-genealogists
+/packages/engine/plugin/agents/ @PioneerAIAcademy/senior-genealogists @PioneerAIAcademy/senior-developers
 
 # Eval fixtures and tests — genealogist-adjudicated scenario/expected-
 # findings JSON and e2e/unit test fixtures (docs/skill-lifecycle.md: these
 # are one co-edited unit with the skills they test).
-/eval/fixtures/ @PioneerAIAcademy/senior-genealogists
-/eval/tests/ @PioneerAIAcademy/senior-genealogists
+/eval/fixtures/ @PioneerAIAcademy/senior-genealogists @PioneerAIAcademy/senior-developers
+/eval/tests/ @PioneerAIAcademy/senior-genealogists @PioneerAIAcademy/senior-developers
 
 # Run logs and their .ann.json calibration annotations.
-/eval/runlogs/ @PioneerAIAcademy/senior-genealogists
+/eval/runlogs/ @PioneerAIAcademy/senior-genealogists @PioneerAIAcademy/senior-developers
 
 # The judge prompt — grading doctrine applied to every unit eval run. No
 # extension rule matches it (.md has none above) and no other path-prefix
 # rule does either, so before this line it required no senior review at all.
-/eval/harness/judge/ @PioneerAIAcademy/senior-genealogists
+/eval/harness/judge/ @PioneerAIAcademy/senior-genealogists @PioneerAIAcademy/senior-developers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,14 +50,15 @@
 ## Test plan
 
 <!-- If this PR touches a code/infra file (.ts/.tsx/.js/.mjs/.cjs/.py/.json/
-     .yml/.yaml/.toml/.bat, Makefile, .gitattributes) outside
+     .yml/.yaml/.toml/.bat, Makefile, .gitattributes), or anything under
      packages/engine/plugin/skills/, packages/engine/plugin/agents/,
-     eval/fixtures/, eval/tests/, or eval/runlogs/, a senior-developers
-     approval is required by branch protection — see .github/CODEOWNERS for
-     the exact rule. Peer approval alone will not unblock merge. Note that
-     docs/ is no longer an exclusion: prose there needs no senior, but a
-     schema or other code file under it does. This is a convenience note;
-     GitHub's merge button is the actual enforcement. -->
+     eval/fixtures/, eval/tests/, eval/runlogs/ or eval/harness/judge/, one
+     of your two approvals must come from a senior — EITHER senior team
+     satisfies it. See .github/CODEOWNERS for the exact rule. Peer approval
+     alone will not unblock merge. Note that docs/ is no longer an exclusion:
+     prose there needs no senior, but a schema or other code file under it
+     does. This is a convenience note; GitHub's merge button is the actual
+     enforcement. -->
 
 - [ ] I ran `make test-all` (or `scripts/test.sh` — the same command) and it passed.
       <!-- On Windows without Git Bash: `scripts\windows\test-all.bat` runs the

--- a/.github/tests/codeowners-routing.test.mjs
+++ b/.github/tests/codeowners-routing.test.mjs
@@ -46,6 +46,7 @@ const grab = (re, label) => {
 // scriptBody() dedents to column 0, so a top-level `}` in column 0 ends a function.
 const loadSrc = grab(/async function loadCodeowners\(\) \{[\s\S]*?\n\}/, 'loadCodeowners');
 const ownersSrc = grab(/^function ownersOf\(file, rules\) \{[\s\S]*?\n\}/m, 'ownersOf');
+const queueSrc  = grab(/^function queueTeamOf\(file, rules\) \{[\s\S]*?\n\}/m, 'queueTeamOf');
 
 // loadCodeowners() reads the default branch over the API; here it reads disk.
 const stubGithub = `
@@ -60,8 +61,8 @@ const stubGithub = `
   const owner = 'o', repo = 'r';
 `;
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-const { loadCodeowners, ownersOf } = await new AsyncFunction('require',
-  `${stubGithub}${loadSrc}\n${ownersSrc}\nreturn { loadCodeowners, ownersOf };`)(
+const { loadCodeowners, ownersOf, queueTeamOf } = await new AsyncFunction('require',
+  `${stubGithub}${loadSrc}\n${ownersSrc}\n${queueSrc}\nreturn { loadCodeowners, ownersOf, queueTeamOf };`)(
   (await import('node:module')).createRequire(import.meta.url));
 
 const { rules, unknown } = await loadCodeowners();
@@ -78,10 +79,31 @@ if (unknown.length) {
   console.log(`ok    all ${rules.length} CODEOWNERS rules are shapes senior-queue.yml can resolve`);
 }
 
-// 2. Who reviews what, stated as a table so a reordering that inverts
-//    last-match-wins fails here rather than in review. `null` means no senior
-//    team is required — the two ordinary approvals still are.
 const D = 'senior-developers', G = 'senior-genealogists';
+const SENIORS = [D, G];
+
+// 2. Every rule names BOTH senior teams. A rule's owners are an OR, so this is
+//    what lets a senior of either kind approve a PR that spans both. A line
+//    that drops one silently re-narrows who can unblock a merge, and nothing
+//    downstream would say so: the PR just sits at REVIEW_REQUIRED with the
+//    "wrong" senior's approval on it.
+{
+  const before = failures;
+  for (const r of rules) {
+    const missing = SENIORS.filter(t => !r.teams.includes(t));
+    if (missing.length) {
+      fail(`${r.pattern} names [${r.teams.join(', ')}] — every rule must name both ` +
+           `senior teams, missing ${missing.join(', ')}`);
+    }
+  }
+  if (failures === before) console.log(`ok    all ${rules.length} rules name both senior teams`);
+}
+
+// 3. Which QUEUE each path lands in, stated as a table so a reordering that
+//    inverts last-match-wins fails here rather than in review. This is the
+//    FIRST-listed team, which is what senior-queue.yml labels for — widening
+//    who may approve must not change who gets queued. `null` means no senior
+//    team is required, and no label; the two ordinary approvals still are.
 const TABLE = [
   // Code and the infra that breaks silently.
   ['packages/engine/mcp-server/src/index.ts', D],
@@ -111,12 +133,16 @@ const TABLE = [
   ['.gitignore', null],
   ['scripts/test.sh', null],
 ];
-for (const [file, want] of TABLE) {
-  const got = ownersOf(file, rules);
-  const ok = want === null ? got.length === 0 : got.length === 1 && got[0] === want;
-  if (!ok) fail(`${file} routes to [${got.join(', ') || 'no senior team'}], expected ${want ?? 'no senior team'}`);
+{
+  const before = failures;
+  for (const [file, want] of TABLE) {
+    const got = queueTeamOf(file, rules);
+    if (got !== want) {
+      fail(`${file} queues to ${got ?? 'no senior team'}, expected ${want ?? 'no senior team'}`);
+    }
+  }
+  if (failures === before) console.log(`ok    ${TABLE.length} queue-routing assertions`);
 }
-if (!failures) console.log(`ok    ${TABLE.length} routing assertions`);
 
 console.log(failures ? `\n${failures} check(s) failed` : '\nall checks passed');
 process.exit(failures ? 1 : 0);

--- a/.github/workflows/senior-queue.yml
+++ b/.github/workflows/senior-queue.yml
@@ -8,8 +8,10 @@ name: senior-queue
 #   is:open is:pr label:ready-for-senior-genealogist
 #   is:open is:pr label:ready-for-senior-developer
 #
-# A PR whose files span both teams gets both labels; both approvals are
-# required, so both queues need to see it.
+# A PR whose files span both teams gets both labels, so each queue sees the
+# paths it owns. Every CODEOWNERS rule names both senior teams, so one approval
+# from either satisfies the merge gate — the labels say who is best placed to
+# read what, not how many approvals are outstanding.
 #
 # The senior review is the SECOND review, and it happens only after the first
 # round has been answered. That is what the changes-requested and unresolved-
@@ -232,10 +234,21 @@ jobs:
             }
 
             // Last matching rule wins, exactly as GitHub resolves CODEOWNERS.
+            // Returns every owner of the winning rule, in the order written.
             function ownersOf(file, rules) {
               let teams = [];
               for (const r of rules) if (r.test(file)) teams = r.teams;
               return teams;
+            }
+
+            // Every rule names BOTH senior teams, because a rule's owners are an
+            // OR and either team's approval must satisfy the merge gate. The
+            // QUEUE is a different question: it is the team listed FIRST, the one
+            // whose judgment the path normally wants. Queueing on the full owner
+            // list would put every senior-owned PR in both queues and make each
+            // queue useless as a filter.
+            function queueTeamOf(file, rules) {
+              return ownersOf(file, rules)[0] || null;
             }
 
             // ---- the two decision rules, kept pure and testable ---------------
@@ -412,10 +425,11 @@ jobs:
               const statuses = status.data.statuses || [];
               const statusFailed = statuses.filter(s => s.state === 'failure' || s.state === 'error');
 
-              // Which senior teams own anything in this diff.
+              // Which senior teams are the primary owner of anything in this diff.
               const owning = new Set();
-              for (const f of files) for (const t of ownersOf(f.filename, rules)) {
-                if (TEAMS[t]) owning.add(t);
+              for (const f of files) {
+                const t = queueTeamOf(f.filename, rules);
+                if (t && TEAMS[t]) owning.add(t);
               }
               const wanted = [...owning].map(t => TEAMS[t].label);
 

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -246,19 +246,25 @@ Keep PRs small. A forty-file PR turns both review steps into rubber stamps.
 ### 9. Peer review, then senior review — on the paths that need it
 
 Peer review is another developer, and it is now **sufficient to merge** on
-files with no `senior-developers` entry in
-[`.github/CODEOWNERS`](../.github/CODEOWNERS). Senior review is a senior
-developer or the lead, and branch protection requires it specifically on
-code and infrastructure file types — `.ts`/`.tsx`/`.js`/`.mjs`/`.cjs`/`.py`/
-`.json`/`.yml`/`.yaml`, repo-wide — with an explicit carve-out putting
-genealogist-authored content (plugin skills, plugin agents, eval fixtures
-and tests, run logs, and `docs/` prose) back under `senior-genealogists`
-even where it happens to be `.py`, `.json`, or otherwise one of those
-extensions. The split is **genealogists review skills and runlogs;
-developers review infrastructure** — by the time a senior developer looks
-at a PR, everything mechanical should be settled, so their time goes to
-whether the approach is right, on the PRs where that specifically needs a
-senior's judgment.
+files no rule in [`.github/CODEOWNERS`](../.github/CODEOWNERS) claims.
+Senior review is a member of either senior team, or the lead, and branch
+protection requires one on code and infrastructure file types —
+`.ts`/`.tsx`/`.js`/`.mjs`/`.cjs`/`.py`/`.json`/`.yml`/`.yaml`, repo-wide —
+plus the genealogist-authored trees (plugin skills, plugin agents, eval
+fixtures and tests, run logs), which are claimed by name so they stay
+senior-reviewed where they happen to be `.py`, `.json`, or otherwise one of
+those extensions.
+
+**Every rule names both senior teams, so a senior of either kind can approve
+any of it.** The team a rule names FIRST is the one whose judgment the path
+normally wants, and it is the one `senior-queue.yml` puts the PR's review
+label on — `.ts`/`.py`/`.json` and friends queue to `senior-developers`, the
+skill, agent and eval trees to `senior-genealogists`. So the working split is
+still **genealogists review skills and runlogs; developers review
+infrastructure**; what the second team on each line buys is that a PR is never
+stuck waiting on one specific team when a senior is already reading it. By the
+time a senior looks at a PR everything mechanical should be settled, so their
+time goes to whether the approach is right.
 
 **CODEOWNERS is the source of truth for which paths need a senior, not this
 paragraph.** Read the file rather than trusting a path list here — it can
@@ -268,11 +274,12 @@ drift out of sync with what's actually enforced and this one can't.
 this process. Turning up with `make test-all` green, `/code-review` run, and its
 findings resolved is what keeps that gate spent on judgment.
 
-**A PR touching both kinds of file needs both approvals.** GitHub resolves
-CODEOWNERS per file, not per PR — a PR that changes a `.ts` tool
-implementation alongside a `SKILL.md` still requires a `senior-developers`
-approval for the `.ts` file and a `senior-genealogists` approval for the
-`SKILL.md`, on top of whatever else the other files need.
+**One senior approval covers a PR that spans both kinds of file.** GitHub
+resolves CODEOWNERS per file, not per PR, and a rule's owners are an OR — so
+a PR changing a `.ts` tool implementation alongside a `SKILL.md` is unblocked
+by one approval from either senior team. It will carry both queue labels,
+because each queue shows the paths it owns; that is a routing signal, not two
+outstanding requirements.
 
 **Peer-only merges aren't reviewed by a senior zero times — they're sampled
 after merge, not before.** `/audit-merged-prs` is the lead's weekly pass
@@ -342,8 +349,9 @@ Three rules can each hold a green, approved PR. Check them in this order:
 
 - **An unresolved conversation.** Every review thread must be marked resolved.
   Resolve the ones you answered; the reviewer resolves the ones they raised.
-- **A code owner hasn't approved yet.** `.github/CODEOWNERS` decides which team
-  is required per path. Four approvals from the wrong team is still zero.
+- **No senior has approved yet.** On the paths `.github/CODEOWNERS` claims, one
+  of the two approvals must come from a senior team — either one. Four approvals
+  from four juniors is still zero against that rule.
 - **A review request left over from an older CODEOWNERS.** Owners are computed
   when the PR opens; editing `.github/CODEOWNERS` later never re-runs against an
   open PR, and GitHub never withdraws a request it has already made. So a PR can


### PR DESCRIPTION
## What this changes

Every rule in `.github/CODEOWNERS` now names **both** senior teams instead of one.
A rule's owners are an OR, so one approval from either team satisfies the merge
gate on any path a rule claims.

Today a PR spanning code and skill/eval files needs one approval from each team,
and a senior developer's approval cannot unblock a `SKILL.md`. PR #1545 is the
live example: it has two approvals, one of them from a senior developer, and is
still `REVIEW_REQUIRED` because four genealogist-owned rules are unsatisfied.

## Review labels do not change

The queue is now the team listed **first** on the winning rule — the team that
owned it before — so `senior-queue.yml` applies exactly the same labels it does
today. `ownersOf()` still returns the full owner list (that is CODEOWNERS truth);
a new `queueTeamOf()` takes the first entry, and the label loop uses that.

Verified by resolving every tracked file through the workflow's own parser under
the old and new files:

```
files checked:                 3826
queue label CHANGED:           0
approver set WIDENED to both:  3564
still single-owner:            0
queue distribution:            {"senior-genealogists":2709,"senior-developers":855,"none":262}
```

## Acceptance check

`node .github/tests/codeowners-routing.test.mjs` asserts both halves:

- every rule names both senior teams (the OR that widens who may approve)
- the queue table, unchanged, now resolved through `queueTeamOf` (the labels that must not move)

Both were broken to watch them fail, not just added:

- dropping `senior-genealogists` from the `*.ts` rule → `FAIL *.ts names [senior-developers] — every rule must name both senior teams`
- swapping the order on the skills rule → `FAIL packages/engine/plugin/skills/citation/SKILL.md queues to senior-developers, expected senior-genealogists`

All four `workflow-logic-tests` jobs pass on the branch, and `senior-queue.yml`
still parses as YAML.

## Test plan

- [x] `node .github/tests/codeowners-routing.test.mjs`
- [x] `node .github/tests/senior-queue-readiness.test.mjs`
- [x] `node .github/tests/project-status-sync-routing.test.mjs`
- [x] `python3 scripts/claude-hooks/test-gate-issue-create.py`
- [ ] After merge: `gh api repos/PioneerAIAcademy/cowork-genealogy/codeowners/errors` — a rule naming a team that does not exist is dropped silently and no test can see it.

## Prose corrected alongside

- `docs/task-lifecycle.md` — "A PR touching both kinds of file needs both approvals" was the rule this PR removes; also the "it says approved but it won't merge" bullet, which said approvals from the wrong team count for nothing.
- `.github/pull_request_template.md` — said a `senior-developers` approval specifically.
- `.claude/skills/audit-merged-prs/SKILL.md` — **behavioral.** It selected its audit pool as "touched no `senior-developers`-owned path", which every senior-owned path now matches, so the pool would have gone empty. It selects on "matched no rule at all", which is what it always meant.
- `.claude/skills/fill-ready/SKILL.md`, `.claude/skills/triage-standup/references/roster.md` — lane routing is still true of the queue; both also claimed `docs/` is genealogist-owned, which no rule has said for a while.

## What this does not do

Does not touch the `protect-main` ruleset. Two approvals and `require_code_owner_review`
both stay on; the gate is still "two approvals, at least one from a senior."

## Two things to know

**PR #1545 will not clear the moment this merges.** Code owners are computed when
a PR opens or is pushed to, not read live. #1545 is currently level with main, so
merging this puts it one commit behind, and the up-to-date-before-merging policy
forces a branch update — that update is what re-resolves CODEOWNERS.
`dismiss_stale_reviews_on_push` is off, so both existing approvals survive it.

**One thing here cannot be tested before it lands:** that a line naming two teams
is an OR rather than an AND. GitHub reads CODEOWNERS from the base branch, so no
PR can exercise the new file until it is on `main`. It is documented GitHub
behavior. If it turned out to be an AND, #1545 would need a genealogist anyway —
no worse than today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)