### PR TITLE
review-ready: gate both pools, and count the premise before believing it

### DIFF
--- a/.claude/agents/task-reviewer.md
+++ b/.claude/agents/task-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: task-reviewer
-description: Use to review ONE cowork-genealogy issue before it is handed to a junior developer working with Claude Code. Trigger phrases include "review issue #N before we assign it", "is #N ready for a junior", "vet this task", "is #N still a good idea", "check #N against the architecture guide". Reads the issue body, the code and specs it cites, the matching docs/architecture.md "If you're asked to…" block and ADRs, and open PRs touching the same files — then returns one verdict (ready / ready-after-edit / needs-a-decision / senior / stale-rewrite / close) with the exact replacement text for the issue body and any question the lead must answer. Read-only — never edits an issue, a label, the board, a doc, or any code; the caller applies what the lead approves.
+description: Use to review ONE cowork-genealogy issue before it is handed to a junior developer working with Claude Code. Trigger phrases include "review issue #N before we assign it", "is #N ready for a junior", "vet this task", "is #N still a good idea", "check #N against the architecture guide". Reads the issue body, the code and specs it cites, the matching docs/architecture.md "If you're asked to…" block and ADRs, and open PRs touching the same files — and counts the population the issue's premise rests on, since zero instances is a close — then returns one verdict (ready / ready-after-edit / needs-a-decision / senior / stale-rewrite / close) with the exact replacement text for the issue body and any question the lead must answer. Read-only — never edits an issue, a label, the board, a doc, or any code; the caller applies what the lead approves.
 tools: Read, Grep, Glob, Bash
 ---
 
@@ -63,6 +63,19 @@ Rationale, contracts and rejected alternatives: `docs/specs/task-review-spec.md`
 4. **Numbers still hold.** Re-run any measurement the body quotes (`du -sh`, a
    count, a grep). A figure that has moved changes the priority, not just the
    number.
+5. **The premise has instances — count them, even when the body gives no count.**
+   When an issue's value rests on a population ("N files drifted", "users hit
+   this", "the shape is in the field"), re-derive the number. An **uncited**
+   population is not a small gap: it is the claim the whole issue rests on, never
+   measured. **Zero instances is a `close` verdict** however good the reasoning
+   reads — report the count and the command that produced it, not the conclusion
+   alone.
+
+   Count the way the data is shaped, not the way it greps. A bare `grep` for a
+   field name matches that name in valid positions too: asked to heal six
+   "drifted" `research.json` keys, a grep reported 50–70 files carrying them and a
+   structured walk of the objects that would actually hold them reported **0 of
+   90**. The grep was counting correct data.
 
 ## Pass B — can a junior execute it?
 

--- a/.claude/skills/fill-ready/SKILL.md
+++ b/.claude/skills/fill-ready/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fill-ready
-description: Use when the lead wants the day's work chosen off the cowork-genealogy kanban board — "what should the team work on today", "fill the Ready column", "review the backlog", "groom the board", "what should I take on", or a bare "/fill-ready". The follow-on to triage-standup, which files new issues into Backlog; this skill decides which of them the team starts. Ranks the Backlog against the two committed milestones and holds Ready at two standing depths — ~10 unassigned developer tasks and ~10 unassigned genealogist tasks — promoting only what is unblocked and swapping a lower-ranked item back when a pool is at target. Routes by seniority before priority: every developer takes from the junior pool, and the lead takes no issues at all. Work above the junior pools splits three ways and the split decides who can start — `needs-decision` (one answer from the lead unblocks it, and the work behind it is often junior), `senior` (hard regardless, assigned to a senior in the developer or genealogist lane), and logistics (unlabelled, anyone once cleared). The one thing that arrives pre-assigned is a `cross-cutting` item, which the lead hands to a named person and which counts toward no pool target. Holds each skill's eval slot to one item at a time, since two changes to one skill's snapshot cannot share a paid run. Gates every developer issue it moves through review-ready before promoting. Labels, splits, and grooms; verifies claims against the repo first. Proposes, then applies only what the lead approves; never starts the work.
+description: Use when the lead wants the day's work chosen off the cowork-genealogy kanban board — "what should the team work on today", "fill the Ready column", "review the backlog", "groom the board", "what should I take on", or a bare "/fill-ready". The follow-on to triage-standup, which files new issues into Backlog; this skill decides which of them the team starts. Ranks the Backlog against the two committed milestones and holds Ready at two standing depths — ~10 unassigned developer tasks and ~10 unassigned genealogist tasks — promoting only what is unblocked and swapping a lower-ranked item back when a pool is at target. Routes by seniority before priority: every developer takes from the junior pool, and the lead takes no issues at all. Work above the junior pools splits three ways and the split decides who can start — `needs-decision` (one answer from the lead unblocks it, and the work behind it is often junior), `senior` (hard regardless, assigned to a senior in the developer or genealogist lane), and logistics (unlabelled, anyone once cleared). The one thing that arrives pre-assigned is a `cross-cutting` item, which the lead hands to a named person and which counts toward no pool target. Holds each skill's eval slot to one item at a time, since two changes to one skill's snapshot cannot share a paid run. Gates every issue it moves through review-ready before promoting — both pools. Labels, splits, and grooms; verifies claims against the repo first. Proposes, then applies only what the lead approves; never starts the work.
 allowed-tools:
   - Read
   - Bash
