### PR TITLE
fill-ready: pair a bare directory on what it means, not how big it is

### DIFF
--- a/.claude/skills/fill-ready/SKILL.md
+++ b/.claude/skills/fill-ready/SKILL.md
@@ -534,8 +534,21 @@ re-measuring; the counts below are from the 2026-08-27 board.
 | Guard | Why | Without it |
 |---|---|---|
 | A concrete file never implies its directory | Two files in `src/tools/` are not a collision | Every `src/tools/` item paired with every other — 14 pairs on one issue |
-| A directory holding more than 10 tracked files is not pairable (snapshot dirs exempt) | Naming `src/tools/` (47 files) means "I add a file here", not "I edit all 47" | 3 of 8 pairs false, all from one issue's `src/tools/` entry |
+| A bare directory pairs only if it is a snapshot path or a **unit dir** — never an ordinary container | Naming `src/tools/` means "I add a file here", not "I edit all 47". A skill dir, a scenario, an e2e fixture *is* the unit, so naming it does mean all of it | 3 of 8 pairs false from one `src/tools/` entry; and see the row below |
 | A file named by more than 3 candidates is a hub, reported once | `docs/architecture.md` is the repo's map; everyone edits it, in different sections | 26 of 79 shared-path hits were that one file |
+
+**Do not swap the unit/container test back for a size threshold.** It was one
+(`<= 10 tracked files`) until 2026-08-27, and size is a proxy that misses in both
+directions: `apps/server/app/sandbox` is 5 files and a container,
+`eval/runlogs/unit/<skill>` is 11 and a unit. The threshold paired issue #1959 —
+whose entry reads `apps/server/app/sandbox/ (LocalProvider WS path)`, i.e.
+`local.py` — against #1729 and #1489, which name `e2b.py`. Two notes nearly went
+onto three issues telling people to coordinate on work that does not overlap.
+
+**A parenthetical that narrows a directory is still not read.** `(LocalProvider WS
+path)` names the file, and the extractor drops it as punctuation. That is why the
+"too broad to pair" list exists and why it says *read these by hand* — it is the
+honest bucket, not a failure.
 
 The verdict it prints is advisory: a shared **snapshot** path means Gate 4 and is
 hard, anything else is Gate 3 and only needs the notes below. Read the pairs, do

--- a/.claude/skills/fill-ready/collisions.py
+++ b/.claude/skills/fill-ready/collisions.py
@@ -25,10 +25,26 @@ import sys
 ROOTS = ("packages/", "eval/", "docs/", "apps/", "scripts/", ".github/", ".claude/")
 _TOKEN = re.compile(r"(?:" + "|".join(re.escape(r) for r in ROOTS) + r")[A-Za-z0-9_./*-]+")
 
-# Guard 2. A directory holding more than this many tracked files is too coarse to
-# pair on: naming it means "I add a file here", not "I edit every file here".
-# Snapshot directories are exempt -- there, breadth IS the Gate 4 unit.
-_PREFIX_MAX_FILES = 10
+# Guard 2. A bare directory pairs only when it names a UNIT -- a directory that is
+# itself the thing being worked on, so naming it really does mean "all of this".
+# Everything else is a CONTAINER, where naming it means "a file in here" and
+# pairing it against its own siblings is a false positive.
+#
+# This replaced a tracked-file-count threshold (<= 10 files) on 2026-08-27. Size is
+# a proxy for the distinction and gets it wrong in both directions: measured over
+# the 27 bare-directory Touches entries then on the board, `apps/server/app/sandbox`
+# (5 files) and `eval/app/tests/unit` (6) passed the threshold and are containers,
+# while `eval/runlogs/unit/<skill>` (11) failed it and is a unit. The false pair it
+# produced: issue #1959 says `apps/server/app/sandbox/ (LocalProvider WS path)` --
+# i.e. local.py -- and was paired against #1729 and #1489, which name e2b.py.
+_UNIT_DIRS = (
+    re.compile(r"^packages/engine/plugin/skills/[a-z0-9-]+$"),
+    re.compile(r"^eval/tests/unit/[a-z0-9-]+$"),
+    re.compile(r"^eval/tests/e2e/[a-z0-9-]+$"),
+    re.compile(r"^eval/fixtures/scenarios/[a-z0-9-]+$"),
+    re.compile(r"^eval/runlogs/unit/[a-z0-9-]+$"),
+    re.compile(r"^eval/runlogs/e2e/[a-z0-9-]+$"),
+)
 
 # Guard 3. A concrete file named by more than this many candidates is a hub, not a
 # collision. Pairing on it emits N-squared rows nobody reads.
