### PR TITLE
fill-ready: give Gate 3 a way to find collisions

### DIFF
--- a/.claude/skills/fill-ready/SKILL.md
+++ b/.claude/skills/fill-ready/SKILL.md
@@ -498,6 +498,50 @@ pick them up will never read your report.
 **Contention over a skill's eval snapshot is the exception and is Gate 4** — that
 one is hard, because the second item cannot land without paying for a second run.
 
+#### Finding them — because until 2026-08-27 nothing here did
+
+This gate told you to write reciprocal notes and never said how to find a pair.
+The Gate 4 map below was the only automated collision check, and it keys on
+snapshot paths by construction, so a collision anywhere else — engine source, the
+harness, a spec — was invisible to every mechanism in this skill.
+
+**The half that nothing else can cover is issue-against-issue.** `/review-ready`
+fans out one agent per issue and those agents do check open PRs, so the
+issue-against-PR half is largely redundant with the gate. But each agent sees
+exactly one issue, so a pair of issues that edit the same file is invisible to
+all of them — which is why `/review-ready` §3 asks its collator to cross-check
+the agents by hand. This is that check, mechanised.
+
+Run it over `Ready,In Progress,Review` for the issue-against-issue half, and over
+the promotion shortlist for the issue-against-PR half. It reads `**Touches:**`
+lines, so it is only ever as good as they are — a missing line means an item
+simply does not appear.
+
+```sh
+gh project item-list 1 --owner PioneerAIAcademy --format json --limit 1000 > /tmp/board.json
+gh issue list --repo PioneerAIAcademy/cowork-genealogy --state open --limit 300 \
+  --json number,title,body > /tmp/open.json
+gh pr list --repo PioneerAIAcademy/cowork-genealogy --state open --limit 200 \
+  --json number,title,files > /tmp/prs.json
+python3 .claude/skills/fill-ready/collisions.py \
+  /tmp/board.json /tmp/open.json /tmp/prs.json "Ready,In Progress,Review"
+```
+
+**Three guards keep it from becoming a constant, and each one is there because
+the version without it fired on almost everything.** Do not remove one without
+re-measuring; the counts below are from the 2026-08-27 board.
+
+| Guard | Why | Without it |
+|---|---|---|
+| A concrete file never implies its directory | Two files in `src/tools/` are not a collision | Every `src/tools/` item paired with every other — 14 pairs on one issue |
+| A directory holding more than 10 tracked files is not pairable (snapshot dirs exempt) | Naming `src/tools/` (47 files) means "I add a file here", not "I edit all 47" | 3 of 8 pairs false, all from one issue's `src/tools/` entry |
+| A file named by more than 3 candidates is a hub, reported once | `docs/architecture.md` is the repo's map; everyone edits it, in different sections | 26 of 79 shared-path hits were that one file |
+
+The verdict it prints is advisory: a shared **snapshot** path means Gate 4 and is
+hard, anything else is Gate 3 and only needs the notes below. Read the pairs, do
+not paste them — the script cannot tell "both edit this file" from "one deletes
+what the other adds".
+
 **Write a reciprocal note at the top of both bodies** — below a `> **Reviewed …**`
 marker if `/review-ready` already left one — in the lead's own form:
 
@@ -643,6 +687,11 @@ named three other skills. Discount a `Touches:` line inherited from an issue sin
 **The map is a snapshot.** It is right for the pass that produced it and stale by the next
 one — re-run it before you write anything to the board, and tell a junior to re-check the
 slot before opening a PR rather than trusting a table in an issue body.
+
+**This map only sees snapshot paths, and that is correct — but it is not the whole
+collision picture.** `build_snapshot` deliberately excludes
+`packages/engine/mcp-server/src/**`, so two items rewriting one engine file collide
+without ever appearing here. That is Gate 3's detector, above; run both.
 
 **Reclaim a stalled slot.** A holder that has not moved in ~10 days is blocking a
 whole skill. Say so in your report with the assignee and the idle count, and

