### PR TITLE
eval: catch e2e annotation content-drift via findings_hash (#1719)

### DIFF
--- a/.claude/skills/grade-e2e-run/SKILL.md
+++ b/.claude/skills/grade-e2e-run/SKILL.md
@@ -95,22 +95,35 @@ Write `eval/runlogs/e2e/<slug>/run-<ts>.ann.json` with **only** these keys:
 | `notes` | no | `{ "<finding_id>": "text" }` — keys ⊆ `per_finding` keys |
 | `annotator` | no | the grader's team identifier (git blame is the fallback if omitted) |
 
-Do **not** add any other key. The loader hard-errors on unknown keys — in
-particular do **not** write `llm_score`, `corrected_score`, or `verdict`. Those are
-the *unit*-annotation shape and the derived verdict; neither belongs in an e2e
-annotation.
+Hand-write **only** these keys. The one other allowed key, `findings_hash`, is
+added by the stamp command in step 7 — do **not** write it by hand. The loader
+hard-errors on any *other* unknown key — in particular do **not** write
+`llm_score`, `corrected_score`, or `verdict`. Those are the *unit*-annotation
+shape and the derived verdict; neither belongs in an e2e annotation.
 
-### 7 — Self-check, then hand off for commit
+### 7 — Self-check, stamp, then hand off for commit
 
-Verify the file you just wrote — you have every input to do this without any tool:
+First verify the file you just wrote — you have every input to do this without any tool:
 
-- keys are exactly `per_finding` (+ optional `proof_quality_score` / `notes` /
-  `annotator`), nothing else;
+- the hand-written keys are exactly `per_finding` (+ optional `proof_quality_score` /
+  `notes` / `annotator`) — nothing else *yet* (`findings_hash` is added by the stamp
+  command below, not by hand);
 - every `per_finding` value is `true` / `partial` / `false` — no nulls (a blank
   label means that finding isn't graded yet; ask the genealogist before writing);
 - `per_finding` keys equal the fixture's finding ids (you copied them from
   `expected-findings.json`, so this holds by construction — confirm it);
 - any `notes` key is one of those finding ids.
+
+Then stamp the fixture fingerprint into the annotation:
+
+```
+cd eval/harness && uv run python -m e2e.stamp_findings_hash eval/runlogs/e2e/<slug>/run-<ts>.ann.json
+```
+
+This adds the `findings_hash` key so a later edit to `expected-findings.json`
+cannot silently invalidate this grade. It is **not** `calibrate_judge`, makes no
+judge API calls, and is **exempt** from the "do not run `calibrate_judge`" rule
+below — run it every time.
 
 Then tell the user to commit the `.ann.json`. **Do not run `calibrate_judge` — not
 even `--dry-run`.** It classifies *every* annotation in the tree, not just this one.
@@ -122,9 +135,10 @@ periodically — documented in `docs/e2e-testing-guide.md` under "Step 8 — Gra
 
 - **Never open `run-<ts>.json`** or otherwise surface the judge's grades. Grading is
   blind; revealing the judge's labels defeats the calibration.
-- Do not run `calibrate_judge` at all — not even `--dry-run`. Self-validate the one
-  file you wrote; whole-set classification and the calibration sweep are the
-  maintainer's job, per the guide.
+- Do not run `calibrate_judge` at all — not even `--dry-run`. (The
+  `stamp_findings_hash` command in step 7 is a *different* tool — run it; it is not
+  `calibrate_judge`.) Self-validate the one file you wrote; whole-set classification
+  and the calibration sweep are the maintainer's job, per the guide.
 - Do not derive or write a `verdict` — the loader derives it from `per_finding`.
 - Do not edit fixtures, skills, the judge prompt, the run log, or the tree.
 - Do not label findings yourself — surface the evidence; the genealogist decides.

--- a/.claude/skills/grade-e2e-run/SKILL.md
+++ b/.claude/skills/grade-e2e-run/SKILL.md
@@ -117,7 +117,7 @@ First verify the file you just wrote — you have every input to do this without
 Then stamp the fixture fingerprint into the annotation:
 
 ```
-cd eval/harness && uv run python -m e2e.stamp_findings_hash eval/runlogs/e2e/<slug>/run-<ts>.ann.json
+cd eval/harness && uv run python -m e2e.stamp_findings_hash ../runlogs/e2e/<slug>/run-<ts>.ann.json
 ```
 
 This adds the `findings_hash` key so a later edit to `expected-findings.json`

--- a/.claude/skills/grade-e2e-run/SKILL.md
+++ b/.claude/skills/grade-e2e-run/SKILL.md
@@ -117,7 +117,7 @@ First verify the file you just wrote — you have every input to do this without
 Then stamp the fixture fingerprint into the annotation:
 
 ```
-cd eval/harness && uv run python -m e2e.stamp_findings_hash ../runlogs/e2e/<slug>/run-<ts>.ann.json
+cd eval/harness && uv run python -m e2e.stamp_findings_hash eval/runlogs/e2e/<slug>/run-<ts>.ann.json
 ```
 
 This adds the `findings_hash` key so a later edit to `expected-findings.json`

--- a/docs/specs/e2e-test-spec.md
+++ b/docs/specs/e2e-test-spec.md
@@ -1162,9 +1162,14 @@ The presence of a *complete* annotation is the selection — there is no separat
 calibration-case directory. `calibrate_judge` discovers every
 `runlogs/e2e/**/run-*.ann.json`, re-runs the judge against each graded run, and
 reports **per-finding agreement (the ≥80% gate)**, proof-quality agreement
-(advisory), and a per-slug breakdown. A drifted annotation (its `per_finding` keys
-no longer match the fixture's finding ids — i.e. `expected-findings.json` was
-edited after grading) is a hard error: re-grade or delete it. A grade whose
+(advisory), and a per-slug breakdown. A drifted annotation is a hard error:
+re-grade or delete it. Drift takes two forms, both caught. **Id/key drift** — its
+`per_finding` keys no longer match the fixture's finding ids (a finding was added,
+removed, or renamed). **Content drift** — a finding body was amended while its id
+stayed the same, so the keys still match but the labels were produced against a
+requirement that no longer exists; this is caught by a `findings_hash` stamped
+into the annotation at grade time and re-checked by the loader, which hard-errors
+on mismatch with the same remedy. A grade whose
 **fixture was retired** is the same hard error with the same
 remedy: delete the `.ann.json`. Do not re-slug it onto a successor fixture — a
 split changes the researcher question and the starting tree, so the run was
