### PR TITLE
board skills: state the instructions, drop the history — and the cross-lane merge ruling

### DIFF
--- a/.claude/skills/audit-board/SKILL.md
+++ b/.claude/skills/audit-board/SKILL.md
@@ -13,15 +13,12 @@ allowed-tools:
 
 `/fill-ready` ranks the Backlog, `/review-ready` vets one shortlist,
 `/review-icebox` sweeps the frozen pool. All three look at issues one at a time.
-This skill is the only pass that looks at the pool **as a whole** — the merges,
-the rot, the clusters, and the handling that no single body can propose because
-no single body can see the others.
+This skill is the only pass that looks at the pool **as a whole** — merges, rot,
+clusters, and cross-cutting handling.
 
-**Run it weekly, and run it before `/fill-ready`.** That ordering is the point:
-filers search once and then file, because judging fit needs the whole pool and
-cannot be made from inside one PR. This pass is where duplicates get merged,
-premises get corrected and dead items get dropped. `/fill-ready` then ranks a
-deduped Backlog. Run it the other way round and it ranks duplicates.
+**Run it weekly, and run it before `/fill-ready`**, so that pass ranks a deduped
+Backlog. This is where duplicates get merged, premises get corrected and dead
+items get dropped.
 
 **You propose, then apply what is approved.** No branches, no PRs, no code edits.
 You have no `Edit` or `Write` tool on purpose.
@@ -60,16 +57,13 @@ which pairs collide.
 
 ### Reading the pool without silently sampling it
 
-§1 and §3 need every body in one head — that is where collisions and clusters
-come from, and it is why you read them all. **§2 does not.** Its checks are
-per-issue and mechanical, and running eight of them across ~220 bodies will not
-fit alongside everything else. A pass that quietly does forty and reports as
-though it did all of them is worse than one that states its sample.
-
-So split the work: read the whole pool yourself for §1 and §3, and **fan §2 out**.
-Partition the issue numbers into batches of ~25–30 and give each batch an
-explicit, non-overlapping list, so nothing is checked twice and nothing is
-missed. Generate the partition — do not eyeball it.
+Read the whole pool yourself for the merges and the clusters — both need every
+body in one head. **Fan the obsolescence checks out.** They are per-issue and
+mechanical, and eight of them across ~220 bodies will not fit alongside
+everything else. Partition the issue numbers into batches of ~25–30 and give each
+batch an explicit, non-overlapping list, so nothing is checked twice and nothing
+is missed. Generate the partition — do not eyeball it. Never report a sample as
+though it were the whole pool.
 
 Give each batch the five verdicts rather than a summary instruction: **FIXED**
 (name the commit or PR), **STILL BROKEN** (quote the evidence), **PARTLY**
@@ -120,11 +114,10 @@ neither filed recently, both quietly wanting the same lines — plus obsolescenc
 clusters, eval-slot queues and board hygiene. None of those change materially in a
 day, and all of them need every body in one head.
 
-If you cannot reach the target, **say so at the top of the output**: the number you
-propose, the target, and the gap. Four merges against a week of two hundred
-filings is not a successful audit; the shortfall is the finding, and burying it
-under the merges you did find misreports the week. The lead still approves every
-item — the target binds what you propose, not what he accepts.
+If you cannot reach the target, **say so at the top of the output**: the number
+you propose, the target, and the gap. The shortfall is itself a finding — report
+it above the merges you did find. The target binds what you propose, not what the
+lead accepts.
 
 ## 1. Merges
 
@@ -142,32 +135,23 @@ claim before acting on it, then either close the subset or narrow the superset
 so exactly one owns the scope.
 
 **Batch — separate issues, one paid run.** This is the most common and the most
-valuable. See §4.
+valuable. See the paid-run tax below.
 
-**Split the lanes — only when each half finishes without the other.** Two halves
-that are genuinely different labor — a `developer` lint and a `genealogist` audit
-on unrelated ground — can stay apart. **The reason is not that a two-lane card has
-no single assignee.** That premise is retired: the lead ruled on 2026-08-31 that a
-`developer` half and a `genealogist` half of one skill's work belong on one card,
-*"because genealogists and developers can request help as needed"* — whoever holds
-it pulls in the other lane rather than the board splitting the work for them. So
-**"these are different lanes" is not a reason to keep two issues apart**, and on
-the same skill it is not even a reason to hesitate.
+**Split the lanes — only when each half finishes without the other.** One test
+decides it: **can each half be finished, reviewed and merged without waiting on
+the other?** If yes, split at the lane boundary and move the content, so neither
+issue is left pointing at the other for something it needs, and give each its own
+acceptance. If no, merge and let the card carry both labels.
 
-One test survives, and it is now the only one: **can each half be finished,
-reviewed and merged without waiting on the other?** If yes, split at the lane
-boundary and move the content, so neither issue is left pointing at the other for
-something it needs, and give each its own acceptance.
+**"These are different lanes" is never on its own a reason to keep two issues
+apart.** A `developer` half and a `genealogist` half of one skill's work go on one
+card; whoever holds it asks the other lane for the half they do not own.
 
-If no — merge, and let the card carry both labels.
-
-**"Schedule together, leave both open" is not a verdict.** The lead ruled it out
-on 2026-08-11: *"Anything that should be done together sounds like a reason to
-merge. Otherwise we have to cross-reference the issues and rely on people
-remembering to assign both issues to themselves, which they have forgotten
-several times."* Same decision, same files, same paid run, same reviewer, or
-class-and-instance — all merge. Splitting on *mechanism purity* (two tools, two
-matchers, two code paths) is an author's aesthetic, not a work boundary.
+**"Schedule together, leave both open" is not a verdict, and neither is
+"cross-reference and note it".** Same decision, same files, same paid run, same
+reviewer, or class-and-instance — all merge. Splitting on *mechanism purity* (two
+tools, two matchers, two code paths) is an author's aesthetic, not a work
+boundary.
 
 The one legitimate not-a-merge is a **one-way mechanical dependency**: issue B
 only needs to *apply* something issue A defines. Then edit B's body so it reads as
@@ -191,49 +175,32 @@ invisible the moment the tracker scrolls.
 Ask: does one person, doing this once, finish all of it? If no, they are
 separate issues no matter how alike the bodies read.
 
-Template-filled bodies are the trap, because a fleet of them looks like mass
-duplication at a glance. This happened, and cost real data: on 2026-08-04 this
-skill closed twenty `test <slug>` record-hint adjudications into one tracker,
-justifying it as "byte-identical bodies differing only in a name and two URLs".
-They were not duplicates in any sense — twenty different people, twenty
-different records, four different countries — and the shared text was the
-`/resolve-record-hint` boilerplate every one of them carries. The tracker then
-asserted three things that were false within days: that eighteen fixtures were
-still draft (ten were), that the unlisted ones had no card (three did, all
-assigned), and it dropped one fixture's hint ark entirely, pointing at a README
-that did not contain it. All four were reopened 2026-08-10 and the tracker
-deleted.
+**Template-filled bodies are the trap.** A fleet of them looks like mass
+duplication at a glance and is not: twenty `test <slug>` record-hint
+adjudications are twenty different people, twenty different records and four
+different countries, and the shared text is the `/resolve-record-hint`
+boilerplate every one of them carries.
 
 If a set genuinely wants shared coordination, the tools for that are the
-`cluster:*` label and §4's batching, which keep every issue open and assignable.
-A standing `next run:` issue is the one legitimate umbrella, and it schedules
-work rather than containing it.
+`cluster:*` label and the paid-run batching below, which keep every issue open
+and assignable. A standing `next run:` issue is the one legitimate umbrella, and
+it schedules work rather than containing it.
 
 Search for merge candidates **by fix site, not by topic**. Issues that collide
 here almost never share a title; they want different lines in one file.
 
 **Two issues wanting different lines in the same file default to one issue.**
-Keeping them apart needs a stated reason, and there are only two left: a **blocker
-on one side** — never park an unblocked issue behind a blocked one — or **each half
-genuinely finishes without the other**, tested as the lane-split verdict above
-tests it. Absent one, merge.
+Decide in this order and stop at the first that applies:
 
-Two reasons that used to sit on this list are gone:
+1. **A blocker on one side** — keep them apart. Never park an unblocked issue
+   behind a blocked one.
+2. **A paid run they would otherwise each need** — merge. Two changes to one
+   skill's snapshot cannot share a run while they sit on separate cards.
+3. **Each half finishes without the other**, tested as the lane-split verdict
+   above tests it — keep them apart.
 
-- **"Different lane" is not one** (lead, 2026-08-31 — see the lane-split verdict).
-- **"A paid-run slot they cannot share" is not one — it is the single strongest
-  reason to merge.** It read as a keep-apart reason here and as a merge reason in
-  §4, which is one fact pointing two ways; §4 is right. Two changes to one skill's
-  snapshot cannot share a paid run, so leaving them on separate cards buys two
-  runs at $8–12 and 45–65 minutes each, plus two annotation passes. Merging buys
-  one of each.
-
-**A shared paid run outranks the finishes-independently test.** Two issues can
-each be finished alone and still both need the same skill's snapshot re-run — that
-is a merge, because the run is what the split actually costs. Read the two reasons
-in order: a blocker on one side keeps them apart no matter what; absent a blocker,
-a shared run merges them; only when no run is at stake does finishing
-independently decide.
+Absent all three, merge. Neither "different lane" nor "different reviewer" is a
+reason to keep two issues apart.
 
 Bodies filed from 2026-08-04 open with a `**Touches:**` line — the instruction
 lives in `CLAUDE.md`'s `gh issue create` recipe, and essentially every issue in
@@ -259,18 +226,12 @@ grep -ho '\(docs\|eval\|packages\|apps\|scripts\)/[A-Za-z0-9._/-]*\.\(py\|ts\|ts
   /tmp/bodies.txt | sort | uniq -c | sort -rn | awk '$1 >= 3'
 ```
 
-**The `>= 3` line is a triage cutoff, not an exclusion filter.** It orders where
-to spend attention first on a large pool — it is not a claim that a 2-hit file
-never hides a real duplicate. A pair of issues filed close together, before
-either has accumulated other unrelated citations, is exactly the shape most
-likely to sit at count 2 and be skipped by a skim. Run the 2-hit tier too
-(same command, `awk '$1 == 2'`) and give it the same close read — #1395 and
-#1396 cited the identical two lines (`research/SKILL.md:147`,
-`research-exhaustiveness/SKILL.md:113-116`) and were a clean absorb, but sat
-at count 2 in a large pool and were missed on a first pass that only read the
-`>= 3` tier. On a small pool, or when re-checking a single
-column against itself, drop the threshold to 2 outright rather than reporting
-only the head of the tally.
+**The `>= 3` line is a triage cutoff, not an exclusion filter.** A 2-hit file can
+hide a real duplicate, and a pair filed close together — before either has
+accumulated unrelated citations — is exactly the shape that sits at count 2. Run
+the 2-hit tier too and give it the same close read. On a small pool, or when
+re-checking a single column against itself, drop the threshold to 2 outright
+rather than reporting only the head of the tally.
 
 ```sh
 grep -ho '\(docs\|eval\|packages\|apps\|scripts\)/[A-Za-z0-9._/-]*\.\(py\|ts\|tsx\|md\|json\)' \
@@ -278,12 +239,10 @@ grep -ho '\(docs\|eval\|packages\|apps\|scripts\)/[A-Za-z0-9._/-]*\.\(py\|ts\|ts
 ```
 
 Same-file convergence is a strong batch signal on its own — verify it, don't
-wave it through. Same-*topic* convergence across different files is a weaker
-one and is usually not a batch: two issues that both say "the judge fabricated
-something" can be unrelated defects on different tests (this happened —
-issues #1330 and #1332 read alike by topic and turned out to be distinct
-fabrications on different runs). Don't merge on topic resemblance alone; open
-the files both cite and confirm they want the same edit.
+wave it through. Same-*topic* convergence across different files is weak and
+usually not a batch: two issues that both say "the judge fabricated something"
+are routinely unrelated defects on different tests. Never merge on topic
+resemblance alone — open the files both cite and confirm they want the same edit.
 
 Cross-check the file-convergence list against open PRs on the same files — a
 file with four issues *and* five PRs is a rebase queue nobody is sequencing:
@@ -341,17 +300,13 @@ on #N", "gated on the #N probe", "land after PR #N". Extract every one and
 resolve it. A closed blocker on an issue still marked blocked is the highest-value
 find in this section, because nothing else in the workflow notices.
 
-**Sweep it, do not read for it.** This check was prose-only until 2026-08-20 and
-therefore never ran; a `/fill-ready` pass that day found **six** items whose every
-named blocker had closed — including issue #847, the prompt-injection gate for the
-public launch, freed when its probe closed and parked for weeks anyway. Two more
-were found by accident the same morning, each after a promotion had already been
-proposed on a stale body.
+**Sweep it, do not read for it.** Run this every pass, before proposing any
+promotion — a stale banner is invisible to a body read.
 
 ```sh
 python3 - <<'PY'
 import json, re, subprocess
-issues = json.load(open('/tmp/issues.json', encoding='utf-8'))    # written by §0
+issues = json.load(open('/tmp/issues.json', encoding='utf-8'))    # written above
 BLOCK = re.compile(r'(blocked on|do not start until|wait for|waits on|prerequisite'
                    r'|gated on|land(?:s)? first|must land|queues behind|start(?:s)? after'
                    r'|do after)', re.I)
