### PR TITLE
drift test: close four routes that stayed green with real drift (#1165 follow-up)

### DIFF
--- a/packages/viewer-ui/src/__tests__/schema-interface-drift.test.ts
+++ b/packages/viewer-ui/src/__tests__/schema-interface-drift.test.ts
@@ -92,6 +92,7 @@ function interfaceFields(path: string): {
   fields: Map<string, Set<string>>
   optional: Map<string, Set<string>>
   inheriting: string[]
+  duplicated: string[]
 } {
   const sourceFile = ts.createSourceFile(
     path,
@@ -102,9 +103,15 @@ function interfaceFields(path: string): {
   const out = new Map<string, Set<string>>()
   const optionalOut = new Map<string, Set<string>>()
   const inheriting: string[] = []
+  const duplicated: string[] = []
   sourceFile.forEachChild((node) => {
     if (!ts.isInterfaceDeclaration(node)) return
     if (node.heritageClauses?.length) inheriting.push(node.name.text)
+    // TypeScript MERGES two declarations of one interface, but this Map is
+    // last-wins, so a drifted declaration placed BEFORE the real one is simply
+    // overwritten and never compared. Collect the collision instead of letting
+    // position decide whether the lint looks.
+    if (out.has(node.name.text)) duplicated.push(node.name.text)
     const fields = new Set<string>()
     const optional = new Set<string>()
     for (const member of node.members) {
@@ -120,10 +127,15 @@ function interfaceFields(path: string): {
     out.set(node.name.text, fields)
     optionalOut.set(node.name.text, optional)
   })
-  return { fields: out, optional: optionalOut, inheriting }
+  return { fields: out, optional: optionalOut, inheriting, duplicated }
 }
 
-const { fields: parsed, optional: parsedOptional, inheriting } = interfaceFields(sourcePath)
+const {
+  fields: parsed,
+  optional: parsedOptional,
+  inheriting,
+  duplicated,
+} = interfaceFields(sourcePath)
 
 /**
  * Which interfaces each helper actually compared — recorded only once the helper's
@@ -203,6 +215,20 @@ describe('@genealogy/schema interfaces mirror research.schema.json', () => {
   it('parsed a plausible number of interfaces', () => {
     // A parser that silently returns nothing reads exactly like a clean run.
     expect(parsed.size, 'interfaces parsed out of packages/schema/src/index.ts').toBeGreaterThan(25)
+  })
+
+  it('no interface is declared twice', () => {
+    // Declaration merging is silent and this parser is last-wins, so a second
+    // declaration of the same interface hides whichever copy loses. Which one
+    // loses depends only on source order, so one ordering is compared and the
+    // other is not; fail here naming the interface rather than comparing a
+    // merged type the file only half-describes.
+    expect(
+      duplicated,
+      'declared more than once in packages/schema/src/index.ts — TypeScript merges ' +
+        'them into one type, but only the last declaration is compared, so the other ' +
+        "half's fields are never checked against the schema",
+    ).toEqual([])
   })
 
   it('no interface inherits its fields', () => {

--- a/packages/viewer-ui/src/__tests__/schema-interface-drift.test.ts
+++ b/packages/viewer-ui/src/__tests__/schema-interface-drift.test.ts
@@ -133,7 +133,11 @@ const { fields: parsed, optional: parsedOptional, inheriting } = interfaceFields
  * hiding a real regression), and a count cannot tell a skipped interface from a
  * smaller one.
  */
-const seen = { names: new Set<string>(), optionality: new Set<string>() }
+const seen = {
+  names: new Set<string>(),
+  optionality: new Set<string>(),
+  optionalityFields: new Set<string>(),
+}
 
 /** One interface against one subschema's `properties`, by field name. */
 function expectMirrors(tsName: string, def: any, help: string) {
@@ -191,6 +195,7 @@ function expectOptionality(tsName: string, def: any, help: string): void {
       `the type marks \`?\`. Schema-optional MUST be TypeScript-optional ` +
       `(ADR-0008, #1165); no exemptions.`,
   ).toEqual({ missingQuestion: [], spuriousQuestion: [] })
+  for (const k of shared) seen.optionalityFields.add(`${tsName}.${k}`)
   seen.optionality.add(tsName)
 }
 
@@ -366,6 +371,36 @@ describe('every intended interface was actually compared', () => {
     expected.add(RENAMED[defName] ?? pascal(defName))
   }
   for (const tsName of Object.values(TREE_INTERFACES)) expected.add(tsName)
+
+  it('expectOptionality compared every schema property, field by field', () => {
+    // Interface-level coverage cannot see a single FIELD dropped inside the helper's
+    // own filter, and an expectation co-derived from the loop's `type` predicate
+    // cannot see a $def leave that predicate. This expectation comes from an
+    // INDEPENDENT key -- `additionalProperties: false`, the anchor the tree half
+    // already uses -- so neither edit can shrink the expectation along with the
+    // thing it is meant to catch. expectMirrors proves the TS field set equals the
+    // schema key set, so every schema property must have been compared.
+    const want: string[] = []
+    for (const [defName, def] of Object.entries<any>(schema.$defs).filter(
+      ([, d]) => d.additionalProperties === false,
+    )) {
+      const tsName = RENAMED[defName] ?? pascal(defName)
+      for (const k of Object.keys(def.properties)) want.push(`${tsName}.${k}`)
+    }
+    expect(
+      want.filter((n) => !seen.optionalityFields.has(n)).sort(),
+      'these schema properties were never optionality-compared',
+    ).toEqual([])
+  })
+
+  it('RENAMED leaves no unchecked PascalCase sibling', () => {
+    // RENAMED redirects a $def's comparison to a differently-named interface, and
+    // the `expected` set is derived THROUGH it, so an appended entry can point at a
+    // clean clone while the real interface drifts unchecked -- the same escape
+    // NO_INTERFACE is pinned against below, one line cheaper.
+    const orphans = Object.keys(RENAMED).filter((d) => parsed.has(pascal(d)))
+    expect(orphans, 'a RENAMED $def still has a same-named interface that nothing compares').toEqual([])
+  })
 
   it('NO_INTERFACE is still empty', () => {
     // The ruling on #1165 is "no exemption list". This is one, and the failure

--- a/packages/viewer-ui/src/components/sections/__tests__/AssertionsSection.test.tsx
+++ b/packages/viewer-ui/src/components/sections/__tests__/AssertionsSection.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import AssertionsSection from '../AssertionsSection'
 import type { ResearchData } from '../../../lib/schema'
 import { patrickFlynnResearch } from '../../../lib/__fixtures__/patrick-flynn'
@@ -30,8 +29,8 @@ function mockResearch(overrides: Partial<ResearchData> = {}): void {
   )
 }
 
-// Helper: cards collapse by default. Find the card with the given title
-// and click its header to expand the body where the Persona row lives.
+// Cards collapse by default, so the body holding the Persona row needs an
+// expand first; expandCardByTitle picks the card out by its title.
 
 describe('AssertionsSection — B1 persona row', () => {
   beforeEach(() => {

--- a/packages/viewer-ui/src/components/sections/__tests__/ConflictsSection.test.tsx
+++ b/packages/viewer-ui/src/components/sections/__tests__/ConflictsSection.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import ConflictsSection from '../ConflictsSection'
 import type { Conflict, ResearchData } from '../../../lib/schema'
 import { patrickFlynnResearch } from '../../../lib/__fixtures__/patrick-flynn'
+import { expandCardByTitle } from './expandCard'
 
 vi.mock('../../../contexts/ResearchDataContext', async () => {
   const actual = await vi.importActual<typeof import('../../../contexts/ResearchDataContext')>(
@@ -36,12 +36,11 @@ describe('ConflictsSection', () => {
   it('renders a recorded conflict with its resolution rationale', async () => {
     mockResearch()
     render(<ConflictsSection />)
-    const title = screen.getByText(
+    const cardTitle =
       "Patrick Flynn's birthplace: Ireland (censuses) vs. Pennsylvania (death certificate)"
-    )
-    expect(title).toBeInTheDocument()
+    expect(screen.getByText(cardTitle)).toBeInTheDocument()
     // Body (with the resolution) is collapsed until the card header is clicked.
-    await userEvent.click(title.parentElement as HTMLElement)
+    await expandCardByTitle(cardTitle)
     expect(screen.getByText('Resolution Rationale')).toBeInTheDocument()
     expect(screen.getByText(/Ireland is accepted/)).toBeInTheDocument()
   })

--- a/packages/viewer-ui/src/components/sections/__tests__/EvaluationsSection.test.tsx
+++ b/packages/viewer-ui/src/components/sections/__tests__/EvaluationsSection.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import EvaluationsSection from '../EvaluationsSection'
 import type { EvaluationEntry, ResearchData } from '../../../lib/schema'
 import { patrickFlynnResearch, patrickFlynnGedcomx } from '../../../lib/__fixtures__/patrick-flynn'

--- a/packages/viewer-ui/src/components/sections/__tests__/PersonEvidenceSection.test.tsx
+++ b/packages/viewer-ui/src/components/sections/__tests__/PersonEvidenceSection.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import PersonEvidenceSection from '../PersonEvidenceSection'
 import type { ResearchData } from '../../../lib/schema'
 import { patrickFlynnResearch, patrickFlynnGedcomx } from '../../../lib/__fixtures__/patrick-flynn'

--- a/packages/viewer-ui/src/components/sections/__tests__/ProjectOverview.test.tsx
+++ b/packages/viewer-ui/src/components/sections/__tests__/ProjectOverview.test.tsx
@@ -81,8 +81,13 @@ describe('ProjectOverview — researcher profile', () => {
 
 /**
  * The shape the optionality flip exists to admit: the key ABSENT, not present-and-null.
- * 18 of the 25 flipped keys are absent from committed documents tens of thousands of
- * times, and nothing normalizes the wire payload before it is cast to ResearchData.
+ * The reason THIS key needs the guard is not the corpus: `subject_person_ids` is present
+ * in every committed document that carries a project object. It is that nothing
+ * normalizes the wire payload before it is cast to ResearchData
+ * (`apps/web/src/transport/WsResearchTransport.ts:29,39`), so an absent key is reachable
+ * whatever the committed files happen to contain. For how often the 25 keys are actually
+ * absent, run the script issue #1165 carries instead of quoting a figure: it moves as run
+ * logs land, and it depends on which files you count as the corpus (ADR-0008).
  *
  * tsc guards the narrowing itself (reverting `== null` to `=== null` here is TS18048),
  * but it cannot see WHAT the component does once someone satisfies the compiler a

--- a/packages/viewer-ui/src/components/sections/__tests__/SourcesSection.test.tsx
+++ b/packages/viewer-ui/src/components/sections/__tests__/SourcesSection.test.tsx
@@ -52,7 +52,7 @@ function makeSource(overrides: Partial<Source> = {}): Source {
   }
 }
 
-// Cards are collapsed by default; click the header (parent of the title)
+// Cards are collapsed by default; expandFirstCard clicks the chevron's header
 // to expand the body and footer.
 
 describe('SourcesSection — B2 transcription', () => {

--- a/packages/viewer-ui/src/components/sections/__tests__/TimelinesSection.test.tsx
+++ b/packages/viewer-ui/src/components/sections/__tests__/TimelinesSection.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import TimelinesSection from '../TimelinesSection'
 import type { ResearchData, Timeline } from '../../../lib/schema'
 import { patrickFlynnResearch, patrickFlynnGedcomx } from '../../../lib/__fixtures__/patrick-flynn'

--- a/packages/viewer-ui/src/components/sections/__tests__/expandCard.ts
+++ b/packages/viewer-ui/src/components/sections/__tests__/expandCard.ts
@@ -6,10 +6,12 @@ import userEvent from '@testing-library/user-event'
  * starts `expanded` false and renders `children` only when true), so any test
  * asserting on a card's body must expand it first.
  *
- * Consolidated from five copies across the section tests, which had drifted into
- * four different mechanisms: three chevron-based, one title-based, and one that
- * reached for `document.getElementById(...).firstElementChild`. They all click the
- * same element. CLAUDE.md: two near-duplicates is the signal to consolidate.
+ * Consolidated from five call sites in two mechanisms: four named local helpers
+ * (chevron-based in EvaluationsSection, SourcesSection and TimelinesSection;
+ * title-based in AssertionsSection) plus an inline title-based click in
+ * ConflictsSection. They all click the same element, and the shared chevron
+ * helper keeps the length guard EvaluationsSection's copy lacked.
+ * CLAUDE.md: two near-duplicates is the signal to consolidate.
  */
 export async function expandFirstCard(): Promise<void> {
   const chevrons = screen.getAllByText(/^[▾▸]$/)


### PR DESCRIPTION
## Summary

- **Normal.** The optionality lint added in #1926 could be defeated four ways while a genuine TypeScript-vs-schema drift sat in the tree. Three assertions close all four, replacing what would have been four one-off patches.
- Corrects three pieces of prose #1926 shipped, including a code comment describing a mechanism that exists nowhere in this repository, and a corpus figure that ADR-0008 in that same PR says belongs in a command rather than in prose.
- Removes four dead `userEvent` imports left by the helper extraction, and folds in the fifth card-expansion call site that the consolidation missed.

Found while reviewing #1926. It merged before these landed, so the routes below are live on main today. Follow-up to #1165 and #1926; closes neither, since #1165 was auto-closed by that merge.

### What was wrong

Each route was reproduced with a real regression planted, either `Assertion.date` losing its `?` or a field that `additionalProperties: false` rejects:

| Route | Before |
|---|---|
| `RENAMED` gets one appended line pointing a `$def` at a clean clone | 74 green |
| a `$def` loses `type: "object"` | 74 to 72, green |
| `&& k !== 'date'` inside `expectOptionality`'s own filter | 74 green |
| a duplicate `export interface` declared BEFORE the real one | 74 green |

The common root of the first three is an expectation co-derived from the thing it checks. The coverage `expected` set used the same `type === 'object' && properties` predicate as the comparison loop, so a `$def` leaving that predicate left both halves together. Coverage was also recorded per interface, so a single field dropped inside a helper's filter was invisible.

The fourth is different: TypeScript merges two declarations of one interface, but `interfaceFields()` builds a last-wins Map, so source position alone decided whether the lint looked. Declared after the real interface it was caught; declared before, it was silent, with `tsc` exiting 0 and the merged type genuinely carrying a field the schema rejects. That is the exact `TimelineEvent.place_id` failure this test's own header cites as its motivation.

### What it does not solve

`expectMirrors`' name direction still accepts a field-level filter edit. Coverage assertions cannot close that one, because the population they would check is the schema-and-TS intersection, which shrinks along with the drift. It needs mutation testing of the guard itself, which is not in this PR. Also unchanged and still disclosed as before: value types, and the three interfaces mirroring inline `items` objects.

## Review guidance

**Start here:** the new `expectOptionality compared every schema property, field by field` test, and specifically why its expectation is keyed on `additionalProperties === false` rather than on the loop's own `type === 'object' && properties`. That independence is the whole point; keying it on the loop's predicate reproduces the bug it fixes. All 22 research `$defs` carry `additionalProperties: false` today, and the tree half already uses that anchor, so the two predicates select identical sets and this is a drop-in.

**Unsure about:** whether `duplicated` should fail here or be pushed down into `gen-enums.mjs`, which already guards the related `export *` shadowing trap on the same file. I put it here because this is the test that reads the interfaces, but a reviewer may reasonably prefer the build-time home.

## Plan

**Didn't change:** `expectMirrors`' name-direction hole, deliberately, because the remedy I tried for it did not work and I am not shipping an untested one. `eval/app`'s forked mirror, which #1165 ruled out of scope by name and #1488 owns. The 25 flipped fields and their `| null`, which I re-derived and found correct in both directions.

**Acceptance check:** on main, planting any of the four routes above leaves the suite green. On this branch each reddens by name: `expectOptionality compared every schema property, field by field` (naming `Assertion.date`, and 19 properties for the `type` route), `RENAMED leaves no unchecked PascalCase sibling` (naming `assertion`), and `no interface is declared twice` (naming `Assertion`). The duplicate case reddens in **both** orderings, not only the one my fixture used. Unmutated, the file is green at 77.

**Deviated from the plan:** no PLAN.md. This came out of reviewing #1926, and the fourth guard was added after the first commit, which is why that commit's message says the route was left unfixed. It is fixed in the second.

## Test plan

- [x] I ran `make test-all` (or `scripts/test.sh` — the same command) and it passed.

- [ ] For every skill whose **run-log snapshot** I changed ... — N/A, no skill dir, agent, `eval/tests/`, fixture or scenario is touched. The diff is nine files, all under `packages/viewer-ui`.

- [ ] If I changed a skill's `description` frontmatter or its DO NOT clauses ... — N/A, no skill description or DO NOT clause is touched.

Also run, all uncached: `turbo typecheck --force` 5/5, `turbo test --force` 4/4 (web 10, electron 97, viewer-ui 274), engine packaging 590, and `tsc --noUnusedLocals` reporting zero TS6133 where it previously reported four.

## Follow-on issues

None filed.

**Folded in / filed instead:** Everything found was folded in. The fourth guard was the one candidate for filing, and it did not qualify: CLAUDE.md's test is whether the work carries four-person overhead, and it is a four-line collection plus one assertion. The `expectMirrors` name-direction gap is stated above rather than filed, because it is a known limitation of the approach and not a discrete task yet; say the word if you would rather it were a `nothing-checks` issue.
