### PR TITLE
eval: make --replay's output reachable on Windows, and take the reviewer's fixture-drift wording

### DIFF
--- a/eval/harness/e2e/guardrail_shadow_report.py
+++ b/eval/harness/e2e/guardrail_shadow_report.py
@@ -422,18 +422,18 @@ def replay_post_hoc(
 
     **The seed tree is today's, not the one that run started from.** Warnings are
     diffed against `eval/tests/e2e/<slug>/starting-tree.gedcomx.json` as it exists
-    in the current checkout. Exactly **one** committed fixture has had its
-    relationship key set changed after a run against it already existed:
-    `teitje-harkema-parents-1833`, whose seed was touched 2026-07-03, a day after
-    its only committed run. Replaying that run against its run-time seed changes
-    no count, so this is a live hazard rather than a current error — the
-    fixture-side twin of the predicate-version gap noted above.
+    in the current checkout. Of the 18 fixtures with committed runs whose
+    seed-tree file changed after their earliest run, exactly one changed its
+    relationship key SET: `teitje-harkema-parents-1833`, which gained 25 keys
+    (1 -> 26) the day after its only committed run. That run fires on neither
+    seed, so replaying changed no count as of 2026-08-22 — a live hazard rather
+    than a current error, and the fixture-side twin of the predicate-version gap
+    noted above.
 
-    An earlier draft of this docstring named five fixtures. Four do not qualify
-    and the check is one command: `crowder-grandparents` and
-    `scotland-thomson-grandparents` have no committed runs at all, and
-    `young-marriage-1828` and `anders-monsen-ancestry` had their seeds finalised
-    *before* their runs, which is the ordinary case rather than drift.
+    An earlier draft named five fixtures on a review agent's say-so. Two have no
+    committed runs at all and two had their seeds finalised *before* their runs,
+    which is the ordinary case rather than drift. A file's mtime changing is not
+    the same as its key set changing, and only the second matters here.
     """
     out = PostHocReplay()
     for path in paths:
@@ -728,6 +728,15 @@ def format_warnings_unchecked(violations: list[dict[str, Any]]) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # The house pattern (`e2e/author.py`). A Windows console defaults to cp1252
+    # and dies on the `≥` in `format_provenance_replay` — which prints BEFORE the
+    # post-hoc replay block, so the whole of `--replay`'s new output is
+    # unreachable there. This module's own docstring now tells readers to run
+    # `--replay` before concluding a check never fires, and the team it is
+    # written for is on Windows.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
     ap = argparse.ArgumentParser(
         description=(
             "Replay the §7 shadow window and report the §8/§7.5 post-hoc families "


### PR DESCRIPTION
## Summary

Trivial tier. One file, two changes that missed PR #1839 — they were pushed a few minutes after it merged.

- **Takes johnmarkpeterbrown's fixture-drift wording**, which is better founded than the correction that landed. His blocking note was addressed in #1839, but with text I derived from only the five names I had wrongly published; he checked all **18** fixtures with committed runs whose seed changed after their earliest run and found exactly one changed the relationship key SET (`teitje-harkema-parents-1833`, 1 → 26 keys). Same conclusion, but what shipped was a five-sample claim phrased as a corpus-wide one. His version also records the distinction that matters — a seed file's mtime moving is not its key set moving.
- **Makes `--replay`'s output reachable on Windows.** `format_provenance_replay` prints U+2265, before the post-hoc block, so on a cp1252 console `make e2e-guardrail-shadow REPLAY=1` dies before any of the new output appears. Uses the house pattern from `e2e/author.py`.

The second one matters more than it looks. That module's docstring and the Makefile both now tell readers to run `--replay` before concluding a check never fires, and the genealogist team those instructions are written for is on Windows — so shipping output they cannot reach makes the instruction false for exactly the people it targets. It was flagged as optional and pre-existing on main; it stops being optional once we tell people to run the thing.

## Review guidance

**Start here:** the two-line `sys.stdout.reconfigure` block at the top of `main()`. Everything else is docstring prose.

**Unsure about:** nothing.

## Test plan

- [x] `make test-all` on top of the merged main — 2610 passed, 2 skipped. `make harness-lint` clean.
- [x] No skill run-log snapshot changed, so no paid eval run applies — this touches `eval/harness/e2e/` only.
- [x] Not applicable — no skill `description` or DO-NOT clause changed.

## Follow-on

None. PR #1839 merged with everything else from that review, including the `no_project` marker fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
