### PR TITLE
Record the first six structural bets in the ledger

### DIFF
--- a/.claude/skills/find-big-wins/SKILL.md
+++ b/.claude/skills/find-big-wins/SKILL.md
@@ -695,8 +695,11 @@ Four rules:
   `deferred` cell means it belongs in the issue.
 - **Write nothing he has not decided.** An idea he did not reach is `deferred`,
   which is a decision about the run, not about the idea.
-- **This file and this table only.** Your `Edit` grant does not reach anything
-  else, including the rest of this ADR.
+- **This table and the `Last updated:` line only.** Bump that line every time you
+  write a row — `docs/adrs/_template.md` requires it on every edit, and a header
+  two weeks older than the rows beneath it is what a reviewer catches instead of
+  the reasoning. Your `Edit` grant does not reach anything else, including the
+  rest of this ADR.
 
 ## Output shape
 

--- a/docs/adrs/ADR-0010-record-structural-bets-in-a-ledger.md
+++ b/docs/adrs/ADR-0010-record-structural-bets-in-a-ledger.md
@@ -137,10 +137,14 @@ depend on a manual step at the end of a long session.
 
 ### The ledger
 
-*Empty. `/find-big-wins` has not been run.*
-
 | First proposed | Claim | Verdict | What was learned | Issue |
 |---|---|---|---|---|
