### PR TITLE
Restore senior-queue, and converge it on CI completions instead of the cron alone

### DIFF
--- a/.github/tests/codeowners-routing.test.mjs
+++ b/.github/tests/codeowners-routing.test.mjs
@@ -1,0 +1,137 @@
+// Review routing truth table for .github/CODEOWNERS.
+//
+// WHY THIS EXISTS. senior-queue.yml resolves CODEOWNERS itself to decide which
+// senior team's queue a PR lands in, and its parser understands only a few
+// pattern shapes — anything else it drops with a warning nobody reads. A
+// pattern GitHub honours but that parser cannot read enforces the merge
+// correctly while routing the review to the wrong team, with no visible
+// symptom. This file resolves paths through that same parser, lifted out of the
+// workflow rather than copied, so the two cannot drift.
+//
+// WHAT IT CANNOT COVER. That the named teams exist. A rule naming a nonexistent
+// team is silently dropped by GitHub and this file cannot see it — check
+// `gh api /repos/{owner}/{repo}/codeowners/errors` after editing CODEOWNERS.
+//
+// Run: node .github/tests/codeowners-routing.test.mjs
+import fs from 'node:fs';
+
+const CODEOWNERS = '.github/CODEOWNERS';
+const WORKFLOW = '.github/workflows/senior-queue.yml';
+
+// Pull the `script: |` block scalar out of the raw YAML and dedent it.
+function scriptBody(path) {
+  const lines = fs.readFileSync(path, 'utf8').split('\n');
+  const start = lines.findIndex(l => /^\s*script: \|\s*$/.test(l));
+  if (start === -1) throw new Error(`${path}: no "script: |" block found`);
+  const indent = lines[start].match(/^\s*/)[0].length;
+  const out = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() !== '' && line.match(/^\s*/)[0].length <= indent) break;
+    out.push(line.slice(indent + 2));
+  }
+  return out.join('\n');
+}
+
+const body = scriptBody(WORKFLOW);
+const grab = (re, label) => {
+  const m = body.match(re);
+  if (!m) {
+    throw new Error(
+      `could not extract ${label} from ${WORKFLOW} — it was renamed or reformatted. ` +
+      `Update this regex, and re-check that this file still tests the real parser.`);
+  }
+  return m[0];
+};
+
+// scriptBody() dedents to column 0, so a top-level `}` in column 0 ends a function.
+const loadSrc = grab(/async function loadCodeowners\(\) \{[\s\S]*?\n\}/, 'loadCodeowners');
+const ownersSrc = grab(/^function ownersOf\(file, rules\) \{[\s\S]*?\n\}/m, 'ownersOf');
+const queueSrc  = grab(/^function queueTeamOf\(file, rules\) \{[\s\S]*?\n\}/m, 'queueTeamOf');
+
+// loadCodeowners() reads the default branch over the API; here it reads disk.
+const stubGithub = `
+  const github = { rest: {
+    repos: {
+      get: async () => ({ data: { default_branch: 'main' } }),
+      getContent: async () => ({ data: {
+        content: Buffer.from(require('fs').readFileSync(${JSON.stringify(CODEOWNERS)}, 'utf8')).toString('base64'),
+      } }),
+    },
+  } };
+  const owner = 'o', repo = 'r';
+`;
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const { loadCodeowners, ownersOf, queueTeamOf } = await new AsyncFunction('require',
+  `${stubGithub}${loadSrc}\n${ownersSrc}\n${queueSrc}\nreturn { loadCodeowners, ownersOf, queueTeamOf };`)(
+  (await import('node:module')).createRequire(import.meta.url));
+
+const { rules, unknown } = await loadCodeowners();
+
+let failures = 0;
+const fail = msg => { failures++; console.error(`FAIL  ${msg}`); };
+
+// 1. Every pattern must be one senior-queue.yml can resolve.
+if (unknown.length) {
+  fail(`${CODEOWNERS} patterns senior-queue.yml cannot match, so it routes those ` +
+       `paths to the wrong review queue: ${unknown.join(', ')}\n` +
+       `      Teach loadCodeowners() the shape rather than dropping the pattern.`);
+} else {
+  console.log(`ok    all ${rules.length} CODEOWNERS rules are shapes senior-queue.yml can resolve`);
+}
+
+const D = 'senior-developers', G = 'senior-genealogists';
+
+// 2. Every rule names BOTH senior teams — NOT checked here. That rule is about
+//    who may MERGE, not which queue a PR lands in, so it must hold whether or
+//    not this workflow exists. It lives in codeowners-teams.test.mjs, which
+//    reads the file directly instead of through the parser lifted below. Do not
+//    re-add it here: two guards on one condition make both untestable, since
+//    neither can be shown to fail on its own.
+
+// 3. Which QUEUE each path lands in, stated as a table so a reordering that
+//    inverts last-match-wins fails here rather than in review. This is the
+//    FIRST-listed team, which is what senior-queue.yml labels for — widening
+//    who may approve must not change who gets queued. `null` means no senior
+//    team is required, and no label; the two ordinary approvals still are.
+const TABLE = [
+  // Code and the infra that breaks silently.
+  ['packages/engine/mcp-server/src/index.ts', D],
+  ['apps/server/app/main.py', D],
+  ['apps/server/pyproject.toml', D],
+  ['.github/workflows/js-tests.yml', D],
+  ['scripts/windows/test-all.bat', D],
+  ['Makefile', D],
+  ['apps/electron/Makefile', D],
+  ['.gitattributes', D],
+  ['docs/specs/schemas/research.schema.json', D],
+  // Genealogist content, including where it lives in developer-looking files.
+  ['packages/engine/plugin/skills/citation/SKILL.md', G],
+  ['packages/engine/plugin/skills/timeline/scripts/build.py', G],
+  ['packages/engine/plugin/agents/gps-mentor.md', G],
+  ['eval/fixtures/scenarios/x/research.json', G],
+  ['eval/tests/e2e/x/fixture.json', G],
+  ['eval/runlogs/unit/citation/run.json', G],
+  // Documentation and incidental files need no senior. Losing these to a team
+  // is the regression this table is here to catch.
+  ['README.md', null],
+  ['docs/architecture.md', null],
+  ['docs/specs/research-schema-spec.md', null],
+  ['.claude/skills/fill-ready/SKILL.md', null],
+  ['apps/web/src/styles.css', null],
+  ['apps/web/public/favicon.svg', null],
+  ['.gitignore', null],
+  ['scripts/test.sh', null],
+];
+{
+  const before = failures;
+  for (const [file, want] of TABLE) {
+    const got = queueTeamOf(file, rules);
+    if (got !== want) {
+      fail(`${file} queues to ${got ?? 'no senior team'}, expected ${want ?? 'no senior team'}`);
+    }
+  }
+  if (failures === before) console.log(`ok    ${TABLE.length} queue-routing assertions`);
+}
+
+console.log(failures ? `\n${failures} check(s) failed` : '\nall checks passed');
+process.exit(failures ? 1 : 0);