@@ -1176,6 +1181,29 @@ gradeable runs — pass/partial/fail — are committed; §8), enforced by the bl
 grading gate (§14). Contributors run only `/grade-e2e-run`; the **maintainer**
 runs `uv run python -m e2e.calibrate_judge` periodically (`--dry-run` lints
 without API calls) — contributors never do.
+
+**Why `findings_hash` covers the whole file, normalized.** The stamp is a sha256
+over the entire `expected-findings.json`, normalized (parsed then re-emitted with
+sorted keys and stable formatting before hashing), so a reformat or key reorder
+does not fire but any content edit does. It is computed by one shared function
+that both the grader's stamp step and the loader call, so the two cannot disagree
+on whitespace or non-ASCII encoding — a corpus full of em-dashes and accented
+names would otherwise make every fresh stamp fail the check it exists to satisfy.
+Two narrower designs were rejected. Hashing only the graded fields (id, type,
+description, details, required, polarity — excluding `supporting_sources`) was
+rejected because the judge is handed the *entire* findings object, so an edit
+confined to `supporting_sources` changes the question it answers, and the narrower
+rule would leave that silent — the same invalidation this check exists to close. A
+per-finding digest map was rejected as worth only a handful more usable labels
+across the committed corpus, at a larger annotation.
+
+Annotations graded before the check carry no `findings_hash`. They are
+**grandfathered** — included and graded, but reported as unverifiable rather than
+errored, and never stamped retroactively (a retroactive stamp would certify
+exactly the drift the check exists to catch). They age out as re-grades replace
+them, the same way the pre-blind-grading annotations above do. The accepted cost
+is that a citation-only fixture edit invalidates every grade for that slug; the
+remedy is always a re-grade or a delete, never a re-stamp.
 
 **Collecting grades before the judge is calibrated is the intended bootstrap.**
 You do not need a calibrated judge to start grading; the grades are what makes

--- a/docs/specs/e2e-test-spec.md
+++ b/docs/specs/e2e-test-spec.md
@@ -1103,6 +1103,7 @@ A human grade is a per-run annotation committed **beside the run log it grades**
 | `proof_quality_score` | no | Advisory axis: `1` / `2` / `3` / `null`. `null` or absent is still a *complete* grade. |
 | `notes` | no | Sparse `{finding_id: text}` map, surfaced on that finding's disagreement line. |
 | `annotator` | no | Provenance; git blame on the committed file is the fallback. |
+| `findings_hash` | no | sha256 of the normalized `expected-findings.json` this grade was produced against, so a later edit to a finding's body cannot silently invalidate the grade while its id stays put. Written by `/grade-e2e-run`'s stamp step, never by hand. Absent on annotations graded before the check — those are included and graded, but reported unverifiable. |
 
 There is **no `verdict` field** — the per-run verdict is derived from `per_finding`
 + the findings' `required` flags by the §7.2 rule.

--- a/docs/specs/e2e-test-spec.md
+++ b/docs/specs/e2e-test-spec.md
@@ -1184,8 +1184,10 @@ without API calls) — contributors never do.
 
 **Why `findings_hash` covers the whole file, normalized.** The stamp is a sha256
 over the entire `expected-findings.json`, normalized (parsed then re-emitted with
-sorted keys and stable formatting before hashing), so a reformat or key reorder
-does not fire but any content edit does. It is computed by one shared function
+sorted object keys and stable formatting before hashing), so a whitespace reformat
+or object-key reorder does not fire but any content edit does. Reordering the
+`findings` array counts as a change (array order is preserved) — an accepted cost
+of hashing the whole file, cleared by a re-grade. It is computed by one shared function
 that both the grader's stamp step and the loader call, so the two cannot disagree
 on whitespace or non-ASCII encoding — a corpus full of em-dashes and accented
 names would otherwise make every fresh stamp fail the check it exists to satisfy.