--- a/.claude/skills/fill-ready/collisions.py
+++ b/.claude/skills/fill-ready/collisions.py
@@ -1,0 +1,225 @@
+"""Gate 3 soft-collision detector for /fill-ready.
+
+Finds items that edit the same files, so the reciprocal notes Gate 3 asks for can
+actually be written. Reads `**Touches:**` lines, so it is only as good as they
+are: an issue with no such line does not appear at all.
+
+The load-bearing half is issue-against-issue. `/review-ready` fans out one agent
+per issue and those agents do check open PRs, so the issue-against-PR half is
+largely redundant with that gate — but each agent sees exactly one issue, so a
+pair of issues touching one file is invisible to every one of them.
+
+Usage:
+    python3 collisions.py board.json open.json prs.json "Ready,In Progress,Review"
+
+Three guards keep the output from becoming a constant. Each is here because the
+version without it fired on nearly every candidate; see the table in SKILL.md.
+Do not relax one without re-measuring the pair count on a real board.
+"""
+
+import json
+import re
+import subprocess
+import sys
+
+ROOTS = ("packages/", "eval/", "docs/", "apps/", "scripts/", ".github/", ".claude/")
+_TOKEN = re.compile(r"(?:" + "|".join(re.escape(r) for r in ROOTS) + r")[A-Za-z0-9_./*-]+")
+
+# Guard 2. A directory holding more than this many tracked files is too coarse to
+# pair on: naming it means "I add a file here", not "I edit every file here".
+# Snapshot directories are exempt -- there, breadth IS the Gate 4 unit.
+_PREFIX_MAX_FILES = 10
+
+# Guard 3. A concrete file named by more than this many candidates is a hub, not a
+# collision. Pairing on it emits N-squared rows nobody reads.
+_HUB_MAX = 3
+
+# Paths inside a skill's eval run-log snapshot. A collision here is Gate 4 (hard,
+# costs a second paid run); anything else is Gate 3 (sequence + reciprocal notes).
+# Mirrors `build_snapshot` in eval/harness/harness/snapshot.py, which deliberately
+# excludes packages/engine/mcp-server/src/** -- an eval run never executes it.
+SNAPSHOT = (
+    re.compile(r"^packages/engine/plugin/skills/[a-z0-9-]+/"),
+    re.compile(r"^eval/tests/unit/[a-z0-9-]+/"),
+    re.compile(r"^packages/engine/plugin/agents/[a-z0-9-]+\.md$"),
+    re.compile(r"^eval/fixtures/(scenarios|mcp)/"),
+)
+
+
+def in_snapshot(path):
+    return any(r.search(path) for r in SNAPSHOT)
+
+
+_count_cache = {}
+
+
+def tracked_count(prefix):
+    """Number of git-tracked files under `prefix`."""
+    if prefix not in _count_cache:
+        out = subprocess.run(
+            ["git", "ls-files", prefix],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        ).stdout
+        _count_cache[prefix] = len([ln for ln in out.split("\n") if ln.strip()])
+    return _count_cache[prefix]
+
+
+def pairable(kind, path):
+    if kind == "file":
+        return True
+    if in_snapshot(path + "/"):
+        return True
+    n = tracked_count(path)
+    return 0 < n <= _PREFIX_MAX_FILES
+
+
+def parse(entry):
+    """-> ('file', path) | ('prefix', dir).
+
+    A glob, or a last segment with no dot, means the entry names a directory.
+    """
+    p = entry.rstrip("/")
+    if "*" in p:
+        return ("prefix", p.split("*")[0].rstrip("/"))
+    last = p.rsplit("/", 1)[-1]
+    return ("file", p) if "." in last else ("prefix", p)
+
+
+def paths_from_touches(body):
+    m = re.search(r"\*\*Touches:\*\*(.*?)(?:\n\n|\Z)", body or "", re.S)
+    if not m:
+        return set()
+    seg = m.group(1).replace("`", " ").replace("·", " ")
+    out = set()
+    for tok in _TOKEN.findall(seg):
+        tok = tok.rstrip(".,;:)").rstrip("/")
+        if tok:
+            out.add(parse(tok))
+    return out
+
+
+def under(path, prefix):
+    return path == prefix or path.startswith(prefix + "/")
+
+
+def overlap(entries, paths):
+    """Files in `paths` that collide with `entries`.
+
+    Guard 1 lives here: a ('file', p) entry matches only the identical path. It
+    never implies its directory, because two files in one directory are not a
+    collision.
+    """
+    hit = set()
+    for kind, p in entries:
+        if not pairable(kind, p):
+            continue
+        if kind == "file":
+            if p in paths:
+                hit.add(p)
+        else:
+            hit |= {f for f in paths if under(f, p)}
+    return hit
+
+
+def entry_overlap(a, b):
+    hit = overlap(a, {p for k, p in b if k == "file"})
+    hit |= overlap(b, {p for k, p in a if k == "file"})
+    for ka, pa in a:
+        for kb, pb in b:
+            if ka == kb == "prefix" and pairable(ka, pa) and pairable(kb, pb):
+                if under(pa, pb) or under(pb, pa):
+                    hit.add(pa if len(pa) > len(pb) else pb)
+    return hit
+
+
+def main(board_path, open_path, prs_path, statuses):
+    board = json.load(open(board_path, encoding="utf-8"))["items"]
+    issues = {i["number"]: i for i in json.load(open(open_path, encoding="utf-8"))}
+    prs = json.load(open(prs_path, encoding="utf-8"))
+    status = {(it.get("content") or {}).get("number"): it.get("status") for it in board}
+
+    cand, broad = {}, {}
+    for n, issue in issues.items():
+        if status.get(n) not in statuses:
+            continue
+        entries = paths_from_touches(issue.get("body") or "")
+        if not entries:
+            continue
+        cand[n] = entries
+        wide = [p for k, p in entries if k == "prefix" and not pairable(k, p)]
+        if wide:
+            broad[n] = wide
+
+    touch = {}
+    for entries in cand.values():
+        for kind, p in entries:
+            if kind == "file":
+                touch[p] = touch.get(p, 0) + 1
+    hubs = {p for p, c in touch.items() if c > _HUB_MAX}
+
+    pr_paths = {p["number"]: {f["path"] for f in p["files"]} for p in prs}
+
+    def show(pairs):
+        shown = 0
+        for (a, b), shared in sorted(pairs.items()):
+            shared = shared - hubs
+            if not shared:
+                continue
+            shown += 1
+            gate = "GATE 4 (hard)" if any(in_snapshot(s) for s in shared) else "GATE 3"
+            print(f"  {a} + {b}  [{gate}]")
+            # Snapshot paths first: they are what justifies a GATE 4 label, so
+            # truncation must never hide them.
+            ordered = sorted(shared, key=lambda s: (not in_snapshot(s), s))
+            for s in ordered[:4]:
+                print(f"       {s}{'   [snapshot]' if in_snapshot(s) else ''}")
+            if len(ordered) > 4:
+                print(f"       ... and {len(ordered) - 4} more")
+        if not shown:
+            print("  (none)")
+        return shown
+
+    print("=== issue + issue (invisible to per-issue review agents) ===")
+    pairs = {}
+    numbers = sorted(cand)
+    for idx, a in enumerate(numbers):
+        for b in numbers[idx + 1:]:
+            shared = entry_overlap(cand[a], cand[b])
+            if shared:
+                pairs[(f"issue #{a}", f"issue #{b}")] = shared
+    n_ii = show(pairs)
+
+    print("\n=== issue + open PR (mostly covered by /review-ready) ===")
+    pairs = {}
+    for n, entries in cand.items():
+        for pn, paths in pr_paths.items():
+            shared = overlap(entries, paths)
+            if shared:
+                pairs[(f"issue #{n}", f"PR #{pn}")] = shared
+    n_ip = show(pairs)
+
+    if hubs:
+        print("\n=== hub files -- many items touch these; not a pairing signal ===")
+        for h in sorted(hubs):
+            who = sorted(n for n, e in cand.items() if ("file", h) in e)
+            print(f"  {h}: {len(who)} items -- {', '.join('#' + str(x) for x in who)}")
+
+    if broad:
+        print("\n=== directories too broad to pair -- read these by hand ===")
+        for n, wide in sorted(broad.items()):
+            desc = ", ".join(f"{p} ({tracked_count(p)} files)" for p in wide)
+            print(f"  issue #{n}: {desc}")
+
+    print(
+        f"\nsummary: {n_ii} issue-issue, {n_ip} issue-PR, "
+        f"{len(hubs)} hubs, {len(broad)} broad"
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 5:
+        print(__doc__)
+        sys.exit(2)
+    main(sys.argv[1], sys.argv[2], sys.argv[3], set(sys.argv[4].split(",")))


### PR DESCRIPTION
## What this fixes

Gate 3 in `/fill-ready` tells you to write reciprocal `**IMPORTANT**: If you do this, do #N at the same time.` notes on items that edit the same files. It never said how to *find* a pair.

The Gate 4 map was the skill's only automated collision check, and it keys on eval-snapshot paths by construction — `build_snapshot` deliberately excludes `packages/engine/mcp-server/src/**`, because an eval run never executes it. So a collision in engine source, the harness, or a spec was invisible to every mechanism in the skill.

**The half nothing else can cover is issue-against-issue.** `/review-ready` fans out one agent per issue and those agents do check open PRs on their own initiative — in the 2026-08-27 run all nine did, and two independently flagged PR #1877. So the issue-against-PR half of this is largely redundant with that gate, and it is shipped as the secondary output. But each agent sees exactly one issue, so a pair of issues editing one file is invisible to all of them. `/review-ready` §3 already asks its collator to *"cross-check the agents against each other… a collision neither could see"* and gives no mechanism. This is that check, mechanised.

## Honest scoping

Gate 3 is second-tier next to Gate 4. A missed soft collision costs a merge conflict and some rework, and git surfaces it. A missed Gate 4 costs another paid eval run plus a full annotation pass, and landing the second invalidates the first run log. This PR does not change that ordering — it fills a hole in the cheaper gate, and the issue-against-PR half is explicitly labelled as mostly redundant so nobody mistakes it for new coverage.

## The three guards, and why each exists

Every guard was added after watching the version without it fire on nearly every candidate. Counts are from the 2026-08-27 board.

| Guard | Rationale | Measured effect of removing it |
|---|---|---|
| A concrete file never implies its directory | Two files in `src/tools/` are not a collision | Every item naming a file under `src/tools/` paired with every other — **14 pairs on one issue** |
| A directory holding >10 tracked files is not pairable (snapshot dirs exempt) | `src/tools/` is 47 files; naming it means "I add a file here", not "I edit all 47" | **3 of 8** surviving pairs were false, all from one issue's `src/tools/` entry |
| A file named by >3 candidates is a hub, reported once instead of paired | `docs/architecture.md` is the repo's map — everyone edits it, in different sections | **26 of 79** shared-path hits were that one file |

Breadth is measured as a real `git ls-files` count, not path depth. Depth was the first attempt and it let `packages/engine/mcp-server/src/tools` (5 segments, 47 files) through.

## Output on the current board

```
summary: 5 issue-issue, 39 issue-PR, 2 hubs, 2 broad     # Ready,In Progress,Review
summary: 0 issue-issue, 13 issue-PR, 0 hubs, 1 broad     # Ready pool only
```

The 5 issue-issue pairs are all real, including `#1429 + #1853` on `person-evidence/SKILL.md` (correctly labelled GATE 4) and `#1866 + #1902` on `eval/harness/harness/orchestrator.py`.

Snapshot paths sort first inside a pair, so truncating the file list can never hide the path that justified a `GATE 4` label. An earlier revision did exactly that on `#1429 + PR #1977`.

## How this was verified

`eval/harness/tests/unit/test_encoding_lint.py` — 4 passed.

Per CLAUDE.md's *"a new lint must be proven to fail"*, the pass alone proves nothing: it could mean the file is outside the lint's scan. Removing the `encoding="utf-8"` kwarg from the one `subprocess.run` makes it fail, naming the exact line:

```
FAILED tests/unit/test_encoding_lint.py::test_no_bare_text_mode_file_io
  .claude/skills/fill-ready/collisions.py:59: subprocess.run() has no encoding= (add encoding="utf-8")
```

Restored, green again.

## Limits, stated

- It reads `**Touches:**` lines, so it is only as good as they are. An issue with no such line does not appear at all. That is a known and separate weakness the skill already documents.
- It cannot tell "both edit this file" from "one deletes what the other adds". The output is advisory; the SKILL.md text says to read the pairs, not paste them.
- No CI job runs it. It is a skill-time tool, like the Gate 4 map beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