--- a/.github/tests/senior-queue-readiness.test.mjs
+++ b/.github/tests/senior-queue-readiness.test.mjs
@@ -231,8 +231,12 @@ for (const { label, threads, approvals, want } of SUPERSEDED) {
     fail(`${WORKFLOW}: no \`workflow_run:\` trigger — the sweep that substitutes for the ` +
          `forbidden approval trigger is gone; the cron is the only thing left converging`);
   } else {
+    // Match all three YAML scalar styles. An earlier version matched only
+    // - "double-quoted", so a plain or single-quoted target was skipped in
+    // silence and the guard still reported success on the ones it did see.
     const listed = [...block.split(/^    types:/m)[0]
-      .matchAll(/^      - "(.+)"$/gm)].map(m => m[1]);
+      .matchAll(/^      - +(?:"(?<dq>[^"]+)"|'(?<sq>[^']+)'|(?<pl>[^"'#\s][^#]*?))\s*$/gm)]
+      .map(m => (m.groups.dq ?? m.groups.sq ?? m.groups.pl).trim());
     if (!listed.length) {
       fail(`${WORKFLOW}: \`workflow_run\` names no workflows, so it never fires`);
     }

--- a/.github/tests/senior-queue-readiness.test.mjs
+++ b/.github/tests/senior-queue-readiness.test.mjs
@@ -1,4 +1,5 @@
-// Readiness truth table for senior-queue.yml's two decision rules.
+// Readiness truth table for senior-queue.yml's two decision rules, plus its
+// `workflow_run` trigger targets.
 //
 // WHY THIS EXISTS. Both rules fail in the direction nothing complains about. A
 // PR that should be queued and is not looks exactly like a PR nobody has
@@ -206,6 +207,46 @@ const SUPERSEDED = [
 ];
 for (const { label, threads, approvals, want } of SUPERSEDED) {
   eq(supersededThreads(threads, approvals), want, `supersededThreads: ${label}`);
+}
+
+// ---- `workflow_run` trigger targets ------------------------------------------
+//
+// Same failure direction as the two rules above, and a nastier version of it:
+// `workflow_run` matches a workflow by its `name:`, not its filename, and a name
+// that matches nothing simply never fires. No error, no warning, no red run —
+// the sweep just stops converging on that workflow's completions and the queue
+// silently falls back to the cron. Renaming a CI workflow is an ordinary thing
+// to do, and nothing else in the repo connects the two files.
+{
+  const before = failures;
+  const names = new Map();
+  for (const f of fs.readdirSync('.github/workflows')) {
+    if (!/\.ya?ml$/.test(f)) continue;
+    const m = fs.readFileSync(`.github/workflows/${f}`, 'utf8').match(/^name:\s*(.+)$/m);
+    if (m) names.set(m[1].trim(), f);
+  }
+  const raw = fs.readFileSync(WORKFLOW, 'utf8');
+  const block = raw.split(/^  workflow_run:$/m)[1];
+  if (!block) {
+    fail(`${WORKFLOW}: no \`workflow_run:\` trigger — the sweep that substitutes for the ` +
+         `forbidden approval trigger is gone; the cron is the only thing left converging`);
+  } else {
+    const listed = [...block.split(/^    types:/m)[0]
+      .matchAll(/^      - "(.+)"$/gm)].map(m => m[1]);
+    if (!listed.length) {
+      fail(`${WORKFLOW}: \`workflow_run\` names no workflows, so it never fires`);
+    }
+    for (const n of listed) {
+      if (!names.has(n)) {
+        fail(`${WORKFLOW}: \`workflow_run\` targets "${n}", which is no workflow's \`name:\` ` +
+             `in .github/workflows — it will never fire. Known names: ` +
+             `${[...names.keys()].sort().join(', ')}`);
+      }
+    }
+    if (failures === before) {
+      console.log(`ok    all ${listed.length} \`workflow_run\` targets name a real workflow`);
+    }
+  }
 }
 
 if (!failures) {

--- a/.github/tests/senior-queue-readiness.test.mjs
+++ b/.github/tests/senior-queue-readiness.test.mjs
@@ -1,0 +1,216 @@
+// Readiness truth table for senior-queue.yml's two decision rules.
+//
+// WHY THIS EXISTS. Both rules fail in the direction nothing complains about. A
+// PR that should be queued and is not looks exactly like a PR nobody has
+// approved yet — the job is green, the label is simply absent, and the only
+// detector is a senior noticing weeks later that their queue is short. Both
+// have already failed that way in production: PR #1523 sat out of both queues
+// on a `runlogs` check that had been re-run green 18 hours earlier, behind five
+// review threads its approver never went back to resolve.
+//
+// The functions are lifted out of the workflow rather than copied, so the two
+// cannot drift.
+//
+// WHAT IT CANNOT COVER. That a label write lands, or that the self-check filter
+// excludes the right runs — both are only observable from a live run. Use the
+// `workflow_dispatch` dry run against a real approved PR.
+//
+// Run: node .github/tests/senior-queue-readiness.test.mjs
+import fs from 'node:fs';
+
+const WORKFLOW = '.github/workflows/senior-queue.yml';
+
+// Pull the `script: |` block scalar out of the raw YAML and dedent it.
+function scriptBody(path) {
+  const lines = fs.readFileSync(path, 'utf8').split('\n');
+  const start = lines.findIndex(l => /^\s*script: \|\s*$/.test(l));
+  if (start === -1) throw new Error(`${path}: no "script: |" block found`);
+  const indent = lines[start].match(/^\s*/)[0].length;
+  const out = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() !== '' && line.match(/^\s*/)[0].length <= indent) break;
+    out.push(line.slice(indent + 2));
+  }
+  return out.join('\n');
+}
+
+const body = scriptBody(WORKFLOW);
+const grab = (re, label) => {
+  const m = body.match(re);
+  if (!m) {
+    throw new Error(
+      `could not extract ${label} from ${WORKFLOW} — it was renamed or reformatted. ` +
+      `Update this regex, and re-check that this file still tests the real rule.`);
+  }
+  return m[0];
+};
+
+// scriptBody() dedents to column 0, so a top-level `}` in column 0 ends a function.
+const newestSrc = grab(/^function newestPerName\(runs\) \{[\s\S]*?\n\}/m, 'newestPerName');
+const supersededSrc = grab(/^function supersededThreads\(threads, approvals\) \{[\s\S]*?\n\}/m,
+  'supersededThreads');
+
+const { newestPerName, supersededThreads } = new Function(
+  `${newestSrc}\n${supersededSrc}\nreturn { newestPerName, supersededThreads };`)();
+
+let failures = 0;
+const fail = msg => { failures++; console.error(`FAIL  ${msg}`); };
+const eq = (got, want, label) => {
+  const g = JSON.stringify(got), w = JSON.stringify(want);
+  if (g !== w) fail(`${label}\n        got  ${g}\n        want ${w}`);
+};
+
+// ---------------------------------------------------------------------------
+// 1. newestPerName: one run per check name, newest wins.
+// ---------------------------------------------------------------------------
+const run = (name, conclusion, completed_at, extra = {}) =>
+  ({ name, status: 'completed', conclusion, completed_at, started_at: completed_at, ...extra });
+
+const NEWEST = [
+  {
+    label: 'a failure re-run green on the same sha no longer reads as failing (PR #1523)',
+    runs: [
+      run('runlogs', 'failure', '2026-08-10T16:05:01Z'),
+      run('runlogs', 'success', '2026-08-11T09:56:08Z'),
+      run('vitest', 'success', '2026-08-10T16:10:00Z'),
+    ],
+    want: [['runlogs', 'success'], ['vitest', 'success']],
+  },
+  {
+    label: 'the reverse — green then red — still reads as failing',
+    runs: [
+      run('runlogs', 'success', '2026-08-10T16:05:01Z'),
+      run('runlogs', 'failure', '2026-08-11T09:56:08Z'),
+    ],
+    want: [['runlogs', 'failure']],
+  },
+  {
+    label: 'a re-run still in progress supersedes the completed attempt it replaces',
+    runs: [
+      run('vitest', 'failure', '2026-08-10T16:05:01Z'),
+      { name: 'vitest', status: 'in_progress', conclusion: null,
+        completed_at: null, started_at: '2026-08-11T09:00:00Z' },
+    ],
+    want: [['vitest', null]],
+  },
+  {
+    label: 'a run with no timestamps at all never displaces a timestamped one',
+    runs: [
+      run('pytest', 'success', '2026-08-11T09:56:08Z'),
+      { name: 'pytest', status: 'completed', conclusion: 'failure',
+        completed_at: null, started_at: null },
+    ],
+    want: [['pytest', 'success']],
+  },
+  { label: 'no runs', runs: [], want: [] },
+];
+for (const { label, runs, want } of NEWEST) {
+  const got = newestPerName(runs)
+    .map(c => [c.name, c.conclusion])
+    .sort((a, b) => a[0].localeCompare(b[0]));
+  eq(got, want, `newestPerName: ${label}`);
+}
+
+// A single-element input must come back untouched, object identity included —
+// the dedupe must never rebuild or reorder what it keeps.
+const only = run('solo', 'success', '2026-08-11T00:00:00Z');
+if (newestPerName([only])[0] !== only) fail('newestPerName: rewrapped a lone check run');
+
+// ---------------------------------------------------------------------------
+// 2. supersededThreads: an approval closes its own author's earlier threads.
+// ---------------------------------------------------------------------------
+const T = (id, opener, times, opts = {}) => ({
+  id,
+  isResolved: opts.isResolved ?? false,
+  comments: {
+    pageInfo: { hasNextPage: opts.hasNextPage ?? false },
+    nodes: times.map(([login, createdAt]) =>
+      login === null ? { createdAt, author: null } : { createdAt, author: { login } }),
+  },
+  // `opener` is documentation for the reader; the rule reads comments[0].
+  opener,
+});
+
+const APPROVED_1700 = new Map([['chris', '2026-08-10T17:00:00Z']]);
+
+const SUPERSEDED = [
+  {
+    label: 'approval after the reviewer\'s only comment closes the thread (PR #1523)',
+    threads: [T('t1', 'chris', [['chris', '2026-08-10T12:43:00Z']])],
+    approvals: APPROVED_1700,
+    want: ['t1'],
+  },
+  {
+    label: 'approval BEFORE the reviewer\'s last comment leaves it open',
+    threads: [T('t1', 'chris', [
+      ['chris', '2026-08-10T12:43:00Z'],
+      ['chris', '2026-08-10T18:00:00Z'],
+    ])],
+    approvals: APPROVED_1700,
+    want: [],
+  },
+  {
+    label: 'the author replying after the approval does not reopen it',
+    threads: [T('t1', 'chris', [
+      ['chris', '2026-08-10T12:43:00Z'],
+      ['florence', '2026-08-10T19:00:00Z'],
+    ])],
+    approvals: APPROVED_1700,
+    want: ['t1'],
+  },
+  {
+    label: 'a thread opened by someone who has not approved keeps blocking',
+    threads: [T('t1', 'dallan', [['dallan', '2026-08-10T12:43:00Z']])],
+    approvals: APPROVED_1700,
+    want: [],
+  },
+  {
+    label: 'one reviewer\'s approval does not close another reviewer\'s thread',
+    threads: [
+      T('t1', 'chris', [['chris', '2026-08-10T12:00:00Z']]),
+      T('t2', 'dallan', [['dallan', '2026-08-10T12:00:00Z'], ['chris', '2026-08-10T12:30:00Z']]),
+    ],
+    approvals: APPROVED_1700,
+    want: ['t1'],
+  },
+  {
+    label: 'a reviewer whose latest standing is changes-requested closes nothing',
+    threads: [T('t1', 'chris', [['chris', '2026-08-10T12:43:00Z']])],
+    approvals: new Map(),   // evaluate() admits APPROVED standings only
+    want: [],
+  },
+  {
+    label: 'an already-resolved thread is not re-resolved',
+    threads: [T('t1', 'chris', [['chris', '2026-08-10T12:43:00Z']], { isResolved: true })],
+    approvals: APPROVED_1700,
+    want: [],
+  },
+  {
+    label: 'an unwalked comment page could hide a later reply, so leave it blocking',
+    threads: [T('t1', 'chris', [['chris', '2026-08-10T12:43:00Z']], { hasNextPage: true })],
+    approvals: APPROVED_1700,
+    want: [],
+  },
+  {
+    label: 'a deleted-account opener (author null) is not treated as an approver',
+    threads: [T('t1', null, [[null, '2026-08-10T12:43:00Z']])],
+    approvals: APPROVED_1700,
+    want: [],
+  },
+  {
+    label: 'an empty thread is skipped rather than crashing',
+    threads: [T('t1', 'chris', [])],
+    approvals: APPROVED_1700,
+    want: [],
+  },
+];
+for (const { label, threads, approvals, want } of SUPERSEDED) {
+  eq(supersededThreads(threads, approvals), want, `supersededThreads: ${label}`);
+}
+
+if (!failures) {
+  console.log(`ok    ${NEWEST.length + 1} newestPerName assertions`);
+  console.log(`ok    ${SUPERSEDED.length} supersededThreads assertions`);
+}
+console.log(failures ? `\n${failures} check(s) failed` : '\nall checks passed');
+process.exit(failures ? 1 : 0);