@@ -676,12 +676,25 @@ auto-add workflow that sets nothing else — a freshly filed issue that belongs 
 Ready still needs this move. (The exception is a `feedback` item, which the same
 workflow files directly into Ready and which you never move at all.)
 
-**Gate every `developer` issue you are moving into Ready through `/review-ready`
-before you promote it — not just the ones you rank as junior.** Your seniority
-test (§1) is a pre-filter read off the issue body; that skill fans out one agent
-per item to check the same call against the cited code, the architecture guide's
-site list, and the board's what-nothing-checks issues — which is where a
-"junior-safe" item turns out to hide an open API decision.
+**Gate every issue you are moving into Ready through `/review-ready` before you
+promote it — both pools, not just `developer`, and not just the ones you rank as
+junior.** Your seniority test (§1) is a pre-filter read off the issue body; that
+skill fans out one agent per item to check the same call against the cited code,
+the architecture guide's site list, and the board's what-nothing-checks issues —
+which is where a "junior-safe" item turns out to hide an open API decision, or a
+body's central claim turns out to have no instances behind it.
+
+**The genealogist half was ungated until 2026-08-19, and that was wrong.** A
+stale premise is not a developer-shaped defect, and the genealogist half is the
+more expensive one to get wrong: a bad developer premise reds a test, a bad
+genealogist premise surfaces inside a paid `make eval-skill` run or not at all.
+The reversal and what refuted the old scope are in
+`docs/specs/task-review-spec.md` §6 — do not re-argue it here.
+
+**Budget for it.** The gate costs ~110k tokens per issue, so a full fill of both
+pools is roughly 2M. That is cheap against a junior's wasted week and it is not
+free; if the genealogist half was gated earlier in the week, `--developer-only`
+is the escape.
 
 **"Every" means every one you move, including a `senior`-labeled item.** A senior
 item's body is stale in exactly the ways a junior item's is, and it is the more
