### PR TITLE
Agent effort: binds in Cowork — correct the four sites that say otherwise

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -395,7 +395,7 @@ agents.**
 |---|---|---|
 | **Agent `model:`** | Cowork, hosted, both harnesses | `gps-mentor` → `claude-sonnet-5`; `image-reader-opus` → `claude-opus-4-8`; `record-extractor`, `image-reader`, `proof-conclusion` + `research-exhaustiveness` → `claude-sonnet-4-6` |
 | **Skill `model:`** | **the unit eval harness only** | no skill pins one |
-| **Agent `effort:`** | hosted + both harnesses; **Cowork unverified** | no agent pins one |
+| **Agent `effort:`** | Cowork, hosted, both harnesses — Cowork and Claude Code verified live 2026-08-25 | no agent pins one |
 | **Session effort** | `.claude/settings.json` `effortLevel`; never set by `real_agent.build_options` | both harnesses pin `high` to match Cowork; hosted inherits |
 
 > **Do not add a `model:` pin to a new skill.** The mechanism still exists in the
@@ -408,9 +408,14 @@ agents.**
 > **Agent `effort:` takes `low|medium|high|xhigh|max` or an integer**, and is a
 > property of the agent *definition* — the `Agent` tool's call site accepts only
 > `model`. It binds wherever `.claude/agents/*.md` is parsed, which is the hosted
-> control plane (`stage_plugin_agents` + `setting_sources=["project"]`) and both
-> harnesses. **Whether Cowork honours it has not been checked on a live session**,
-> the way the `model:` pins were; check before relying on it there.
+> control plane (`stage_plugin_agents` + `setting_sources=["project"]`), both
+> harnesses, **and Cowork — verified live on 2026-08-25**, the way the `model:` pins
+> were. A probe plugin pinned `record-extractor` to `effort: low` and a `PreToolUse`
+> hook read the payload back: four subagent tool calls in a macOS Cowork session, every
+> one `{"level": "low"}` against the session's `high`. The same hook in Claude Code
+> showed `{"level": "low"}` for a pinned agent beside `{"level": "xhigh"}` on the main
+> thread, one session. **The payload spells it as an object, not a string** — a grep
+> for `"effort": "low"` finds nothing.
 >
 > **And know the ceiling before you plan around it.** Because agents are the only
 > surface, the share of work that *can* be routed to another model is the share

--- a/docs/plan/research-performance-2026-07-27.md
+++ b/docs/plan/research-performance-2026-07-27.md
@@ -298,8 +298,13 @@ evidenced by that number.
 **Addresses F0 — the 58% no other change reaches.**
 
 Drop the orchestrator below `high`; reserve high-effort work for
-`proof-conclusion` / `conflict-resolution`. Effort is session-wide and reaches
-every skill *and* subagent, so the e2e suite is the gate.
+`proof-conclusion` / `conflict-resolution`. **Corrected 2026-08-25:** agent
+`effort:` binds (verified live in Cowork and Claude Code), so reserving high effort
+for a named step *is* possible — but only for steps that are plugin **agents**.
+`proof-conclusion` and `research-exhaustiveness` became agents on 2026-08-19 and
+2026-08-23; `conflict-resolution` is still a skill and still runs at the session
+effort. Session effort reaches every skill *and* subagent that does not pin its own,
+so the e2e suite is still the gate.
 
 **Prerequisite:** the unit suite cannot serve even as a screen until it pins
 effort. `eval/harness/harness/` writes no `effortLevel`, so unit runs inherit the

--- a/docs/specs/e2e-test-spec.md
+++ b/docs/specs/e2e-test-spec.md
@@ -651,10 +651,14 @@ the `max_cost_usd` note in §6 step 5.
    a documented reporting threshold.
 
    **Agent `model:` pins interact with reasoning effort, and one pin is
