### PR TITLE
roster: record Promise's second GitHub account

### DIFF
--- a/.claude/skills/triage-standup/references/roster.md
+++ b/.claude/skills/triage-standup/references/roster.md
@@ -89,6 +89,17 @@ author.
 - **Ernest** commits as `ernestjacob789@gmail.com` while his GitHub account is
   `aghadiayeamayanvboernest`. Any roll call derived from git activity rather than
   from this roster will count him twice, as two different people.
+- **Promise has two GitHub accounts.** `promise-emmanuel` — the one in the table
+  above — is on `senior-developers` and is what opens the PRs. The commits inside
+  them are authored by **`promise-emmanuel-20`**, which is on no team, under two
+  emails (`Promiseemmanuel2019@gmail.com`, `promiseemmanuel@byui.edu`). 177
+  commits on `main` carry the second account. Attribution by commit author will
+  therefore split one person in two, and miss that they are senior.
+  **A senior approval submitted from `promise-emmanuel-20` would not satisfy
+  CODEOWNERS, and nothing would say why** — GitHub would simply keep asking for a
+  senior review that has already been given. They have never reviewed from that
+  account, so this has not bitten yet; check the account on the review, not the
+  name, if a senior-looking approval fails to clear a PR.
 - **Richard** (`chesworthrm`) works 1–2 hours a day and covers for the lead when
   he is away. He attends standup and usually posts, so report him missing on days
   he does not — but read a short update as expected, not as a red flag.


### PR DESCRIPTION
Found during today's standup triage. One line of `references/roster.md`, in the "Known identity quirks" section next to Ernest's — the two are the same failure shape, one person with two git identities.

## What is true

- `promise-emmanuel` opens the PRs and is the account on the `senior-developers` team.
- The commits inside those PRs are authored by **`promise-emmanuel-20`**, which is on no team, under two emails (`Promiseemmanuel2019@gmail.com`, `promiseemmanuel@byui.edu`). 177 commits on `main` carry the second account.

Verified with `gh api /users/promise-emmanuel-20`, `gh api /orgs/PioneerAIAcademy/teams/senior-developers/members`, and a `git log --format=%ae` tally on `origin/main`.

## Why it is worth a line in the roster

Two ways it misleads a reader who does not know:

1. **Attribution by commit author splits one person in two** and loses the senior flag on the half that does the committing.
2. **A senior approval submitted from `promise-emmanuel-20` would not satisfy CODEOWNERS, and nothing would say why.** GitHub would simply keep requesting a senior review that had already been given.

## What it deliberately does not claim

The second point has never happened — `promise-emmanuel-20` has never submitted a review in this repository. The entry says so, so a future triage run does not open it as a live problem. Nothing is broken today; this is a note that stops the next run re-discovering the accounts as an anomaly, the way `Leduthet` used to be re-discovered before her line was added.

The roster table is unchanged. `promise-emmanuel` is the right primary handle there — it is what opens the PRs and what carries the team membership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)