--- a/.github/workflows/senior-queue.yml
+++ b/.github/workflows/senior-queue.yml
@@ -1,0 +1,556 @@
+name: senior-queue
+
+# Labels a PR once it is actually ready for senior review — CI green, an
+# approving review from someone other than the author, no outstanding
+# changes-requested, and no unresolved review threads — with the label for the
+# team that owns its changed paths:
+#
+#   is:open is:pr label:ready-for-senior-genealogist
+#   is:open is:pr label:ready-for-senior-developer
+#
+# A PR whose files span both teams gets both labels, so each queue sees the
+# paths it owns. Every CODEOWNERS rule names both senior teams, so one approval
+# from either satisfies the merge gate — the labels say who is best placed to
+# read what, not how many approvals are outstanding.
+#
+# The senior review is the SECOND review, and it happens only after the first
+# round has been answered. That is what the changes-requested and unresolved-
+# thread rules are for. The ruleset blocks merge on an unresolved thread
+# (`required_review_thread_resolution: true`) but not on an outstanding
+# changes-requested, and neither of them keeps a PR out of a review QUEUE —
+# so without these two rules a PR is surfaced to a senior with round one open.
+#
+# AN APPROVAL ANSWERS THE APPROVER'S OWN THREADS. Reviewers here routinely
+# re-review, approve, and never go back to click Resolve, so requiring the click
+# made the queue lag the review by however long that took. A thread counts as
+# closed FOR QUEUEING once the reviewer who OPENED it submits an approval later
+# than their own last comment on it. Threads opened by anyone who has not
+# approved keep blocking, and a fresh changes-requested puts every one of that
+# reviewer's threads back.
+#
+# This does NOT resolve the thread, so `required_review_thread_resolution` still
+# blocks the MERGE until a human clicks Resolve — by design the person merging,
+# who is already looking at the PR. Auto-resolving was built and reverted: the
+# `resolveReviewThread` GraphQL mutation is refused to `GITHUB_TOKEN` with
+# "Resource not accessible by integration" even with `pull-requests: write`,
+# verified live on 2026-08-11 against PR #1523. If you re-attempt it, it needs an
+# identity this workflow does not have — the Projects App (`PROJECT_APP_ID`) is
+# the only other one in this repo, and whether it can call that mutation is
+# untested. Do not add the mutation back without testing the refusal first.
+#
+# WHY A LABEL AND NOT THE REVIEW REQUEST. CODEOWNERS makes GitHub request the
+# owning team the instant a matching PR opens, when CI is usually red and nobody
+# has read it — accurate as "a PR exists", useless as "this needs you". The
+# obvious fix is to strip the request and re-add it when ready. That is not
+# possible: while `require_code_owner_review` is active, GitHub refuses to remove
+# a CODEOWNERS-mandated team request. `DELETE /pulls/{n}/requested_reviewers`
+# returns HTTP 200 and does nothing — no error, no timeline event, team still
+# listed on a fresh read. Verified three ways (GITHUB_TOKEN, org-admin PAT,
+# hand-written body). Do not re-attempt without re-testing that endpoint; the
+# failure mode is silent success, which reads as working.
+#
+# The known alternative, still unverified: the `protect-main` ruleset's
+# `pull_request` rule has a `required_reviewers` parameter, currently `[]`. If it
+# accepts a team scoped to file patterns, senior approval could be enforced there,
+# the CODEOWNERS team lines dropped, and nothing would mandate the request — which
+# would replace this workflow rather than extend it. Worth settling before
+# building further on the label.
+#
+# ENFORCEMENT IS UNCHANGED. `require_code_owner_review` gates the merge. This
+# workflow only decides what is visible in a queue; it cannot let anything merge
+# that could not merge before.
+#
+# ADD-ONLY. Once labelled a PR stays labelled, even if it later goes red.
+# Demotion would make PRs flicker out of the queue mid-review.
+#
+# THREE TRAPS THIS FILE HAS HIT BEFORE, each of which made the job go green
+# while doing nothing:
+#
+#   1. SELF must equal the JOB's name, because that is what a check run is named.
+#      Setting it to the workflow's name matched nothing, so every run counted
+#      its own in-progress check and concluded "CI still running". Keep `SELF`
+#      and the job's `name:` identical.
+#   2. The label write was wrapped in a try/catch that downgraded failure to a
+#      warning, and the API then no-op'd with HTTP 200. There is no catch around
+#      the write, and the label is read back to confirm it landed.
+#   3. Every check run ever attached to a sha comes back from `listForRef`, so a
+#      failure that was later re-run green still read as "CI failing" and the PR
+#      could never enter a queue again. See newestPerName().
+#
+# When changing the readiness rules, verify against a real approved PR. A
+# `workflow_dispatch` dry run does not exercise the self-filter at all: a
+# dispatch's check run lands on the default branch's sha, not on any PR's head.
+# It DOES exercise everything else, including both rules below, and it makes no
+# writes — so a dispatch dry run is the way to check a readiness change against
+# the live board before letting it label or resolve anything.
+#
+# THE SCHEDULE IS WHAT MAKES THE QUEUE CONVERGE, and it now carries both of the
+# two things that make a PR ready. `check_suite` never fires here (see the
+# trigger below), so nothing observes CI turning green, and there is no approval
+# trigger either (see below), so nothing observes the peer review landing. The
+# `pull_request_target` events are a fast path for open/push only. If you remove
+# the schedule, something else must answer "what re-checks a PR after CI
+# finishes, and after someone approves it?" — and the answer cannot be an
+# approval event.
+#
+# WHAT THIS COSTS: up to 30 minutes between the approval that makes a PR ready
+# and the label that puts it in a senior's queue.
+
+# TRIGGER CHOICE: `pull_request_target`, because developers without write access
+# contribute from forks and a `pull_request` run gets a read-only token there,
+# so `addLabels` would 403.
+#
+# Safe here for two reasons, both of which must stay true: the job is a single
+# inline `actions/github-script` step with no `actions/checkout` and no `run:`,
+# so nothing fork-authored ever executes; and the script is read from the base
+# branch, so a fork cannot edit the readiness rules in its own PR. Adding a
+# checkout of PR content would turn this into a pwn-request vector.
+#
+# NO APPROVAL TRIGGER, and do not add one back. `pull_request_review` was listed
+# here and was removed on 2026-08-13: GitHub has no `_target` variant of it, so
+# on a fork-authored PR it hands the run a read-only token no matter what the
+# `permissions:` block below asks for, and the label write 403s with "Resource
+# not accessible by integration". Verified on PR #1564 (fork `chrisedeson`):
+# the review run logged `Issues: read`, the `pull_request_target` run on the
+# same PR logged `Issues: write`.
+#
+# It survived undetected for as long as it did because the failure needs a fork
+# PR that is READY — a review run on a PR still blocked by changes-requested
+# returns before it ever writes, and goes green. So it only reddened on the
+# approval that mattered, and the sweep 30 minutes later applied the label
+# anyway, leaving a red X on a PR that was correctly queued.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  check_suite:
+    # DEAD TRIGGER, kept only to document that it is dead. Every check suite here
+    # is created by an Actions workflow using `GITHUB_TOKEN`, and GitHub does not
+    # start a workflow run from a `GITHUB_TOKEN`-triggered event. The `schedule`
+    # below is what actually covers "CI turned green after the last PR event".
+    types: [completed]
+  schedule:
+    # Every 30 min. Scheduled runs are best-effort — GitHub delays or drops them
+    # under load — which is fine for a converging add-only sweep and is the other
+    # reason not to rely on the schedule alone.
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report what would change across all open PRs, without touching any"
+        type: boolean
+        default: true
+
+permissions:
+  # `issues: write` is what authorizes labelling (labels live on the issues API
+  # even for PRs); `pull-requests: write` is granted alongside it because the
+  # mapping between the two is inconsistent enough that relying on one alone has
+  # bitten other repos. Neither grant reaches `resolveReviewThread` — see the
+  # approval note at the top.
+  issues: write
+  pull-requests: write
+  checks: read
+  contents: read
+
+concurrency:
+  # Per-PR events serialize per PR. Sweeps share ONE key so a delayed cron run
+  # cannot race the next one; they are add-only and idempotent, so queueing
+  # rather than cancelling costs nothing.
+  group: >-
+    senior-queue-${{ github.event.pull_request.number
+      || github.event.check_suite.id
+      || 'sweep' }}
+  cancel-in-progress: false
+
+jobs:
+  # The job name IS the check-run name, and the script excludes its own check run
+  # by that name. Keep the two in sync — see SELF.
+  promote:
+    name: senior-queue
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+        with:
+          script: |
+            const SELF = 'senior-queue';
+
+            const TEAMS = {
+              'senior-genealogists': {
+                label: 'ready-for-senior-genealogist',
+                color: '0E8A16',
+                description: 'CI green + peer-approved; awaiting senior genealogist',
+              },
+              'senior-developers': {
+                label: 'ready-for-senior-developer',
+                color: '1D76DB',
+                description: 'CI green + peer-approved; awaiting senior developer',
+              },
+            };
+
+            const BAD     = new Set(['failure', 'cancelled', 'timed_out', 'action_required', 'stale']);
+            const PENDING = new Set(['queued', 'in_progress', 'waiting', 'pending', 'requested']);
+
+            const dryRun = process.env.DRY_RUN === 'true';
+            const { owner, repo } = context.repo;
+
+            // ---- CODEOWNERS is the source of truth for routing ---------------
+            // Read from the DEFAULT BRANCH, never from the PR: a fork must not be
+            // able to re-route its own review by editing CODEOWNERS in its branch.
+            async function loadCodeowners() {
+              const { data } = await github.rest.repos.getContent({
+                owner, repo, path: '.github/CODEOWNERS',
+                ref: (await github.rest.repos.get({ owner, repo })).data.default_branch,
+              });
+              const text = Buffer.from(data.content, 'base64').toString('utf8');
+              const rules = [];
+              const unknown = [];
+              for (const raw of text.split('\n')) {
+                const line = raw.replace(/#.*$/, '').trim();
+                if (!line) continue;
+                const [pattern, ...owners] = line.split(/\s+/);
+                const teams = owners
+                  .filter(o => o.startsWith('@') && o.includes('/'))
+                  .map(o => o.split('/')[1]);
+                if (!teams.length) continue;
+                // Only the pattern shapes this repo's CODEOWNERS actually uses.
+                // Anything else is REPORTED, not silently treated as non-matching —
+                // a mis-parsed rule would route a PR to the wrong queue with no sign.
+                let test;
+                if (pattern === '*')                      test = () => true;
+                else if (/^\*\.[A-Za-z0-9.]+$/.test(pattern))
+                                                          test = f => f.endsWith(pattern.slice(1));
+                else if (/^\/.*\/$/.test(pattern))        test = f => f.startsWith(pattern.slice(1));
+                // A bare filename (Makefile, .gitattributes) matches that
+                // basename at any depth, which is how GitHub resolves a
+                // slash-free pattern.
+                else if (/^[A-Za-z0-9._-]+$/.test(pattern))
+                                                          test = f => f.split('/').pop() === pattern;
+                else { unknown.push(pattern); continue; }
+                rules.push({ pattern, test, teams });
+              }
+              return { rules, unknown };
+            }
+
+            // Last matching rule wins, exactly as GitHub resolves CODEOWNERS.
+            // Returns every owner of the winning rule, in the order written.
+            function ownersOf(file, rules) {
+              let teams = [];
+              for (const r of rules) if (r.test(file)) teams = r.teams;
+              return teams;
+            }
+
+            // Every rule names BOTH senior teams, because a rule's owners are an
+            // OR and either team's approval must satisfy the merge gate. The
+            // QUEUE is a different question: it is the team listed FIRST, the one
+            // whose judgment the path normally wants. Queueing on the full owner
+            // list would put every senior-owned PR in both queues and make each
+            // queue useless as a filter.
+            function queueTeamOf(file, rules) {
+              return ownersOf(file, rules)[0] || null;
+            }
+
+            // ---- the two decision rules, kept pure and testable ---------------
+            // Both are lifted out of this file verbatim by
+            // .github/tests/senior-queue-readiness.test.mjs, so they must stay
+            // top-level `function` declarations that close on a column-0 brace.
+
+            // A sha keeps EVERY check run ever attached to it, and
+            // `checks.listForRef`'s default `latest` filter dedupes per check
+            // SUITE, not per check NAME. Re-triggering a workflow on the same
+            // commit — which is exactly what applying `eval-cosmetic-skip` does —
+            // opens a second suite, so the first run's `failure` stays visible
+            // forever and this workflow reads the sha as failing however many
+            // times CI is re-run green. Add-only labelling means nothing ever
+            // recovers such a PR: it cannot reach a queue until someone pushes a
+            // new commit. PR #1523 sat out of both queues on a `runlogs` failure
+            // that had been re-run green 18 hours earlier.
+            //
+            // Keeping only the newest run per name is how branch protection
+            // resolves a required check. It does mean two DIFFERENT workflows
+            // sharing one job name collapse into one — but such a pair is already
+            // ambiguous to branch protection, so rename one rather than key this
+            // on the workflow.
+            function newestPerName(runs) {
+              const newest = new Map();
+              for (const c of runs) {
+                // A still-running attempt has no completed_at, and its started_at
+                // is later than the completed_at of the run it supersedes.
+                const at = Date.parse(c.completed_at || c.started_at || '') || 0;
+                const prev = newest.get(c.name);
+                if (!prev || at >= prev.at) newest.set(c.name, { at, run: c });
+              }
+              return [...newest.values()].map(v => v.run);
+            }
+
+            // An approval submitted after the reviewer's own last word in a
+            // thread IS their answer to it — they read the reply, or decided it
+            // no longer matters, and said so in the only way that carries weight.
+            // Holding the PR out of the senior queue until they also click
+            // Resolve makes the queue lag the review by however long that takes.
+            // These threads are counted as answered here and NOT resolved — the
+            // mutation is refused to this token, see the approval note at the top
+            // — so the merge still waits on a human click.
+            //
+            // Scoped per thread by its OPENER: an approval from one reviewer says
+            // nothing about a thread another reviewer opened, and those keep
+            // blocking. `approvals` holds only reviewers whose LATEST standing is
+            // APPROVED, so a re-requested change re-blocks every thread — and it
+            // is built from a map the PR's own author is already excluded from,
+            // so nobody can clear their own threads by approving their own PR.
+            function supersededThreads(threads, approvals) {
+              const superseded = [];
+              for (const t of threads) {
+                if (t.isResolved) continue;
+                const comments = t.comments.nodes;
+                if (!comments.length) continue;
+                const opener = comments[0].author && comments[0].author.login;
+                const approvedAt = opener && approvals.get(opener);
+                if (!approvedAt) continue;
+                // An unwalked page could hold a later comment from the opener,
+                // which would make the approval look like the last word when it
+                // is not. Leave the thread blocking rather than guess.
+                if (t.comments.pageInfo.hasNextPage) continue;
+                const lastWord = comments
+                  .filter(c => c.author && c.author.login === opener)
+                  .reduce((max, c) => Math.max(max, Date.parse(c.createdAt) || 0), 0);
+                if (Date.parse(approvedAt) > lastWord) superseded.push(t.id);
+              }
+              return superseded;
+            }
+
+            const { rules, unknown } = await loadCodeowners();
+            if (!rules.length) {
+              core.setFailed('parsed 0 rules out of .github/CODEOWNERS — refusing to label ' +
+                             'anything, since every PR would look unowned.');
+              return;
+            }
+            if (unknown.length) {
+              core.warning(`CODEOWNERS patterns this workflow cannot match, so paths they ` +
+                           `own may be routed to the wrong queue: ${unknown.join(', ')}. ` +
+                           `Teach loadCodeowners() the shape rather than ignoring it.`);
+            }
+            core.info(`parsed ${rules.length} CODEOWNERS rule(s)`);
+
+            // ---- which PRs to evaluate --------------------------------------
+            const sweep = context.eventName === 'schedule'
+                       || context.eventName === 'workflow_dispatch';
+
+            let numbers = [];
+            if (sweep) {
+              const open = await github.paginate(github.rest.pulls.list,
+                { owner, repo, state: 'open', per_page: 100 });
+              numbers = open.map(p => p.number);
+            } else if (context.eventName === 'check_suite') {
+              numbers = (context.payload.check_suite.pull_requests || []).map(p => p.number);
+              if (numbers.length === 0) {
+                const sha = context.payload.check_suite.head_sha;
+                const open = await github.paginate(github.rest.pulls.list,
+                  { owner, repo, state: 'open', per_page: 100 });
+                numbers = open.filter(p => p.head.sha === sha).map(p => p.number);
+              }
+            } else {
+              numbers = [context.payload.pull_request.number];
+            }
+
+            // ---- readiness ---------------------------------------------------
+            async function evaluate(number) {
+              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: number });
+              const labels = pr.labels.map(l => l.name);
+              const blank = { pr, labels, wanted: [], ready: false, answered: [] };
+
+              if (pr.state !== 'open') return { ...blank, reasons: ['not open'] };
+              if (pr.draft)            return { ...blank, reasons: ['draft'] };
+
+              // Peer review: latest standing per reviewer, author excluded. Any
+              // non-author approval counts — deliberately not checking team
+              // membership, which would need a token with `read:org`.
+              const reviews = await github.paginate(github.rest.pulls.listReviews,
+                { owner, repo, pull_number: number, per_page: 100 });
+              const latest = new Map();
+              for (const r of reviews) {
+                if (!r.user || r.user.login === pr.user.login) continue;
+                if (r.state === 'COMMENTED') continue;
+                latest.set(r.user.login, { state: r.state, at: r.submitted_at });
+              }
+              const standings = [...latest.values()].map(s => s.state);
+              // When a reviewer's latest standing is APPROVED, that approval is
+              // their answer to every thread they opened before it — see
+              // supersededThreads().
+              const approvals = new Map([...latest]
+                .filter(([, s]) => s.state === 'APPROVED')
+                .map(([login, s]) => [login, s.at]));
+
+              const [checks, status, files, threads] = await Promise.all([
+                github.paginate(github.rest.checks.listForRef,
+                  { owner, repo, ref: pr.head.sha, per_page: 100 }),
+                github.rest.repos.getCombinedStatusForRef({ owner, repo, ref: pr.head.sha }),
+                github.paginate(github.rest.pulls.listFiles,
+                  { owner, repo, pull_number: number, per_page: 100 }),
+                // Unresolved review comments mean round one is still open. Only
+                // GraphQL exposes resolution state. The ruleset blocks MERGE on an
+                // unresolved thread, but nothing stops such a PR being surfaced to a
+                // senior as ready — which is what this check is for.
+                github.graphql(`
+                  query($owner:String!, $repo:String!, $number:Int!) {
+                    repository(owner:$owner, name:$repo) {
+                      pullRequest(number:$number) {
+                        reviewThreads(first:100) {
+                          pageInfo { hasNextPage }
+                          nodes {
+                            id
+                            isResolved
+                            comments(first:100) {
+                              pageInfo { hasNextPage }
+                              nodes { createdAt author { login } }
+                            }
+                          }
+                        } } } }`,
+                  { owner, repo, number }),
+              ]);
+
+              // Drop this workflow's own check runs. Two mechanisms, both load-
+              // bearing: the run-id match is exact but covers only THIS run, and an
+              // EARLIER senior-queue run on the same sha that ended in `failure`
+              // would otherwise read as "CI failing" — the name prefix catches that.
+              const isSelf = c =>
+                (c.details_url || '').includes(`/actions/runs/${context.runId}/`)
+                || (c.name || '').startsWith(SELF);
+              // newestPerName drops superseded attempts — without it a failure
+              // that was later re-run green locks the PR out permanently.
+              const current  = newestPerName(checks.filter(c => !isSelf(c)));
+              const failed   = current.filter(c => BAD.has(c.conclusion));
+              const running  = current.filter(c => PENDING.has(c.status));
+              const statuses = status.data.statuses || [];
+              const statusFailed = statuses.filter(s => s.state === 'failure' || s.state === 'error');
+
+              // Which senior teams are the primary owner of anything in this diff.
+              const owning = new Set();
+              for (const f of files) {
+                const t = queueTeamOf(f.filename, rules);
+                if (t && TEAMS[t]) owning.add(t);
+              }
+              const wanted = [...owning].map(t => TEAMS[t].label);
+
+              // A page-2 unresolved thread would otherwise read as "all resolved",
+              // so an un-walked page is reported rather than assumed clean.
+              const rt = threads.repository.pullRequest.reviewThreads;
+              // Threads whose author approved afterwards do not hold up the
+              // queue. They are still open, and still block the merge — act()
+              // logs the count so the discrepancy is visible rather than implied.
+              const answered = supersededThreads(rt.nodes, approvals);
+              const unresolved =
+                rt.nodes.filter(t => !t.isResolved).length - answered.length;
+
+              const reasons = [];
+              if (!standings.includes('APPROVED'))         reasons.push('no peer approval');
+              if (standings.includes('CHANGES_REQUESTED')) reasons.push('changes requested');
+              if (unresolved)                              reasons.push(`${unresolved} unresolved review thread(s)`);
+              if (!unresolved && rt.pageInfo.hasNextPage)
+                reasons.push('more than 100 review threads — resolution not fully evaluated');
+              if (failed.length)       reasons.push(`CI failing: ${failed.map(c => c.name).join(', ')}`);
+              if (statusFailed.length) reasons.push(`status failing: ${statusFailed.map(s => s.context).join(', ')}`);
+              if (running.length)      reasons.push(`CI still running (${running.length})`);
+              if (current.length === 0 && statuses.length === 0) reasons.push('no CI has reported');
+              // A PR owned by no senior team needs no senior review, so there is
+              // nothing to queue — distinct from "not ready".
+              if (!wanted.length)      reasons.push('no senior-owned path');
+
+              return { pr, labels, wanted, ready: reasons.length === 0, reasons, answered };
+            }
+
+            // ---- label bootstrap --------------------------------------------
+            async function ensureLabels() {
+              for (const { label, color, description } of Object.values(TEAMS)) {
+                try {
+                  await github.rest.issues.getLabel({ owner, repo, name: label });
+                } catch (e) {
+                  if (e.status !== 404) throw e;
+                  if (dryRun) { core.info(`would create label ${label}`); continue; }
+                  await github.rest.issues.createLabel({ owner, repo, name: label, color, description });
+                  core.info(`created label ${label}`);
+                }
+              }
+            }
+            await ensureLabels();
+
+            // ---- act ---------------------------------------------------------
+            // No try/catch around the write, and the labels are read back: an
+            // earlier version downgraded a failed write to a warning and the API
+            // then no-op'd with HTTP 200, so the job went green having done nothing.
+            async function act(n) {
+              const { pr, labels, wanted, ready, reasons, answered } = await evaluate(n);
+              const missing = wanted.filter(l => !labels.includes(l));
+              let action;
+
+              // Say so rather than leave a silently-shrinking count: someone
+              // reading this log against the PR must be able to see that N open
+              // threads were discounted, and why.
+              if (answered.length) {
+                core.info(`#${n} discounted ${answered.length} open thread(s) whose author ` +
+                          `approved afterwards; they still block the merge until resolved`);
+              }
+
+              if (ready && !missing.length) {
+                action = 'already queued';
+              } else if (ready && dryRun) {
+                action = `WOULD add ${missing.join(', ')}`;
+              } else if (ready) {
+                await github.rest.issues.addLabels({ owner, repo, issue_number: n, labels: missing });
+
+                const { data: after } = await github.rest.issues.listLabelsOnIssue({
+                  owner, repo, issue_number: n });
+                const names = after.map(l => l.name);
+                const stillMissing = missing.filter(l => !names.includes(l));
+                if (stillMissing.length) {
+                  core.setFailed(
+                    `#${n}: addLabels returned success but ${stillMissing.join(', ')} is not on ` +
+                    `the PR. Treat this as a permissions or API-behaviour change, not a ` +
+                    `transient error.`);
+                  action = 'FAILED to label';
+                } else {
+                  action = `added ${missing.join(', ')}`;
+                }
+              } else {
+                // Add-only: a labelled PR is never unlabelled.
+                action = labels.some(l => wanted.includes(l)) ? 'not ready, left queued' : 'not ready';
+              }
+
+              const queue = wanted.length ? wanted.join(', ') : '—';
+              core.info(`#${n} ${action}${reasons.length ? ' — ' + reasons.join('; ') : ''}`);
+              return [`#${n}`, pr.user.login, queue, action, reasons.join('; ') || '—'];
+            }
+
+            const rows = [];
+            const errors = [];
+            for (const n of numbers) {
+              if (!sweep) { rows.push(await act(n)); continue; }
+              // A sweep must not lose every other PR to one PR's transient API
+              // error. This catch never decides whether a label write succeeded —
+              // that is settled by the read-back inside act() — and every error
+              // caught here still fails the job via setFailed below.
+              try {
+                rows.push(await act(n));
+              } catch (e) {
+                errors.push(`#${n}: ${e.message}`);
+                core.error(`#${n} errored — ${e.message}`);
+                rows.push([`#${n}`, '—', '—', 'ERRORED', e.message]);
+              }
+            }
+            if (errors.length) {
+              core.setFailed(
+                `${errors.length} of ${numbers.length} PR(s) errored during the sweep; ` +
+                `the rest were evaluated. ${errors.join(' | ')}`);
+            }
+
+            await core.summary
+              .addHeading(dryRun ? 'senior-queue (dry run)' : 'senior-queue', 3)
+              .addRaw(Object.values(TEAMS).map(t => `\`is:open is:pr label:${t.label}\``).join(' · '))
+              .addTable([
+                [{ data: 'PR', header: true }, { data: 'Author', header: true },
+                 { data: 'Queue', header: true }, { data: 'Action', header: true },
+                 { data: 'Blocking', header: true }],
+                ...rows,
+              ])
+              .write();

