### PR TITLE
docs(architecture): an autonomous run must reach what a production run can

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1603,6 +1603,7 @@ changes how a correct change is made:
    the success gate can and cannot see"). `make e2e-corpus` deliberately reports
    counts, refusing a percentage whose denominator would be doing the work. Read
    its `concentration:` block before quoting even a count.
+
 ### 9.5 An autonomous run must be able to reach what a production run can
 
 **The e2e tier is the only instrument that answers "is this getting better for a
@@ -1632,12 +1633,12 @@ gone.
 Removing a capability is the bug. Two were found on 2026-08-31, both in skill bodies,
 both green in CI for months:
 
-- **The plan freeze.** `search-records` told an autonomous run it had no ad-hoc
-  searches, which dead-ended the skill's one route back to `research-plan`. An
-  interactive researcher who noticed the plan was wrong could get it revised; an
-  autonomous one could not. `research-plan` compounded it by superseding a plan
+- **The plan freeze.** `search-records` tells an autonomous run it has no ad-hoc
+  searches, which closes the skill's self-initiated route back to `research-plan`. An
+  interactive researcher who notices the plan is wrong can get it revised; an
+  autonomous one cannot. `research-plan` compounds it by superseding a plan
   "only when the user is explicitly re-planning" — never true with no user — so even
-  reaching the skill would have changed nothing. Measured consequence: across the
+  reaching the skill changes nothing. Measured consequence: across the
   committed e2e corpus, 93% of question-plan pairs carry exactly one plan, and only
   seven plans in the whole corpus were ever superseded.
 - **External-site captures.** `search-external-sites` marks a plan item `skipped`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1606,12 +1606,13 @@ changes how a correct change is made:
 
 ### 9.5 An autonomous run must be able to reach what a production run can
 