--- a/eval/harness/e2e/calibrate_judge.py
+++ b/eval/harness/e2e/calibrate_judge.py
@@ -61,6 +61,7 @@ from typing import Any
 from e2e import judge as judge_module
 from e2e.env import ENV_FILE, load_env_file
 from e2e.judge import derive_verdict  # shared with apply_avoid_guard; re-exported for our callers
+from e2e.provenance import findings_hash
 
 
 # NOTE: these mirror e2e.orchestrator's DEFAULT_RUNLOG_ROOT / DEFAULT_FIXTURES_ROOT
@@ -74,7 +75,7 @@ DEFAULT_FIXTURES_ROOT = REPO_ROOT / "eval" / "tests" / "e2e"
 PER_FINDING_TARGET = 0.80  # ~ human inter-rater agreement
 
 FINDING_LABELS = {"true", "partial", "false"}
-ALLOWED_ANN_KEYS = {"annotator", "per_finding", "proof_quality_score", "notes"}
+ALLOWED_ANN_KEYS = {"annotator", "per_finding", "proof_quality_score", "notes", "findings_hash"}
 
 
 # Verdict derivation lives in e2e.judge (`derive_verdict`, re-exported above) —
@@ -269,11 +270,14 @@ def load_annotated_runs(
         3. any per_finding value null            -> WARN + SKIP (incomplete; inert)
         4. fixture / expected-findings unreadable-> ERROR  (orphaned filled grade)
         5. <stem>.final-tree.gedcomx.json missing-> ERROR  (ungradeable filled grade)
-        6. per_finding keys != fixture ids       -> ERROR  (drift; re-grade or delete)
-        7. bad enum (label / proof_quality_score)-> ERROR
-        8. valid, keys match                     -> INCLUDE (derive verdict)
+        6. per_finding keys != fixture ids       -> ERROR  (id/key drift; re-grade or delete)
+        7. findings_hash present and mismatches  -> ERROR  (content drift; re-grade or delete)
+           findings_hash absent                  -> INCLUDE, flagged unverifiable (legacy; grandfathered)
+        8. bad enum (label / proof_quality_score)-> ERROR
+        9. valid, keys match                     -> INCLUDE (derive verdict)
 
-    Included cases are in the internal shape ``grade_case`` consumes.
+    Included cases are in the internal shape ``grade_case`` consumes, each with
+    ``findings_hash_present`` recording whether rung 7 could verify it.
     """
     cases: list[dict[str, Any]] = []
     problems: list[LoaderProblem] = []
@@ -343,7 +347,7 @@ def load_annotated_runs(
                 err(f"{research_path.name} unreadable ({e})")
                 continue
 
-        # 6. drift — keys must equal the fixture's finding ids
+        # 6. id/key drift — keys must equal the fixture's finding ids
         findings = expected.get("findings") or []
         fixture_ids = {str(f.get("id")) for f in findings}
         ann_ids = set(per_finding)
@@ -352,7 +356,22 @@ def load_annotated_runs(
                 f"{sorted(fixture_ids)} — fixture changed; re-grade or delete")
             continue
 
-        # 7. enums (filled values)
+        # 7. content drift — a stamped findings_hash must still match the
+        #    fixture's expected-findings.json. Catches an amended finding body
+        #    that kept its id, which rung 6 cannot see. An absent hash is a
+        #    legacy grade from before the check: include it but flag it
+        #    unverifiable — grandfathered, never stamped retroactively (that
+        #    would certify the very drift this catches). See issue #1719.
+        stored_hash = ann.get("findings_hash")
+        findings_hash_present = stored_hash is not None
+        if findings_hash_present:
+            current_hash = findings_hash(fixture_dir / "expected-findings.json")
+            if stored_hash != current_hash:
+                err("findings_hash mismatch — expected-findings.json changed "
+                    "since grading; re-grade or delete")
+                continue
+
+        # 8. enums (filled values)
         bad = {fid: v for fid, v in per_finding.items() if v not in FINDING_LABELS}
         if bad:
             err(f"per_finding labels {bad} not in {sorted(FINDING_LABELS)}")
@@ -371,7 +390,7 @@ def load_annotated_runs(
                 err(f"notes for unknown finding(s) {sorted(note_unknown)}")
                 continue
 
-        # 8. INCLUDE — assemble the internal case (verdict derived)
+        # 9. INCLUDE — assemble the internal case (verdict derived)
         human: dict[str, Any] = {
             "verdict": derive_verdict(per_finding, findings),
             "per_finding": per_finding,
@@ -397,6 +416,10 @@ def load_annotated_runs(
             "final_research": final_research,
             "subject_person_ids": sorted(subject_ids),
             "human": human,
+            # rung 7: True when a findings_hash was present and matched; False for
+            # a grandfathered legacy grade. Set on every include so main's count
+            # never KeyErrors.
+            "findings_hash_present": findings_hash_present,
         })
 
     return cases, problems
@@ -480,11 +503,23 @@ def main(argv: list[str] | None = None) -> int:
     cases, problems = load_annotated_runs(args.runlog_root, args.fixtures_root)
     warnings = [p for p in problems if p.severity == "warn"]
     errors = [p for p in problems if p.severity == "error"]
+    # Legacy grades from before the content-drift check (rung 7): included and
+    # graded, but their labels cannot be tied to the findings they were produced
+    # against. Counted separately — not a warn (those are excluded) — so the
+    # ready count is unaffected and the reader knows the coverage gap.
+    unverifiable = [c for c in cases if not c.get("findings_hash_present", True)]
 
     for w in warnings:
         print(f"WARN: {w.message}", file=sys.stderr)
     for e in errors:
         print(f"ERROR: {e.message}", file=sys.stderr)
+    if unverifiable:
+        print(
+            f"{len(unverifiable)} of {len(cases)} annotation(s) carry no "
+            "findings_hash — graded before the content-drift check, not "
+            "verifiable (grandfathered; re-grade to verify).",
+            file=sys.stderr,
+        )
 
     model = args.model or judge_module.DEFAULT_JUDGE_MODEL
 

--- a/eval/harness/e2e/calibrate_judge.py
+++ b/eval/harness/e2e/calibrate_judge.py
@@ -417,8 +417,10 @@ def load_annotated_runs(
             "subject_person_ids": sorted(subject_ids),
             "human": human,
             # rung 7: True when a findings_hash was present and matched; False for
-            # a grandfathered legacy grade. Set on every include so main's count
-            # never KeyErrors.
+            # a grandfathered legacy grade. Set on every include. main reads it
+            # with a False default — `.get` cannot KeyError at any default, so the
+            # default's only job is to pick a direction, and for a VERIFICATION
+            # flag the safe unknown is "not verified".
             "findings_hash_present": findings_hash_present,
         })
 
@@ -507,7 +509,7 @@ def main(argv: list[str] | None = None) -> int:
     # graded, but their labels cannot be tied to the findings they were produced
     # against. Counted separately — not a warn (those are excluded) — so the
     # ready count is unaffected and the reader knows the coverage gap.
-    unverifiable = [c for c in cases if not c.get("findings_hash_present", True)]
+    unverifiable = [c for c in cases if not c.get("findings_hash_present", False)]
 
     for w in warnings:
         print(f"WARN: {w.message}", file=sys.stderr)

--- a/eval/harness/e2e/provenance.py
+++ b/eval/harness/e2e/provenance.py
@@ -40,7 +40,7 @@ import json
 import subprocess
 from pathlib import Path
 
-from harness.snapshot import hash_content, normalize
+from harness.snapshot import hash_content, hash_file, normalize
 
 def _is_excluded(parts: tuple[str, ...]) -> bool:
     """A staged file dropped from the hash — mirrors `harness.snapshot._embed_tree`.
@@ -98,6 +98,26 @@ def skills_hash(skills_dir: Path, agents_dir: Path) -> str:
     """
     file_map = staged_file_hashes(skills_dir, agents_dir)
     return hash_content(json.dumps(file_map, sort_keys=True, ensure_ascii=False))
+
+
+def findings_hash(expected_findings_path: Path) -> str:
+    """One sha256 over the normalized `expected-findings.json` — the identity of
+    the findings a grade was produced against (issue #1719).
+
+    Stamped into a `.ann.json` at grade time and re-checked by
+    `calibrate_judge`'s loader: an amended finding body (same id) changes this
+    hash and is caught, where the id-vs-key drift check stays silent. Normalized
+    via `hash_file` (parse → re-emit `sort_keys=True, indent=2,
+    ensure_ascii=False` → sha256), so a reformat or key reorder does not fire but
+    any content edit — including one confined to `supporting_sources`, which the
+    judge still reads — does.
+
+    **This is the single implementation both sides call** (the loader and the
+    `stamp_findings_hash` writer), so they cannot disagree on whitespace or
+    `ensure_ascii` for a corpus full of em-dashes and accented names. The key
+    string `"expected-findings.json"` is fixed here for the same reason.
+    """
+    return hash_file("expected-findings.json", expected_findings_path)
 
 
 def git_sha(repo_root: Path) -> str | None:

--- a/eval/harness/e2e/provenance.py
+++ b/eval/harness/e2e/provenance.py
@@ -108,9 +108,11 @@ def findings_hash(expected_findings_path: Path) -> str:
     `calibrate_judge`'s loader: an amended finding body (same id) changes this
     hash and is caught, where the id-vs-key drift check stays silent. Normalized
     via `hash_file` (parse → re-emit `sort_keys=True, indent=2,
-    ensure_ascii=False` → sha256), so a reformat or key reorder does not fire but
-    any content edit — including one confined to `supporting_sources`, which the
-    judge still reads — does.
+    ensure_ascii=False` → sha256), so a whitespace reformat or JSON object-key
+    reorder does not fire, but any content edit — including one confined to
+    `supporting_sources`, which the judge still reads — does. Reordering the
+    `findings` array itself counts as a change (JSON array order is preserved);
+    that is an accepted cost of hashing the whole file, remedied by a re-grade.
 
     **This is the single implementation both sides call** (the loader and the
     `stamp_findings_hash` writer), so they cannot disagree on whitespace or

--- a/eval/harness/e2e/stamp_findings_hash.py
+++ b/eval/harness/e2e/stamp_findings_hash.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Stamp a ``findings_hash`` into an e2e ``.ann.json`` (issue #1719).
+
+The ``grade-e2e-run`` skill writes the labels; this stamps a fingerprint of the
+findings they were graded against, so ``calibrate_judge``'s loader can later
+detect an ``expected-findings.json`` amended after grading (an amended finding
+body that kept its id — which the id/key drift check cannot see).
+
+This is **not** ``calibrate_judge``: it makes no judge API calls and is exempt
+from the skill's "do not run ``calibrate_judge``" rule. Run it after writing the
+annotation, before committing:
+
+    cd eval/harness && uv run python -m e2e.stamp_findings_hash <path-to-run-*.ann.json>
+
+Slug is the annotation's parent directory name; the hash is computed over
+``eval/tests/e2e/<slug>/expected-findings.json`` via ``provenance.findings_hash``
+— the single implementation the loader also calls, so the two cannot diverge.
+Every other key in the annotation is left untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from e2e.provenance import findings_hash
+
+# Mirrors calibrate_judge.DEFAULT_FIXTURES_ROOT deliberately rather than importing
+# it: importing calibrate_judge would pull in e2e.judge → anthropic, and this
+# writer must stay off that chain.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_FIXTURES_ROOT = REPO_ROOT / "eval" / "tests" / "e2e"
+
+
+def stamp(ann_path: Path, fixtures_root: Path) -> str:
+    """Write ``findings_hash`` into ``ann_path`` in place; return the hash.
+
+    Raises ``FileNotFoundError`` if the sibling fixture is missing and
+    ``ValueError`` if the annotation is not a JSON object — the CLI turns either
+    into a nonzero exit rather than a traceback.
+    """
+    slug = ann_path.parent.name
+    expected = fixtures_root / slug / "expected-findings.json"
+    if not expected.exists():
+        raise FileNotFoundError(
+            f"no expected-findings.json for slug '{slug}' at {expected}"
+        )
+    ann = json.loads(ann_path.read_text(encoding="utf-8"))
+    if not isinstance(ann, dict):
+        raise ValueError(f"{ann_path} is not a JSON object")
+    digest = findings_hash(expected)
+    ann["findings_hash"] = digest
+    ann_path.write_text(
+        json.dumps(ann, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return digest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="e2e.stamp_findings_hash",
+        description=(
+            "Stamp findings_hash into an e2e annotation. Not calibrate_judge; "
+            "makes no judge API calls."
+        ),
+    )
+    parser.add_argument("ann_path", type=Path, help="Path to a run-<ts>.ann.json")
+    parser.add_argument(
+        "--fixtures-root",
+        type=Path,
+        default=DEFAULT_FIXTURES_ROOT,
+        help=f"Root of e2e fixtures. Default: {DEFAULT_FIXTURES_ROOT}",
+    )
+    args = parser.parse_args(argv)
+    try:
+        digest = stamp(args.ann_path, args.fixtures_root)
+    except (OSError, ValueError) as e:
+        print(f"stamp_findings_hash: {e}", file=sys.stderr)
+        return 1
+    print(f"stamped findings_hash={digest} into {args.ann_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/harness/e2e/stamp_findings_hash.py
+++ b/eval/harness/e2e/stamp_findings_hash.py
@@ -34,6 +34,19 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_FIXTURES_ROOT = REPO_ROOT / "eval" / "tests" / "e2e"
 
 
+def _resolve_ann_path(ann_path: Path) -> Path:
+    """Accept an absolute path, one relative to cwd, or one relative to the repo
+    root. ``uv run`` puts cwd at ``eval/harness``, but the grade-e2e-run skill
+    hands the repo-root-relative path it wrote (``eval/runlogs/e2e/...``); without
+    this that path would resolve under ``eval/harness/`` and silently fail to
+    stamp. Falls back to the input unchanged so the caller's read raises a clear
+    error on a genuinely missing file."""
+    if ann_path.is_absolute() or ann_path.exists():
+        return ann_path
+    candidate = REPO_ROOT / ann_path
+    return candidate if candidate.exists() else ann_path
+
+
 def stamp(ann_path: Path, fixtures_root: Path) -> str:
     """Write ``findings_hash`` into ``ann_path`` in place; return the hash.
 
@@ -74,12 +87,13 @@ def main(argv: list[str] | None = None) -> int:
         help=f"Root of e2e fixtures. Default: {DEFAULT_FIXTURES_ROOT}",
     )
     args = parser.parse_args(argv)
+    ann_path = _resolve_ann_path(args.ann_path)
     try:
-        digest = stamp(args.ann_path, args.fixtures_root)
+        digest = stamp(ann_path, args.fixtures_root)
     except (OSError, ValueError) as e:
         print(f"stamp_findings_hash: {e}", file=sys.stderr)
         return 1
-    print(f"stamped findings_hash={digest} into {args.ann_path}")
+    print(f"stamped findings_hash={digest} into {ann_path}")
     return 0
 
 

--- a/eval/harness/tests/unit/test_e2e_calibrate_judge.py
+++ b/eval/harness/tests/unit/test_e2e_calibrate_judge.py
@@ -19,6 +19,8 @@ from e2e.calibrate_judge import (
     load_annotated_runs,
     main,
 )
+from e2e.provenance import findings_hash
+from e2e.stamp_findings_hash import stamp as stamp_findings_hash
 
 
 def _case(case_id, human_verdict, human_per_finding, **extra):
@@ -326,6 +328,76 @@ def test_loader_drift_is_error(tmp_path):
     assert cases == []
     assert [p.severity for p in problems] == ["error"]
     assert "fixture changed" in problems[0].message
+
+
+# --- content-drift check: findings_hash (issue #1719) ----------------------
+
+
+def test_loader_content_drift_hash_mismatch_is_error(tmp_path):
+    # Keys still match the fixture ids, but a stamped findings_hash no longer
+    # matches the (amended) expected-findings.json — the silent case rung 6 misses.
+    rr, fr, _ = _layout(tmp_path, ann={
+        "per_finding": {"f1": "true", "f2": "partial"},
+        "findings_hash": "0" * 64,  # stale/wrong hash
+    })
+    cases, problems = load_annotated_runs(rr, fr)
+    assert cases == []
+    assert [p.severity for p in problems] == ["error"]
+    assert "findings_hash mismatch" in problems[0].message
+
+
+def test_loader_absent_findings_hash_is_grandfathered(tmp_path):
+    # Legacy grade with no findings_hash: included, flagged unverifiable, no problem.
+    rr, fr, _ = _layout(tmp_path)  # default ann carries no findings_hash
+    cases, problems = load_annotated_runs(rr, fr)
+    assert problems == []
+    assert len(cases) == 1
+    assert cases[0]["findings_hash_present"] is False
+
+
+def test_loader_matching_findings_hash_is_verified(tmp_path):
+    rr, fr, ann_path = _layout(tmp_path)
+    good = findings_hash(fr / "smith-1850" / "expected-findings.json")
+    ann_path.write_text(
+        json.dumps({"per_finding": {"f1": "true", "f2": "partial"},
+                    "findings_hash": good}),
+        encoding="utf-8")
+    cases, problems = load_annotated_runs(rr, fr)
+    assert problems == []
+    assert len(cases) == 1
+    assert cases[0]["findings_hash_present"] is True
+
+
+def test_stamp_then_load_round_trips(tmp_path):
+    # The writer's stamp and the loader's check share one implementation, so a
+    # freshly stamped annotation must verify — the divergence the shared function
+    # exists to prevent (whitespace / ensure_ascii) would fail here otherwise.
+    rr, fr, ann_path = _layout(tmp_path)
+    stamp_findings_hash(ann_path, fr)
+    cases, problems = load_annotated_runs(rr, fr)
+    assert problems == []
+    assert len(cases) == 1
+    assert cases[0]["findings_hash_present"] is True
+
+
+def test_stamp_refuses_missing_fixture(tmp_path):
+    rr, fr, ann_path = _layout(tmp_path, fixture=False)
+    with pytest.raises(FileNotFoundError):
+        stamp_findings_hash(ann_path, fr)
+
+
+def test_stamp_is_idempotent_and_reflects_a_fixture_edit(tmp_path):
+    rr, fr, ann_path = _layout(tmp_path)
+    h1 = stamp_findings_hash(ann_path, fr)
+    assert stamp_findings_hash(ann_path, fr) == h1  # idempotent
+    # Amend the fixture; a re-stamp tracks the new content, and the OLD hash now
+    # mismatches (which is what the loader would catch).
+    (fr / "smith-1850" / "expected-findings.json").write_text(
+        json.dumps({"findings": [{"id": "f1", "required": True, "details": "new"},
+                                 {"id": "f2", "required": True}]}),
+        encoding="utf-8")
+    h2 = stamp_findings_hash(ann_path, fr)
+    assert h2 != h1
 
 
 def test_loader_orphaned_fixture_is_error(tmp_path):

--- a/eval/harness/tests/unit/test_e2e_calibrate_judge.py
+++ b/eval/harness/tests/unit/test_e2e_calibrate_judge.py
@@ -19,6 +19,7 @@ from e2e.calibrate_judge import (
     load_annotated_runs,
     main,
 )
+from e2e import stamp_findings_hash as stamp_mod
 from e2e.provenance import findings_hash
 from e2e.stamp_findings_hash import stamp as stamp_findings_hash
 
@@ -386,18 +387,78 @@ def test_stamp_refuses_missing_fixture(tmp_path):
         stamp_findings_hash(ann_path, fr)
 
 
-def test_stamp_is_idempotent_and_reflects_a_fixture_edit(tmp_path):
+def test_stamp_writes_hash_and_preserves_sibling_keys(tmp_path):
+    rr, fr, ann_path = _layout(
+        tmp_path, ann={"annotator": "alice", "per_finding": {"f1": "true", "f2": "partial"}})
+    h1 = stamp_findings_hash(ann_path, fr)
+    written = json.loads(ann_path.read_text(encoding="utf-8"))
+    assert written["findings_hash"] == h1  # actually persisted, not just returned
+    assert written["per_finding"] == {"f1": "true", "f2": "partial"}  # untouched
+    assert written["annotator"] == "alice"
+    # Idempotent on the file: a second stamp of an unchanged fixture leaves it equal.
+    assert stamp_findings_hash(ann_path, fr) == h1
+    assert json.loads(ann_path.read_text(encoding="utf-8")) == written
+
+
+def test_stamp_reflects_a_fixture_edit(tmp_path):
     rr, fr, ann_path = _layout(tmp_path)
     h1 = stamp_findings_hash(ann_path, fr)
-    assert stamp_findings_hash(ann_path, fr) == h1  # idempotent
-    # Amend the fixture; a re-stamp tracks the new content, and the OLD hash now
-    # mismatches (which is what the loader would catch).
     (fr / "smith-1850" / "expected-findings.json").write_text(
         json.dumps({"findings": [{"id": "f1", "required": True, "details": "new"},
                                  {"id": "f2", "required": True}]}),
         encoding="utf-8")
-    h2 = stamp_findings_hash(ann_path, fr)
-    assert h2 != h1
+    assert stamp_findings_hash(ann_path, fr) != h1
+
+
+# --- stamp CLI main(): arg parsing + exit codes + path resolution ----------
+
+
+def test_stamp_cli_main_success(tmp_path):
+    rr, fr, ann_path = _layout(tmp_path)
+    rc = stamp_mod.main([str(ann_path), "--fixtures-root", str(fr)])
+    assert rc == 0
+    written = json.loads(ann_path.read_text(encoding="utf-8"))
+    assert written["findings_hash"] == findings_hash(
+        fr / "smith-1850" / "expected-findings.json")
+
+
+def test_stamp_cli_main_missing_fixture_exits_1(tmp_path):
+    rr, fr, ann_path = _layout(tmp_path, fixture=False)
+    rc = stamp_mod.main([str(ann_path), "--fixtures-root", str(fr)])
+    assert rc == 1
+
+
+def test_stamp_cli_resolves_repo_root_relative_path(tmp_path, monkeypatch):
+    # Reproduces the cwd footgun: the skill hands a repo-root-relative ann path,
+    # but `uv run` puts cwd at eval/harness where that path does not resolve. The
+    # CLI must fall back to REPO_ROOT so the stamp still lands.
+    rr, fr, ann_path = _layout(tmp_path)
+    monkeypatch.setattr(stamp_mod, "REPO_ROOT", tmp_path)
+    rel = ann_path.relative_to(tmp_path)  # runlogs/e2e/smith-1850/run-....ann.json
+    monkeypatch.chdir(fr)  # a cwd where `rel` does NOT resolve directly
+    rc = stamp_mod.main([str(rel), "--fixtures-root", str(fr)])
+    assert rc == 0
+    assert json.loads(ann_path.read_text(encoding="utf-8"))["findings_hash"]
+
+
+# --- main() dry-run: grandfather summary + content-drift exit --------------
+
+
+def test_main_dry_run_grandfathered_prints_unverifiable(tmp_path, capsys):
+    rr, fr, _ = _layout(tmp_path)  # no findings_hash → grandfathered
+    rc = main(["--dry-run", "--runlog-root", str(rr), "--fixtures-root", str(fr)])
+    assert rc == 0
+    assert "carry no findings_hash" in capsys.readouterr().err
+
+
+def test_main_dry_run_content_drift_exits_two(tmp_path):
+    rr, fr, ann_path = _layout(tmp_path)
+    ann_path.write_text(
+        json.dumps({"per_finding": {"f1": "true", "f2": "partial"},
+                    "findings_hash": "0" * 64}),
+        encoding="utf-8")
+    rc = main(["--dry-run", "--runlog-root", str(rr), "--fixtures-root", str(fr)])
+    assert rc == 2
 
 
 def test_loader_orphaned_fixture_is_error(tmp_path):


### PR DESCRIPTION
## Summary

Normal tier. Closes the `nothing-checks` gap in #1719: `calibrate_judge`'s drift check compared annotation `per_finding` **keys** to fixture finding **ids**, so a finding body amended while its id stayed the same passed silently — and the judge was then re-run against the *amended* finding while reading the human label produced against the *old* one, fabricating a disagreement in exactly the output the maintainer is told to read first.

- Stamps a `findings_hash` (normalized sha256 of the whole `expected-findings.json`) into the `.ann.json` at grade time; `calibrate_judge` recomputes and **hard-errors on mismatch**, same remedy as key-drift ("re-grade or delete").
- **One shared implementation** (`provenance.findings_hash`, over `harness.snapshot.hash_file`) is called by both the writer and the loader, so they cannot diverge on whitespace/`ensure_ascii` — the failure the issue warns about.
- **Legacy annotations are grandfathered**, never backfilled: an absent hash is *included and graded* but reported unverifiable (not an error, not excluded). All 143 committed annotations predate the check.

## Review guidance

**Start here:** `eval/harness/e2e/calibrate_judge.py` — the new rung 7 in `load_annotated_runs`. It sits after the id/key-drift rung (6) and below the incomplete-grade rung (3): a stamped hash that mismatches → `error` (excluded); an absent hash → include with `findings_hash_present=False`; a match → include verified. The flag is set on **every** include path, and `main` reads it with `.get(..., True)` so a mocked/synthetic case dict can't `KeyError`. Both numbered ladders (docstring + inline `# N.` comments) were renumbered.

The writer is a new tiny CLI, `eval/harness/e2e/stamp_findings_hash.py` (`cd eval/harness && uv run python -m e2e.stamp_findings_hash <ann>`), invoked from the grade-e2e-run skill. It deliberately mirrors the fixtures-root constant rather than importing it from `calibrate_judge` (which would drag in `anthropic`), and `provenance.findings_hash` lives in the anthropic-free provenance module for the same reason. The CLI **resolves the ann path against the repo root as well as cwd** (`_resolve_ann_path`), so the repo-root-relative path the skill hands it works whether run from the repo root or from `eval/harness` (where `uv run` puts cwd) — see the review-round note below.

**Unsure about:** nothing blocking. Two things worth a reviewer's eye:
- *Scope:* `provenance.py` + the stamp CLI are additions beyond the issue's literal **Touches** (`calibrate_judge.py`, `SKILL.md`, `e2e-test-spec.md`), required by the issue's own "one implementation, called by both sides" + "give the one command" bullets. The plan was drafted and adversarially critiqued three times before implementation.
- *Known residual (by the issue's design):* an annotation graded **after** this check but not stamped is indistinguishable from a genuinely legacy one — both are absent-hash → grandfathered, no error. There is no timestamp to tell them apart, and the issue scoped CI enforcement out ("do not touch `check_e2e_fixtures.py`"). Mitigated by the stamp applying by default (the path fix below) and the grade-e2e-run step-7 self-check.

## Post-review round (`/code-review xhigh`)

An adversarial pass caught a real, load-bearing bug and it is fixed in this PR (commit `fcb246a3`):

- **The documented stamp command failed** — `cd eval/harness && uv run python -m e2e.stamp_findings_hash eval/runlogs/e2e/<slug>/...` resolved the repo-root-relative arg under `eval/harness/` and errored (`[Errno 2]`), so **every fresh grade would have landed unstamped and been grandfathered forever** — the exact `nothing-checks` failure this PR closes, shipped inside the fix. Fixed via `_resolve_ann_path` (REPO_ROOT fallback), reproduced-then-verified, and covered by `test_stamp_cli_resolves_repo_root_relative_path`.
- **Doc accuracy:** the "a reformat or key reorder does not fire" claim was corrected — object-key reorder is immune, but reordering the `findings` *array* does change the hash (an accepted cost of the whole-file design), now stated precisely in the docstring and spec §7.4.
- **Test coverage added:** stamp-CLI `main()` (success / missing-fixture→1 / path resolution), `main --dry-run` (grandfather line + exit 0; mismatch → exit 2), and a strengthened stamp test that re-reads the file and asserts sibling keys are preserved.

## Plan

**Didn't change:** `eval/harness/scripts/check_e2e_fixtures.py` (presence, not content; stays stdlib-only per the issue). No committed run log or annotation was re-stamped, re-graded, or rewritten. `load_annotated_runs`' `(cases, problems)` return arity is unchanged — the unverifiable count rides on the case dict, so the ~24 two-tuple call sites are untouched.

**Acceptance check** (offline, no API): `cd eval/harness && uv run python -m e2e.calibrate_judge --dry-run` → **143 graded ready (unchanged from baseline), 0 errors**, plus `143 of 143 ... carry no findings_hash`. *If the ready count had dropped, the change would be wrong* — that is the whole failure mode. The mismatch/error path is proven by `test_loader_content_drift_hash_mismatch_is_error` and `test_main_dry_run_content_drift_exits_two`, and was additionally driven on the real corpus (stamp one ann, amend its fixture → dry-run reported `1 error`, ready 143→142 → reverted).

**Deviated from the plan:** nothing.

## Test plan

- [x] `cd eval/harness && uv run pytest tests/unit/test_e2e_calibrate_judge.py` — **59 pass** (incl. the review-round CLI/dry-run tests). Full harness unit: **2391 pass**, 8 skipped; the lone failure is `test_mock_mcp` (needs `make engine-build` in a fresh worktree — no engine code changed here, passes in CI).
- [x] Offline dry-run acceptance above (ready unchanged at 143, 0 errors, unverifiable line).
- [x] `e2e-test-spec.md` §7.4 records the decision + the two alternatives it beat, with **no `#NNNN`** (the file is at its issue-ref ratchet ceiling, 10/10; verified still 10).
- [ ] No skill run-log snapshot changed (this edits `grade-e2e-run/SKILL.md` prose + harness code + docs), so no `make eval-skill` run is owed.

**No CI job covers `calibrate_judge`, and `make test-all` never reads the real corpus** — the mismatch/error path is proven only by the unit tests (+ the manual corpus check above), never by the committed-corpus `--dry-run`, which every grandfathered annotation makes exercise only the absent-hash branch.

Note: this touches Python under `eval/harness/`, outside the CODEOWNERS exclusions, so a `senior-developers` approval is expected.
