### PR TITLE
research: delete the blocking address_first table — the lead ruled it out twice

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -648,15 +648,12 @@ There **is** an orchestrator, and it is a skill:
    can be reversed by that section.
 3. **Two modes.** Interactive surfaces meaningful decisions to the user.
    `--autonomous` runs the loop in one continuous turn: no clarifying questions
-   and decisions logged to the audit-trail fields. Whether the router may ever
-   yield mid-loop is **not settled**: autonomous mode says yielding the turn to
-   announce a next step is a failure, while the `address_first` row of the
-   verdict table under `### Verdict handling protocol` tells it to
-   `Then end your turn — no further tool calls` — and a second, unheaded verdict
-   table (`| Verdict | Action |`) later in the same file says the opposite again
-   (`Do not block, re-open the resolved question, or force a remediation skill`).
-   Treat the sanctioned-yield question as open until the lead rules on which
-   verdict table is doctrine; do not write a test or a gate that assumes either.
+   and decisions logged to the audit-trail fields. **The router does not yield on
+   a mentor verdict.** The one verdict table in the file is advisory in both modes
+   — `address_first` is surfaced and recorded, and does not block, re-open a
+   resolved question, or force a remediation skill. A second, blocking table
+   said the opposite for seven weeks — a merge had restored text that an
+   earlier change deliberately deleted — and it was ruled out and removed.
 4. **Completion is gated twice.** Before `project.status = "completed"` is
    written via `research_append`: the **tree-encoding gate** — every
    tier-≥-probable conclusion must be encoded in `tree.gedcomx.json`; and the
@@ -690,11 +687,11 @@ record), and it never writes identity links or eliminations inline
 
 > **Direction.** `eval/tests/unit/research/` now exists: trigger
 > corpus (15 tests) plus stubbed routing tests covering rows 1–4 and the
-> shortcut guard. Rows 14 (post-verdict `address_first` handler) and 16
-> (`project.status = "completed"`) remain blocked on the two
-> contradictory verdict tables in the body (item 3 above). A live e2e run
-> is still the only instrument for routing-table rows the unit suite does
-> not yet cover.
+> shortcut guard. Row 14 (post-verdict `address_first` handler) is now
+> gradeable — the contradiction it was blocked on is gone (item 3 above).
+> Row 16 (`project.status = "completed"`) stays blocked, on who owns that
+> write rather than on a verdict table. A live e2e run is still the only
+> instrument for routing-table rows the unit suite does not yet cover.
 
 ### If you're asked to…
 

--- a/packages/engine/plugin/skills/research/SKILL.md
+++ b/packages/engine/plugin/skills/research/SKILL.md
@@ -248,8 +248,8 @@ time, regardless of how directly the request named the destination.
    re-assess sufficiency — route to `research-exhaustiveness` once the
    evidence plausibly answers the active question — before reflexively
    executing the next `planned` item. **Before that route to
-   `research-exhaustiveness` (or to the pre-exhaustiveness mentor gate),
-   re-run the log-vs-assertion cross-check from Step 1 across the
+   `research-exhaustiveness`, re-run the log-vs-assertion cross-check
+   from Step 1 across the
    *whole* log, not just the entries from the most recent search.** A
    run naturally accumulates entries from earlier in the same session —
    an early re-examination of an already-attached source, a FAN pull —
@@ -359,6 +359,12 @@ re-invocation and act on the existing verdict. Otherwise, invoke
 `@plugin:gps-mentor` with a delegation message naming the focus
 and target_id.
 
+| Verdict | Action |
+|---------|--------|
+| `looks_solid` / `consider_addressing` | Surface `narrative_for_user`; continue. |
+| `address_first` | Surface `narrative_for_user` and record each `must_address` item to the audit trail. **Do not block, re-open the resolved question, or force a remediation skill.** In interactive mode the watching researcher may choose to act on it; under `--autonomous`, log and continue. The mentor is a support, not a gatekeeper. |
+| `refused` | Surface the refusal message; it names the correct target. |
+
 ### On-demand invocation
 
 When the user says "review my work", "is this defensible?", "what
@@ -366,39 +372,6 @@ would a senior genealogist say?", "mentor", "second opinion", or
 any equivalent, invoke `@plugin:gps-mentor` with `focus: on-demand`
 and `target_id` set to the most recent question, proof summary, or
 the literal string `"project"` if no specific target is implied.