-**The e2e tier is the only instrument that answers "is this getting better for a
-real user?" It answers that question only to the extent the run it measures can do
-what a user's run can do.** Every capability an autonomous run cannot reach is a
-capability the benchmark never exercises and never scores — so the gap is invisible
-in exactly the place you would look for it. A divergence here does not make the
-number noisy; it makes the number about the harness.
+**Nothing here measures production — every figure in this repo is computed over the
+eval corpus (§9.4). The e2e tier is the closest proxy: live FamilySearch, the whole
+route end to end. It holds only so far as the run it measures can do what a user's
+run can do.** Every capability an autonomous run cannot reach is a capability the
+benchmark never exercises and never scores — so the gap is invisible in exactly the
+place you would look for it. A divergence here does not make the number noisy; it
+makes the number about the harness.
 
 This generalizes a rule `CLAUDE.md` already states narrowly for one dimension —
 "the eval harness emulates production's permission model," grant what production

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,7 @@ is `eval/JUNIOR-WALKTHROUGH.md` (first PR) and `eval/SENIOR-WALKTHROUGH.md`
 | Add a field to `research.json` · Add an enum value · Add a tree field | [§6](#if-youre-asked-to-3) |
 | Add a viewer feature · Change what the sandbox runs · Add a control-plane endpoint | [§7](#if-youre-asked-to-4) |
 | Change hosted agent config | [§8](#if-youre-asked-to-5) |
-| Verify a change · Debug a failing e2e run · Add a unit eval test · Write a spec | [§9](#if-youre-asked-to-6) |
+| Verify a change · Debug a failing e2e run · Add a unit eval test · Write a spec · **Write a rule that behaves differently under `--autonomous`** | [§9](#if-youre-asked-to-6) |
 
 > **Before you trust a green CI run, read [§9.4 — What nothing checks](#94-what-nothing-checks).**
 > Much of this system has no automated guard, and several of those gaps fail
@@ -1603,6 +1603,69 @@ changes how a correct change is made:
    the success gate can and cannot see"). `make e2e-corpus` deliberately reports
    counts, refusing a percentage whose denominator would be doing the work. Read
    its `concentration:` block before quoting even a count.
+### 9.5 An autonomous run must be able to reach what a production run can
+
+**The e2e tier is the only instrument that answers "is this getting better for a
+real user?" It answers that question only to the extent the run it measures can do
+what a user's run can do.** Every capability an autonomous run cannot reach is a
+capability the benchmark never exercises and never scores — so the gap is invisible
+in exactly the place you would look for it. A divergence here does not make the
+number noisy; it makes the number about the harness.
+
+This generalizes a rule `CLAUDE.md` already states narrowly for one dimension —
+"the eval harness emulates production's permission model," grant what production
+grants. Permissions were the first instance, not the whole rule. `CLAUDE.md` owns
+that statement and wins on conflict; this section is the general case and the
+reason it exists.
+
+**The test that separates a correct mode difference from a bug: does the rule
+remove a *pause*, or a *capability*?**
+
+Removing the pause is correct and is the established shape. `agents/proof-conclusion.md`
+states it for one gate — under `--autonomous`, route to the missing skill
+automatically instead of asking, because "autonomous mode changes who decides, not
+whether the gate runs." **Generalized: it changes who decides, not what the run can
+reach.** `question-selection` applies the same shape — with no user to answer, skip
+the ask and take the action. Production behaviour is preserved; only the prompt is
+gone.
+
+Removing a capability is the bug. Two were found on 2026-08-31, both in skill bodies,
+both green in CI for months:
+
+- **The plan freeze.** `search-records` told an autonomous run it had no ad-hoc
+  searches, which dead-ended the skill's one route back to `research-plan`. An
+  interactive researcher who noticed the plan was wrong could get it revised; an
+  autonomous one could not. `research-plan` compounded it by superseding a plan
+  "only when the user is explicitly re-planning" — never true with no user — so even
+  reaching the skill would have changed nothing. Measured consequence: across the
+  committed e2e corpus, 93% of question-plan pairs carry exactly one plan, and only
+  seven plans in the whole corpus were ever superseded.
+- **External-site captures.** `search-external-sites` marks a plan item `skipped`
+  under `--autonomous` because no user can click a paywalled link. Controlling for
+  fallback items, that produces a 76% skip rate on primary Ancestry items against
+  12% on FamilySearch — so corpus breadth on external repositories cannot be read as
+  production breadth.
+
+**When the divergence is genuinely forced, supply the input rather than removing the
+capability.** The second case above is not irreducible: `provided-documents/` in a
+fixture is copied into the workspace root where an uploaded capture would land, and
+named in the user message so the agent reads it instead of asking. The mechanism is
+built, spec'd and unit-tested; it is used by three of the fixtures. A headless run
+cannot click a link, but the fixture can hand it what clicking would have produced.
+
+**If you truly cannot supply it, label the outcome honestly.** The failure mode is
+reusing a status that already means something else: `skipped` is defined as "the
+search was determined to be unnecessary," while a deferred capture means "could not
+be attempted." Those are opposite claims to the exhaustiveness gate, whose own
+doctrine separates a pursued-and-unavailable source from an unsearched one. A
+forced divergence that is recorded as a judgement call is worse than one recorded
+as a limitation, because only the second can be measured later.
+
+**What nothing checks.** No test compares the capability set an autonomous run can
+reach against an interactive one's, and no fixture check asserts that a plan reaching
+an external repository ships the capture that repository requires. Both instances
+above were added to a skill body, in prose, with every suite green. Per §9.4, that
+absence belongs on the board under `nothing-checks` rather than in a table here.
 
 ### If you're asked to…
 
@@ -1614,6 +1677,15 @@ plus the annotation gate (§3); routing or anything cross-skill → a live
 run `make test-all`, which the PR template requires. **If you cannot name the
 check that would have caught your change, say so in the PR** rather than implying
 CI covered you (§9.4).
+
+**Write a rule that behaves differently under `--autonomous`.** Ask which of the two
+things it removes — a pause, or a capability (§9.5). Removing the pause is the
+established shape and is fine: decide instead of asking, and log the decision.
+Removing a capability makes the benchmark stop measuring production, silently, and
+is almost never what you want. If a headless run genuinely cannot perform the step,
+supply its input as a fixture rather than deleting the step, and if you cannot do
+even that, record the outcome as a limitation rather than reusing a status that
+means a judgement was made.
 
 **Debug a failing e2e run.** Check the two setup gates first — `make e2e-preflight`
 and `make e2e-login` (the FS token lasts ~24h, and its absence looks exactly like


### PR DESCRIPTION
Adds a new section to the architecture guide: **an autonomous run must be able to reach what a production run can.**

The lead ruled this on 2026-08-31 while deciding the plan-revision work, and it immediately changed the shape of a fix that was already drafted. Recorded only as an issue comment it would be re-derived, so it goes in the map.

## Why it belongs in the guide rather than nowhere

The e2e tier is the only instrument in this repo that answers "is this getting better for a real user?" It answers that only as far as the run it measures can do what a user's run can do. A capability an autonomous run cannot reach is never exercised and never scored — the gap is invisible in exactly the place you would look for it. A divergence does not make the number noisy; it makes the number about the harness.

`CLAUDE.md` already states this for one dimension — "the eval harness emulates production's permission model," grant what production grants. Permissions were the first instance, not the whole rule. The new section says so explicitly and defers to `CLAUDE.md` on conflict, per the doc-map convention.

## The operative test

Does the rule remove a **pause**, or a **capability**?

Removing the pause is the established shape and is fine — `agents/proof-conclusion.md` and `question-selection` both do it: decide instead of asking, and log the decision. Removing a capability is the defect, and it is silent.

Two instances found on 2026-08-31, both prose in skill bodies, both green in CI for months:

- **The plan freeze** — `search-records` told an autonomous run it had no ad-hoc searches, dead-ending its one route back to `research-plan`; `research-plan` compounded it by superseding "only when the user is explicitly re-planning." Across the committed e2e corpus, 93% of question-plan pairs carry exactly one plan and only seven plans were ever superseded. Fixed on its own PR.
- **External-site captures** — controlling for fallbacks, a 76% skip rate on primary Ancestry items against 12% on FamilySearch, so corpus breadth on external repositories cannot be read as production breadth.

The section also records the remedy the second case demonstrates, because it is the non-obvious half: **supply the input as a fixture rather than removing the capability.** `provided-documents/` is built, spec'd and unit-tested — a fixture's captures are copied where an uploaded PDF would land and named in the user message. Three fixtures use it. A headless run cannot click a paywalled link, but the fixture can hand it what clicking would have produced. And where a divergence really is forced, label it as a limitation rather than reusing a status that already means a judgement was made — `skipped` means "determined to be unnecessary," not "could not be attempted," and the exhaustiveness gate reads the difference.

## Placement and constraints

Numbered **9.5** rather than inserted ahead of "What nothing checks" — that section's `9.4` anchor is cited by the `nothing-checks` label description and several skills, so renumbering would break live references for a cosmetic gain.

Adds a row to "Find your block" and a trigger to section 9's "If you're asked to…" block, since the moment this binds is when someone is about to write "under `--autonomous`" in a skill body.

**Carries no issue references.** `docs/architecture.md`'s `ISSUE_REF_BASELINE` in the doc-links test is an exact-match ratchet and any addition fails outright, so the two instances are named by what they are rather than by ticket.

## Verification

`make engine-test` — 118 files, 2783 tests, all passing, including `doc-links.test.ts` (142 tests), which is the lint that would have caught both the reference ratchet and a broken internal link.

No skill, agent, fixture or harness path is touched, so the runlog gate does not arm and this needs no paid eval run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016H7sRvBhZmpghKgxUyw9fG