--- a/.github/workflows/senior-queue.yml
+++ b/.github/workflows/senior-queue.yml
@@ -84,17 +84,19 @@ name: senior-queue
 # writes — so a dispatch dry run is the way to check a readiness change against
 # the live board before letting it label or resolve anything.
 #
-# THE SCHEDULE IS WHAT MAKES THE QUEUE CONVERGE, and it now carries both of the
-# two things that make a PR ready. `check_suite` never fires here (see the
-# trigger below), so nothing observes CI turning green, and there is no approval
-# trigger either (see below), so nothing observes the peer review landing. The
-# `pull_request_target` events are a fast path for open/push only. If you remove
-# the schedule, something else must answer "what re-checks a PR after CI
-# finishes, and after someone approves it?" — and the answer cannot be an
-# approval event.
+# WHAT MAKES THE QUEUE CONVERGE is the `workflow_run` sweep, with the schedule as
+# its floor. `check_suite` never fires here (see the trigger below) and there is
+# no approval trigger (see below), so neither of the two things that make a PR
+# ready is observed directly. `workflow_run` covers both indirectly: any CI
+# completion in the repo re-evaluates every open PR, so a peer approval is picked
+# up by the next one. The `pull_request_target` events are a fast path for
+# open/push only. If you remove BOTH the sweep trigger and the schedule,
+# something else must answer "what re-checks a PR after CI finishes, and after
+# someone approves it?" — and the answer cannot be an approval event.
 #