+| 2026-08-23 | Stop gating a skill edit on a paid eval run plus an annotation pass | rejected | Committed run logs are converged states — the failing intermediate runs the gate exists to catch never enter the corpus, so no measurement over them can price the gate. The between-run figures that motivated this (14% of test outcomes flip, 5% of dimension scores move, both under the measured 22–26% / 9–17% same-code noise floor) measure convergence, not the gate. The annotation half was re-measured separately and is improving, not failing: the 5-test sampler (#1637, 2026-08-15) cut median rows per pass 72→35 while raising the score-disagreement rate 0.3%→4.2% and cutting "agree with all" passes 74%→30%. The flat-dimension finding (104 of 170 dimension keys never vary) falls to the same selection effect — "always 3" is equally consistent with authors fixing the 1s before landing, and `make judge-report` cannot tell the two apart | |
+| 2026-08-23 | Per-subagent `effort` shipped upstream; three repo sites still record it as session-wide | accepted | Resolves the contradiction blocking issue #1136, and adds a second payoff to skill→agent-pair conversion beyond attribution | |
+| 2026-08-23 | Have the plugin self-report its resolved tool roster instead of testing binding from outside | accepted | Six core issues, not the ten first claimed; buys a repeatable per-mode check, not CI coverage | |
+| 2026-08-23 | Production telemetry as one bet across four issues | deferred | | |
+| 2026-08-23 | Replay the guardrail detectors over feedback-bundle session logs | accepted | Yields production examples, not rates — the half of ADR-0009's satisfiability constraint that binds | |
+| 2026-08-23 | Delete the dead `flaky` field and settle the six warn-only checks | set aside (magnitude) | Direction right, too small to carry an issue; folded into the next harness PR | |
 
 ## Alternatives considered
 

--- a/docs/adrs/ADR-0010-record-structural-bets-in-a-ledger.md
+++ b/docs/adrs/ADR-0010-record-structural-bets-in-a-ledger.md
@@ -8,7 +8,7 @@
 
 - **Status:** Accepted
 - **Decided:** 2026-08-09
-- **Last updated:** 2026-08-09 (created alongside `/find-big-wins`)
+- **Last updated:** 2026-08-23 (PR #1849 — first six ledger rows)
 - **Deciders:** Dallan Quass
 - **Supersedes:** —
 - **Superseded by:** —
@@ -139,12 +139,12 @@ depend on a manual step at the end of a long session.
 
 | First proposed | Claim | Verdict | What was learned | Issue |
 |---|---|---|---|---|
-| 2026-08-23 | Stop gating a skill edit on a paid eval run plus an annotation pass | rejected | Committed run logs are converged states — the failing intermediate runs the gate exists to catch never enter the corpus, so no measurement over them can price the gate. The between-run figures that motivated this (14% of test outcomes flip, 5% of dimension scores move, both under the measured 22–26% / 9–17% same-code noise floor) measure convergence, not the gate. The annotation half was re-measured separately and is improving, not failing: the 5-test sampler (#1637, 2026-08-15) cut median rows per pass 72→35 while raising the score-disagreement rate 0.3%→4.2% and cutting "agree with all" passes 74%→30%. The flat-dimension finding (104 of 170 dimension keys never vary) falls to the same selection effect — "always 3" is equally consistent with authors fixing the 1s before landing, and `make judge-report` cannot tell the two apart | |
-| 2026-08-23 | Per-subagent `effort` shipped upstream; three repo sites still record it as session-wide | accepted | Resolves the contradiction blocking issue #1136, and adds a second payoff to skill→agent-pair conversion beyond attribution | |
-| 2026-08-23 | Have the plugin self-report its resolved tool roster instead of testing binding from outside | accepted | Six core issues, not the ten first claimed; buys a repeatable per-mode check, not CI coverage | |
+| 2026-08-23 | Stop gating a skill edit on a paid eval run plus an annotation pass | rejected | Committed run logs are converged states — the failing intermediate runs the gate exists to catch never enter the corpus, so no measurement over them can price the gate. The between-run figures that motivated this (14% of test outcomes flip, 5% of dimension scores move, both under the record-extraction suite's measured 22–26% / 9–17% same-code noise floor — the only suite where a floor has been measured) measure convergence, not the gate. The annotation half was re-measured separately and is improving, not failing: the 5-test sampler (PR #1637, 2026-08-15) cut median rows per pass 72→35 while raising the score-disagreement rate 0.3%→4.2% and cutting "agree with all" passes 74%→30%. The flat-dimension finding (104 of 170 dimension keys never vary) falls to the same selection effect — "always 3" is equally consistent with authors fixing the 1s before landing, and `make judge-report` cannot tell the two apart | |
+| 2026-08-23 | Per-subagent `effort` shipped upstream; the repo still records it as session-wide | accepted | Confirmed in the *pinned* SDK's `AgentDefinition`, not only in upstream docs; resolves the contradiction blocking issue #1136, and adds a second payoff to skill→agent-pair conversion beyond attribution. The stale sites are enumerated in the stage-3 issue, not here — two careful passes produced two different lists | |
+| 2026-08-23 | Have the plugin self-report its resolved tool roster instead of testing binding from outside | accepted | Six issues are one mechanism, not the ten first claimed; three held under `cluster:tool-binding` and three run ahead; buys a repeatable per-mode check, not CI coverage | |
 | 2026-08-23 | Production telemetry as one bet across four issues | deferred | | |
 | 2026-08-23 | Replay the guardrail detectors over feedback-bundle session logs | accepted | Yields production examples, not rates — the half of ADR-0009's satisfiability constraint that binds | |
-| 2026-08-23 | Delete the dead `flaky` field and settle the six warn-only checks | set aside (magnitude) | Direction right, too small to carry an issue; folded into the next harness PR | |
+| 2026-08-23 | Delete the dead `flaky` field and settle the six warn-only checks | set aside (magnitude) | Direction right, but the first scoping undercounted: `flaky` has TypeScript consumers in `eval/app/` (`lib/types.ts` declares it **required**, plus `lib/compare.ts` and the results page's badge), so removing it crosses a package boundary and that app's own CI job. Not a harness-only edit | |
 
 ## Alternatives considered
 


### PR DESCRIPTION
First `/find-big-wins` run. Six rows in the ledger table, one per bet the lead decided.

**Touches:** docs/adrs/ADR-0010-record-structural-bets-in-a-ledger.md, .claude/skills/find-big-wins/SKILL.md

The one worth reading is the `rejected` row, because it closes a direction and the reasoning is the payload:

> Stopping the paid-run gate on skill edits was proposed off a corpus measurement — 14% of test outcomes flip between consecutive paid runs and 5% of dimension scores move, both under the measured 22–26% / 9–17% same-code noise floor. The lead refuted it: committed run logs are converged states, and the failing intermediate runs where the gate does its work never enter the corpus. No measurement over committed logs can price that gate.

The annotation half was then re-measured separately and is improving rather than failing — the 5-test sampler that landed 2026-08-15 cut median rows per pass from 72 to 35 while raising the score-disagreement rate from 0.3% to 4.2% and cutting "agree with all" passes from 74% to 30%. Halving the volume made the remaining review roughly 14× more productive per row.

The same selection effect retires the "104 of 170 rubric dimensions never discriminate" finding: "always 3" is equally consistent with authors fixing the 1s before landing, and `make judge-report` cannot tell the two apart.

Three rows are `accepted` and go to research next, none of them started here:

- Per-subagent `effort` shipped upstream — it is in the *pinned* SDK's `AgentDefinition`, not only in the docs — while this repo still records it as session-wide. That resolves the contradiction the lead recorded on issue #1136 as blocking spend. The stale sites are enumerated in the stage-3 issue rather than here; see the review round below for why no count appears.
- Having the plugin self-report its resolved tool roster, instead of testing binding from outside. Holds issues #1084, #1160 and #1639 behind it, now carrying a `cluster:tool-binding` label.
- Replaying the guardrail detectors over feedback-bundle session logs, which carry full tool I/O — production examples rather than production rates.

One row is `deferred` (production telemetry) and one `set aside` on magnitude — the dead `flaky` field and six warn-only checks. That row was corrected in review: `flaky` has TypeScript consumers in `eval/app/` where the type declares it required, so removing it crosses a package boundary and that app's own CI job. It is not the harness-only edit the first scoping assumed.

## Review round

Six findings, all taken, in b82b1eb7. Four applied as written. Two changed the fix rather than the wording, and one corrected an error of mine:

- **The `effort` row's site count came out entirely rather than being corrected.** The review named `run_e2e.py:225`, which accurately describes a session-level flag and already carries the caveat "not the only lever — `ClaudeAgentOptions.effort` also works", and `run_e2e.py:240`, which is about output tokens. Neither pass had `orchestrator.py:803` — "Session-wide (parent + every subagent)" — which is genuinely stale. Two careful passes produced two different lists, so a number in a one-clause cell is exactly the figure `ADR-0009` exists to stop people restating.
- **The tool-binding row conflated two things.** Six issues are one *mechanism*; only three are *held* under `cluster:tool-binding`. The other three run ahead deliberately — #1787 is a user-facing bug and #1732 is an assigned census whose output feeds the spike.
- **`flaky` was my own verification error**, not a wording fix: I claimed "read by nothing" off a grep of `eval/harness --include=*.py`, which excluded the TypeScript consumers. That is the grep-excludes-its-own-tree failure `CLAUDE.md` warns about.

Also bumped `Last updated`, and widened the skill's `Edit` grant to cover that line so the next run does not reproduce the same finding.

## Decisions applied alongside this, on the board rather than here

- Issue #1404 — adversarial fixtures first, rather than tightening seven flat rubric dimensions blind. Its stale "land both eval slots first" note corrected, since issues #1472 and #1392 have closed.
- Issue #1824 — treat all images as original, knowingly against Jones, because the users are online-only genealogists. Enforced as a `research_append` precondition rather than agent prose.
- Issue #1008 — the "drop given name" lever wins outright; two clauses banning it come out of `search-records/SKILL.md`. Truncation was never in conflict and PR #929's flip stands. The card's cost measurement is still open and now unblocked, since issue #1093 has closed.
- Issue #1790 — `merge_tree_persons` is a legitimate cross-cutting writer of research.json; `ownership.json` is the stale artifact. It calls `atomicWriteBoth`, so routing the research.json half elsewhere would break atomicity. A check that a declared `writerTools` list matches what the tool actually writes lands in the same PR.
- Issue #1152 — moved from `needs-decision` to `senior`.
- Issue #1732 — `needs-decision` removed as premature; that card's ruling comes after its measurement, and the census is an input to the tool-binding spike rather than a duplicate of it.

**Decision queue went from 10 to 4.** All four remaining carry `cluster:research-loop` and are held for a dedicated pass — the loop moved twice on 2026-08-23 (PRs #1832 and #1847), so ruling them now would be ruling against ground that shifted the same day.

## Verification

`npx vitest run tests/packaging/adr-links.test.ts tests/packaging/doc-links.test.ts` — 155 passed on b82b1eb7. Those are the checks that would catch a broken pointer in either changed file: `adr-links` for this ADR's own live sections, `doc-links` for the `docs/adrs/_template.md` citation the skill edit adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