-
-### Verdict handling protocol
-
-| Verdict | Interactive mode | `--autonomous` mode |
-|---------|------------------|---------------------|
-| `looks_solid` | Print `narrative_for_user`. Proceed to the gated routing step. | Same. |
-| `consider_addressing` | Print `narrative_for_user`. Proceed to the gated routing step. | Same. |
-| `address_first` | Print `narrative_for_user`. Ask the user: "The mentor flagged N item(s) to address before `<gated step>`. Want me to invoke `<suggested_skill of first must_address>` on the first one, or proceed anyway?" **Then end your turn — no further tool calls, no invoking the gated step, no applying the fix yourself.** | Invoke `suggested_skill` on the first `must_address` item. Log the decision and the must_address text in the appropriate `research.json` field (new plan item rationale, log entry note, or conflict analysis) so the audit trail captures it. |
-| `refused` | Print the refusal message. Route to the action it names. | Same. |
-
-**This is the one place in this entire skill where the instruction
-is to stop, not to keep going.** Every other section here —
-"Autonomous mode," "Iterate — without yielding," the repeated
-warnings against ending your turn to announce a next step — tells
-you the opposite: keep working, don't yield, don't stop to ask.
-That instinct is correct everywhere else and wrong here. An
-`address_first` verdict in interactive mode is a deliberate, narrow
-exception: print the question above and then actually yield the
-turn, even mid-run, even if you were several tool calls deep in an
-uninterrupted loop a moment ago. Do not quietly apply the mentor's
-suggested fix yourself and then present the finished result as if
-nothing needed the researcher's input — that is auto-routing past
-the gate in substance even when you never literally invoked the
-named `suggested_skill`. Never auto-route past an `address_first`
-verdict in interactive mode. The mentor's role is to inform the
-researcher's decision, not to make it for them — this is the
-"support, don't replace" contract that distinguishes the mentor
-from a gatekeeper.
-| Verdict | Action |
-|---------|--------|
-| `looks_solid` / `consider_addressing` | Surface `narrative_for_user`; continue. |
-| `address_first` | Surface `narrative_for_user` and record each `must_address` item to the audit trail. **Do not block, re-open the resolved question, or force a remediation skill.** In interactive mode the watching researcher may choose to act on it; under `--autonomous`, log and continue. The mentor is a support, not a gatekeeper. |
-| `refused` | Surface the refusal message; it names the correct target. |
 
 ## When to stop
 


### PR DESCRIPTION
**Tier:** Normal. Executes Ruling 1 on issue #1335. Ruling 2 (who writes `project.status = "completed"`) is **not** in this PR — issue #1335 stays open for it.

## What was wrong

`research/SKILL.md` carried **two** verdict tables for a mentor `address_first` verdict, 25 lines apart, under the same heading, saying opposite things:

- **Table A**, under `### Verdict handling protocol` — *"Then end your turn — no further tool calls, no invoking the gated step, no applying the fix yourself"*, plus an 18-line paragraph calling it *"the one place in this entire skill where the instruction is to stop, not to keep going."*
- **Table B**, unheaded — *"Do not block, re-open the resolved question, or force a remediation skill… The mentor is a support, not a gatekeeper."*

They were never a two-table design. `1bc84e58` deleted Table A and added Table B **in a single hunk**. `54eb6386`, cut from the same parent `909af548` before that deletion existed, hardened Table A's row on a sibling branch. The merge reconciled both sides additively and Table A came back — text that had been deliberately removed. The lead ruled for Table B on **2026-08-09** and again on **2026-08-25**; the edit was never made, and both tables are on `main` today.

## What changed

**`research/SKILL.md`** — deletes Table A, its `### Verdict handling protocol` heading, and the 18-line reinforcement paragraph. Then **reseats Table B under the heading it belongs to**, `### Verdict handling — the recommendation is advisory; invoking the gate isn't`.

That reseating is not tidying. A literal deletion of the ruled span drops Table B directly under `### On-demand invocation`, which mis-scopes the advisory table to on-demand reviews only — a worse contradiction than the one being removed. Section order is now: verdict handling with its table, then on-demand invocation.

Also drops one clause, `(or to the pre-exhaustiveness mentor gate)`, naming a gate that the same commit which added Table B removed. Same merge vintage, one clause, fixed here rather than left for someone to trip over.

**`docs/architecture.md`** — removes the notice telling readers to *"Treat the sanctioned-yield question as open until the lead rules on which verdict table is doctrine; do not write a test or a gate that assumes either"*, which the ruling ordered removed in the same PR and which has been stale since 2026-08-09. Updates the routing-suite Direction note: **row 14 (post-verdict `address_first` handler) is now gradeable**; row 16 stays blocked, on Ruling 2 rather than on a verdict table.

One line cite in the ruling is off and I followed the text, not the number: it gives the reinforcement paragraph as `:385-392`, but the paragraph runs 379–396.

## This owes a paid eval run — that changed today

`research` was runlog-gate exempt only because `eval/tests/unit/research/` did not exist. PR #1929 merged at 11:05 UTC today and created it, so the exemption is gone and the gate now fires:

```
::error::skill `research`: latest full-skill run log `v1_2026-08-31_10-18-41.json` is NOT active
  - packages/engine/plugin/agents/gps-mentor.md: content-differs
  - packages/engine/plugin/skills/research/SKILL.md: content-differs
```

**Note the first line: `gps-mentor.md` is not touched by this PR.** That snapshot drift landed on `main` on 2026-08-31 with PR #1955, so the committed research run log was already stale before this branch existed. The re-run clears both.

To re-run:

```
cd /Users/dallan/pioneeradademy/cowork-genealogy/.claude/worktrees/table-a-deletion
make eval-skill SKILL=research
```

If you judge this cosmetic — it deletes a rule the corpus shows was almost never followed, and adds none — the alternative is the `eval-cosmetic-skip` label, which is a senior's call and not mine.

## Verification

`npx vitest run tests/packaging/` → **32 files, 616 tests, all passing**. That includes `doc-links`, which caught a real mistake in an earlier draft: PR #2125 had just driven `architecture.md` to zero issue references and my first wording added one back. Reworded to state the fact without the ticket.

Repo-wide grep confirms nothing still references the deleted heading or the removed notice, and `The mentor is a support, not a gatekeeper` now appears exactly once.

## Not in this PR

Ruling 2 — `proof-conclusion` owning the `project.status = "completed"` write, and the `question-selection` sequencing that follows from it. It touches two more skill/agent bodies and owes their eval slots, so it is a separate change. Issue #1335 stays open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192wQejdsBMDMw2HoqaG5jw
