### PR TITLE
Ledger: the per-agent effort bet's research came back, and it binds

### DIFF
--- a/docs/adrs/ADR-0010-record-structural-bets-in-a-ledger.md
+++ b/docs/adrs/ADR-0010-record-structural-bets-in-a-ledger.md
@@ -8,7 +8,7 @@
 
 - **Status:** Accepted
 - **Decided:** 2026-08-09
-- **Last updated:** 2026-08-23 (PR #1849 — first six ledger rows)
+- **Last updated:** 2026-08-25 (the per-agent `effort` row's research came back)
 - **Deciders:** Dallan Quass
 - **Supersedes:** —
 - **Superseded by:** —
@@ -140,7 +140,7 @@ depend on a manual step at the end of a long session.
 | First proposed | Claim | Verdict | What was learned | Issue |
 |---|---|---|---|---|
 | 2026-08-23 | Stop gating a skill edit on a paid eval run plus an annotation pass | rejected | Committed run logs are converged states — the failing intermediate runs the gate exists to catch never enter the corpus, so no measurement over them can price the gate. The between-run figures that motivated this (14% of test outcomes flip, 5% of dimension scores move, both under the record-extraction suite's measured 22–26% / 9–17% same-code noise floor — the only suite where a floor has been measured) measure convergence, not the gate. The annotation half was re-measured separately and is improving, not failing: the 5-test sampler (PR #1637, 2026-08-15) cut median rows per pass 72→35 while raising the score-disagreement rate 0.3%→4.2% and cutting "agree with all" passes 74%→30%. The flat-dimension finding (104 of 170 dimension keys never vary) falls to the same selection effect — "always 3" is equally consistent with authors fixing the 1s before landing, and `make judge-report` cannot tell the two apart | |
-| 2026-08-23 | Per-subagent `effort` shipped upstream; the repo still records it as session-wide | accepted | Confirmed in the *pinned* SDK's `AgentDefinition`, not only in upstream docs; resolves the contradiction blocking issue #1136, and adds a second payoff to skill→agent-pair conversion beyond attribution. The stale sites are enumerated in the stage-3 issue, not here — two careful passes produced two different lists | |
+| 2026-08-23 | Per-subagent `effort` shipped upstream; the repo still records it as session-wide | accepted | **Researched 2026-08-25 — it binds.** Live probe: `{"level": "low"}` on four `record-extractor` calls in Cowork against a `high` session, and a pinned agent at `low` beside an `xhigh` main thread in Claude Code. Also in the pinned SDK's `AgentDefinition`. No new issue — the work it unlocks is already issue #1136's, and the four stale sites are PR #1887 | #1136 |
 | 2026-08-23 | Have the plugin self-report its resolved tool roster instead of testing binding from outside | accepted | Six issues are one mechanism, not the ten first claimed; three held under `cluster:tool-binding` and three run ahead; buys a repeatable per-mode check, not CI coverage | |
 | 2026-08-23 | Production telemetry as one bet across four issues | deferred | | |
 | 2026-08-23 | Replay the guardrail detectors over feedback-bundle session logs | accepted | Yields production examples, not rates — the half of ADR-0009's satisfiability constraint that binds | |


### PR DESCRIPTION
**Touches:** docs/adrs/ADR-0010-record-structural-bets-in-a-ledger.md

The per-agent `effort` row was `accepted` on 2026-08-23 with its research pending. The research ran; this records what it found and closes the row out.

## What it found

It binds — in both environments, measured rather than inferred.

- **Cowork, macOS, live:** a probe plugin pinned `record-extractor` to `effort: low`; four subagent tool calls came back `{"level": "low"}` against the session's `high`.
- **Claude Code:** a pinned agent at `{"level": "low"}` beside `{"level": "xhigh"}` on the main thread, same session.
- `AgentDefinition.effort` is also in the pinned SDK, not only in upstream docs.

## Why the Issue cell points at #1136 and not a new card

Walking the ladder rather than reaching for step 4: the work this unlocks — revisiting `record-extractor`'s forced `claude-sonnet-4-6` downgrade, and deciding which agents pin what — is issue #1136's, which is open and assigned. A new card would duplicate it. The four stale doc sites are a small correction PR (#1887), not issue-sized.

The row previously promised the stale sites would be "enumerated in the stage-3 issue." There is no stage-3 issue, so that pointer is removed rather than left dangling.

## Also

Bumps `Last updated`, using the grant widened in PR #1849 after review caught the same omission there.

## Verification

`npx vitest run tests/packaging/adr-links.test.ts tests/packaging/doc-links.test.ts` — 155 passed. That is the check that would catch a broken pointer in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