@@ -874,6 +887,26 @@ du -sh <path>                                            # do the cited measurem
 git log --oneline -5 -- <cited path>                     # did someone already fix it?
 git log --diff-filter=D --all -- '<cited path>'          # was it deliberately deleted?
 ```
+
+**An uncited count is not a small gap — produce one.** When an issue's value
+rests on a population ("N files drifted", "users hit this", "the shape is in the
+field") and the body names no number, measure it *before* proposing any
+disposition. That is the shape which survives every other check: it reads as a
+real problem, its reasoning is sound, and there is nothing behind it. One request
+wanted a six-way genealogical adjudication to heal drifted `research.json` keys;
+the drift appears in **0 of 90** committed documents and no write path can create
+it. It closed `not planned` in one command.
+
+**Count the way the data is shaped, not the way it greps.** On that same request a
+bare `grep` for the six key names returned 50–70 files — `person_id` is a correct
+key on `person_evidence[]`, `record_id` is correct on assertions, `notes` is
+correct on sources. The grep was counting valid data. Walk the objects that would
+actually hold the field.
+
+Do not repeat this for the shortlist you are about to gate — `/review-ready`'s
+agents now count the premise per issue in fresh context (`docs/specs/task-review-spec.md`
+§7). Spend it here on what the gate never sees: the items you are about to close,
+consolidate, split, or route to the lead.
 
 **Read the mechanism the issue proposes to build, before agreeing it needs
 building.** A near-miss extension of something that exists is a different,

--- a/.claude/skills/review-ready/SKILL.md
+++ b/.claude/skills/review-ready/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-ready
-description: Use when the lead wants tasks vetted before juniors start them — "vet these before I hand them out", "are these tasks still a good idea", "is this safe for a junior", "review the fill-ready shortlist", "check the junior queue", or a bare "/review-ready". The gate between fill-ready (which ranks and promotes) and standup (which hands work out). Fans out one read-only task-reviewer agent per candidate issue, in parallel, each in fresh context — every agent reads the issue's cited code, the matching docs/architecture.md "If you're asked to…" block, the board's what-nothing-checks issues, and the relevant ADRs, then returns a verdict, the exact body text to add, and any decision only the lead can make. Collates the verdicts, puts the strategic questions to the lead, and applies only what he approves. Do NOT use to choose what the team works on, to rank the Backlog, or to move anything on the board — that is fill-ready, which calls this skill on its shortlist. Never starts the work.
+description: Use when the lead wants tasks vetted before juniors start them — "vet these before I hand them out", "are these tasks still a good idea", "is this safe for a junior", "review the fill-ready shortlist", "check the junior queue", or a bare "/review-ready". The gate between fill-ready (which ranks and promotes) and standup (which hands work out); covers both unassigned pools, developer and genealogist, with `--developer-only` to narrow it. Fans out one read-only task-reviewer agent per candidate issue, in parallel, each in fresh context — every agent reads the issue's cited code, the matching docs/architecture.md "If you're asked to…" block, the board's what-nothing-checks issues, and the relevant ADRs, then returns a verdict, the exact body text to add, and any decision only the lead can make. Collates the verdicts, puts the strategic questions to the lead, and applies only what he approves. Do NOT use to choose what the team works on, to rank the Backlog, or to move anything on the board — that is fill-ready, which calls this skill on its shortlist. Never starts the work.
 allowed-tools:
   - Agent
   - AskUserQuestion
@@ -44,13 +44,28 @@ Other entry points:
 
 - **Issue numbers as arguments** (`/review-ready 945 1031 1094`) — review exactly
   those, in any column. This is also how a re-review is asked for.
-- **Bare `/review-ready`** — the standing pool: unassigned `developer`-labeled
-  items in Ready. A first run, or a run after a gap.
-- **`--all`** — also include unassigned `genealogist` items, **except those
-  labelled `feedback`**, which are user bug reports rather than vetted tasks and
-  have nothing to review. Off by default because the three passes are
-  developer-shaped; the reason and what would change it are in the spec, §6. Say
-  so if asked rather than re-arguing it.
+- **Bare `/review-ready`** — the standing pool: unassigned items in Ready, **both
+  pools**, `developer` and `genealogist`. A first run, or a run after a gap.
+- **`--developer-only`** — the old default, kept for a cheap pass when you know
+  the genealogist half was gated this week. Halves the token cost and halves the
+  coverage.
+
+**`feedback`-labeled items are never in scope**, in any mode. They carry
+`genealogist`, so they would otherwise land in the fan-out, but they are user bug
+reports filed automatically — the body is a Drive link, and every question the
+three passes ask is answered by working the case, not by reading the issue.
+Reviewing one costs ~110k tokens to learn nothing. Their triage is
+`docs/alpha-feedback-guide.md`.
+
+**Why both pools, since this was developer-only until 2026-08-19.** A stale
+premise is not a developer-shaped defect. The run that changed it gated six
+developer issues and zero genealogist ones, and four of the six came back
+not-pickable — two carrying checks that would have shipped green and inert. The
+genealogist half went to Ready on one reader's judgment. And a bad genealogist
+premise is the more expensive one to discover: it surfaces in a paid
+`make eval-skill` run, not in CI. The cost is real — roughly double, ~110k tokens
+per issue — and is the point of the `--developer-only` escape, not a reason to
+default to it.
 
 ### Review on entry, not daily
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -783,9 +783,10 @@ explicitly with the Agent tool.
 - **`skill-improver`** — report-only. Proposes evidence-cited `SKILL.md` edits
   from a skill's latest annotated run log. `/improve-skill <skill>`.
 - **`task-reviewer`** — read-only. Vets one Backlog/Ready issue before it is
-  handed to a junior developer working with Claude Code: staleness, whether the
-  premise was already refuted, the blast radius the issue omits, what verifies
-  the change, and which decisions are the lead's. Fanned out one-per-issue by
+  handed to a junior working with Claude Code: staleness, whether the premise
+  was already refuted, whether the population it rests on has any instances at
+  all, the blast radius the issue omits, what verifies the change, and which
+  decisions are the lead's. Fanned out one-per-issue by
   the `review-ready` skill; never edits an issue, the board, or any code.
   Spec: `docs/specs/task-review-spec.md`.
 

--- a/docs/specs/task-review-spec.md
+++ b/docs/specs/task-review-spec.md
@@ -141,28 +141,67 @@ reader, not state for a machine.
 
 Re-review is explicit: `/review-ready <N>`.
 
-## 6. Scope: the developer pool
+## 6. Scope: both unassigned pools
 
-The default candidate set is **unassigned `developer`-labeled items**. The
-genealogist pool is opt-in (`--all`) and that is a scope judgment, not a priority
-one: the three passes are developer-shaped — blast radius from
+The candidate set is **every unassigned item in Ready** — `developer` and
+`genealogist` alike. `--developer-only` narrows it to the old default.
+
+This reversed on 2026-08-19. The prior scope was developer-only, on the argument
+that the three passes are developer-shaped: blast radius from
 `docs/architecture.md`'s "If you're asked to…" block, the command that verifies
-the change, §9.4 exposure. Pointed at a `test <slug>` fixture adjudication they
-mostly return "checked, clean" at full token cost.
+the change, the what-nothing-checks exposure. That argument was half right and
+the wrong half was load-bearing.
 
-Gating that pool needs a different and much shorter agent — does the hint record
-exist, is the ark resolvable, is anyone else on this fixture — not a wider
-fan-out of this one. That agent does not exist yet.
+**What refuted it.** The fill that day gated six developer issues and zero
+genealogist ones. Four of the six came back not-pickable, and two of those
+carried checks that would have shipped **green and inert** — one validator that
+passed on the very run it was written from, one that fired on runs which had done
+real work. Meanwhile six genealogist items went to Ready on a single reader's
+judgment with no independent read at all. Nothing about either failure was
+developer-shaped: both were *a claim in a body that nobody had checked against
+the artifact*.
 
-**`feedback`-labeled items are out of scope even under `--all`.** They carry
-`genealogist`, so they would otherwise land in that fan-out, but they are user
-bug reports filed automatically by the feedback endpoint — the body is a Drive
-link and a `make feedback-case` command, and every question this agent asks
+**And the genealogist half is the more expensive one to get wrong.** A bad
+developer premise surfaces when a test goes red. A bad genealogist premise
+surfaces inside a paid `make eval-skill` run — $8–12, 45–65 minutes, plus a
+genealogist's annotation pass — or not at all.
+
+**The cost is real and is not disputed:** roughly double a fill's review spend,
+~110k tokens per issue. That is what `--developer-only` is for. It is an escape
+for a week when the genealogist half was gated already, not a default.
+
+**A fixture-adjudication item will still often return "checked, clean" at full
+cost.** That is accepted. The alternative — a second, shorter agent shaped for
+fixture work (does the hint record exist, is the ark resolvable, is anyone else on
+this fixture) — remains unbuilt and is still the better long-run answer; it is
+listed in §8.
+
+**`feedback`-labeled items are out of scope in every mode.** They carry
+`genealogist`, so they would otherwise land in the fan-out, but they are user bug
+reports filed automatically by the feedback endpoint — the body is a Drive link
+and a `make feedback-case` command, and every question this agent asks
 (staleness, refuted premise, blast radius, what verifies it) is answered by
 working the case, not by reading the issue. Reviewing one costs ~110k tokens to
 learn nothing. The triage they do need is `docs/alpha-feedback-guide.md`.
 
 ## 7. Measurements
+
+**Counting the premise is part of the review, not a courtesy.** When an issue's
+value rests on a population, the agent re-derives the number — *including when the
+body cites none*. An uncited population is the claim the issue rests on, never
+measured, and it is the shape that survives every other check: it reads as a real
+problem, its reasoning is sound, and there is nothing to fix.
+
+Zero instances is a `close`. The count and the command that produced it go in the
+report, so the disposition can be re-checked in seconds rather than re-derived.
+
+**Count the way the data is shaped, not the way it greps.** A request to heal six
+drifted `research.json` keys survived every other check until someone counted. A
+bare `grep` for those key names returned 50–70 files; a structured walk of the
+objects that would actually carry them returned **0 of 90**, because `person_id`
+is a correct key on `person_evidence[]`, `record_id` is correct on assertions, and
+`notes` is correct on sources. The grep was counting valid data, and the request
+closed `not planned`.
 
 From the first run, 2026-08-02, over the unassigned `developer` pool:
 
@@ -215,7 +254,19 @@ line in the staleness check:
   no-op). Both are right for their case; the repo has no rule that decides it.
 - **One agent for the whole batch.** Rejected: cheaper, and it is exactly the
   contamination the fresh-context rule exists to stop.
-- **Extending the fan-out to the genealogist pool.** Rejected for now — see §6.
+- **Extending the fan-out to the genealogist pool.** Rejected until 2026-08-19,
+  then **adopted** — see §6 for what refuted it. The narrower agent shaped for
+  fixture adjudication is still unbuilt and is still the better long-run answer
+  for that half of the pool.
+- **Letting the lead's questions catch a hollow premise instead.** Rejected: a
+  question is answered inside the frame it was asked in. On 2026-08-19 the lead
+  ruled cleanly on a stale spec paragraph, and the agent then found the ruling was
+  incomplete — the spec asserted the same false claim in three places, not the one
+  the question named. Asking about every promotion also drowns the forks that matter:
+  eleven promotions that day, seven forks worth his time.
+- **A `premise-empty` verdict.** Rejected: `close` already covers it. What was
+  missing was not a verdict but the *obligation to count*, which now sits in
+  Pass A.
 
 ## 9. What nothing checks
 


### PR DESCRIPTION
Two gaps the 2026-08-19 fill exposed, fixed in the same pass.

## The genealogist pool was never gated

That fill ran `/review-ready` over six developer issues and zero genealogist ones. **Four of the six came back not pickable** — one needed a senior, three needed a decision — and two of those carried checks that would have shipped green and inert: one validator that passed on the very run it was written from, another that fired on runs which had done real work.

Meanwhile six genealogist items went to Ready on one reader's judgment with no independent read at all.

Neither failure was developer-shaped. Both were the same thing: a claim in a body that nobody had checked against the artifact. And the genealogist half is the more expensive one to get wrong, because a bad premise there surfaces inside a paid `make eval-skill` run — or not at all — rather than when a test goes red.

**So the default is both unassigned pools**, with `--developer-only` as the escape for a week when the genealogist half was gated already. `feedback` items stay out of scope in every mode, unchanged.

The cost is real and is now stated in the skill rather than discovered: roughly double a fill's review spend, ~110k tokens per issue.

## Nothing counted the population a premise rests on

One request wanted a six-way genealogical adjudication to heal drifted `research.json` keys. The drift appears in **0 of 90** committed documents, and no write path can create it. Only a hand count caught that, and only because the item happened to carry a label that made someone stop and look.

- **`task-reviewer`'s Pass A** now re-derives that number *even when the body cites none*. An uncited population is the claim the issue rests on, never measured. Zero instances is a `close`, reported with the command that produced it.
- **`fill-ready`'s verify step** says the same for the items it disposes of directly — the closes, consolidations and splits the gate never sees.

Both carry the same trap: **count the way the data is shaped, not the way it greps.** On that request a bare grep returned 50–70 files, because `person_id` is a correct key on `person_evidence[]`, `record_id` is correct on assertions, and `notes` is correct on sources. The grep was counting valid data.

## Spec

`task-review-spec.md`'s scope section is rewritten from the developer pool to both pools, with what refuted the old scope kept rather than erased. Its alternatives list gains three rows: the reversal itself, why asking the lead about every promotion was rejected (a question is answered inside the frame it was asked in — that same day a clean ruling turned out to name one of three sites), and why no new `premise-empty` verdict was needed (`close` already covers it; what was missing was the obligation to count).

## Note

The `doc-links` issue-reference ratchet failed the first draft of this — "state the fact, not the ticket" — and was right to. The facts are stated without ticket numbers rather than the baseline being raised.

- `npx vitest run tests/packaging/` — 489 passed
- `make harness-test` — 2356 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)