### PR TITLE
docs: record two settled doctrines where they get broken

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,44 +390,21 @@ ToolSearch is the real load path there. Search by bare tool name —
 `query: "+research_append"` — which matches whatever prefix the session exposes.
 The same packaging test fails any `select:mcp__…` in a plugin body.
 
-**`ENABLE_TOOL_SEARCH=true` turns tool search ON, not off.** Verified against
-CLI v2.1.220 (2026-08-02): a truthy value (`true|1|yes|on`) enables
-deferred/tool-search mode, `auto`/`auto:N` is adaptive, and a **falsy** value
-(`false|0|no|off`) is what disables it — **unset also means on**. Both harnesses
-and the hosted path set `"true"`, so they run *with* deferral, which is the
-opposite of what their comments claimed until they were corrected. Nothing here
-depends on the flag's value; the bare-name rule above is correct either way.
-Flipping it is separate work that has to re-measure the tool mix.
+**`ENABLE_TOOL_SEARCH=true` turns tool search ON, not off** — and unset also
+means on, so both harnesses and the hosted path run *with* deferral. The
+bare-name rule above holds either way. Full polarity, what now depends on
+deferral being on, and what flipping it would cost: `docs/architecture.md`,
+"Agent frontmatter: spelled per registrar, exactly matched".
 
 **No playbook/reference files for agents — an agent body is self-contained.**
 Everything an agent needs at runtime lives inline in its `.md`. Do **not**
 split per-topic reference material (e.g. per-record-type extraction tables)
 into sibling files for the agent to `Read` on demand, and do **not** assemble
 them into the body at build time. Decided 2026-07-27 after measuring both;