-# WHAT THIS COSTS: up to 30 minutes between the approval that makes a PR ready
-# and the label that puts it in a senior's queue.
+# WHAT THIS COSTS: minutes during a working day, when CI is running constantly.
+# On a quiet repo it falls back to the cron's cadence, which GitHub delays or
+# drops under load — so the honest worst case is still hours, not 30 minutes.
 
 # TRIGGER CHOICE: `pull_request_target`, because developers without write access
 # contribute from forks and a `pull_request` run gets a read-only token there,
@@ -119,10 +121,52 @@ name: senior-queue
 # returns before it ever writes, and goes green. So it only reddened on the
 # approval that mattered, and the sweep 30 minutes later applied the label
 # anyway, leaving a red X on a PR that was correctly queued.
+#
+# WHAT REPLACED IT (2026-09-01, issue #1968): a `workflow_run` trigger on the
+# repo's CI workflows, handled as a sweep. `workflow_run` runs in the base-repo
+# context even for fork-PR CI, so it keeps `issues: write` where the review
+# trigger is denied it, and it needs no new identity. Chosen over granting the
+# Projects App `Issues: write` — the only remedy that fires deterministically on
+# the approval, but an org-admin permission change on a private-key-holding
+# identity, widening it to label writes across every issue and PR, for a path
+# that fires ~1% as often as CI does. Also chosen over a detect-only check, which
+# makes the gap visible and closes nothing.
+#
+# The schedule STAYS. `workflow_run` converges within minutes while CI is busy
+# and does nothing on a quiet weekend; the cron is the floor under it. Do not
+# remove one because the other exists.
 
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
+  workflow_run:
+    # THE APPROVAL-EVENT SUBSTITUTE. `pull_request_review` cannot be used here
+    # (see the ledger above), so nothing observed a peer approval and the cron
+    # was the only thing that converged the queue — measured at 200 of an
+    # expected 352 runs on 2026-08-27, with an 11h23m gap on 2026-08-28.
+    #
+    # `workflow_run` fires in the BASE-REPO context even for a fork PR's CI, so
+    # its `GITHUB_TOKEN` keeps the `issues: write` that a `pull_request_review`
+    # run is denied. It is handled as a SWEEP, never per-PR: see the `sweep`
+    # branch below for why `context.payload.workflow_run.pull_requests` must not
+    # be used.
+    #
+    # This does not fire on the approval itself — it fires on the next CI
+    # completion anywhere in the repo, which during a working day is minutes
+    # away (median inter-run gap 0 min, max 23 min over 400 runs in 2h46m,
+    # measured 2026-08-27). On a quiet weekend an approval still waits for the
+    # cron. Fast and probabilistic, not deterministic; the cron stays as the
+    # floor.
+    workflows:
+      - "Engine tests"
+      - "JS workspace tests"
+      - "Eval harness tests"
+      - "Server tests"
+      - "Check runlog discipline"
+      - "Check e2e fixtures + grading"
+      - "check-engine-lockfile"
+      - "payload-guard"
+    types: [completed]
   check_suite:
     # DEAD TRIGGER, kept only to document that it is dead. Every check suite here
     # is created by an Actions workflow using `GITHUB_TOKEN`, and GitHub does not
