### PR TITLE
docs: reasoning effort is a per-agent setting now, not only a session one

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -386,15 +386,17 @@ The cost is knowingly accepted: there is no per-record-type ownership surface, s
 a probate specialist edits the same file as everyone else. **Revisit only with a
 mechanism that cannot silently skip.**
 
-### 3.5 Model routing
+### 3.5 Model and effort routing
 
-Per-step model routing exists **only through plugin agents.**
+Per-step routing of **model** and **reasoning effort** exists **only through plugin
+agents.**
 
 | Surface | Honored where | Today |
 |---|---|---|
 | **Agent `model:`** | Cowork, hosted, both harnesses | `gps-mentor` → `claude-sonnet-5`; `image-reader-opus` → `claude-opus-4-8`; `record-extractor`, `image-reader`, `proof-conclusion` + `research-exhaustiveness` → `claude-sonnet-4-6` |
 | **Skill `model:`** | **the unit eval harness only** | no skill pins one |
-| **Reasoning effort** | session-wide; never set by `real_agent.build_options` | not a per-step lever |
+| **Agent `effort:`** | hosted + both harnesses; **Cowork unverified** | no agent pins one |
+| **Session effort** | `.claude/settings.json` `effortLevel`; never set by `real_agent.build_options` | both harnesses pin `high` to match Cowork; hosted inherits |
 
 > **Do not add a `model:` pin to a new skill.** The mechanism still exists in the
 > unit harness (`harness/orchestrator.py` honours the field, falling back to
@@ -402,6 +404,13 @@ Per-step model routing exists **only through plugin agents.**
 > the harness default — and were deleted, because a pin that changes nothing
 > makes per-step routing look like it exists. To route a step to a different
 > model, delegate it to a plugin agent.
+>
+> **Agent `effort:` takes `low|medium|high|xhigh|max` or an integer**, and is a
+> property of the agent *definition* — the `Agent` tool's call site accepts only
+> `model`. It binds wherever `.claude/agents/*.md` is parsed, which is the hosted
+> control plane (`stage_plugin_agents` + `setting_sources=["project"]`) and both
+> harnesses. **Whether Cowork honours it has not been checked on a live session**,
+> the way the `model:` pins were; check before relying on it there.
 >
 > **And know the ceiling before you plan around it.** Because agents are the only
 > surface, the share of work that *can* be routed to another model is the share


### PR DESCRIPTION
## Summary

- **Trivial.** One prose row in the architecture guide's routing table said reasoning effort was "session-wide; not a per-step lever." An agent definition now takes an `effort:` frontmatter field, alongside `model:`, so that row was telling readers a lever does not exist when it does.
- Splits the row in two — the per-agent field and the session-wide `effortLevel` setting are different levers with different reach — and renames the section from "Model routing" to "Model and effort routing" to match what it now covers.
- Adds a short note on the accepted values, the fact that it is a property of the agent *definition* rather than the call site, and which runtimes it is confirmed to bind in.

## Review guidance

**Start here:** the two new table rows and the note under them. The claim worth checking is **where `effort:` actually binds**, since that is the part a reader will act on. I verified it by reading the shipped Claude Code 2.1.241 binary: the markdown agent parser reads `effort`, validates it against `low|medium|high|xhigh|max` or an integer, warns `Agent file … has invalid effort '…'` on a bad value, and emits it on the definition; the Agent SDK's agent-definition schema declares the same field as "Reasoning effort level for this agent." That parser is what loads `.claude/agents/*.md`, which is the path the hosted control plane takes (it stages the plugin agents into the project and reads project settings) and the path both eval harnesses take.

**Unsure about:** whether **Cowork** honours it. I could not check that from here — it needs a live session, the way the `model:` pins were checked on 2026-08-01. Rather than guess in either direction, the table says "Cowork unverified" and the note says to check before relying on it there. If you would rather the row not carry an unverified cell at all, say so and I will drop it to a note.

## Test plan

- [x] I ran `make test-all` (`scripts/test.sh`) and it passed — 2624 passed, 2 skipped. That includes the doc-link and ADR-link packaging checks, which read this file.
- [x] Checked that nothing cites the renamed heading by name or by number before renaming it; there are no citers.
- [ ] No skill run-log snapshot changed — this PR touches one file under `docs/`, no skill dir, no agent body, no fixture.
- [ ] No skill `description` or DO NOT clause changed.

## Follow-on issues

**Folded in / filed instead:** Nothing filed. The obvious follow-on — pin `effort:` on an agent and measure it — belongs to **issue #1136**, the lead's personally-held reasoning-effort A/B, which states plainly that the A/B is not to be filed as a separate issue. Its analysis also carries a line this change contradicts: that reserving high effort for the proof-conclusion and conflict-resolution steps is impossible because "there is no per-skill effort knob." Still true for skills, but both of those steps are becoming skill-agent pairs, and an agent *does* have the knob. That belongs on issue #1136 as a comment for its owner, not in this PR and not in a new issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)