### PR TITLE
The no-ceiling rule needs a home that outlives the plan doc

### DIFF
--- a/docs/plan/enforcement-layer-phases.md
+++ b/docs/plan/enforcement-layer-phases.md
@@ -101,22 +101,9 @@ fix a known-unsatisfiable gate in the body first.
 | `conflict-resolution` | 9 | ~48 KB |
 | `person-evidence` | 149 | ~52 KB |
 
-**There is no fold ceiling. `record-extractor.md`'s size is precedent, not a
-limit** — it is the largest agent body the team has shipped and lived with, and
-that is the whole of its authority. Quoting it as a bar has produced a pass/fail
-test that decides nothing: the file measured 53,845 bytes, then 58,541, and
-measures 57,229 today, so a candidate can cross the "ceiling" in either
-direction without anyone touching it. `docs/specs/unit-test-spec.md` has already
-ruled on a threshold in this band — "**the variable is anchoring, not length**",
-plugin agents are "exempt from the decay argument entirely" because they run in
-fresh context per invocation, and "the only band that binds `search-records`
-alone and spares `record-extractor` is a ~1 KB window around a single file."
-ADR-0003 says the same from the other side: reopen a size argument only on a
-measurement that body size costs something end to end, "not on a byte count."
-
-So do not disqualify a candidate on `wc -c`. Use the folded size to *size the
-work* — what moves, what stays skill-side, how much prose a reviewer has to
-read — and decide on the rationale the candidate is being converted for.
+**There is no fold ceiling** — see `docs/skill-to-agent-pair-conversion.md`,
+"Folded size sizes the work; it does not disqualify". Do not rank or disqualify
+a candidate in the table above on `wc -c`.
 
 **`search-records` is the largest candidate by a wide margin and it is
 genuinely blocked, but not by a byte count.** It folds to roughly 143 KB, of
@@ -126,10 +113,6 @@ whether `wiki_search` can serve that reference layer. Note also that stripping
 the references leaves the body at 56,244 bytes, which "clears" any
 record-extractor-derived ceiling by about 2%, i.e. inside the meaningless
 window — another reason not to run this decision through a threshold.
-
-**Agent bodies do not only grow.** Of the committed revisions of
-`record-extractor.md`, roughly a quarter shrank it, including recent ones.
-The direction of that file is not evidence about any other.
 
 **Do not split references back out.** Measured and reverted: on-demand `Read`
 inside an agent scored 6/19 against a 12–14/19 baseline, and the external

--- a/docs/plan/enforcement-layer-phases.md
+++ b/docs/plan/enforcement-layer-phases.md
@@ -110,9 +110,9 @@ genuinely blocked, but not by a byte count.** It folds to roughly 143 KB, of
 which about 87 KB is `references/` — and an agent cannot keep a `references/`
 directory. That is the real constraint, and issue #2123 is its prerequisite:
 whether `wiki_search` can serve that reference layer. Note also that stripping
-the references leaves the body at 56,244 bytes, which "clears" any
-record-extractor-derived ceiling by about 2%, i.e. inside the meaningless
-window — another reason not to run this decision through a threshold.
+the references leaves the body at 56,244 bytes — within 2% of
+`record-extractor.md`, and well inside the range that file has moved through
+on its own. One more reason not to run this decision through a threshold.
 
 **Do not split references back out.** Measured and reverted: on-demand `Read`
 inside an agent scored 6/19 against a 12–14/19 baseline, and the external

--- a/docs/skill-to-agent-pair-conversion.md
+++ b/docs/skill-to-agent-pair-conversion.md
@@ -147,6 +147,26 @@ will spend runs chasing the fixture believing it is the skill.
 relationship — assert it in a validator, not in judge prose.** A validator names
 the defect in one line; a judge gives an opinion that moves between runs.
 
+## 5. Folded size sizes the work; it does not disqualify
+
+There is no size ceiling. `wc -c` on `record-extractor.md` gives the largest
+agent body shipped so far — precedent, not a limit — and it moves (53,845 bytes,
+then 58,541, then 57,229), so a candidate measured against it crosses in either
+direction without anyone touching the candidate. Nor do agent bodies only grow:
+roughly a quarter of that file's committed revisions shrank it.
+
+`docs/specs/unit-test-spec.md` carries the ruling — the variable is anchoring,
+not length, and plugin agents are exempt from the decay argument entirely
+because they run in fresh context per invocation. ADR-0003 says the same from
+the other side: reopen a size argument only on a measurement that body size
+costs something end to end, not on a byte count.
+
+Use the folded size to size the work — what moves, what stays skill-side, how
+much prose a reviewer has to read. What does bind is step 4 below: a fold
+deletes `references/`, so a candidate whose references carry content the body
+cannot absorb is blocked until that content has another home, whatever it
+measures.
+
 ## The process, in order
 
 1. Record the pre-conversion baseline from existing run logs.