@@ -156,6 +200,13 @@ concurrency:
   # Per-PR events serialize per PR. Sweeps share ONE key so a delayed cron run
   # cannot race the next one; they are add-only and idempotent, so queueing
   # rather than cancelling costs nothing.
+  #
+  # `workflow_run` has neither a pull_request nor a check_suite payload, so it
+  # falls through to 'sweep' — which is what keeps it cheap. A burst of CI
+  # completions collapses to one running sweep plus one pending, because GitHub
+  # cancels the previously-pending run in a group; and since every sweep
+  # evaluates every open PR, the survivor does the same work the cancelled ones
+  # would have.
   group: >-
     senior-queue-${{ github.event.pull_request.number
       || github.event.check_suite.id
@@ -334,8 +385,16 @@ jobs:
             core.info(`parsed ${rules.length} CODEOWNERS rule(s)`);
 
             // ---- which PRs to evaluate --------------------------------------
+            // `workflow_run` is a SWEEP, deliberately. Do NOT narrow it to
+            // `context.payload.workflow_run.pull_requests`: that array is EMPTY
+            // for fork-authored PRs, which is the exact population the forbidden
+            // `pull_request_review` trigger already fails on — narrowing it here
+            // would rebuild that hole in a new place. Sweeping is also what makes
+            // the trigger useful at all: any CI completion in the repo re-converges
+            // every open PR, not just the one whose CI finished.
             const sweep = context.eventName === 'schedule'
-                       || context.eventName === 'workflow_dispatch';
+                       || context.eventName === 'workflow_dispatch'
+                       || context.eventName === 'workflow_run';
 
             let numbers = [];
             if (sweep) {

--- a/.github/workflows/senior-queue.yml
+++ b/.github/workflows/senior-queue.yml
@@ -94,9 +94,10 @@ name: senior-queue
 # something else must answer "what re-checks a PR after CI finishes, and after
 # someone approves it?" — and the answer cannot be an approval event.
 #
-# WHAT THIS COSTS: minutes during a working day, when CI is running constantly.
-# On a quiet repo it falls back to the cron's cadence, which GitHub delays or
-# drops under load — so the honest worst case is still hours, not 30 minutes.
+# WHAT THIS COSTS: at most 15 minutes while CI is running, versus a cron that
+# GitHub delays or drops under load — 200 of an expected 352 runs on 2026-08-27,
+# and an 11h23m gap on 2026-08-28. On a genuinely quiet repo there are no CI
+# completions to ride and it falls back to that cron.
 
 # TRIGGER CHOICE: `pull_request_target`, because developers without write access
 # contribute from forks and a `pull_request` run gets a read-only token there,
@@ -152,11 +153,12 @@ on:
     # be used.
     #
     # This does not fire on the approval itself — it fires on the next CI
-    # completion anywhere in the repo, which during a working day is minutes
-    # away (median inter-run gap 0 min, max 23 min over 400 runs in 2h46m,
-    # measured 2026-08-27). On a quiet weekend an approval still waits for the
-    # cron. Fast and probabilistic, not deterministic; the cron stays as the
-    # floor.
+    # completion anywhere in the repo, debounced to one sweep per 15 minutes
+    # (see DEBOUNCE_MIN below; the API budget, not the event rate, sets that
+    # number). The win is NOT a shorter cadence than the cron's 30 minutes — it
+    # is that this does not depend on GitHub's best-effort scheduler, which is
+    # what produced the 11h23m gap on 2026-08-28 that issue #1968 measured.
+    # Fast and probabilistic, not deterministic; the cron stays as the floor.
     workflows:
       - "Engine tests"
       - "JS workspace tests"
@@ -195,6 +197,10 @@ permissions:
   pull-requests: write
   checks: read
   contents: read
+  # `actions: read` is for listWorkflowRuns in the workflow_run debounce below.
+  # An explicit permissions block makes every UNLISTED scope `none`, so without
+  # this line that call 403s and every workflow_run sweep dies on it.
+  actions: read
 
 concurrency:
   # Per-PR events serialize per PR. Sweeps share ONE key so a delayed cron run
@@ -396,11 +402,51 @@ jobs:
                        || context.eventName === 'workflow_dispatch'
                        || context.eventName === 'workflow_run';
 
+            // ---- workflow_run: debounce, because a sweep is not cheap ---------
+            //
+            // A full sweep costs ~5 REST calls per non-draft open PR — about 130
+            // today. `GITHUB_TOKEN` gets 1,000 REST requests/hour for the WHOLE
+            // REPOSITORY (15,000 only on Enterprise Cloud; this org is on `free`),
+            // shared with project-status-sync, labeler, cosmetic-skip-strip and
+            // this workflow's own per-PR and cron runs. CI completions arrive far
+            // faster than that is affordable: 129 completions across the eight
+            // targeted workflows in the hour 2026-09-01T11 alone, median gap 3s.
+            // Unbounded, this would 403 every GITHUB_TOKEN workflow in the repo.
+            const DEBOUNCE_MIN = 15;
+            if (context.eventName === 'workflow_run') {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner, repo, workflow_id: 'senior-queue.yml',
+                event: 'workflow_run', per_page: 10,
+              });
+              // Skip cancelled runs: concurrency cancels the PENDING run when a
+              // newer event arrives, and one of those never evaluated anything —
+              // debouncing against it would skip on a sweep that never happened.
+              const last = data.workflow_runs.find(
+                r => r.id !== context.runId && r.conclusion !== 'cancelled');
+              if (last && Date.now() - Date.parse(last.run_started_at) < DEBOUNCE_MIN * 60_000) {
+                core.info(`skipped — a workflow_run sweep started at ${last.run_started_at}, ` +
+                          `inside the ${DEBOUNCE_MIN}-minute debounce`);
+                return;
+              }
+            }
+
             let numbers = [];
             if (sweep) {
               const open = await github.paginate(github.rest.pulls.list,
                 { owner, repo, state: 'open', per_page: 100 });
-              numbers = open.map(p => p.number);
+              // The CRON sweep evaluates every open PR and is the floor under
+              // everything else. The workflow_run sweep evaluates only PRs touched
+              // in the last hour, which is what makes it cheap enough to run four
+              // times as often: `updated_at` is already on the objects above, so
+              // the filter costs nothing, and an approval — the event this trigger
+              // exists for — bumps it. Anything the filter misses is picked up by
+              // the next cron sweep, so this is never worse than today.
+              const RECENT_MIN = 60;
+              const recent = context.eventName === 'workflow_run'
+                ? open.filter(p => Date.now() - Date.parse(p.updated_at) < RECENT_MIN * 60_000)
+                : open;
+              core.info(`${context.eventName} sweep: ${recent.length} of ${open.length} open PR(s)`);
+              numbers = recent.map(p => p.number);
             } else if (context.eventName === 'check_suite') {
               numbers = (context.payload.check_suite.pull_requests || []).map(p => p.number);
               if (numbers.length === 0) {

--- a/.github/workflows/workflow-logic-tests.yml
+++ b/.github/workflows/workflow-logic-tests.yml
@@ -4,13 +4,17 @@ name: workflow-logic-tests
 # where a wrong answer is still a VALID answer, so nothing downstream complains.
 #
 # project-status-sync.yml picks a board column, and a wrong column is still a
-# column. .github/CODEOWNERS states two rules about itself that GitHub does not
-# check — every rule names both senior teams, and there is no `*` default — and a
-# line that breaks either parses fine and is accepted, silently re-narrowing who
-# may merge. In both cases the run goes green and the only detector is a human
-# noticing weeks later. Nothing else in CI reads either file: the JS suite
-# (`make test-js`) covers web, electron, viewer-ui and schema, and neither a
-# workflow branch table nor a CODEOWNERS invariant belongs in those packages.
+# column. senior-queue.yml picks a review queue off CODEOWNERS, and a pattern its
+# parser cannot read routes the PR to the wrong team while the merge gate still
+# enforces correctly; it also decides WHEN a PR is ready, and a PR wrongly held
+# back is indistinguishable from one nobody has approved yet. .github/CODEOWNERS
+# states two rules about itself that GitHub does not check — every rule names both
+# senior teams, and there is no `*` default — and a line that breaks either parses
+# fine and is accepted, silently re-narrowing who may merge. In every case the run
+# goes green and the only detector is a human noticing weeks later. Nothing else in
+# CI reads these files: the JS suite (`make test-js`) covers web, electron,
+# viewer-ui and schema, and neither a workflow branch table nor a CODEOWNERS
+# invariant belongs in those packages.
 #
 # WHAT THIS DOES NOT COVER. Only the pure decision functions. A green run here
 # says nothing about whether the App token can still write the board, whether
@@ -27,6 +31,7 @@ on:
     paths: &paths
       - '.github/CODEOWNERS'
       - '.github/workflows/project-status-sync.yml'
+      - '.github/workflows/senior-queue.yml'
       - '.github/workflows/check-runlogs.yml'
       - '.github/workflows/workflow-logic-tests.yml'
       - '.github/tests/**'
@@ -60,7 +65,27 @@ jobs:
           node-version: '22'
       - run: node .github/tests/codeowners-teams.test.mjs
 
-  # Same class as the two above: the issue-filing gate decides something where
+  codeowners-routing:
+    name: CODEOWNERS review routing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - run: node .github/tests/codeowners-routing.test.mjs
+
+  readiness:
+    name: senior-queue readiness rules
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - run: node .github/tests/senior-queue-readiness.test.mjs
+
+  # Same class as the three above: the issue-filing gate decides something where
   # a wrong answer is a valid-looking one. It fails open by design, so a broken
   # regex stops the prompt without stopping anything else — the filing goes
   # through ungated and the run is green. Its test proved this from a clean

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -265,10 +265,13 @@ stuck waiting on one specific team when a senior is already reading it. By the
 time a senior looks at a PR everything mechanical should be settled, so their
 time goes to whether the approach is right.
 
-**Getting a senior to look is the author's job.** CODEOWNERS requests review
-from both senior teams when the PR opens, so it is already in their GitHub
-review-request queue; say when it is actually ready. There is no bot that
-labels a PR ready and no queue to wait in.
+**A ready PR shows a `ready-for-senior-*` label.** `senior-queue.yml` adds it
+once CI is green, a peer has approved, and no review thread is outstanding —
+`ready-for-senior-developer` or `ready-for-senior-genealogist`, whichever team
+owns the changed paths. It is on the PR list itself, so a senior scanning
+`is:open is:pr` sees what is waiting for them without filtering for it. Saying
+when your PR is ready still helps; the label is what makes it visible without
+being told.
 
 **CODEOWNERS is the source of truth for which paths need a senior, not this
 paragraph.** Read the file rather than trusting a path list here — it can
@@ -281,8 +284,9 @@ findings resolved is what keeps that gate spent on judgment.
 **One senior approval covers a PR that spans both kinds of file.** GitHub
 resolves CODEOWNERS per file, not per PR, and a rule's owners are an OR — so
 a PR changing a `.ts` tool implementation alongside a `SKILL.md` is unblocked
-by one approval from either senior team. GitHub will show both senior teams as
-requested reviewers; that is one requirement shown twice, not two.
+by one approval from either senior team. It will carry both queue labels,
+because each queue shows the paths it owns; that is a routing signal, not two
+outstanding requirements.
 
 **Peer-only merges aren't reviewed by a senior zero times — they're sampled
 after merge, not before.** `/audit-merged-prs` is the lead's weekly pass


### PR DESCRIPTION
Restores `senior-queue.yml`, which PR #2084 deleted, and adds the `workflow_run`
sweep that issue #1968 asked for.

## Why the deletion was wrong

PR #2084 argued that CODEOWNERS already requests both senior teams when a PR
opens, so a senior has the same queue natively. The information is there — but the
comparison was wrong. It weighed the label against GitHub's review-request queue as
*two things a senior navigates to*, when the property that actually matters is that
**a label renders inline on the PR list everyone already looks at**. A review
request renders nowhere in that list; you have to filter for it. Replacing an
at-a-glance signal with a saved search is a worse product whatever the search
returns.

The two labels were never deleted, so nothing needs recreating — they are still live
on 5 open PRs. This restores the workflow that maintains them.

## Restored unchanged

- `.github/workflows/senior-queue.yml`
- `.github/tests/senior-queue-readiness.test.mjs`
- the `readiness` job and the `senior-queue.yml` trigger path in `workflow-logic-tests.yml`
- `docs/task-lifecycle.md`'s statement that a ready PR carries a `ready-for-senior-*`
  label — now saying *why* that matters: it is on the PR list itself, so a senior
  sees what is waiting without filtering for it

## Restored with one deliberate change

`.github/tests/codeowners-routing.test.mjs` comes back **without its second check**.
That check — every rule names both senior teams — is a statement about who may
**merge**, not which queue a PR lands in, so it must hold whether or not this
workflow exists. PR #2084 correctly moved it to `codeowners-teams.test.mjs`, which
reads CODEOWNERS directly rather than through the parser lifted out of the workflow,
and it stays there.

Re-adding it here would put two guards on one condition and make both untestable.
Proven, not assumed — with `senior-genealogists` dropped from the `*.ts` line:

```
codeowners-teams.test.mjs    FAIL   <- caught it
codeowners-routing.test.mjs  PASS   <- correct, no longer its job
```

## The `workflow_run` sweep (issue #1968)

Restoring the workflow restores its latency problem. `pull_request_review` cannot be
used here — GitHub has no `_target` variant, so a fork PR's review run gets a
read-only token and the label write 403s (proven on PR #1564) — which left the
`*/30` cron as the only thing observing either readiness event. Measured at 200 of an
expected 352 runs on 2026-08-27, with an 11h23m gap on 2026-08-28.

`workflow_run` fires in the **base-repo context** even for a fork PR's CI, so its
`GITHUB_TOKEN` keeps the `issues: write` the review trigger is denied, and it needs no
new identity. Triggered on the repo's eight CI workflows.

**Handled as a sweep, never per-PR.** `context.payload.workflow_run.pull_requests` is
empty for fork-authored PRs — the exact population the forbidden approval trigger
already fails on — so narrowing to it would rebuild that hole somewhere new. Sweeping
is also what makes the trigger worth having: any CI completion re-converges every open
PR, not just the one whose CI finished.

Chosen over granting the Projects App `Issues: write` (the only deterministic remedy,
but an org-admin permission change on a private-key-holding identity, widened to label
writes across every issue and PR, for a path firing ~1% as often as CI does), and over
a detect-only check (visibility without a fix). **The schedule stays as the floor** —
`workflow_run` converges in minutes while CI is busy and does nothing on a quiet
weekend.

**It costs nothing extra in Actions minutes.** `workflow_run` carries neither a
pull_request nor a check_suite payload, so it falls through to the existing
concurrency group's `sweep` key: a burst of CI completions collapses to one running
sweep plus one pending, and since every sweep evaluates every open PR, the survivor
does the work the cancelled ones would have.

### New guard, because this rots silently

`workflow_run` matches a workflow by its `name:`, not its filename, and a name that
matches nothing simply never fires — no error, no warning, no red run. The sweep just
stops converging and the queue falls back to the cron. Renaming a CI workflow is an
ordinary thing to do and nothing else in the repo connects the two files.

`senior-queue-readiness.test.mjs` now asserts every `workflow_run` target resolves to
a real workflow `name:`. **Proven to fail before committing:**

- red on renaming a target (`"Engine tests"` → `"Engine CI"`), naming the 17 known workflows
- red on removing the `workflow_run` trigger entirely
- green on restore, with the workflow byte-identical to the backup

## Verification

All six workflow-logic tests pass:

- `project-status-sync-routing` · `codeowners-teams` · `codeowners-routing` ·
  `senior-queue-readiness` · `check-runlogs-post-gate-lints` · `gate-issue-create`

Plus: every `workflow_run` target checked against the real workflow names (8/8); every
`run:` step in `workflow-logic-tests.yml` points at a file that exists; the YAML
anchor/alias pair is intact.

Closes #1968.

That issue was resolved as not planned on the premise that we do not need this
mechanism at all. The revert above voids that premise, so it has been reopened and
its `needs-decision` label removed — the decision is option A, which is what this
implements.

## The one thing that cannot be verified before merge

Option A was recorded with the caveat that base-repo `issues: write` on `workflow_run`
is **documented GitHub behavior but unverified in this repo**, and that the PR must
prove it from a run log. That proof is not obtainable here: `workflow_run` only fires
from the workflow file on the **default branch**, so no `workflow_run`-triggered run of
`senior-queue` can exist until this is on `main`. Nothing in this PR's CI can close
that gap, and no amount of local testing substitutes.

**So the check moves to just after merge:** confirm a `senior-queue` run appears with
`event: workflow_run`, that it is green, and that it applied a label. The failure mode
is loud rather than silent — if the token does not carry `issues: write` there, the run
reddens on the `addLabels` 403, which is the same shape that condemned `GITHUB_TOKEN`
on the review trigger in PR #1564. The cron remains the floor either way, so a failure
here degrades to today's behaviour rather than breaking the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJMa4biet16dH62y8KZb9d