@@ -384,11 +339,10 @@ shipped, which is the very next check below. A blocker closed `not planned` free
 the issue too, but for the opposite reason: nobody is doing that work, so the
 dependent item needs its premise re-read, not just its banner deleted.
 
-**Report only the freed items sitting in Backlog.** The sweep reads the whole open
-pool, and on 2026-08-20 it returned 14 — but a freed item already in Ready, In
-Progress or Review is not a find: someone holds it, and its banner is their
-problem, not the board's. Cross the list against `/tmp/board.json` before you
-report. Backlog is where a cleared blocker leaves an item invisible.
+**Report only the freed items sitting in Backlog.** The sweep reads the whole
+open pool, but a freed item already in Ready, In Progress or Review is not a
+find — someone holds it, and its banner is their problem. Cross the list against
+`/tmp/board.json` before you report.
 
 Each survivor needs its stale banner struck in the body — a
 `> **Do not start until #N**` line outlives the blocker and parks the issue again
@@ -401,11 +355,7 @@ not trust it — an issue can be closed `completed` with the work never landed.
 
 Resolve every closed issue cited **as a tracker**, in a body or in the code
 (`grep -rn '#<N>' packages/ apps/ eval/ docs/ scripts/ CLAUDE.md`), by checking
-the artifact, not the
-state. One case: a consolidation issue closed `completed` while all five copies
-it was meant to remove are still on `main` — with a source comment pointing
-readers at it. Anyone following that pointer lands on a closed ticket and an
-unsolved problem.
+the artifact, not the state.
 
 Where the work did not land, say so on the closed issue and name what actually
 owns the scope. Reopening is usually wrong: the right survivor is often a
@@ -455,12 +405,8 @@ The `--all` search reads local refs, so a branch nobody fetched looks identical
 to a branch that never existed — hence the `fetch --prune` first, which also
 drops refs for branches deleted after merging.
 
-Both showed up in one 22-issue sample: an issue asserting a function had shipped
-warn-only when it sat on `origin/<feature-branch>`, with two follow-up comments
-written against code `main` does not contain; and a cluster of four issues citing
-test ids from an auditor's working tree, one of which had never existed in any
-branch. **Whole clusters can be filed from a tree that is not `main`** — when one
-issue in a group fails this check, check its siblings before trusting any of them.
+**Whole clusters can be filed from a tree that is not `main`.** When one issue in
+a group fails this check, check its siblings before trusting any of them.
 
 ## 3. Clusters — find them, then manage them
 
@@ -487,28 +433,22 @@ a cluster's work is done, delete the label rather than leaving it on closed issu
 
 Every cluster reaches a point where the next move is a spend or doctrine call —
 which of two designs, whether to pay for six eval runs, which measurement window
-is canonical. **Those are the lead's and cannot be delegated.** Surface them in §5
-as decisions, not as work.
+is canonical. **Those are the lead's and cannot be delegated.** Surface them
+under better handling as decisions, not as work.
 
 But **do not record the lead as the standing owner of a cluster** and stop there.
-An owner with no forcing function is how #911 sat uncalibrated for weeks while
-#980 was filed specifically to avoid repeating it and #1231 then repeated it
-anyway — three issues, one task, no one sequencing. A name on a cluster is
-unfalsifiable; it reads identically in six weeks.
+A name on a cluster is unfalsifiable — it reads identically in six weeks, and an
+owner with no forcing function is how one task becomes three issues nobody
+sequences.
 
-That sequence — #911, #980, #1231 — is also a *merge* miss, not only a
-staleness one: three issues each re-derived the same undone calibration
-instead of one issue tracking it once. Check every cluster for the same
-shape before writing its Since date: **has this cluster's decision been
-independently re-filed more than once?** If a second or third issue exists
-whose body restates "we need to measure/decide X before graduating" for a
-decision an earlier issue in the same cluster already owns, that is not
-three parallel tasks — merge them into the one that's furthest along and
-close the rest as duplicates-of-the-decision (§1's Duplicate verdict), even
-if their bodies aren't about the same file. The tell is the *sentence*, not
-the file: "before graduating," "before hard-denying," "measure first" said
-more than once in one cluster is the same missing mechanism asking to be
-merged, not scheduled harder.
+Check every cluster for a **re-filed decision** before writing its Since date:
+has this cluster's decision been independently re-filed more than once? If a
+second or third issue restates "we need to measure/decide X before graduating"
+for a decision an earlier issue in the same cluster already owns, merge them into
+the one that is furthest along and close the rest as duplicates of the decision,
+even if their bodies are not about the same file. The tell is the *sentence*, not
+the file: "before graduating", "before hard-denying", "measure first" said more
+than once in one cluster is one missing mechanism, not three parallel tasks.
 
 Instead every cluster carries, and this skill re-checks weekly:
 
@@ -528,7 +468,8 @@ check the standing-owner model does not have.
 
 - **A cluster with no owner.** Every member says "coordinate with the others" and
   none of them is the coordinator. This is where issues rot at full body quality.
-- **A cluster converging on one file.** Count open PRs against it (§1). Whoever
+- **A cluster converging on one file.** Count open PRs against it, as the
+  file-convergence check does. Whoever
   lands last rebases, and the bodies name only the collision that existed the day
   they were written. This kind is usually not a real cluster — it is a transient
   rebase queue, and it wants a merge order stated in a comment, not a label.
@@ -567,7 +508,7 @@ the live example — the matchers can only pin values once the mechanism exists.
 
 Rule 2 requires the skill's latest run log to be active **against the PR branch's
 state**, and the snapshot covers every file under the skill dir — "including a
-`references/` doc or even a comment" (`eval/CLAUDE.md`, § Snapshot model). So the
+`references/` doc or even a comment" (`eval/CLAUDE.md`, the snapshot model). So the
 run log goes stale the moment the *next* edit lands. Six issues landing as six
 sequential PRs is six runs, however carefully they are ordered.
 
@@ -587,14 +528,10 @@ which holders have gone quiet, and which queues have grown long enough that the
 answer is to merge issues rather than to wait.
 
 **Check open PRs against the snapshot set too, not just issue columns.** A PR
-can hold a skill's slot without the issue that spawned it ever needing to sit
-in Ready/In Progress/Review as a separate card — the PR's own file list is the
-thing that actually collides. Two live violations existed simultaneously this
-way: `record-extraction` had PR #1441 and PR #1294 both open against
-`record-extractor.md` at once, and `search-records` had #1319 (an in-progress
-issue) *and* PR #1328 open against `search-records/SKILL.md` at the same
-time — neither caught by an issue-column-only read, because the second
-occupant in each pair was a PR, not a competing issue.
+holds a skill's slot whether or not the issue that spawned it ever sits in
+Ready/In Progress/Review as a separate card — the PR's own file list is what
+collides, and an issue-column-only read misses every pair whose second occupant
+is a PR.
 
 ```sh
 gh pr list --repo PioneerAIAcademy/cowork-genealogy --state open --limit 60 \
@@ -604,14 +541,14 @@ gh pr list --repo PioneerAIAcademy/cowork-genealogy --state open --limit 60 \
 
 Run this per skill with anything in the paid-run tax table. Two PRs (or a
 PR plus an issue) against one slot is the same "who rebases last" problem
-as §1's file-convergence check — report it as a reconciliation finding, not
+as the file-convergence check — report it as a reconciliation finding, not
 a new merge, since the fix is usually sequencing the two PRs, not combining
 their issues.
 
 This is a *collision* rule, not a cost rule, and the distinction matters when
-reporting on it. It stops two people editing one SKILL.md at once and invalidating
-each other's run — PRs #929 and #924 both edited `search-records/SKILL.md`
-concurrently. It does **not** by itself reduce the number of runs.
+reporting on it. It stops two people editing one SKILL.md at once and
+invalidating each other's run. It does **not** by itself reduce the number of
+runs.
 
 Three things this pass owes the rule:
 
@@ -626,12 +563,11 @@ slot only if its work lands under that skill's snapshot set:
 Issues that only touch tool or harness code do **not** take the lock even when
 their title names the skill. #1073 is about `record-search.ts` and says in its own
 DoD *not* to edit `search-records/SKILL.md`; locking search-records for it would
-be wrong. The `**Touches:**` line is what makes this decidable (§1).
+be wrong. The `**Touches:**` line is what makes this decidable.
 
 **2. Reclaim a stalled slot.** A held slot blocks a whole skill, so a card that
 has not moved in ~10 days hands its slot back to Backlog and the next issue is
-promoted. Report every reclaim with the assignee and the idle days — today's board
-carries six cards untouched for a week or more, so this rule will fire.
+promoted. Report every reclaim with the assignee and the idle days.
 
 **3. Make the queue's size the finding.** A skill whose queue is five deep is not
 a scheduling problem, it is a sizing problem — see below.
@@ -647,26 +583,20 @@ three. Seven issues serialized is seven runs; the same work merged into three
 issues is three. Same economics as batching branches, no new git process.
 
 Merge when the issues share a **skill** — the same doctrine question, the same
-test files, the same agent body, the same snapshot. **Merge across lanes when they
-do.** The lead ruled on 2026-08-31 that a `developer` precondition and a
-`genealogist` wording change on one skill belong on one card: *"it's okay to merge
-developer and genealogist lanes for the same skill because genealogists and
-developers can request help as needed."* The rule here previously said the
-opposite — that such a card is unassignable and costs more than the run saved —
-and it was wrong on the premise, not on the arithmetic. A junior holding a
-two-lane card asks the other lane for the half they do not own, which is cheaper
-than a second paid run and a second annotation pass.
+test files, the same agent body, the same snapshot. **Merge across lanes when
+they do**: a `developer` precondition and a `genealogist` wording change on one
+skill go on one card, and whoever holds it asks the other lane for the half they
+do not own.
 
-**Sharing a skill is necessary and not sufficient.** The run being paid once is
-what makes a merge pay, so this only applies where a single run covers the
-merged work — one snapshot, one suite, one annotation pass. It does **not**
-apply to N independent pieces of research that merely happen to be filed
-against the same directory. Twenty record-hint adjudications are
-twenty separate investigations of twenty different people; merging them buys no
-run at all, because each still costs its own. Same-directory-and-nothing-else is
-where this rule has misfired — apply the "does one person finish all of it in
-one sitting?" test from §1, reading *one person* as one person who can ask the
-other lane for help, not as one person who must already hold both skills.
+**Sharing a skill is necessary and not sufficient.** This applies only where a
+single run covers the merged work — one snapshot, one suite, one annotation
+pass. It does **not** apply to N independent pieces of research that merely
+happen to be filed against the same directory. Twenty record-hint adjudications
+are twenty separate investigations of twenty different people; each still costs
+its own run, so merging them buys none. Before merging on a shared directory
+alone, apply the "does one person finish all of it in one sitting?" test — where
+*one person* means one person who can ask the other lane for help, not one who
+must already hold both skills.
 
 Do **not** reach for `eval-cosmetic-skip` to squeeze a second edit past the gate.
 It is for behavior-neutral changes only, and a gate too expensive to satisfy
@@ -682,8 +612,7 @@ It is the queue made visible. Without it, an issue that is merely *waiting its
 turn* looks identical to one nobody wants, and the person who filed it has no way
 to see which. It holds pointers only — `#N — one clause` — never content.
 
-Rules that keep it from becoming a queue file — the failure the repo's retired
-staging queue was closed for:
+Rules that keep it from becoming a queue file:
 
 - **It holds pointers, never content.** Each line is `#N — one clause`. The work,
   the reasoning and the acceptance criteria stay in the real issue. If someone
@@ -696,7 +625,8 @@ staging queue was closed for:
   add the pointer here.
 
 When a skill's list is long enough to justify a run, that becomes the cluster's
-**next action** under §3, with a doer and a date — not a standing intention.
+**next action** on that cluster, with a doer and a date — not a standing
+intention.
 
 Check `check_runlogs.py` rule 2 directly for skills that are *already* stale, since
 those cost a run before any new work lands:
@@ -712,10 +642,10 @@ where you propose something that only makes sense across several.
 
 Ask these, and answer only the ones with a real finding:
 
-- **Is a family of near-identical issues better as one worklist?** Many issues
-  with byte-identical bodies differing by a name and a URL generate one board
-  card, one assignment decision and one PR each, and are discussed in none of
-  them. A tracking issue plus a checklist table costs less and loses nothing.
+- **Is a family of near-identical issues waiting on one missing mechanism?**
+  Bodies differing only by a name and a URL usually point at a generator, lint or
+  convention nobody has built — propose that. Do **not** propose folding them
+  into a tracker or worklist; that is the anti-pattern above.
 - **Has the same decision been made more than twice?** If the lead has
   independently decided the same tradeoff on three issues, that is doctrine and
   belongs written down once — an ADR the next issue cites instead of
@@ -786,7 +716,7 @@ confidence.
 
 ## Output shape
 
-Open with the week's arithmetic (§0) — filed, closed, and whether this run's
+Open with the week's arithmetic — filed, closed, and whether this run's
 proposals meet the target, naming the gap when they do not. Then the two or three
 things that change what happens this week. Then:
 
@@ -797,7 +727,7 @@ things that change what happens this week. Then:
    than a close. One line of evidence each. Keep **blocked on an unmerged branch**
    as its own group: those are not obsolete, they are unbuildable, and the fix is
    naming the branch rather than closing the issue. Keep **freed — every blocker