-tried on `record-extractor` (issue #702, closed) and reverted.
-
-*Why not on-demand `Read`:* it is unreliable in a way nothing catches. Across
-a full `record-extraction` suite run with the files provably reachable, the
-agent read the playbook on some tests, ignored it on others (every assertion
-fell back to `informant_proximity: "unknown"`), and over-applied it on others
-(`witness` on all 16) — pass rate 6/19 against a 12–14/19 baseline, fails up
-from 0–1 to 6. Every one of those modes is silent: no error, and the unit
-harness only records MCP tool calls (`skill_runner.py` filters on `mcp__`),
-so a skipped `Read` leaves no trace at all. This is behavioral, not
-environmental — it persisted after the harness was made to load the plugin
-the way both production paths do.
-
-*Why not build-time assembly:* it works mechanically but splits the reviewed
-artifact from the executed one. In this repo the prompt **is** the product —
-whoever edits a fragment must be able to see the whole body it lands in
-(contradictions 400 lines up, the total context budget). Seeing the real size
-is also the pressure that produces a smaller prompt; hiding it removes the
-incentive.
-
-*What this costs, knowingly:* there is no per-record-type ownership surface,
-so a probate specialist edits the same file as everyone else. That need is
-declined, not disproven — revisit only with a mechanism that cannot silently
-skip, and re-read this note first.
+tried on `record-extractor` (issue #702, closed) and reverted. Revisit only
+with a mechanism that cannot silently skip. What each alternative measured,
+and the ownership cost knowingly accepted: `docs/architecture.md`, "Agent
+bodies are self-contained — do not split them".
 
 ## Handling user feedback submissions
 
@@ -669,39 +646,27 @@ field-name match that collides with an unrelated key.
 
 ### A measurement that disagrees with belief is re-measured, not reworded
 
-When a recorded measurement says one thing and we believe another, **probe again until
-the two reach consensus.** Do not reword prose until the guard goes green, and do not add
-a provenance escape hatch so the belief can be asserted alongside a verdict that
-contradicts it. The recorded verdict and the shipped text have to say the same thing, and
-the way to get there is measurement.
-
-This binds hardest where a guard matches *wording* rather than meaning, because rewording
-is always available and always wrong: `packages/engine/mcp-server/tests/packaging/measured-figures.test.ts`
-fires on phrasings that contradict a recorded probe verdict, and its own failure message
-already says not to relax the pattern. Re-run the probe instead — and if the probe returns
-`OPEN` or `NOT MEASURED`, settling it is a measurement-design task, not a re-run.
+When a recorded measurement contradicts what you believe, re-probe until the two agree.
+Do not reword prose until the guard goes green, and do not add a provenance escape hatch
+so the belief can sit beside a verdict that denies it. A verdict stuck at `OPEN` or
+`NOT MEASURED` is a measurement-design task, not a re-run. The guard that matches wording
+rather than meaning is `measured-figures.test.ts`; its failure message says the same.
 
 ### The eval harness emulates production's permission model
 
-**Grant what production grants.** Both production paths hold every MCP tool the server
-advertises — the hosted control plane runs `permission_mode="bypassPermissions"` with no
-allowlist, and Cowork loads the plugin whole. A harness that denies a tool production
-allows produces false alarms *and* false negatives, and it perturbs the run it is
-measuring rather than observing it.
+Grant what production grants. Both production paths hold every MCP tool the server
+advertises — the hosted control plane runs `bypassPermissions` with no allowlist, and
+Cowork loads the plugin whole. A skill's `allowed-tools` is a **grant, not a
+restriction**: the field that removes a tool from the pool is `disallowed-tools`, which
+no skill here declares, so a deny list derived as the complement of a grant inverts the
+field's meaning. The unit harness still derives one; retiring it is open work.
 
-**A skill's `allowed-tools` is a grant, not a restriction.** Claude Code documents it as
-"tools Claude can use **without asking permission** during the turn that invokes this
-skill"; the field that removes a tool from the pool is `disallowed-tools`, which no skill
-here declares. anthropics/claude-code#37683 — that `allowed-tools` does not restrict — is
-closed as not planned. So deriving a deny list as its complement inverts the field's
-meaning; that is a harness construct and never a fidelity measure.
-
-**The boundary, so this is not over-applied:** emulate production's *permission model*;
-construct the test's *inputs* freely. A deny that hides the answer from the agent — e2e's
-`is_blocked_tree_tool`, a fixture's `blocked_tools` — is a fixture and stays. A deny that
-changes what the agent is *allowed to do* is a distortion and goes. Denies production
-genuinely has stay too: the protected-file write lockdown mirrors the shipped plugin hook,
-and agent `disallowedTools:` binds even under `bypassPermissions`.
+The boundary, so this is not over-applied: emulate production's *permission model*,
+construct the test's *inputs* freely. A deny that hides the answer from the agent — the
+e2e tree-read block, a fixture's `blocked_tools` — is a fixture and stays. A deny that
+changes what the agent may *do* is a distortion and goes. Denies production genuinely has
+stay too: the protected-file write lockdown mirrors the shipped plugin hook, and agent
+`disallowedTools:` binds even under `bypassPermissions`.
 
 ### Python file I/O: always pass `encoding="utf-8"`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,92 +153,52 @@ mocks (no E2B/Anthropic/OAuth needed).
 ## Work you find along the way
 
 Implementing one task always turns up others. **Filing an issue is the last
-resort, not the default.**
-
-**Why: an issue costs about four people.** Someone decides whether it is ready
-(`/review-ready`, which fans out a `task-reviewer` per candidate), someone
-implements it, and two review it — the branch needs two approvals. So the test
-is not "is this issue justified?" — it is **"is the work big enough to carry
-four-person overhead?"** That is a ratio. A half-day genealogist deep dive
-carries it comfortably. A change of four functions in one file does not; build
-that one.
+resort, not the default** — an issue costs about four people: someone vets it
+(`/review-ready`), someone implements it, and two review it. So the test is not
+"is this issue justified?" — it is **"is the work big enough to carry
+four-person overhead?"** A half-day genealogist deep dive carries it comfortably.
+A change of four functions in one file does not; build that one.
 
 Walk these in order and stop at the first that fits:
 
 1. **Fix it in the current PR.** The default, and the right answer about two
    times in three. You already have the context loaded; whoever picks up the
    ticket has to rebuild it from nothing.
-2. **Drop it.** If it is a nit — a wording preference, a tidier structure, a
-   test you would like but nothing is broken without — say nothing and move on.
-   A filed nit costs triage every morning for as long as it stays open.
-3. **Comment on the issue that already covers it.** One search:
+2. **Drop it** if it is a nit — a wording preference, a tidier structure, a test
+   you would like but nothing is broken without.
+3. **Comment on the issue that already covers it.** One search, then stop:
    `gh issue list --state open --search "<path or symbol>"`, plus a grep of the
-   `**Touches:**` lines. Then stop searching — `/audit-board` sees the whole
-   pool weekly and is the only vantage point from which every duplicate is
-   visible.
+   `**Touches:**` lines.
 4. **File a new issue**, in the same PR that defers it.
 
 You may only reach step 4 by naming, in both the PR body and the issue body,
-which of these is true:
-
-- the fix needs a different reviewer or skill — a code fix surfaced during a
-  genealogist's fixture work, or vice versa;
-- it depends on a decision only the lead can make — **and he is not reachable.**
-  A decision is a *question*, not work: filed, it costs triage every morning
-  until someone asks him anyway, and then costs the four people above on top. If
-  you can ask, ask;
-- it is a different skill's eval slot, and bundling it would force a second
-  paid run;
-- it is too big for this PR — **and you have opened the call sites and counted.**
-  State the number of files and roughly the number of lines. "It feels out of
-  scope" is not a measurement; asserting scope instead of measuring it is the
-  single most common way a foldable fix becomes an orphaned ticket.
-
-"I noticed it in passing" and "I'm not sure if this is in scope" are not on
-that list. They are reasons to fix it now (step 1) or to drop it (step 2).
-
-Filing runs one command, no board write:
-
-```sh
-gh issue create --label developer|genealogist [--label icebox] \
-  [--label nothing-checks] \
-  --title "…" --body "**Touches:** path/one.ts, path/two.py
-
-…"
-```
-
-Open the body with a `**Touches:**` line naming the files the work would
-change, when you know them. Overlap here is almost never same-title — it is two
-issues wanting different lines in one file — and that line is what makes it
-greppable. Best guess is fine; the weekly `/audit-board` pass reads it, no gate
-does.
-
-| Label | Use for |
-|---|---|
-| `developer` | Lints, CI, validators, harness/Python, MCP tools, refactors, tooling bugs — anything with a mechanical pass/fail |
-| `genealogist` | Fixture adjudication, run-log annotation, record research, doctrine prose |
-| `icebox` | Add alongside either one when the item is a candidate with **no decision behind it**, so triage skips it instead of re-ranking it every morning |
-| `nothing-checks` | Add alongside either one when the item **is a missing guard** — a way CI can be green while the thing is broken. This label is the register `docs/architecture.md` §9.4 points at, so an unlabelled gap is invisible to every reader who follows that section |
+which of these is true: the fix needs a different reviewer or skill; it depends
+on a decision only the lead can make **and he is not reachable** (a decision is a
+question, not work — if you can ask, ask); it is a different skill's paid eval
+slot; or it is too big for this PR **and you have opened the call sites and
+counted**, stating the files and roughly the lines. "It feels out of scope" is
+not a measurement. "I noticed it in passing" and "I'm not sure if this is in
+scope" are not on that list at all — they are reasons to fix it now, or drop it.
 
 **Creating the issue is the whole job: do not call the Projects API yourself**
-(no `gh project` commands, no `addProjectV2ItemById`).
-`.github/workflows/add-to-project.yml` fires on `issues: opened` and puts the
-card in Backlog; the one exception is the `feedback` label, which routes to
-Ready. A `gh` token without the `project` scope — the default after
-`gh auth login` — fails a board write *while still creating the issue*, which
-looks like success. Reference the number in the PR body.
+(no `gh project` commands, no `addProjectV2ItemById`). A workflow files the card
+into Backlog the moment the issue opens. A `gh` token without the `project`
+scope — the default after `gh auth login` — fails a board write *while still
+creating the issue*, which looks like success.
 
 **Do not reintroduce a queue file under any name.** This replaced
 `docs/TODOs.md`, retired 2026-08-02.
 
-`gh issue create` is gated by a `PreToolUse` hook
-(`scripts/claude-hooks/gate-issue-create.py`, wired in `.claude/settings.json`)
-that stops the call and puts steps 1–3 in front of the lead before anything is
-filed. It is a prompt, not a refusal — answer it with which exemption applies.
+Label `developer` or `genealogist` by who does the work, and add
+`nothing-checks` when the item **is a missing guard** — a way CI can be green
+while the thing is broken. That label is the register `docs/architecture.md`
+keeps under "What nothing checks", so an unlabelled gap is invisible to every
+reader who goes looking there.
 
-The rest — how to pick the label, what belongs in a body and what doesn't, the
-`TODOs.md` postmortem — is in [`DEVELOPMENT.md`](./DEVELOPMENT.md) §
-"Follow-on work you find along the way", which owns these rules.
+Everything else — the exact `gh issue create` line, the `**Touches:**` line, the
+`icebox` label, what belongs in a body and what does not, and the hook that
+gates filing — is in [`DEVELOPMENT.md`](./DEVELOPMENT.md) § "Follow-on work you
+find along the way", which owns these rules.
 
 ## Tools and skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -667,6 +667,42 @@ than no check at all. The three ways one silently passes here: a grep whose
 pattern excludes its own tree, a `git grep` that skips untracked files, and a
 field-name match that collides with an unrelated key.
 
+### A measurement that disagrees with belief is re-measured, not reworded
+
+When a recorded measurement says one thing and we believe another, **probe again until
+the two reach consensus.** Do not reword prose until the guard goes green, and do not add
+a provenance escape hatch so the belief can be asserted alongside a verdict that
+contradicts it. The recorded verdict and the shipped text have to say the same thing, and
+the way to get there is measurement.
+
+This binds hardest where a guard matches *wording* rather than meaning, because rewording
+is always available and always wrong: `packages/engine/mcp-server/tests/packaging/measured-figures.test.ts`
+fires on phrasings that contradict a recorded probe verdict, and its own failure message
+already says not to relax the pattern. Re-run the probe instead — and if the probe returns
+`OPEN` or `NOT MEASURED`, settling it is a measurement-design task, not a re-run.
+
+### The eval harness emulates production's permission model
+
+**Grant what production grants.** Both production paths hold every MCP tool the server
+advertises — the hosted control plane runs `permission_mode="bypassPermissions"` with no
+allowlist, and Cowork loads the plugin whole. A harness that denies a tool production
+allows produces false alarms *and* false negatives, and it perturbs the run it is
+measuring rather than observing it.
+
+**A skill's `allowed-tools` is a grant, not a restriction.** Claude Code documents it as
+"tools Claude can use **without asking permission** during the turn that invokes this
+skill"; the field that removes a tool from the pool is `disallowed-tools`, which no skill
+here declares. anthropics/claude-code#37683 — that `allowed-tools` does not restrict — is
+closed as not planned. So deriving a deny list as its complement inverts the field's
+meaning; that is a harness construct and never a fidelity measure.
+
+**The boundary, so this is not over-applied:** emulate production's *permission model*;
+construct the test's *inputs* freely. A deny that hides the answer from the agent — e2e's
+`is_blocked_tree_tool`, a fixture's `blocked_tools` — is a fixture and stays. A deny that
+changes what the agent is *allowed to do* is a distortion and goes. Denies production
+genuinely has stay too: the protected-file write lockdown mirrors the shipped plugin hook,
+and agent `disallowedTools:` binds even under `bypassPermissions`.
+
 ### Python file I/O: always pass `encoding="utf-8"`
 
 Every Python `read_text()` / `write_text()` / `open()` on a text file

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -166,7 +166,11 @@ same PR that defers it.** Ask Claude to do it; it is one command and needs no
 board access:
 
 ```sh
-gh issue create --label developer --title "…" --body "…"
+gh issue create --label developer|genealogist [--label icebox] \
+  [--label nothing-checks] \
+  --title "…" --body "**Touches:** path/one.ts, path/two.py
+
+…"
 ```
 
 - **Pick the label by who does the work.** `developer` for anything with a
@@ -176,6 +180,11 @@ gh issue create --label developer --title "…" --body "…"
 - **Add `--label icebox` when it's a maybe** — a candidate with no decision
   behind it. Triage skips those rather than re-ranking them every morning.
   If you'd actually do it given a free afternoon, it isn't icebox.
+- **Add `--label nothing-checks` when the item *is* a missing guard** — a way CI
+  can be green while the thing is broken. That label is the register
+  `docs/architecture.md` keeps under "What nothing checks", and it is read by
+  label, never by searching the text: titles name the mechanism, not the shape,
+  so an unlabelled gap is invisible to everyone who goes looking there.
 - **Creating the issue is all you do — the board takes care of itself.** A CI
   workflow (`add-to-project.yml`) adds the card to Backlog the moment the issue
   opens — the one exception is the `feedback` label, which routes to Ready — and
@@ -239,9 +248,10 @@ entry leaves when it becomes an issue" — never fired on its own. It reached 93
 lines and then 54 unassignable items touched by 54 separate PRs, and became a
 merge-conflict hotspot across concurrent worktrees.
 
-This section is the owner of these rules. [`CLAUDE.md`](./CLAUDE.md) keeps only
-the two whose failure is silent (never write to the board yourself; never start
-a queue file), and points here for the rest.
+This section is the owner of these rules. [`CLAUDE.md`](./CLAUDE.md) keeps the
+four-step order, the exemptions that let you reach step 4, and the three rules
+whose failure is silent — never write to the board yourself, never start a queue
+file, and label a missing guard `nothing-checks`. It points here for the rest.
 
 ## How to test a new tool end-to-end
 

--- a/eval/harness/harness/allowed_tools.py
+++ b/eval/harness/harness/allowed_tools.py
@@ -22,6 +22,18 @@ the session *has*. The harness narrows for real to keep tests honest about
 that declaration — which is why a gap here shows up as a test-only failure
 with no product symptom, and why the fix is measured against production
 rather than against what feels safe (issue #1012).
+
+**And `allowed-tools` is a GRANT, not a restriction.** Claude Code documents
+it as "tools Claude can use without asking permission during the turn that
+invokes this skill"; the field that removes a tool from the pool is
+`disallowed-tools`, which no skill in this repo declares. Omission denies
+nothing anywhere. anthropics/claude-code#37683 -- that `allowed-tools` does
+not restrict tool access -- is closed as not planned. So deriving a deny list
+as this list's complement does not merely narrow more than production: it
+inverts the field's meaning. Retiring that narrowing is issue #1748; see
+CLAUDE.md, "The eval harness emulates production's permission model", for the
+boundary (a deny that hides the answer is a fixture and stays; a deny that
+changes what the agent may do is a distortion and goes).
 """
 
 from __future__ import annotations

--- a/packages/engine/mcp-server/tests/packaging/measured-figures.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/measured-figures.test.ts
@@ -408,7 +408,11 @@ describe("measured figures stay traceable to the probe artifact", () => {
           `  ${rule.verdict} = ${recorded.slice(0, 120)}\n` +
           `  ${rule.why}\n` +
           `  Update the prose, or re-run the section if the behaviour changed.\n` +
-          `  Do NOT relax the pattern to make this pass.`
+          `  Do NOT relax the pattern to make this pass, and do NOT reword around\n` +
+          `  it. When a recorded measurement disagrees with what you believe is true,\n` +
+          `  re-probe until the two agree (CLAUDE.md, "A measurement that disagrees\n` +
+          `  with belief is re-measured, not reworded"). A verdict stuck at OPEN or\n` +
+          `  NOT MEASURED is a measurement-design task, not a re-run.`
       ).toEqual([]);
     });
   }

--- a/packages/engine/mcp-server/tests/packaging/prompt-budget.test.ts
+++ b/packages/engine/mcp-server/tests/packaging/prompt-budget.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect } from "vitest";
 import { execFileSync } from "node:child_process";
 
 // Prompt-budget lint (warn-only). Reports the byte-size delta a PR introduces
-// to every SKILL.md and plugin-agent body, so reviewers see growth at review
-// time — which today nothing surfaces. The unit suite cannot be the gate: it
+// to every SKILL.md, plugin-agent body, and CLAUDE.md — the three prose files
+// billed on every run of the thing that loads them — so reviewers see growth at
+// review time, which today nothing surfaces. The unit suite cannot be the gate: it
 // grades a single invocation in fresh context and blesses an addition as
 // readily as a cut.
 //
@@ -19,9 +20,17 @@ import { execFileSync } from "node:child_process";
 
 const SKILLS_PATH = "packages/engine/plugin/skills";
 const AGENTS_PATH = "packages/engine/plugin/agents";
+// Loaded into every Claude Code session in this repo, and tracked by nothing
+// else. The plugin artifacts above are billed per skill run; this is billed per
+// session, which is why it belongs on the same report.
+const ROOT_PROMPT_PATH = "CLAUDE.md";
 
-/** The two prompt shapes: `skills/<name>/SKILL.md` and `agents/<name>.md`. */
-const TRACKED = /(^|\/)(skills\/[^/]+\/SKILL\.md|agents\/[^/]+\.md)$/;
+/**
+ * The three prompt shapes: `skills/<name>/SKILL.md`, `agents/<name>.md`, and
+ * the repo-root `CLAUDE.md`. The last is anchored so a nested `CLAUDE.md`
+ * (e.g. `eval/CLAUDE.md`, which no session loads wholesale) stays out.
+ */
+const TRACKED = /(^|\/)(skills\/[^/]+\/SKILL\.md|agents\/[^/]+\.md)$|^CLAUDE\.md$/;
 
 // ---------------------------------------------------------------------------
 // Reading sizes out of git
@@ -55,6 +64,7 @@ function lsTree(ref: string): string | null {
         "--",
         SKILLS_PATH,
         AGENTS_PATH,
+        ROOT_PROMPT_PATH,
       ],
       { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
     );
@@ -65,7 +75,7 @@ function lsTree(ref: string): string | null {
 
 /**
  * Parse `git ls-tree -r --long` output into path → byte size, keeping only the
- * two tracked prompt shapes.
+ * three tracked prompt shapes.
  *
  * Row format is `<mode> <type> <sha> <size>\t<path>`, size right-aligned in a
  * fixed-width column, so split the metadata on whitespace and the path on the
@@ -277,8 +287,11 @@ describe("prompt-budget (unit)", () => {
     const out = [
       "100644 blob 4d91252be27df1674ba0815e954117da915916eb   48539\tpackages/engine/plugin/agents/record-extractor.md",
       "100644 blob 8959947c6234ff492c5d5c1c42307c2dc241407a   17747\tpackages/engine/plugin/skills/check-warnings/SKILL.md",
-      // Not a tracked prompt shape — a skill's template, and a tree entry.
+      "100644 blob 2222222222222222222222222222222222222222   30000\tCLAUDE.md",
+      // Not a tracked prompt shape — a skill's template, a nested CLAUDE.md no
+      // session loads wholesale, and a tree entry.
       "100644 blob 0000000000000000000000000000000000000000     120\tpackages/engine/plugin/skills/check-warnings/templates/report.md",
+      "100644 blob 3333333333333333333333333333333333333333    4000\teval/CLAUDE.md",
       "040000 tree 1111111111111111111111111111111111111111       -\tpackages/engine/plugin/skills/check-warnings",
     ].join("\n");
 
@@ -286,6 +299,7 @@ describe("prompt-budget (unit)", () => {
       new Map([
         ["packages/engine/plugin/agents/record-extractor.md", 48539],
         ["packages/engine/plugin/skills/check-warnings/SKILL.md", 17747],
+        ["CLAUDE.md", 30000],
       ]),
     );
   });


### PR DESCRIPTION
Two rules were settled today and lived only in issue comments, where the next person would not find them. This puts each one in CLAUDE.md — which loads itself into every session — and a second copy at the point of use, for the person who is about to break it and is not reading anything.

## A measurement that disagrees with belief is re-measured, not reworded

When a recorded measurement says one thing and we believe another, probe again until the two agree. Do not reword prose until the guard goes green, and do not add a provenance escape hatch so a belief can be asserted alongside a verdict that contradicts it.

This binds hardest where a guard matches **wording** rather than meaning, because rewording is always available and always wrong. The enforcement copy goes in `measured-figures.test.ts`'s failure message, next to the two "Do NOT" lines already there.

## The eval harness emulates production's permission model

Both production paths hold every MCP tool the server advertises — the hosted control plane runs `bypassPermissions` with no allowlist, and Cowork loads the plugin whole.

The sharper finding, which corrects what the repo currently believes: **a skill's `allowed-tools` is a grant, not a restriction.** Claude Code documents it as "tools Claude can use without asking permission during the turn that invokes this skill". The field that removes a tool from the pool is `disallowed-tools`, which no skill here declares, and anthropics/claude-code#37683 — that `allowed-tools` does not restrict tool access — is closed as not planned.

So deriving a deny list as the complement of a grant list does not merely narrow more than production. It inverts the field's meaning. That is a stronger reason to retire the unit harness's narrowing than parity, and it is now recorded in `allowed_tools.py`'s own docstring.

The boundary is stated so this is not over-applied: emulate production's permission model, construct the test's inputs freely. A deny that hides the answer from the agent — the e2e tree-read block, a fixture's blocked tools — is a fixture and stays. A deny that changes what the agent may do is a distortion and goes. Denies production genuinely has stay too: the protected-file write lockdown mirrors the shipped plugin hook, and agent `disallowedTools:` binds even under `bypassPermissions`.

## Verification

The new failure text was proven to render by planting a violating line in `record-search-tool-spec-v2.md`, watching the rule fail, and reverting the plant.

- `npx vitest run tests/packaging/` — 489 passed
- `make harness-test` — 2356 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)