--- a/docs/specs/guardrail-enforcement-spec.md
+++ b/docs/specs/guardrail-enforcement-spec.md
@@ -1322,9 +1322,9 @@ this section before reopening one.
   whole doctrine inlined at 49,900 bytes — between `gps-mentor.md` (40,802) and
   `record-extractor.md` (58,541), so no new high-water mark. Both ends of that
   band moved during the work (the agent grew as rules landed, `record-extractor`
-  grew on main), which is the argument for measuring a ceiling rather than
-  quoting one. Both `references/` files were deleted rather than kept
-  beside it — an agent reading its own reference material on demand scored 6/19
+  grew on main), which is why that mark is precedent rather than a limit. Both
+  `references/` files were deleted rather than kept beside it — an agent reading
+  its own reference material on demand scored 6/19
   against a 12–14/19 baseline, and failed silently. What this bought beyond
   attribution: the agent emits a
   real `agent_id`, which is the thing the success gate below has never had. It
@@ -1356,15 +1356,16 @@ this section before reopening one.
   exactly as the conversion guide above prescribes. Two of the four are now
   converted, so the opening bullet reads as history — and all three of its
   figures have moved, `record-extractor` most of all. **The body-size objection
-  reverses on the unit, so quote the unit.** In bytes, `person-evidence` is
-  41,657 and `conflict-resolution` 26,091 against `record-extractor`'s 58,541,
+  falls whichever unit you quote, because there is no ceiling to clear.** In
+  bytes, `person-evidence` is 41,657 and `conflict-resolution` 26,091 against
+  `record-extractor`'s 58,541,
   and inlining their `references/` (9,403 and 22,540) leaves both **under** the
   high-water mark. In the lines the bullet used, both still clear it — 998 and
-  1,016 against `record-extractor`'s 986, which simply has longer lines. Bytes
-  is the unit this ceiling is about, because prompt cost is what it prices, so
-  the body-size objection falls — on that unit, and only stated with it. The
-  measured reference-reading regression survives either way. Re-measure before
-  quoting any of these figures.
+  1,016 against `record-extractor`'s 986, which simply has longer lines. Neither
+  reading blocks a candidate — see `docs/skill-to-agent-pair-conversion.md`,
+  "Folded size sizes the work; it does not disqualify". The measured
+  reference-reading regression survives either way. Re-measure before quoting
+  any of these figures.
 
   **This is the only route that reopens §7.** An agent is the one form a
   guardrail skill can take that emits a completion signal (`SubagentStop`) and


### PR DESCRIPTION
**Tier:** Normal. Follow-on to PR #2132, which deleted the fold "ceiling" but left the replacement rule in a file that is scheduled for deletion.

## Start here

`docs/skill-to-agent-pair-conversion.md`, the new section 5.

## What was wrong

PR #2132 put the rule — a pair candidate is not disqualified on `wc -c` — in `docs/plan/enforcement-layer-phases.md`, and the nine open conversion issues (#2115–#2123) now cite it by name.

`docs/plan/` is for work not yet built, and the convention is to delete a plan once it ships. That doc's own header says to delete a phase's section as it lands; Phase 5 has landed and Phase 4 has one pair left. When it goes, nine issue bodies point at nothing, and nothing catches it — the doc-links test reads docs, not issues.

Meanwhile `docs/skill-to-agent-pair-conversion.md` — the doc all nine of those issues already tell the reader to open first — said nothing about size at all. That is the gap the ceiling grew into.

## What changed

The conversion guide gets a section: there is no size ceiling, what the folded size is actually good for, and the constraint that does bind — a fold deletes `references/` (already step 4 of that guide's process), so a candidate whose references hold content the body cannot absorb is blocked until that content has somewhere else to live.

The plan doc keeps only what is specific to the phase programme — the `search-records` paragraph and the reference-splitting finding — and points at the guide for the rule. It is 19 lines shorter and can now be deleted without losing anything.

## Didn't change

The nine issue bodies still cite the plan doc. They should be repointed at the conversion guide once this merges; say the word and I will.

## Acceptance check

`grep -n "fold ceiling" docs/plan/enforcement-layer-phases.md` returns the pointer and not the argument, and the argument is findable in `docs/skill-to-agent-pair-conversion.md`.

## Verification

`npx vitest run tests/packaging/` → 616 passed, 32 files. Prose only — no skill body, agent body, schema or engine code — so this buys no eval run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XghGzcNevmv9pPqLBxQ2Va