-   closed** (§2's sweep) as its own group too, and put it first: those are the
+   closed** (the blocker sweep) as its own group too, and put it first: those are the
    opposite of obsolete. They are startable work that has been parked, invisibly,
    for as long as the blocker has been closed, and they are this week's
    `/fill-ready` candidates.
@@ -808,7 +738,8 @@ things that change what happens this week. Then:
    `next run:` issue that needs opening or closing.
 5. **Decisions for the lead** — pulled out as its own list, phrased as questions
    with the options and what each costs. These are the spend and doctrine calls
-   from §3 and §5; they should not be buried inside a cluster block.
+   from the cluster and better-handling passes; they should not be buried inside
+   a cluster block.
 6. **Cross-cutting proposals** — only the ones with a real finding behind them.
    Two good ones beat six speculative ones.
 7. **Board hygiene** — the mechanical list, terse.

--- a/.claude/skills/audit-board/SKILL.md
+++ b/.claude/skills/audit-board/SKILL.md
@@ -144,16 +144,22 @@ so exactly one owns the scope.
 **Batch — separate issues, one paid run.** This is the most common and the most
 valuable. See §4.
 
-**Split the lanes — only when the split is clean.** Two halves that are different
-labor — a `developer` lint and a `genealogist` audit — can stay apart, because one
-card spanning two lanes has no single assignee. That holds **only if neither half
-needs the other to land**. Test it: can each be finished, reviewed and merged
-without waiting on the other? If yes, split at the lane boundary and move the
-content, so neither issue is left pointing at the other for something it needs,
-and give each its own acceptance.
+**Split the lanes — only when each half finishes without the other.** Two halves
+that are genuinely different labor — a `developer` lint and a `genealogist` audit
+on unrelated ground — can stay apart. **The reason is not that a two-lane card has
+no single assignee.** That premise is retired: the lead ruled on 2026-08-31 that a
+`developer` half and a `genealogist` half of one skill's work belong on one card,
+*"because genealogists and developers can request help as needed"* — whoever holds
+it pulls in the other lane rather than the board splitting the work for them. So
+**"these are different lanes" is not a reason to keep two issues apart**, and on
+the same skill it is not even a reason to hesitate.
 
-If no — merge, and let the card carry both labels. A card with two labels is
-assignable; two cards that each need the other are not.
+One test survives, and it is now the only one: **can each half be finished,
+reviewed and merged without waiting on the other?** If yes, split at the lane
+boundary and move the content, so neither issue is left pointing at the other for
+something it needs, and give each its own acceptance.
+
+If no — merge, and let the card carry both labels.
 
 **"Schedule together, leave both open" is not a verdict.** The lead ruled it out
 on 2026-08-11: *"Anything that should be done together sounds like a reason to
@@ -207,8 +213,27 @@ Search for merge candidates **by fix site, not by topic**. Issues that collide
 here almost never share a title; they want different lines in one file.
 
 **Two issues wanting different lines in the same file default to one issue.**
-Keeping them apart needs a stated reason — different lane, different reviewer, or
-a paid-run slot they cannot share. Absent one, merge.
+Keeping them apart needs a stated reason, and there are only two left: a **blocker
+on one side** — never park an unblocked issue behind a blocked one — or **each half
+genuinely finishes without the other**, tested as the lane-split verdict above
+tests it. Absent one, merge.
+
+Two reasons that used to sit on this list are gone:
+
+- **"Different lane" is not one** (lead, 2026-08-31 — see the lane-split verdict).
+- **"A paid-run slot they cannot share" is not one — it is the single strongest
+  reason to merge.** It read as a keep-apart reason here and as a merge reason in
+  §4, which is one fact pointing two ways; §4 is right. Two changes to one skill's
+  snapshot cannot share a paid run, so leaving them on separate cards buys two
+  runs at $8–12 and 45–65 minutes each, plus two annotation passes. Merging buys
+  one of each.
+
+**A shared paid run outranks the finishes-independently test.** Two issues can
+each be finished alone and still both need the same skill's snapshot re-run — that
+is a merge, because the run is what the split actually costs. Read the two reasons
+in order: a blocker on one side keeps them apart no matter what; absent a blocker,
+a shared run merges them; only when no run is at stake does finishing
+independently decide.
 
 Bodies filed from 2026-08-04 open with a `**Touches:**` line — the instruction
 lives in `CLAUDE.md`'s `gh issue create` recipe, and essentially every issue in
@@ -621,20 +646,27 @@ larger ones during this pass**, so that one run carries what would have been
 three. Seven issues serialized is seven runs; the same work merged into three
 issues is three. Same economics as batching branches, no new git process.
 
-Merge when the issues share a lane — the same doctrine question, the same test
-files, the same agent body. Do not merge across lanes to save a run: a
-`developer` harness fix and a `genealogist` fixture adjudication in one issue is
-unassignable, which costs more than the run saved.
+Merge when the issues share a **skill** — the same doctrine question, the same
+test files, the same agent body, the same snapshot. **Merge across lanes when they
+do.** The lead ruled on 2026-08-31 that a `developer` precondition and a
+`genealogist` wording change on one skill belong on one card: *"it's okay to merge
+developer and genealogist lanes for the same skill because genealogists and
+developers can request help as needed."* The rule here previously said the
+opposite — that such a card is unassignable and costs more than the run saved —
+and it was wrong on the premise, not on the arithmetic. A junior holding a
+two-lane card asks the other lane for the half they do not own, which is cheaper
+than a second paid run and a second annotation pass.
 
-**Sharing a lane is necessary and not sufficient.** The run being paid once is
+**Sharing a skill is necessary and not sufficient.** The run being paid once is
 what makes a merge pay, so this only applies where a single run covers the
 merged work — one snapshot, one suite, one annotation pass. It does **not**
-apply to N independent pieces of research that merely happen to be filed by the
-same lane against the same directory. Twenty record-hint adjudications are
+apply to N independent pieces of research that merely happen to be filed
+against the same directory. Twenty record-hint adjudications are
 twenty separate investigations of twenty different people; merging them buys no
-run at all, because each still costs its own. Same-lane plus same-directory is
+run at all, because each still costs its own. Same-directory-and-nothing-else is
 where this rule has misfired — apply the "does one person finish all of it in
-one sitting?" test from §1 before merging on lane alone.
+one sitting?" test from §1, reading *one person* as one person who can ask the
+other lane for help, not as one person who must already hold both skills.
 
 Do **not** reach for `eval-cosmetic-skip` to squeeze a second edit past the gate.
 It is for behavior-neutral changes only, and a gate too expensive to satisfy

--- a/.claude/skills/fill-ready/SKILL.md
+++ b/.claude/skills/fill-ready/SKILL.md
@@ -45,9 +45,8 @@ them too. **Feedback is none of the three** — it is an untriaged inbox that
 `/triage-feedback` owns and this skill never reads.
 
 **Re-read the board immediately before you apply anything.** The lead edits it
-while you work — in one session nine items moved to Ready and 23 assignments
-were cleared between the opening read and the write-back. A snapshot taken at
-the start of a long analysis is stale by the end of it.
+while you work, so a snapshot taken at the start of a long analysis is stale by
+the end of it.
 
 Two labels carry the routing:
 
@@ -92,15 +91,15 @@ re-litigate it; just know the label is doing two jobs.
 **Label only. Never set an assignee — on anyone, including the lead.** People
 self-serve from Ready and the lead hands work out at standup. This skill adds no
 assignee at all; the only pre-assigned items on the board are `cross-cutting`
-ones, and `/find-big-wins` assigns those at filing time (§1).
+ones, and `/find-big-wins` assigns those at filing time.
 
 **And never remove one either — a role/label mismatch is not a mis-route.** The
 lead is deliberately teaching the developers to be simple genealogists and the
 genealogists to be simple developers; they reach out to each other as needed. A
-developer holding a `genealogist` issue is the point, not a defect (ruled
-2026-08-14). So the roster's role column tells you which *pool target* an item
-counts against, and nothing else: do not report a mismatch as a finding, do not
-propose unassigning, and do not rewrite the label to match the person.
+developer holding a `genealogist` issue is the point, not a defect. So the
+roster's role column tells you which *pool target* an item counts against, and
+nothing else: do not report a mismatch as a finding, do not propose unassigning,
+and do not rewrite the label to match the person.
 
 ## 1. Measure Ready depth before you rank anything
 
@@ -125,17 +124,15 @@ them.
 **There is no third pool for the lead.** He takes no issues — his job is coaching
 juniors into seniors — so nothing is ever assigned to `DallanQ` and no target
 covers him. Structural bets go to `/find-big-wins`; decisions get
-`needs-decision`, which `/make-decisions` drains daily (§6).
+`needs-decision`, which `/make-decisions` drains daily.
 
 **`cross-cutting` items are outside both targets** — see "Cross-cutting items are
 the lead's direct assignments" below. Subtract them before you compute a pool.
 
-**Do not size promotions to free people.** An earlier version of this skill
-targeted "free people plus a buffer" and concluded that 19-of-21 busy meant
-promote zero. That is wrong: busy people finish, and the menu has to be stocked
-when they do. How many people are idle right now is not the question. Report
-In Progress / Review counts if they are interesting, but never let them set the
-number.
+**Do not size promotions to free people.** Busy people finish, and the menu has
+to be stocked when they do — how many people are idle right now is not the
+question. Report In Progress / Review counts if they are interesting, but never
+let them set the number.
 
 ### Promotion is a swap, not an addition
 
@@ -158,13 +155,14 @@ Backlog outranks what is there. Say so plainly rather than padding to a number.
 
 ### What loses a swap
 
-Rank the unassigned Ready items with the same §2 heuristics you rank Backlog
-with. What tends to lose:
+Rank the unassigned Ready items with the same heuristics you rank Backlog with.
+What tends to lose:
 
 - An item whose body is a bare pointer to a plan doc — it cannot be chosen off a
   menu without opening something else.
 - An item that is really a question, not a task ("I'm not sure if this is an
-  issue… worth an investigation") — that is Gate 2, and it belongs to the lead.
+  issue… worth an investigation") — that is the unanswered-question gate, and it
+  belongs to the lead.
 - Surplus from a **homogeneous pool**. When one batch supplies many
   interchangeable tasks (the 32 record-hint `test <slug>` adjudications), keep
   enough for real choice — about half a pool's target — and return the rest.
@@ -198,8 +196,9 @@ for the second reason — an open design fork, an unanswered doctrine call, a bl
 radius nobody wrote down. Those get `needs-decision`, and the work behind them is
 often junior once the answer exists. Only what would still be hard after every
 question is answered gets `senior`, and a `senior` item is assigned to a senior in
-its lane. §6 is the whole rule; get the two apart before you label, because
-`senior` on an undecided item makes a sentence look like a scarce skill.
+its lane. "Above the junior pools" below is the whole rule; get the two apart
+before you label, because `senior` on an undecided item makes a sentence look
+like a scarce skill.
 
 Decide seniority **first**, then rank. A high-priority senior item does not win a
 place in the unassigned pool by being important; being important is what moves it
@@ -287,9 +286,8 @@ both, every run, over the last four weeks:
 
 **Do not count with `--search "created:$a..$b"` per week.** GitHub's range is
 inclusive at *both* ends, so consecutive windows both claim the boundary day and
-every week is inflated — on 2026-08-14 that reported 239 filed for a week that
-saw 221, and 92 for one that saw 85. Pull the dates once and bucket them
-locally with a half-open range instead:
+every week is inflated. Pull the dates once and bucket them locally with a
+half-open range instead:
 
 ```sh
 gh issue list --repo PioneerAIAcademy/cowork-genealogy --state all --limit 2000 \
@@ -307,11 +305,6 @@ for w in range(4, 0, -1):
 print('open now:', sum(1 for i in a if i['state'] == 'OPEN'))
 PY
 ```
-
-Baseline measured 2026-08-01, for comparison only — recompute, never quote it:
-the board ran at equilibrium (~17 filed / ~17 closed per week) through late July,
-then an audit wave pushed open issues to 118 with ~90% of them filed in two
-weeks. Median cycle time was 7 days, p90 37.
 
 When arrival exceeds closure for **three consecutive weeks**, say so at the top
 of the report with the arithmetic, and name the three levers plainly, because
@@ -331,7 +324,7 @@ full (`docs/sponsor-status-update.html`, slide 11):
 | Milestone | When | What changes |
 |---|---|---|
 | **Beta** — wider in-house users, all roles and skill levels | **Oct–Nov 2026** | People outside the senior-genealogist alpha use it without an expert watching |
-| **Public rollout** at RootsTech | **2027-03-04** — a fixed conference date, confirmed by the lead 2026-08-01. It cannot slip a week to absorb an overrun | Strangers use it, including the Temple open-house helpers |
+| **Public rollout** at RootsTech | **2027-03-04** — a fixed conference date. It cannot slip a week to absorb an overrun | Strangers use it, including the Temple open-house helpers |
 
 Compute the slack at the top of every run — urgency has to be live, not a
 number frozen into this file:
@@ -343,8 +336,8 @@ python3 -c "import datetime;d=datetime.date.today();print('beta slack:',(datetim
 ### Which items gate a milestone
 
 **Re-derive membership every run; never trust a list of issue numbers, including
-the one below.** This repo's issues go stale in days (§8), and a gating set
-copied forward becomes wrong exactly when it matters. Derive it by asking the
+the one below.** This repo's issues go stale in days, and a gating set copied
+forward becomes wrong exactly when it matters. Derive it by asking the
 milestone's own question:
 
 - **Beta gate** — *would a non-expert user hit this, or would we be unable to
@@ -361,19 +354,16 @@ milestone's own question:
   defense (issue #847, unstarted), the production tool-call ledger (issue
   #1054), and judge calibration (issue #1090).
 
-There is no standing "what to do next" document to rank from — the one that
-existed was retired 2026-08-09 because its priorities went stale faster than
-anyone re-read them. Rank from repo state instead: the board itself — which is
-now also where the what-nothing-checks and open-questions registers live, since
-`docs/architecture.md` §9.4 and §10 were reduced to pointers into it on
-2026-08-09 — and `docs/adrs/ADR-0009-refuted-agent-design-claims.md`, which tells
-you which proposals have already been argued and disproved.
+**There is no standing "what to do next" document, and do not create one.** Rank
+from repo state: the board itself, which is also where the what-nothing-checks
+and open-questions registers live, plus
+`docs/adrs/ADR-0009-refuted-agent-design-claims.md`, which tells you which
+proposals have already been argued and disproved.
 
 **Instrument before fix.** An item that restores a broken measurement outranks
-the fixes that measurement is supposed to evaluate — that is already heuristic 2
-below, and it is doubly true against a deadline: quality work done while the
-quality signal is uncalibrated cannot be shown to have worked, so it buys a date
-nothing.
+the fixes that measurement is supposed to evaluate — heuristic 2 below, and
+doubly true against a deadline: quality work done while the quality signal is
+uncalibrated cannot be shown to have worked, so it buys a date nothing.
 
 Read every Backlog title. Read the **bodies** only of the plausible candidates —
 usually 10–20 of them. Ranking heuristics, in order:
@@ -408,25 +398,18 @@ report says which higher-ranked item it displaced.
 
 **Long-lead work starts a milestone early, not when it becomes urgent.** The
 standing example is prompt-injection defense (issue #847): it gates the public
-rollout, not beta, so it loses every impact ranking today — and its junior half
-cannot begin until a senior settles the doctrine, which means an item that
-"isn't due until March" has to be converted out of the senior queue (§6) in the
-fall or it will not land at all. A pure impact-ranker promotes it the week it is
-already too late. When you find one of these, say so in the escalation line, not
-in a footnote.
+rollout, not beta, so it loses every impact ranking today, and its junior half
+cannot begin until a senior settles the doctrine. An item that "isn't due until
+March" has to be converted out of the senior queue in the fall or it will not
+land at all, and a pure impact-ranker promotes it the week it is already too
+late. When you find one of these, say so in the escalation line, not in a
+footnote.
 
 **Cheapness is a tiebreaker, not a rank.** An issue that names the file, the
 line and the change is worth more than its size suggests — *between two items of
 comparable impact*. It never promotes a low-impact item over a high-impact one.
 Unblocked-and-high-impact usually wins; cheap-and-unblocked is fine every once in
 a while, so cap it at **one** such item per fill and say that is why it is there.
-
-This was rank 3 until 2026-08-01, and the failure it produced is the one to
-watch for: a lint-hardening item (#1014, a loose substring matcher in a lint that
-had shipped the day before) was promoted over #945 and #1085 purely for being
-cheap, unblocked and independent of an open policy call. Zero research or
-performance impact. The correction the lead gave, verbatim: *"I'm ok with cheap
-and unblocked every once in a while, but unblocked and high-impact usually wins."*
 
 **Say the impact out loud for every promotion.** One clause naming what it makes
 better — a right answer reached, a wrong one prevented, wall-clock or spend
@@ -467,10 +450,10 @@ alone clears nothing. Do **not** test whether the sha is an ancestor of `main`:
 this repo squash-merges, so a merged branch's commits never are, and that test
 holds every cleared blocker shut.
 
-Also check *why* it closed. One issue was closed in a sweep as "low value,
-nobody has hit it since July" while a newer issue documented the same root cause
-producing silent data corruption. A closed blocker whose closing rationale is
-contradicted by newer evidence is not a cleared blocker — it is a finding.
+Also check *why* it closed. A closed blocker whose closing rationale is
+contradicted by newer evidence — a sweep closed it as low-value while a newer
+issue documents the same root cause causing real harm — is not a cleared blocker.
+It is a finding.
 
 **A hard blocker disqualifies the item.** Leave it in Backlog and name the
 blocker in your report.
@@ -482,10 +465,10 @@ designs without choosing, is **not Ready** regardless of its dependencies. A
 junior handed it either guesses at a decision that was the lead's, or stalls.
 
 These are not blocked on a task — they are blocked on a decision only the lead
-can make. **Label them `needs-decision`, not `senior`** (§6): the work behind the
-fork is frequently junior, and calling it senior sends a sentence looking for a
-scarce person. Leave them in Backlog and name, in your report, the decision and
-the Ready-able task it unblocks. That pairing is the highest-value line you
+can make. **Label them `needs-decision`, not `senior`**: the work behind the fork
+is frequently junior, and calling it senior sends a sentence looking for a scarce
+person. Leave them in Backlog and name, in your report, the decision and the
+Ready-able task it unblocks. That pairing is the highest-value line you
 produce — one answer turns a stuck item into a junior task.
 
 ### Gate 3 — soft collision (does *not* disqualify)
@@ -497,19 +480,16 @@ pick them up will never read your report.
 **Contention over a skill's eval snapshot is the exception and is Gate 4** — that
 one is hard, because the second item cannot land without paying for a second run.
 
-#### Finding them — because until 2026-08-27 nothing here did
+#### Finding them
 
-This gate told you to write reciprocal notes and never said how to find a pair.
-The Gate 4 map below was the only automated collision check, and it keys on
-snapshot paths by construction, so a collision anywhere else — engine source, the
-harness, a spec — was invisible to every mechanism in this skill.
+The Gate 4 map below keys on snapshot paths by construction, so a collision
+anywhere else — engine source, the harness, a spec — is invisible to it. Run this
+detector as well.
 
-**The half that nothing else can cover is issue-against-issue.** `/review-ready`
-fans out one agent per issue and those agents do check open PRs, so the
-issue-against-PR half is largely redundant with the gate. But each agent sees
-exactly one issue, so a pair of issues that edit the same file is invisible to
-all of them — which is why `/review-ready` §3 asks its collator to cross-check
-the agents by hand. This is that check, mechanised.
+**The half nothing else can cover is issue-against-issue.** `/review-ready` fans
+out one agent per issue and those agents do check open PRs, so the
+issue-against-PR half is largely covered. But each agent sees exactly one issue,
+so a pair of issues that edit the same file is invisible to all of them.
 
 Run it over `Ready,In Progress,Review` for the issue-against-issue half, and over
 the promotion shortlist for the issue-against-PR half. It reads `**Touches:**`
@@ -526,28 +506,23 @@ python3 .claude/skills/fill-ready/collisions.py \
   /tmp/board.json /tmp/open.json /tmp/prs.json "Ready,In Progress,Review"
 ```
 
-**Three guards keep it from becoming a constant, and each one is there because
-the version without it fired on almost everything.** Do not remove one without
-re-measuring; the counts below are from the 2026-08-27 board.
+**Three guards keep it from firing on almost everything. Do not remove one
+without re-measuring.**
 
-| Guard | Why | Without it |
-|---|---|---|
-| A concrete file never implies its directory | Two files in `src/tools/` are not a collision | Every `src/tools/` item paired with every other — 14 pairs on one issue |
-| A bare directory pairs only if it is a snapshot path or a **unit dir** — never an ordinary container | Naming `src/tools/` means "I add a file here", not "I edit all 47". A skill dir, a scenario, an e2e fixture *is* the unit, so naming it does mean all of it | 3 of 8 pairs false from one `src/tools/` entry; and see the row below |
-| A file named by more than 3 candidates is a hub, reported once | `docs/architecture.md` is the repo's map; everyone edits it, in different sections | 26 of 79 shared-path hits were that one file |
+| Guard | What it means |
+|---|---|
+| A concrete file never implies its directory | Two files in `src/tools/` are not a collision |
+| A bare directory pairs only if it is a snapshot path or a **unit dir** — never an ordinary container | Naming `src/tools/` means "I add a file here", not "I edit all 47". A skill dir, a scenario, an e2e fixture *is* the unit, so naming it does mean all of it |
+| A file named by more than 3 candidates is a hub, reported once | `docs/architecture.md` is the repo's map; everyone edits it, in different sections |
 
-**Do not swap the unit/container test back for a size threshold.** It was one
-(`<= 10 tracked files`) until 2026-08-27, and size is a proxy that misses in both
-directions: `apps/server/app/sandbox` is 5 files and a container,
-`eval/runlogs/unit/<skill>` is 11 and a unit. The threshold paired issue #1959 —
-whose entry reads `apps/server/app/sandbox/ (LocalProvider WS path)`, i.e.
-`local.py` — against #1729 and #1489, which name `e2b.py`. Two notes nearly went
-onto three issues telling people to coordinate on work that does not overlap.
+**Do not swap the unit/container test back for a size threshold.** Size is a
+proxy that misses in both directions: `apps/server/app/sandbox` is 5 files and a
+container, `eval/runlogs/unit/<skill>` is 11 and a unit.
 
-**A parenthetical that narrows a directory is still not read.** `(LocalProvider WS
-path)` names the file, and the extractor drops it as punctuation. That is why the
-"too broad to pair" list exists and why it says *read these by hand* — it is the
-honest bucket, not a failure.
+**A parenthetical that narrows a directory is not read.** `apps/server/app/sandbox/
+(LocalProvider WS path)` names one file, and the extractor drops the parenthetical
+as punctuation. That is why the "too broad to pair" list exists and says *read
+these by hand* — it is the honest bucket, not a failure.
 
 The verdict it prints is advisory: a shared **snapshot** path means Gate 4 and is
 hard, anything else is Gate 3 and only needs the notes below. Read the pairs, do
@@ -585,11 +560,11 @@ Then say it in your report as well, so the lead can hand both to one person.
 column at a time** — Ready, In Progress, or Review. If one is already there, the
 next one is not Ready — leave it in Backlog and name the holder.
 
-**Only an open issue in one of those three columns holds a slot.** Never
-"outside Backlog", which is what this rule used to say and which is wrong in
-both terminal directions: Done and Not planned are outside Backlog too. A closed
-issue holds nothing. Whatever it was going to change, it is not going to change
-it, so nothing is waiting on it and the next item can go.
+**Only an open issue in one of those three columns holds a slot.** Never test
+"outside Backlog" — that is wrong in both terminal directions, since Done and Not
+planned are outside Backlog too. A closed issue holds nothing: whatever it was
+going to change, it is not going to change it, so nothing is waiting on it and
+the next item can go.
 
 **When the column and the issue's state disagree, the state wins.** Closing an
 issue does not move its card — `.github/workflows/project-status-sync.yml` does,
@@ -603,13 +578,12 @@ gh issue view <holder> --repo PioneerAIAcademy/cowork-genealogy \
   --json number,state,stateReason,title
 ```
 
-*Why it is hard rather than soft.* A skill's run log goes inactive the moment any
-file under its snapshot changes, so two such items cannot share a run however they
-are sequenced: each pays its own `make eval-skill` **plus a fresh `.ann.json` with
-a correction entry for every dimension of every test** — 27 tests for
-`record-extraction`. The second item also invalidates the first's run log if it
-lands first, so promoting both produces rework, not parallelism. PRs #929 and #924
-both edited `search-records/SKILL.md` concurrently; that is the failure.
+It is hard rather than soft because a skill's run log goes inactive the moment
+any file under its snapshot changes. Two such items cannot share a run however
+they are sequenced: each pays its own `make eval-skill` **plus a fresh
+`.ann.json` with a correction entry for every dimension of every test** — 27
+tests for `record-extraction` — and whichever lands first invalidates the
+other's run log. Promoting both produces rework, not parallelism.
 
 **The snapshot set — an item takes the slot only if it changes one of these:**
 
@@ -619,10 +593,9 @@ both edited `search-records/SKILL.md` concurrently; that is the failure.
   `@plugin:` — that gates **every** skill naming it, so check the fan-out:
   `grep -rl "@plugin:<agent>" packages/engine/plugin/skills/*/SKILL.md`
 
-**Key it on paths, not on the skill's name in the title.** PR #1017 and PR #1196
-are both titled `record-extraction:`; only #1017 touches the snapshot. PR #1073's
-own DoD says *not* to edit `search-records/SKILL.md` — a tool fix does not take
-the skill's slot.
+**Key it on paths, not on the skill's name in the title.** Two PRs can both be
+titled `record-extraction:` while only one touches the snapshot, and a tool fix
+whose own DoD says *not* to edit the SKILL.md does not take the skill's slot.
 
 **Build the whole map in one pass, before you rank anything.** A per-skill query only
 answers about the skill you thought to ask about, and the slot you miss is the one whose
@@ -672,29 +645,24 @@ for s in sorted(set(holders) | set(pr_hold)):
 PY
 ```
 
-**Read a `body-fallback` row as "unverified", never as "held".** It means the issue has no
-`Touches:` line and the skill name merely appears somewhere in its prose — open it and
-decide. Issue #1273 cites `search-images/SKILL.md` four times as *evidence* for a claim
-about a harness hook and edits none of its files; treating that as a holder blocks a free
-slot. An `AGENT:` row gates **every** skill naming that agent via `@plugin:` — check the
-fan-out with the grep above.
+**Read a `body-fallback` row as "unverified", never as "held".** It means the issue has
+no `Touches:` line and the skill name merely appears somewhere in its prose — open it and
+decide. An issue that cites a SKILL.md as *evidence* and edits none of its files is not a
+holder, and treating it as one blocks a free slot. An `AGENT:` row gates **every** skill
+naming that agent via `@plugin:` — check the fan-out with the grep above.
 
 **Neither shortcut works, and they fail in opposite directions.** Keying on the title
-misses a holder whose title names none of its skills: issue #1606 is titled
-*"Source-evaluation findings: prefer 're-read the record' over 'detach source'…"* and its
-`Touches:` holds `check-warnings`, `record-extraction` **and** `research` — three slots,
-invisible to any title match, and it was blocking a fully-reviewed card. Keying on any
-body mention does the reverse and manufactures the false positive above. Only the
-`Touches:` line, with the body as a flagged fallback, gets both right.
+misses a holder whose title names none of its skills — one issue's `Touches:` line held
+three slots that no title match could see. Keying on any body mention does the reverse
+and manufactures the false positive above. Only the `Touches:` line, with the body as a
+flagged fallback, gets both right.
 
-**Scanning only open PRs and Review misses In Progress.** Issue #1490 is In Progress and
-its `Touches:` names `init-project/SKILL.md`; a PR-only read reports that slot free the
-day after the deep dive that held it merged, and the next card in is un-startable.
+**Scanning only open PRs and Review misses In Progress**, so a PR-only read reports a
+slot free the day after the deep dive holding it merged, and the next card in is
+un-startable.
 
 **A `**Touches:**` line is a hint, not proof. Where it and real paths disagree, the paths
-win**: PR #1577 added ten lines to `init-project/SKILL.md` for an issue whose `Touches:`
-named three other skills. Discount a `Touches:` line inherited from an issue since closed
-`not planned` (issue #1322 carried issue #1447's).
+win.** Discount a `Touches:` line inherited from an issue since closed `not planned`.
 
 **The map is a snapshot.** It is right for the pass that produced it and stale by the next
 one — re-run it before you write anything to the board, and tell a junior to re-check the
@@ -707,8 +675,8 @@ without ever appearing here. That is Gate 3's detector, above; run both.
 
 **Reclaim a stalled slot.** A holder that has not moved in ~10 days is blocking a
 whole skill. Say so in your report with the assignee and the idle count, and
-propose returning it to Backlog so the next item can go. Do not reclaim silently —
-it is the lead's call, and today's board carries several week-old cards.
+propose returning it to Backlog so the next item can go. Do not reclaim
+silently — it is the lead's call.
 
 **A queue three or more deep is a finding, not a schedule.** Report it. The fix is
 to merge those issues into fewer, larger ones so one run carries what would have
@@ -719,14 +687,6 @@ been three — that happens in `/audit-board`, not here. Note it and move on.
 A Ready item should be one person's task, start to finish. If it has two halves
 that different people would do — or a cheap measurement that decides whether the
 expensive half is needed at all — split it **before** promoting.
-
-The worked case: one issue asked for (1) verify on a Windows box whether Ctrl-C
-kills in-flight processes, and (2) if it doesn't, re-architect the harness onto
-owned subprocesses. Step 1 is thirty minutes on a machine only the genealogist
-team has. Step 2 inverts how interrupts work and the issue itself warned it was
-not a beginner task. Combined, it was assignable to nobody. Split, step 1 became
-a same-day genealogist task whose *outcome decides whether step 2 is ever
-funded*.
 
 Split when any of these holds:
 
@@ -746,10 +706,11 @@ task; splitting it triples the review and merge cost for nothing.
 run in parallel, and landing them sequentially buys a second paid run plus a
 second full annotation pass for work that would have shared one. Split only when
 **at most one half touches the snapshot** — which is usually what the criteria
-above already select for. #1004 is the model: its doctrine question ("is a census
-residence fact primary or indeterminate?") touches nothing and is answerable by a
-genealogist today, while its mechanical half — adding the matchers once the answer
-exists — merges into whichever record-extraction item next takes the slot.
+above already select for. The model is an item whose doctrine question ("is a
+census residence fact primary or indeterminate?") touches no snapshot and is
+answerable by a genealogist today, while its mechanical half — adding the
+matchers once the answer exists — merges into whichever item next takes the
+skill's slot.
 
 How:
 
@@ -780,9 +741,9 @@ gh issue edit <N> --repo PioneerAIAcademy/cowork-genealogy --add-label developer
 ```
 
 **Leave it unlabeled when it is genuinely both or genuinely contested**, and say
-why in one line. One issue's fix could have been skill prose or a harness change
-and a second open issue disputed which — labeling it would have picked a side
-the board had not picked. Unlabeled with a reason beats a confident wrong label.
+why in one line — where the fix could be skill prose or a harness change and
+another open issue disputes which, labeling picks a side the board has not.
+Unlabeled with a reason beats a confident wrong label.
 
 Then move it:
 
@@ -800,18 +761,16 @@ reaches you as an ordinary issue and is promoted with this move like any other.)
 
 **Gate every issue you are moving into Ready through `/review-ready` before you
 promote it — both pools, not just `developer`, and not just the ones you rank as
-junior.** Your seniority test (§1) is a pre-filter read off the issue body; that
+junior.** Your seniority test above is a pre-filter read off the issue body; that
 skill fans out one agent per item to check the same call against the cited code,
 the architecture guide's site list, and the board's what-nothing-checks issues —
 which is where a "junior-safe" item turns out to hide an open API decision, or a
 body's central claim turns out to have no instances behind it.
 
-**The genealogist half was ungated until 2026-08-19, and that was wrong.** A
-stale premise is not a developer-shaped defect, and the genealogist half is the
-more expensive one to get wrong: a bad developer premise reds a test, a bad
-genealogist premise surfaces inside a paid `make eval-skill` run or not at all.
-The reversal and what refuted the old scope are in
-`docs/specs/task-review-spec.md` §6 — do not re-argue it here.
+**Gating the genealogist half is not optional, and do not re-argue its scope**
+(`docs/specs/task-review-spec.md`). A bad developer premise reds a test; a bad
+genealogist premise surfaces inside a paid `make eval-skill` run, or not at
+all.
 
 **Budget for it.** The gate costs ~110k tokens per issue, so a full fill of both
 pools is roughly 2M. That is cheap against a junior's wasted week and it is not
@@ -833,14 +792,14 @@ for this: a ruling makes three writes, and any later comment by anyone pushes
 `updatedAt` past the marker again. An item carrying no `reviewed` label gates
 normally, ruled or not.
 
-Re-running the gate on an unchanged issue pays for the same deep read twice
-(`docs/specs/task-review-spec.md` §2); skipping it on a genuinely changed one is
-how a refuted premise reaches a junior.
+Re-running the gate on an unchanged issue pays for the same deep read twice;
+skipping it on a genuinely changed one is how a refuted premise reaches a
+junior.
 
 Promote what comes back `ready` or `ready-after-edit`. A `senior` or
-`needs-a-decision` verdict on an item you had ranked junior is a §1 miss caught
-in time — it stays in Backlog and never enters the junior pool. **The two get
-different labels** (`senior` vs `needs-decision`, §6), and the verdict tells you
+`needs-a-decision` verdict on an item you had ranked junior is a seniority miss
+caught in time — it stays in Backlog and never enters the junior pool. **The two
+get different labels** (`senior` vs `needs-decision`), and the verdict tells you
 which: `needs-a-decision` means one answer unblocks it, `senior` means it is hard
 regardless. Running the gate after promotion instead works, but pays for the same
 deep read twice.
@@ -851,10 +810,8 @@ deep read twice.
 is no pool assigned to him, nothing here ever adds `DallanQ` as an assignee, and
 "route it to the lead" is not an available move.
 
-What used to go to him is not one queue. It is **three states that look identical
-on a board and behave completely differently**, and telling them apart is most of
-this section's value. When they were all his, the distinction did not matter — he
-absorbed it. Now it decides who can start.
+Work above the junior pools is **three states that look identical on a board and
+behave completely differently**, and telling them apart decides who can start.
 
 | State | Label | Blocked on | Who takes it |
 |---|---|---|---|
@@ -862,11 +819,10 @@ absorbed it. Now it decides who can start.
 | **Genuinely hard** | `senior` | Nothing. It is difficult | A senior in its lane — see below |
 | **Logistics** | *neither* | An access handover, a scope confirmation, a file someone has to send | Anyone, the moment it is cleared |
 
-**`needs-decision` is a distinct verdict, not a softer `senior`.** It is the label
-form of `task-reviewer`'s existing `needs-a-decision` verdict, which until now
-died in a report because nothing on the board carried it. An item that is merely
-undecided, labelled `senior`, is the worst case: it looks like it needs a rare
-person when it needs a sentence.
+**`needs-decision` is a distinct verdict, not a softer `senior`.** It is the
+label form of `task-reviewer`'s `needs-a-decision` verdict. An item that is
+merely undecided, labelled `senior`, is the worst case: it looks like it needs a
+rare person when it needs a sentence.
 
 **Do not label both.** If the decision is the only thing in the way, it is
 `needs-decision` — the work behind it may well be junior. Reach for `senior` only
@@ -891,19 +847,15 @@ report; the genealogist one is newer and easier to forget.
 ```sh
 # `needs-decision`, split by whether a ruling has been recorded.
 #
-# MATCH BOTH WORDS, AND BOTH MARKUPS. We are instructed to write `**Ruling:**`,
-# but this query does not read what we wrote — it reads what the LEAD wrote, and
-# he writes `## Decision:` and `**Decision (lead, <date>)`. A `**Ruling`-only
-# test called two answered items WAITING on 2026-08-13 (issues #1331 and #1394,
-# both ruled that afternoon), which is the exact inverse of the defect this
-# split exists to catch: it hides a dropped item by reporting the lead as the
-# bottleneck. Bold marker or ATX heading, "Ruling" or "Decision".
+# MATCH BOTH WORDS AND BOTH MARKUPS. This query reads what the LEAD wrote, not
+# what we are instructed to write: bold marker or ATX heading, "Ruling" or
+# "Decision". A `**Ruling`-only test reports answered items as WAITING, which
+# hides a dropped item by naming the lead as the bottleneck.
 #
-# Match anywhere in the body, not at character zero: real ruling comments put a
-# heading above the marker and number it (`## Lead rulings` … `**Ruling 1 — …`),
-# which an exact-prefix test misses.
+# Match anywhere in the body, not at character zero — real ruling comments put a
+# heading above the marker and number it (`## Lead rulings` … `**Ruling 1 — …`).
 #
-# Prove it before trusting a change to this pattern — run it against a known
+# Prove it before trusting a change to this pattern: run it against a known
 # answered issue and a known waiting one and watch the two land in different
 # buckets. A pattern that matches nothing reports a clean board forever.
 gh issue list --repo PioneerAIAcademy/cowork-genealogy --state open --limit 200 \
@@ -920,8 +872,7 @@ gh issue list --repo PioneerAIAcademy/cowork-genealogy --state open --limit 200 
 Report each separately — they have different remedies:
 
 - **`needs-decision`, split `WAITING` / `ANSWERED`.** Report each item's time in
-  queue from when the label went on, not from when the issue was filed; the two
-  are unrelated. `WAITING` items older than a couple of drains mean
+  queue from when the label went on, not from when the issue was filed. `WAITING` items older than a couple of drains mean
   `/make-decisions` is not keeping up with what the board queues, and no amount of
   assigning helps — that line goes at the top of the report.
 
@@ -946,10 +897,10 @@ You do not rank these queues and you do not assign from them.
 
 ### The milestones depend on both queues moving
 
-**Nearly every milestone-gating item is above the junior pools by §1's test** — a
-doctrine call, a gate that is worse wrong than absent, a design spanning harness
-and hosted server — while the junior pools do alpha content work that cannot stop
-and does not burn these down.
+**Nearly every milestone-gating item is above the junior pools** — a doctrine
+call, a gate that is worse wrong than absent, a design spanning harness and
+hosted server — while the junior pools do alpha content work that cannot stop and
+does not burn these down.
 
 Three failure modes to name out loud when you see them:
 
@@ -957,10 +908,9 @@ Three failure modes to name out loud when you see them:
   The loudest line in the report. Say which item has sat, for how long, and
   whether it is waiting on an answer or on a person — the two have opposite fixes.
 - **A long-lead item inside its lead time and still queued.** Prompt-injection
-  defense (issue #847) is the standing example: it gates the public rollout, so it
-  loses every impact ranking today, and nothing can begin until the doctrine is
-  settled. An item that "isn't due until March" has to move in the fall or it will
-  not land at all.
+  defense (issue #847) is the standing example: it gates the public rollout, so
+  it loses every impact ranking today, and nothing can begin until the doctrine
+  is settled.
 - **`needs-decision` growing while the junior pool runs dry.** The cheapest fix on
   this board is almost always the lead answering three questions, because each one
   converts a stuck item into a junior task. Name the three.
@@ -968,15 +918,15 @@ Three failure modes to name out loud when you see them:
 One thing that does **not** belong in the senior queue: an issue with an empty or
 one-line body. It is unactionable in a fresh session no matter who owns it, and
 labelling it `senior` makes it look researched. Leave it in Backlog and ask for a
-scope line — that is §7's `rewrite` verdict.
+scope line — that is the grooming `rewrite` verdict below.
 
 ## 7. Grooming
 
 Same read, nearly free. Cap it at about **eight** proposals — a grooming list
 longer than the promotion list means the day's output was grooming.
 
-**The cap lifts when §1's "Arrival vs. closure" shows arrival leading for three
-consecutive weeks.** Then grooming *is* the day's output: propose as many closes
+**The cap lifts when the arrival-vs-closure measurement shows arrival leading
+for three consecutive weeks.** Then grooming *is* the day's output: propose as many closes
 and merges as the read supports, and say that is what you did.
 
 Candidates: empty-bodied issues months old; issues superseded by a newer, better
@@ -997,21 +947,12 @@ issue.** Never batch a delete under a general approval, and never infer one from
 
 ## 8. Verify before you repeat anything
 
-Inherited from `triage-standup` §2, and it earns its cost here too. An issue
-body is **a claim written on a particular day**, not current repo state. The
-sharpest findings in a real run were both stale issue bodies:
-
-- An issue proposed a fix "also fixes #609" — #609 had been closed hours
-  earlier, on reasoning the proposing issue's own evidence contradicted.
-- A retention issue measured "147MB tracked"; `du -sh` said **269MB**. It had
-  nearly doubled in twelve days, which changes the priority, not just the number.
+An issue body is **a claim written on a particular day**, not current repo
+state. A cross-referenced issue closes; a measured size doubles; a cited symbol
+is deleted — and the stale half is normally the part the recommendation rests on.
 
 **Read the code behind every issue you form a view on** — not just the ones you
-are promoting. This repo moves fast enough that an issue body is usually written
-against code that has since changed, and the stale half is normally the part the
-recommendation rests on. Standing instruction from the lead, 2026-08-01: *"A lot
-of code has changed since the issues were originally written. They are likely
-based on old assumptions or code."*
+are promoting.
 
 That is a real cost, so spend it where it changes an answer: the promotion
 candidates, and **any issue you are about to recommend a disposition for**
@@ -1030,32 +971,23 @@ git log --diff-filter=D --all -- '<cited path>'          # was it deliberately d
 rests on a population ("N files drifted", "users hit this", "the shape is in the
 field") and the body names no number, measure it *before* proposing any
 disposition. That is the shape which survives every other check: it reads as a
-real problem, its reasoning is sound, and there is nothing behind it. One request
-wanted a six-way genealogical adjudication to heal drifted `research.json` keys;
-the drift appears in **0 of 90** committed documents and no write path can create
-it. It closed `not planned` in one command.
+real problem, its reasoning is sound, and there is nothing behind it.
 
-**Count the way the data is shaped, not the way it greps.** On that same request a
-bare `grep` for the six key names returned 50–70 files — `person_id` is a correct
-key on `person_evidence[]`, `record_id` is correct on assertions, `notes` is
-correct on sources. The grep was counting valid data. Walk the objects that would
-actually hold the field.
-
-Do not repeat this for the shortlist you are about to gate — `/review-ready`'s
-agents now count the premise per issue in fresh context (`docs/specs/task-review-spec.md`
-§7). Spend it here on what the gate never sees: the items you are about to close,
-consolidate, split, or route to the lead.
+**Count the way the data is shaped, not the way it greps.** A bare `grep` for a
+field name counts every valid use of it too — `person_id` is a correct key on
+`person_evidence[]`, `record_id` is correct on assertions. Walk the objects that
+would actually hold the field.
 
 **Read the mechanism the issue proposes to build, before agreeing it needs
 building.** A near-miss extension of something that exists is a different,
 smaller, safer task than a new mechanism, and finding that out changes the
 disposition rather than a detail. Worked cases:
-`docs/specs/task-review-spec.md` §7.
+`docs/specs/task-review-spec.md`.
 
-**Do not repeat this read for the shortlist you are about to gate.**
-`/review-ready` (§5) does it per issue in fresh context, which is the point of
-the fan-out. Spend §8 here on what the gate never sees: the items you are about
-to close, consolidate, split, or route to the lead.
+**Do not repeat any of this for the shortlist you are about to gate.**
+`/review-ready` does it per issue in fresh context, which is the point of the
+fan-out. Spend it on what the gate never sees: the items you are about to close,
+consolidate, split, or route to the lead.
 
 Cite so the lead can re-check in seconds: `file:line`, an issue number, a
 command and its output. When a check refutes something you already said, correct
@@ -1104,15 +1036,15 @@ list it does not appear in. Add state when it matters.
    flagged if arrival has led for three.
 2. **Splits** — anything you broke in two, and which half is going to Ready. Skip
    the heading if you split nothing.
-3. **Promote to Ready** — a table: issue, the **impact clause** from §2 (what
-   right answer it wins, what wrong one it prevents, what wall-clock or spend it
+3. **Promote to Ready** — a table: issue, the **impact clause** (what right
+   answer it wins, what wrong one it prevents, what wall-clock or spend it
    recovers), the milestone it gates (or `—`), `developer`/`genealogist`, what it
    displaced (if the pool was at target), and any soft-collision partner. Most
    consequential first — and if any row's impact clause reduces to "small and
    unblocked", it is the one cheap slot, or it should not be in the table.
 4. **Return to Backlog** — what lost each swap, with the one-line reason.
 5. **Above the junior pools** — the `needs-decision` and `senior` queues
-   separately (§6): size, trend since the last fill, oldest three with idle days,
+   separately: size, trend since the last fill, oldest three with idle days,
    which gate a milestone, and for `senior` how many are unassigned and in which
    lane. A growing `needs-decision` queue moves to section 0 — it means the
    bottleneck is answers, not people. You do not rank or assign from either.

--- a/.claude/skills/find-big-wins/SKILL.md
+++ b/.claude/skills/find-big-wins/SKILL.md
@@ -26,7 +26,8 @@ to code architecture.** Review topology, eval economics, team process, and what
 the team is *permitted* to do are all in scope.
 
 **Subtractions count, and are usually cheaper than additions.** Retiring a
-mechanism, dropping a guarantee, deleting a lane. Hunt them (§4).
+mechanism, dropping a guarantee, deleting a lane. Hunt them — see the
+subtraction hunt below.
 
 **You propose, then apply what is approved.** No branches, no PRs, no code
 changes, no eval runs, and **never the plan** — the person assigned the issue
@@ -74,8 +75,8 @@ therefore unavailable.
 
 ## How this run is scoped
 
-One invocation, weekly, after `/audit-board`: §0, all three evidence layers, the
-subtraction hunt, the proposals. It is the expensive pass and is meant to be.
+One invocation, weekly, after `/audit-board`: the carry-forward, all three
+evidence layers, the subtraction hunt, the proposals. It is the expensive pass and is meant to be.
 
 **Answering the queue is `/make-decisions`, which runs daily and stays cheap.**
 Three skills apply `needs-decision` every day, so a consumer that ran only weekly
@@ -92,7 +93,7 @@ Four verdicts, and only one of them closes a direction:
 | Verdict | Do this run |
 |---|---|
 | `deferred` | **Pull it into this run's ranking**, re-ranked against fresh ideas. It does not keep its old position — an idea that was third-best in a thin week is not automatically third-best this week |
-| `set aside` | Considered but **never researched**. Available to re-propose, under the higher burden in §6. Not a refusal |
+| `set aside` | Considered but **never researched**. Available to re-propose, under the higher burden in the ledger check below. Not a refusal |
 | `rejected` | **Researched and rejected, with reasoning. Do not propose it again, and do not re-derive it.** Read the reasoning; if you believe it is wrong, say so as a correction to that row with new evidence, which is a different act from re-proposing |
 | `accepted` | It is an issue now. Nothing to do unless it is evidence for something new |
 
@@ -105,11 +106,7 @@ without a decision. Then say which it is:
 - it keeps not being reached → that is a capacity finding about the review
   ceiling, not about the idea, and the lead should hear it as one.
 
-This is the whole reason the carry-forward exists. The failure it prevents is
-recorded in `docs/adrs/ADR-0009-refuted-agent-design-claims.md`: routing-as-a-tool
-was demoted to a P2 spike, and then nothing aged it visibly, so it sat untouched
-for months and was neither run nor dropped. A row with a date that grows is
-visible; an intention is not.
+A row with a date that grows is visible; an intention is not.
 
 ## 1. Layer 1 — the board as **symptom**, never as idea source
 
@@ -129,8 +126,7 @@ scheduling constraint someone hit repeatedly.
 *sentence*, not a repeated file: "measure this before graduating," "we need to
 decide X first," "this exists so we don't repeat #N." `/audit-board` merges
 those. This skill asks what mechanism is missing such that three people
-independently re-derived the same undone task. Its worked case is issues #911,
-#980 and #1231 — three issues, one calibration, nobody sequencing.
+independently re-derived the same undone task.
 
 ```sh
 gh issue list --repo PioneerAIAcademy/cowork-genealogy --state open --limit 400 \
@@ -218,10 +214,10 @@ nothing:
 | `make e2e-agent-tools` | tools an agent declares and never calls — dead capability |
 | `make e2e-guardrail-shadow` | what a shadow guardrail would have denied |
 
-**Do not quote a violation *rate*.** `docs/architecture.md` §9.4 records that
-the detectors are uncalibrated and no denominator is trustworthy; `make
-e2e-corpus` deliberately prints counts and refuses a percentage. Quote counts,
-and read the report's concentration block before quoting any total.
+**Do not quote a violation *rate*** — the detectors are uncalibrated and no
+denominator is trustworthy, which is why `make e2e-corpus` prints counts and
+refuses a percentage. Quote counts, and read the report's concentration block
+before quoting any total.
 
 **The standing lists of known holes.**
 
@@ -230,15 +226,15 @@ and read the report's concentration block before quoting any total.
   label on the board, not a table in a file: `gh issue list --state open --label
   nothing-checks`. Read it asking *which of these are one mechanism*, not *which
   should we fix*: four issues that all say "no production telemetry exists in any
-  form" are one bet, not four issues. `docs/architecture.md` §9.4 keeps only the
-  three gaps that change how a correct change is made — read those too, then the
-  register for the rest.
+  form" are one bet, not four issues. `docs/architecture.md`'s "What nothing
+  checks" keeps only the gaps that change how a correct change is made — read
+  those too, then the register for the rest.
 - `gh issue list --state open --label needs-decision` — the open questions.
   `/make-decisions` answers them daily; read them here only for repeats. Two more
   sit in `docs/architecture.md` under "Open questions" and carry no label — read
   those too.
-- `docs/adrs/` — every decision, with what it costs. §3 below is how to read
-  these for *expiry* rather than for compliance.
+- `docs/adrs/` — every decision, with what it costs. The outside-the-repo layer
+  below is how to read these for *expiry* rather than for compliance.
 - `docs/specs/guardrail-enforcement-spec.md` § "Options set aside" — a second
   negative record, scoped to guardrails.
 - `docs/e2e-run-latency-findings.md` — the measured split between model
@@ -263,8 +259,8 @@ Four places to look, none of which the developer-lane commands above touch:
 - **Annotation cost per paid run.** `eval/harness/scripts/check_runlogs.py`
   rule 3 requires the `.ann.json` to carry a correction entry for **every
   dimension of every test** in the suite. That is genealogist hours, and it is
-  the binding cost of a skill edit — not the $8–12 of machine time everybody
-  quotes. Verify the current per-suite test count before repeating a number.
+  the binding cost of a skill edit — not the $8–12 of machine time. Verify the
+  current per-suite test count before repeating a number.
 - **Judge audits.** `docs/record-extraction-judge-audit.md`, and the
   `cluster:judge-overrides` issues, which are cases where the judge ignored an
   explicit rubric instruction. A grader that does not follow its own prompt is a
@@ -311,19 +307,16 @@ this working around, and does that limitation still exist?** Not "is this
 decision still good" — that is a compliance read, and it will always come back
 "yes."
 
-The worked example of the shape: agent frontmatter must spell every MCP tool
-name **three times**, once per registrar, because the three environments
-namespace the server differently and no single spelling resolves everywhere
-(`docs/adrs/ADR-0004-dual-spell-mcp-tool-names-in-agent-frontmatter.md`). Every
-guardrail we own inherits that constraint. If upstream has since made the
-namespacing addressable, a consolidated guardrail system gets dramatically
-cheaper — and **nothing inside this repo would ever reveal it**, because from in
-here the workaround simply works.
+The shape to look for: agent frontmatter must spell every MCP tool name **three
+times**, once per registrar, because the three environments namespace the server
+differently (`docs/adrs/ADR-0004-dual-spell-mcp-tool-names-in-agent-frontmatter.md`).
+Every guardrail we own inherits that constraint, and **nothing inside this repo
+can reveal that upstream has lifted it** — from in here the workaround simply
+works.
 
-Do the same for every constraint of that family: hook lifecycle (which
-`SessionStart` behaviour ADR-0005 records as inverted from the
-upstream issue), tool-search deferral, per-subagent model and effort control,
-sandbox capabilities.
+Do the same for every constraint of that family: hook lifecycle (ADR-0005),
+tool-search deferral, per-subagent model and effort control, sandbox
+capabilities.
 
 **Never propose on "I think X shipped."** Find the changelog entry, the docs
 page or the release note, and cite it with its date. A proposal built on a
@@ -336,10 +329,10 @@ multi-agent decomposition, prompt-size budgets, grader calibration. The
 question is not "what is popular" — it is "has a class of work we do by hand
 become a solved commodity."
 
-**3. Published work.** ADR-0009 records that a claim of novelty was falsified by
-a paper published a month earlier and found in one search. Before proposing a
-mechanism as new, look — and where a published result contradicts an internal
-one, say which you believe and why.
+**3. Published work.** Before proposing a mechanism as new, search for it — a
+claim of novelty here has already been falsified by a paper found in one search.
+Where a published result contradicts an internal one, say which you believe and
+why.
 
 ## 4. Hunt subtractions
 
@@ -354,18 +347,18 @@ Four shapes, each greppable:
   other. `docs/adrs/ADR-0008-sync-schema-copies-eliminate-generate-or-lint.md`
   is the worked precedent — its first option is *eliminate the copy*, and only
   then generate or lint it.
-- **A warn-only check nobody reads.** `docs/architecture.md` §9.2 names three
-  lints that never fail, and their warnings compete for GitHub's per-step
-  annotation cap against a standing backlog in the dozens — so the edge a PR
-  *adds* is not distinguishable from the ones already there. A check whose output
-  nobody can read is cost with no signal — either it blocks or it goes.
+- **A warn-only check nobody reads.** `docs/architecture.md`'s lint layer names
+  the lints that never fail; their warnings compete for GitHub's per-step
+  annotation cap against a standing backlog in the dozens, so a PR's own warning
+  is not distinguishable from the ones already there. A check whose output nobody
+  can read is cost with no signal — either it blocks or it goes.
 - **A guarantee nothing consumes.** A held invariant, a preserved field, a
   supported path with no caller. Dropping it can retire a whole validation
   surface.
 - **A lane.** A whole category of work — a review stage, a doc tier, a test
   tier — whose absence would cost less than it does.
 
-A subtraction clears the bar in §5 exactly like an addition: it names the class
+A subtraction clears the bar below exactly like an addition: it names the class
 of work it eliminates and what we would observe. It does **not** need to name a
 replacement.
 
@@ -408,16 +401,8 @@ demoted, dismissed and spiked ideas scattered across the repo:** read them, and
 **do not treat a row as a veto.**
 
 Most of ADR-0009's rows correct *arithmetic, scope or attribution* rather than
-refuting a direction. Three from the ledger itself:
-
-| Row | What was actually refuted |
-|---|---|
-| "the routing table … is 431 lines of prose" | **Arithmetic.** 431 was the whole file; the table is 17 rows |
-| "the single largest unanchored rule we own" | **Nothing.** Never measured at all |
-| routing-as-a-tool as the P0 | **Magnitude and attribution** — the router did invoke the skill in all five failures. Demoted to a P2 spike that nobody ever ran |
-
-Those were quick passes under time pressure. A wrong number is not a refuted
-idea.
+refuting a direction — a wrong count, a claim that was never measured at all, a
+magnitude that was overstated. **A wrong number is not a refuted idea.**
 
 **For any proposal that touches the ledger, state explicitly which was refuted
 — the DIRECTION, the MAGNITUDE, or the ARITHMETIC — and re-size it honestly.**
@@ -432,13 +417,6 @@ table, and `docs/specs/guardrail-enforcement-spec.md` § "Options set aside".
 They record arguments that failed, which is not the same as directions that were
 researched and closed. Only ADR-0010's `rejected` rows are the latter.
 
-### On the first run
-
-**Make a deliberate pass over the ledger and over every idea that was demoted,
-dismissed or spiked but never actually investigated.** That backlog of
-under-considered bets is likely this skill's highest-yield output, and it will
-never be as rich again. Spend the run on it.
-
 ## 7. What every proposal carries, pre-verified
 
 Six fields per proposal, all verified **before** the lead reads it:
@@ -446,11 +424,11 @@ Six fields per proposal, all verified **before** the lead reads it:
 | Field | Rule |
 |---|---|
 | **Claim** | One sentence. What changes about the system |
-| **Constraint removed / class eliminated** | §5's bar. Name the constraint, or the class of work that stops being generated |
+| **Constraint removed / class eliminated** | The bar above. Name the constraint, or the class of work that stops being generated |
 | **What we would observe** | The difference visible if it worked. Not necessarily a number |
 | **Issues it closes or prevents** | Counted against the **real** board, with numbers. "Prevents" needs the shape it prevents, not a guess at volume |
 | **The cheapest probe that could kill it in under a day** | With a cost. A probe that cannot come back negative is not a probe |
-| **Ledger check** | Which row it touches, and whether the direction, the magnitude or the arithmetic was refuted — or "no ledger row". A `rejected` row means it does not get proposed at all (§6) |
+| **Ledger check** | Which row it touches, and whether the direction, the magnitude or the arithmetic was refuted — or "no ledger row". A `rejected` row means it does not get proposed at all |
 
 **Verify counts, dates and the ledger check by running the real commands.**
 Not the design — the design is stage 2's job, and pre-verifying it is how a
@@ -473,8 +451,8 @@ The three that go stale fastest here, and all three have bitten:
 - **Costs.** Per-run figures are recomputed by `make e2e-corpus`; the numbers
   frozen into docs are older than the corpus.
 - **Upstream capabilities.** A platform fact more than a few weeks old is a
-  guess. This one is the whole point of §3 — get it wrong and the proposal is
-  worse than nothing.
+  guess. This is the whole point of the outside-the-repo layer — get it wrong
+  and the proposal is worse than nothing.
 
 If you could not verify something, say so rather than repeating it with
 confidence. A ledger row is itself a claim written on a particular day, not a
@@ -492,8 +470,8 @@ ideas and two filler ones to reach five is strictly worse than producing four,
 because the filler consumes the same scarce read.
 
 **A run that returns zero is a successful run.** Say so plainly, say what you
-swept, and say which layer came back empty — a zero from §3 means something
-different from a zero from §2, and the lead needs to know which.
+swept, and name which layer came back empty — a zero from the outside sweep
+means something different from a zero from the internal evidence.
 
 Rank by expected value, not by confidence: a 30%-confidence bet that eliminates
 a class beats a certain increment, and saying "30%" is what makes that
@@ -549,9 +527,9 @@ Never batch these. He decides one at a time, and each one gets a row.
 | Verdict | Means | Row |
 |---|---|---|
 | **accepted** | goes to stage 2 | written now; the `Issue` cell filled in when stage 3 files it, and `What was learned` filled in from the research |
-| **deferred** | he did not reach it, or reached it and held it | first-proposed date; §0 carries it forward and **re-ranks** it |
+| **deferred** | he did not reach it, or reached it and held it | first-proposed date; the next run carries it forward and **re-ranks** it |
 | **set aside** | considered at proposal stage, **not researched** | one clause plus a **direction** / **magnitude** / **arithmetic** tag. A record, not a bar |
-| **rejected** | **researched in stage 2 and rejected** | the reasoning, in full. **This one is a bar** — §6 stops the next run proposing it again |
+| **rejected** | **researched in stage 2 and rejected** | the reasoning, in full. **This one is a bar** — the ledger check stops the next run proposing it again |
 
 `set aside` and `rejected` are not interchangeable, and the difference is whether
 a deep dive happened. Never write `rejected` for something nobody researched.
@@ -582,8 +560,8 @@ multi-week structural projects, not weekly items.
 ### Writing the ledger
 
 **Every proposal gets a row, including the ones he never reached** — those are
-`deferred`. That is what makes §0's carry-forward complete rather than a
-best-effort recollection of a long session.
+`deferred`. That is what makes the next run's carry-forward complete rather than
+a best-effort recollection of a long session.
 
 Write them yourself, into the table in
 `docs/adrs/ADR-0010-record-structural-bets-in-a-ledger.md`, once he has decided.
@@ -606,17 +584,17 @@ Four rules:
 
 0. **Carried forward** — ideas from previous runs, with first-proposed dates and
    how many runs each has survived. Anything carried more than twice leads, as
-   its own finding (§0). Skip the heading on a first run and say it is the first.
+   its own finding.
 1. **Headline** — how many cleared the bar, and the one thing you would spend
    his first read on. If the answer is zero, this section is the report: what
    you swept, and which layer came back empty.
-2. **The proposals** — ranked by expected value, each with the six fields from
-   §7 and your confidence. Most consequential first. Do not pad to five.
+2. **The proposals** — ranked by expected value, each with the six required
+   fields and your confidence. Most consequential first. Do not pad to five.
 3. **Subtractions** — kept as their own list even though they clear the same
    bar, because they are the ones a reader skims past. Say "none found" if none.
-4. **Genealogist lane** — what §2's genealogist pass found, or explicitly that
-   it found nothing this run.
-5. **Outside evidence** — what §3's sweep turned up, each with a dated primary
+4. **Genealogist lane** — what the genealogist pass found, or explicitly that it
+   found nothing this run.
+5. **Outside evidence** — what the outside sweep turned up, each with a dated primary
    source. If a platform constraint was checked and still holds, say so: that is
    a real result and it stops the next run re-checking it.
 

--- a/.claude/skills/merge-recent-issues/SKILL.md
+++ b/.claude/skills/merge-recent-issues/SKILL.md
@@ -106,18 +106,32 @@ The failure a split invites is worse than a forgotten assignment: someone lands
 half the work, updates the spec to record the gap as closed, and the other half
 stays open with a document claiming otherwise.
 
-### The lane split survives only when it is clean
+**Extended 2026-08-31**, on a pass that reported #2030 (`developer`) and #2032
+(`genealogist`) as independent purely because doctrine forbade a cross-lane merge:
 
-`/audit-board`'s lane-split verdict keeps two halves apart when they are different
-labor — a `developer` lint and a `genealogist` audit — because one card spanning
-two lanes has no single assignee. That reason is real, but it holds **only if
-neither half needs the other to land**. Test it explicitly: can each be finished,
-reviewed and merged without waiting on the other? If yes, split cleanly and give
-each its own acceptance. If no, merge and let the card carry both labels — a card
-with two labels is assignable; two cards that each need the other are not.
+> it's okay to merge developer and genealogist lanes for the same skill because
+> genealogists and developers can request help as needed.
 
-When you do split, split at the lane boundary and move the content, so neither
-issue is left pointing at the other for something it needs.
+So **a lane difference is never on its own a reason to keep two issues apart.**
+
+### The lane split survives only where each half finishes without the other
+
+`/audit-board`'s lane-split verdict used to keep two halves apart when they were
+different labor — a `developer` lint and a `genealogist` audit — on the grounds
+that one card spanning two lanes has no single assignee. **That ground is retired**
+by the ruling above: two issues on one skill merge even when one is `developer` and
+the other `genealogist`. The card carries both labels, and whoever takes it asks
+the other lane for the half they do not own.
+
+One test survives, and it is the only one: **can each half be finished, reviewed
+and merged without waiting on the other?** If yes, split cleanly and give each its
+own acceptance. If no, merge. When you do split, split at the lane boundary and
+move the content, so neither issue is left pointing at the other for something it
+needs.
+
+**Never report "different lanes" as the reason for an independent verdict.** If a
+lane difference is the only thing separating two issues on the same skill, they
+merge — and the paid eval run they would otherwise each need is the reason.
 
 ### One-way mechanical dependencies are a body edit, not a merge
 

--- a/.claude/skills/merge-recent-issues/SKILL.md
+++ b/.claude/skills/merge-recent-issues/SKILL.md
@@ -10,25 +10,20 @@ allowed-tools:
 
 # Merge recent issues
 
-`/audit-board` is the twice-weekly whole-pool pass and it **owns merge doctrine**.
-This skill owns *selection and cadence*: it looks only at what was filed in the
-last couple of days, while the reason for each filing is still recoverable and
-before a duplicate gets ranked, promoted and assigned.
+`/audit-board` is the weekly whole-pool pass and it **owns merge doctrine**. This
+skill owns *selection and cadence*: it looks only at what was filed in the last
+couple of days, while the reason for each filing is still recoverable and before
+a duplicate gets ranked, promoted and assigned.
 
-**Run this daily; do not run `/audit-board` daily instead.** They catch different
-things. A new issue landing on top of an existing one is the case that decays
-fastest — the filer's context is gone within days and the duplicate gets ranked,
-promoted and assigned in the meantime — and it is cheap to check, because one side
-of every comparison is fresh. Two *old* issues colliding, obsolescence, clusters,
-eval-slot queues and board hygiene are what `/audit-board` is for; none of them
-change materially in a day, and all of them need every open body in one head,
-which is why that pass is expensive and this one is not.
+**Run this daily; do not run `/audit-board` daily instead.** A new issue landing
+on top of an existing one is the case that decays fastest and the cheapest to
+check. Two *old* issues colliding, obsolescence, clusters, eval-slot queues and
+board hygiene are what `/audit-board` is for.
 
-**Read `/audit-board`'s merge section before proposing anything, and use its
-verdicts verbatim.** Do not invent a verdict here, do not restate its rules in
-your own words, and if this file and that one ever disagree, that one wins and
-the disagreement is a finding to report. Two skills with two sets of merge rules
-is how the board ends up with two answers for the same pair.
+**Read `.claude/skills/audit-board/SKILL.md`'s merge section before proposing
+anything, and use its verdicts verbatim.** Do not invent a verdict here and do
+not restate its rules in your own words. If this file and that one ever disagree,
+that one wins and the disagreement is a finding to report.
 
 **You propose, then apply what is approved.** No branches, no PRs, no code edits.
 You have no `Edit` or `Write` tool on purpose.
@@ -77,86 +72,52 @@ is a different action from a merge and should never be reported as one.
 
 ## 2. The verdicts
 
-Use `/audit-board`'s four — duplicate, absorb, batch, and the lane split — plus
-the close-as-duplicate-of-active-work above. Its two hard rules bind here in full:
+Read `/audit-board`'s merge section and use its four verdicts — duplicate,
+absorb, batch, and the lane split — plus the close-as-duplicate-of-active-work
+above. Everything it says about **which** verdict applies binds here unchanged;
+do not re-derive it from this file.
+
+Three of its rules decide most of what this pass sees:
 
 - **Search by fix site, not by topic.** Read the `**Touches:**` line first; fall
   back to its grep for older bodies. Issues that collide almost never share a
   title — they want different lines in one file.
 - **Never replace N issues with one issue holding N rows.** No trackers, no
-  umbrellas, no index issues. That anti-pattern cost real data on 2026-08-04 and
-  the reasoning is recorded there.
+  umbrellas, no index issues.
+- **The default is merge.** Same decision, same files, same paid eval run, same
+  reviewer, or one is the class and the other its instance — all merge.
+  "Cross-reference and note it", "schedule together" and "decide together but
+  keep separate" are not verdicts. Splitting on *mechanism purity* — two tools,
+  two matchers, two code paths — is an author's aesthetic, not a work boundary.
 
-### The default is merge
+Two instructions this pass owes on top of that:
 
-Ruled by the lead 2026-08-11, after a pass that produced a "decide together but
-keep separate" bucket:
+**Never report "different lanes" as the reason for an independent verdict.** A
+lane difference is never on its own a reason to keep two issues apart. If it is
+the only thing separating two issues on the same skill, they merge — and the paid
+eval run they would otherwise each need is the reason.
 
-> Anything that should be done together sounds like a reason to merge. Otherwise
-> we have to cross-reference the issues and rely on people remembering to assign
-> both issues to themselves, which they have forgotten several times.
-
-So: **same decision, same files, same paid eval run, same reviewer, or one is the
-class and the other its instance — all merge.** "Cross-reference and note it" is
-not a verdict. Splitting on *mechanism purity* — two tools, two matchers, two
-code paths — is an author's aesthetic, not a work boundary; merge on the decision
-boundary instead.
-
-The failure a split invites is worse than a forgotten assignment: someone lands
-half the work, updates the spec to record the gap as closed, and the other half
-stays open with a document claiming otherwise.
-
-**Extended 2026-08-31**, on a pass that reported #2030 (`developer`) and #2032
-(`genealogist`) as independent purely because doctrine forbade a cross-lane merge:
-
-> it's okay to merge developer and genealogist lanes for the same skill because
-> genealogists and developers can request help as needed.
-
-So **a lane difference is never on its own a reason to keep two issues apart.**
-
-### The lane split survives only where each half finishes without the other
-
-`/audit-board`'s lane-split verdict used to keep two halves apart when they were
-different labor — a `developer` lint and a `genealogist` audit — on the grounds
-that one card spanning two lanes has no single assignee. **That ground is retired**
-by the ruling above: two issues on one skill merge even when one is `developer` and
-the other `genealogist`. The card carries both labels, and whoever takes it asks
-the other lane for the half they do not own.
-
-One test survives, and it is the only one: **can each half be finished, reviewed
-and merged without waiting on the other?** If yes, split cleanly and give each its
-own acceptance. If no, merge. When you do split, split at the lane boundary and
-move the content, so neither issue is left pointing at the other for something it
-needs.
-
-**Never report "different lanes" as the reason for an independent verdict.** If a
-lane difference is the only thing separating two issues on the same skill, they
-merge — and the paid eval run they would otherwise each need is the reason.
-
-### One-way mechanical dependencies are a body edit, not a merge
-
-When issue B only needs to *apply* something issue A defines — a convention, a
-constant, a helper — do not merge and do not cross-reference. **Edit B's body** so
-the dependency reads as an instruction ("apply the convention issue #A defines")
-rather than a coordination requirement. Nobody then needs both assignments, which
-is the whole objection to cross-referencing.
+**A one-way mechanical dependency is a body edit, not a merge.** When issue B
+only needs to *apply* something issue A defines — a convention, a constant, a
+helper — do not merge and do not cross-reference. **Edit B's body** so the
+dependency reads as an instruction ("apply the convention issue #A defines")
+rather than a coordination requirement.
 
 ## 3. Prove it before proposing
 
 **Open the files both issues name.** Title and framing resemblance is the
-dominant false positive here, and it is convincing: on 2026-08-11 this pass
-proposed merging two issues both described as "a prose lint with a file-and-line
-allow-list." Reading the two test files killed it — one compares hashes across
-duplicated file copies, the other matches a banned phrase, and they share no
-mechanism at all.
+dominant false positive here, and it is convincing — two issues both described as
+"a prose lint with a file-and-line allow-list" routinely share no mechanism at
+all, one comparing hashes across duplicated copies and the other matching a
+banned phrase.
 
 Three checks, every proposed merge:
 
 1. **Same fix site?** Open the file. Quote the lines.
 2. **Blocked or unblocked?** **Never merge an unblocked issue into a blocked
-   one.** That same wrong proposal would have parked a cheap, fully-specified,
-   ready-to-start lint behind an adjudication issue it did not need. Check both
-   bodies for a stated blocker and resolve it (`gh issue view <N> --json state`).
+   one** — that parks ready-to-start work behind an adjudication it does not
+   need. Check both bodies for a stated blocker and resolve it
+   (`gh issue view <N> --json state`).
 3. **Does it add a paid eval run?** If the absorbed issue's skill is already in
    the target's touch list, merging is free — say so. If it is not, the merge adds
    a `make eval-skill` run plus an annotation pass, which is a real cost the lead

--- a/.claude/skills/triage-feedback/SKILL.md
+++ b/.claude/skills/triage-feedback/SKILL.md
@@ -20,8 +20,7 @@ it treats a `feedback`-labelled item outside this column as a triage slip and
 refuses to promote it.
 
 **You propose, then apply what is approved.** No branches, no PRs, no code edits.
-You have no `Edit` or `Write` tool on purpose — a session that starts fixing the
-first bug never triages the other seven.
+You have no `Edit` or `Write` tool on purpose.
 
 **One item at a time.** Report, verify, recommend, wait for the verdict, apply,
 move on. Do not batch the report and do not run ahead of the lead.
@@ -48,9 +47,9 @@ reads returns "API rate limit exceeded" while `gh api rate_limit` still shows
 5000/5000. Read the board once at the start of the run and work from that
 snapshot, re-reading only before a write.
 
-**Oldest first**, and **cap the run at about eight**. Quality collapses past
-that, and there is nothing to resume — the column is the queue, so an item you
-did not reach is simply still there next run. Say how many are left when you stop.
+**Oldest first**, and **cap the run at about eight.** The column is the queue, so
+an item you did not reach is still there next run. Say how many are left when you
+stop.
 
 Two items with timestamps a few minutes apart are usually one tester resubmitting,
 not two bugs. Open both before triaging either.
@@ -75,16 +74,11 @@ Give the lead, in this order and nothing else:
 **Separate what the tester observed from what they concluded, and check the
 conclusion against the repo.** Their observations are reliable — they were there.
 Their diagnoses frequently are not, and a fix designed from a wrong diagnosis
-builds the wrong thing.
+builds the wrong thing. A refuted diagnosis routinely sits on top of a real
+observation that is sharper than the report: "feature X is missing" where X ships
+and works, but the project state that made them say it is genuinely broken.
 
-The case that set this rule: a tester reported "Localities is missing from the
-supported schema." It is not, and has not been since 2026-07-15 — it is in both
-schema trees, the validator, `research_append`, the ownership table and the
-viewer. But the observation underneath was real and sharper than the report: that
-project had three plans across four jurisdictions and an empty `localities`, so a
-routing gate that should have fired never did.
-
-So for each claim, say which it is:
+For each claim, say which it is:
 
 - **Confirmed** — you found the code, the doc, or the state that shows it.
 - **Refuted** — the thing the tester says is missing or broken is present and
@@ -96,10 +90,9 @@ So for each claim, say which it is:
 
 ## 3. Check whether an issue already covers it
 
-**Before the expensive code read, not after.** One bundle produced four findings
-on 2026-08-26; two were already filed by someone else and a third belonged on an
-issue that already carried a ruling from the lead. Without this step that bundle
-becomes three duplicate issues.
+**Before the expensive code read, not after.** One bundle routinely produces
+several findings that are already filed, and without this step it becomes several
+duplicate issues.
 
 ```sh
 gh issue list --repo PioneerAIAcademy/cowork-genealogy --state open \
@@ -121,10 +114,10 @@ Put one to the lead with a recommendation and the context behind it. He decides.
 |---|---|---|
 | **Not planned** | Nothing to build: the agent behaved correctly, the ask is out of scope, the claim is refuted with nothing real underneath, or it is a duplicate submission of another feedback item. | Close with a one-line reason. The card moves itself. |
 | **Fold into #N** | An open issue already covers it. | Comment on #N with what this case adds — a second instance, a new cost, a sharper repro. Then close the feedback issue pointing at #N. |
-| **Backlog** | Real work nobody has filed. | Write the instructions (§5), relabel, move the card (§6). |
+| **Backlog** | Real work nobody has filed. | Write the instructions below, relabel, and move the card. |
 
 **A refuted claim is not automatically Not planned.** Ask what the tester saw
-first. The Localities case above would have been closed wrongly.
+first — the observation under a wrong diagnosis is usually real.
 
 **"Worked as expected: yes" is not automatically Not planned either.** Testers
 tick it and then describe four problems. The prose decides.
@@ -191,7 +184,7 @@ Closing moves the card to Not planned on its own. Nothing else to do.
 
 ```sh
 gh issue edit <N> --repo PioneerAIAcademy/cowork-genealogy \
-  --body-file <(...)                       # instructions, per §5
+  --body-file <(...)                       # the instructions written above
 gh issue edit <N> --repo PioneerAIAcademy/cowork-genealogy \
   --add-label developer                    # or genealogist, by who does the work
 gh issue edit <N> --repo PioneerAIAcademy/cowork-genealogy \


### PR DESCRIPTION
Ruled by the lead on 2026-08-31, during a `/merge-recent-issues` pass that reported
issues #2030 (`developer`) and #2032 (`genealogist`) as independent *purely* because
doctrine forbade a cross-lane merge:

> it's okay to merge developer and genealogist lanes for the same skill because
> genealogists and developers can request help as needed.

Both merge skills leaned on the premise that refutes — that a card spanning two
lanes has no single assignee — so everything downstream of it had to move. Two
files, no code, no tests affected.

## `/audit-board`

**§1, the lane-split verdict.** Retitled from "only when the split is clean" to
"only when each half finishes without the other". The assignability argument is
named as retired, with the ruling quoted and dated. `"these are different lanes"`
is stated outright as not a reason to keep two issues apart. The
finishes-independently test survives as the only test.

**§1, the same-file default.** This listed three stated reasons to keep two issues
wanting different lines in one file apart — *"different lane, different reviewer,
or a paid-run slot they cannot share."* Two are gone:

- **"different lane"** — by the ruling.
- **"a paid-run slot they cannot share"** — this was an internal contradiction,
  surfaced by the same pass. §1 read an unshareable run as a reason to keep two
  issues *apart*; §4 ("Merge the issues, not the branches") reads it as the whole
  reason to *merge* — "Seven issues serialized is seven runs; the same work merged
  into three issues is three." One fact pointing two ways. §4 wins.

"Different reviewer" went too: on one skill it is the lane objection in different
clothes.

**§1, precedence (new).** Retiring those two left an ordering gap that would
otherwise have shipped: a blocker on one side keeps two issues apart regardless;
absent a blocker, a shared paid run merges them; only when no run is at stake does
finishing independently decide.

**§4.** Replaces the sentence the ruling directly overturns — *"Do not merge across
lanes to save a run: a `developer` harness fix and a `genealogist` fixture
adjudication in one issue is unassignable, which costs more than the run saved"* —
with the opposite. The section's axis moves from **lane** to **skill**, which is
what actually decides whether one run covers the work.

The twenty-record-hint caveat survives in substance — N independent investigations
still do not merge, because each still costs its own run. Its test now reads *"one
person who can ask the other lane for help"* rather than one person who must
already hold both skills; that reframing is the whole difference between the old
rule and the new one.

## `/merge-recent-issues`

Records the ruling beside the 2026-08-11 one with its provenance, mirrors the
rewritten lane-split section, and adds one instruction to that pass: **never report
"different lanes" as the reason for an independent verdict.** That line exists
because it is the mistake the pass had just made.

## What this does not change

The blocker rule (never park an unblocked issue behind a blocked one), the
never-replace-N-issues-with-one-tracker rule and its 2026-08-04 data loss, the
"does one person finish all of it in one sitting?" test, and the one-way mechanical
dependency → body edit verdict are all untouched.

## Applied under the new doctrine

Both merges were approved and applied before this PR:

- **#2050 → #1837** (absorb) — unaffected by the ruling; both `developer`.
- **#2032 → #2023** (merge) — this is the call the ruling reverses. Two
  `research-plan` plan-content rules that cannot share a paid eval run while they
  sit on separate cards. #2023 retitled to cover both; issue #2032 closed with the
  run arithmetic recorded.

Issue #2030 stays open: it touches `validator.ts`, `research-append.ts` and
`test_research_plan.py` and nothing inside the skill directory, so it consumes no
paid run and merging it would have saved none — the lane was never the real reason
to keep it separate.

## Verification

- Repo-wide grep of `.claude/`, `docs/`, `CLAUDE.md`, `DEVELOPMENT.md` for the
  retired premise (`across lanes`, `no single assignee`, `unassignable`, `spanning
  two lanes`): the only remaining hits are the new text explicitly retiring it. The
  one unrelated hit, `DEVELOPMENT.md:276`, is the `docs/TODOs.md` history.
- Both files are `.claude/skills/`, loaded on demand by the lead — not shipped
  plugin skills, so `CLAUDE.md`'s "no explanatory prose in a SKILL.md" token rule
  does not apply here.
- No CI job reads either file; nothing to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)