-   load-bearing.** Effort is session-wide; `model:` is per-subagent (each
+   load-bearing.** Effort is per-agent too, since agent `effort:` was verified to
+   bind on 2026-08-25 — but no agent pins one today, so in practice every step runs
+   at the session effort and `model:` is the lever that has been used (each
    `packages/engine/plugin/agents/*.md`). So when one agent misbehaves at the
-   run's effort level, repinning that agent is the only change that does not
-   move every other step too. `record-extractor` was repinned `claude-sonnet-5`
+   run's effort level, repinning that agent — its model, its effort, or both —
+   is the change that does not move every other step too. **When the repin below
+   was made, effort was believed to be session-wide, so the model was the only
+   lever available; it is not any more.** `record-extractor` was repinned `claude-sonnet-5`
    → `claude-sonnet-4-6` on 2026-07-18 for exactly this: sonnet-5 hangs as a
    subagent at Cowork/e2e `effortLevel: high` — adaptive-thinking runaway, not a
    model defect, and fine at default effort. Capping its output at 8k instead was

--- a/eval/harness/e2e/orchestrator.py
+++ b/eval/harness/e2e/orchestrator.py
@@ -800,7 +800,9 @@ def build_workspace(
     # route is kept because it is the one that provably reaches subagents; the
     # SDK option's subagent propagation is unverified. Do not restate this as
     # "the only lever" — that claim shaped a spend decision before it was
-    # checked. Session-wide (parent + every subagent). Left unset, the
+    # checked. Session-wide (parent + every subagent that does not pin its own
+    # `effort:` — agent frontmatter overrides this, verified live in Cowork and
+    # Claude Code on 2026-08-25; no agent pins one today). Left unset, the
     # run uses the CLI's bare default, which for sonnet-5 resolves to 'high' —
     # deep enough that the record-extractor subagent can spend its whole output
     # budget on one thinking turn (stop_reason=max_tokens, no tool call) and


### PR DESCRIPTION
**Touches:** docs/architecture.md, docs/specs/e2e-test-spec.md, docs/plan/research-performance-2026-07-27.md, eval/harness/e2e/orchestrator.py

Agent `effort:` binds in Cowork. Four sites said it did not, or rested on the belief that it did not.

## What was measured

A throwaway probe plugin pinned `record-extractor` to `effort: low`, with a `PreToolUse` hook that records the payload's `effort`, `agent_id` and `agent_type` and returns an empty decision on every path.

- **Cowork, macOS, live:** one extraction produced four subagent rows — `project_context`, `record_read`, `extraction_append` ×2 — every one `{"level": "low"}` against the session's `high`.
- **Claude Code:** a pinned agent read `{"level": "low"}` beside `{"level": "xhigh"}` on the main thread, same session, same `prompt_id`.

`AgentDefinition.effort` is also present in the pinned SDK (`claude_agent_sdk/types.py`), not only in the upstream docs.

The probe lives on `worktree-effort-binding-probe`, marked do-not-merge; `PROBE.md` there carries the method and two traps worth knowing — `effort` is an **object** (`{"level": "low"}`), so a grep for the string form finds nothing, and in Cowork the hook's log lands in the cloud container rather than the connected project folder.

## The four corrections

| File | Was | Now |
|---|---|---|
| `docs/architecture.md` | "hosted + both harnesses; **Cowork unverified**" | Cowork included, with the method and the object-shape trap |
| `docs/specs/e2e-test-spec.md` | "Effort is session-wide" — the premise for "repinning the model is the only change that does not move every other step" | Both corrected; the `record-extractor` repin is marked as made under the old belief |
| `docs/plan/research-performance-2026-07-27.md` | "Effort is session-wide and reaches every skill *and* subagent" | C0's remedy is buildable for the two of its three named steps that are now agents; `conflict-resolution` is still a skill |
| `eval/harness/e2e/orchestrator.py` | "Session-wide (parent + every subagent)" | …except a subagent that pins its own |

**`run_e2e.py`'s `--effort-level` help is deliberately left alone.** It describes a session-level flag accurately and already carries the "not the only lever — `ClaudeAgentOptions.effort` also works" caveat. A review pass flagged it as a fifth stale site; it is not one.

## What this does not claim

No agent pins an `effort:` today, so nothing about current behaviour changes — every step still runs at the session effort. This corrects what is *possible*, which is what the four sites got wrong.

The consequence that matters is on issue #1136, where the contradiction that "there is no per-skill effort knob" was recorded as blocking spend. Commented there rather than opening a new card: the work this unlocks — revisiting `record-extractor`'s forced `claude-sonnet-4-6` downgrade, and which agents should pin what — is that issue's, and it is already assigned.

## Verification

`npx vitest run tests/packaging/` — 576 passed, 27 files, including `doc-links` and `adr-links`. `orchestrator.py` parses clean. No suite covers whether a doc sentence is true, which is why the measurement is quoted inline rather than asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