@@ -66,13 +82,17 @@ def tracked_count(prefix):
     return _count_cache[prefix]
 
 
+def is_unit_dir(path):
+    return any(r.match(path) for r in _UNIT_DIRS)
+
+
 def pairable(kind, path):
+    """A file always pairs. A directory pairs only if everything inside it is in
+    scope: a snapshot path (any file under it dirties a run log -- Gate 4), or a
+    unit dir (the directory *is* the thing being worked on)."""
     if kind == "file":
         return True
-    if in_snapshot(path + "/"):
-        return True
-    n = tracked_count(path)
-    return 0 < n <= _PREFIX_MAX_FILES
+    return in_snapshot(path + "/") or is_unit_dir(path)
 
 
 def parse(entry):


### PR DESCRIPTION
Follow-on to PR #1979, from a false positive it produced in live use this afternoon.

## The defect

Guard 2 asked whether a bare directory holds `<= 10` tracked files. That is a proxy for the real question — **is this directory the thing being worked on, or a container someone will add one file to?** — and it misses in both directions:

| Path | Files | Actually |
|---|---|---|
| `apps/server/app/sandbox` | 5 | container — passed the threshold |
| `eval/app/tests/unit` | 6 | container — passed |
| `eval/runlogs/unit/<skill>` | 11 | unit — failed |

**The pair it produced.** Issue #1959's entry reads `apps/server/app/sandbox/ (LocalProvider WS path)` — i.e. `local.py`. It was paired against #1729 and #1489, which name `e2b.py`. Different files, same 5-file directory. Two reciprocal notes were about to go onto three issues telling people to coordinate on work that does not overlap — the exact noise Gate 3 notes exist to prevent.

## The fix

A bare directory pairs only if it is:
- a **snapshot path** — any file under it dirties a run log, so a collision there is a real Gate 4; or
- a **unit dir** — a skill, a unit-test dir, an e2e fixture, a scenario, a run-log dir. The directory *is* the unit, so naming it does mean all of it.

Ordinary containers go to the existing "too broad to pair — read these by hand" list. `_PREFIX_MAX_FILES` is gone; `tracked_count` survives only to annotate that list with `(N files)`.

## Measured effect

Full Backlog+active scope, 2026-08-27 board:

```
before 204 pairs, after 202 pairs
dropped 2, added 0

  issue #1489 + issue #1959   apps/server/app/sandbox/e2b.py
  issue #1729 + issue #1959   apps/server/app/sandbox/e2b.py
```

Exactly the two false pairs, nothing else. On the normal `Ready,In Progress,Review` scope the pair counts are **identical** (5 issue-issue, 39 issue-PR); only the broad bucket grows from 2 to 4, correctly absorbing #1959 and #1964.

## The first attempt was wrong, and how that surfaced

I initially made the unit-dir test a **replacement** for the snapshot exemption rather than an addition. That dropped **18** pairs, including real Gate 4 collisions:

- `#1913 + #1972` — three `eval/fixtures/scenarios/flynn-*/research.json`
- `#1755` and `#1886` against PRs #1946 / #1977 / #1978 — `eval/fixtures/mcp/**`

Both had been independently flagged by `task-reviewer` agents as hard blockers, so losing them would have been a real regression. A before/after **pair diff** caught it; the summary counts alone would not have, because "18 fewer pairs" reads like a successful denoise. If this rule changes again, run the diff, not the counter.

## Limits, restated

A parenthetical that narrows a directory — `(LocalProvider WS path)` — is still dropped as punctuation and not read. Resolving free-form prose hints against filenames is fragile, so the honest answer is the "read these by hand" bucket, and SKILL.md now says so explicitly rather than leaving it as an unexplained gap.

## Verification

`eval/harness/tests/unit/test_encoding_lint.py` — 4 passed. (PR #1979 already proved this file is inside that lint's scan by breaking it and watching it name the line; that scope has not changed.)

No CI job runs the detector — it is a skill-time tool, like the Gate 4 map beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
