### PR TITLE
viewer-ui: empty-state copy names each section's producer, plus a guard (#2211)

### DIFF
--- a/packages/viewer-ui/src/App.tsx
+++ b/packages/viewer-ui/src/App.tsx
@@ -23,7 +23,7 @@ import SidecarPanel from './components/shared/SidecarPanel'
 import ErrorBoundary from './components/ErrorBoundary'
 import styles from './App.module.css'
 
-const sectionComponents: Record<string, React.ComponentType> = {
+export const sectionComponents: Record<string, React.ComponentType> = {
   project_overview: ProjectOverview,
   known_holdings: KnownInformationSection,
   questions: QuestionsSection,

--- a/packages/viewer-ui/src/components/sections/AssertionsSection.tsx
+++ b/packages/viewer-ui/src/components/sections/AssertionsSection.tsx
@@ -175,7 +175,7 @@ export default function AssertionsSection(): React.JSX.Element {
       {filtered.length === 0 ? (
         <p className={styles.empty}>
           {assertions.length === 0
-            ? 'No assertions yet.'
+            ? 'No assertions yet. Assertions are the individual facts pulled from a source — names, dates, places, relationships — recorded during the record-extraction step.'
             : 'No assertions match the current filters.'}
         </p>
       ) : (

--- a/packages/viewer-ui/src/components/sections/ConflictsSection.tsx
+++ b/packages/viewer-ui/src/components/sections/ConflictsSection.tsx
@@ -14,7 +14,10 @@ export default function ConflictsSection(): React.JSX.Element {
     return (
       <div className={styles.section}>
         <h2 className={styles.sectionTitle}>Conflicts</h2>
-        <p className={styles.empty}>No conflicts recorded.</p>
+        <p className={styles.empty}>
+          No conflicts recorded. Contradictions between sources — and how they
+          were resolved — are recorded during the conflict-resolution step.
+        </p>
       </div>
     )
   }

--- a/packages/viewer-ui/src/components/sections/EvaluationsSection.tsx
+++ b/packages/viewer-ui/src/components/sections/EvaluationsSection.tsx
@@ -42,7 +42,10 @@ export default function EvaluationsSection(): React.JSX.Element {
     return (
       <div className={styles.section}>
         <h2 className={styles.sectionTitle}>Mentor Evaluations</h2>
-        <p className={styles.empty}>No mentor evaluations recorded.</p>
+        <p className={styles.empty}>
+          No mentor evaluations recorded. These are added when the GPS mentor
+          reviews the research against the Genealogical Proof Standard.
+        </p>
       </div>
     )
   }

--- a/packages/viewer-ui/src/components/sections/HypothesesSection.tsx
+++ b/packages/viewer-ui/src/components/sections/HypothesesSection.tsx
@@ -13,7 +13,10 @@ export default function HypothesesSection(): React.JSX.Element {
     return (
       <div className={styles.section}>
         <h2 className={styles.sectionTitle}>Hypotheses</h2>
-        <p className={styles.empty}>No hypotheses recorded.</p>
+        <p className={styles.empty}>
+          No hypotheses recorded. Candidate explanations to test are proposed
+          and tracked during the hypothesis-tracking step.
+        </p>
       </div>
     )
   }

--- a/packages/viewer-ui/src/components/sections/LocalitiesSection.tsx
+++ b/packages/viewer-ui/src/components/sections/LocalitiesSection.tsx
@@ -51,7 +51,11 @@ export default function LocalitiesSection(): React.JSX.Element {
     return (
       <div className={styles.section}>
         <h2 className={styles.sectionTitle}>Localities</h2>
-        <p className={styles.empty}>No locality guides saved yet.</p>
+        <p className={styles.empty}>
+          No locality guides saved yet. Guides to the places under research —
+          their jurisdictions, record sets, and repositories — are added during
+          the locality-guide step.
+        </p>
       </div>
     )
   }

--- a/packages/viewer-ui/src/components/sections/PersonEvidenceSection.tsx
+++ b/packages/viewer-ui/src/components/sections/PersonEvidenceSection.tsx
@@ -14,7 +14,11 @@ export default function PersonEvidenceSection(): React.JSX.Element {
     return (
       <div className={styles.section}>
         <h2 className={styles.sectionTitle}>Person Evidence</h2>
-        <p className={styles.empty}>No person evidence recorded.</p>
+        <p className={styles.empty}>
+          No person evidence recorded. The evidence gathered for each person —
+          which sources speak to them and what each one says — is compiled
+          during the person-evidence step.
+        </p>
       </div>
     )
   }

--- a/packages/viewer-ui/src/components/sections/PlansSection.tsx
+++ b/packages/viewer-ui/src/components/sections/PlansSection.tsx
@@ -28,7 +28,11 @@ export default function PlansSection(): React.JSX.Element {
     return (
       <div className={styles.section}>
         <h2 className={styles.sectionTitle}>Plans</h2>
-        <p className={styles.empty}>No plans defined yet.</p>
+        <p className={styles.empty}>
+          No plans defined yet. A research plan — the questions to pursue and
+          the sources to search for each — is drawn up during the research-plan
+          step.
+        </p>
       </div>
     )
   }

--- a/packages/viewer-ui/src/components/sections/ProofSummariesSection.tsx
+++ b/packages/viewer-ui/src/components/sections/ProofSummariesSection.tsx
@@ -15,7 +15,10 @@ export default function ProofSummariesSection(): React.JSX.Element {
     return (
       <div className={styles.section}>
         <h2 className={styles.sectionTitle}>Proof Summaries</h2>
-        <p className={styles.empty}>No proof summaries recorded.</p>
+        <p className={styles.empty}>
+          No proof summaries recorded. The written argument that ties the
+          evidence to a conclusion is composed during the proof-conclusion step.
+        </p>
       </div>
     )
   }

--- a/packages/viewer-ui/src/components/sections/QuestionsSection.tsx
+++ b/packages/viewer-ui/src/components/sections/QuestionsSection.tsx
@@ -91,7 +91,10 @@ export default function QuestionsSection(): React.JSX.Element {
     <div className={styles.section}>
       <h2 className={styles.sectionTitle}>Questions</h2>
       {questions.length === 0 ? (
-        <p className={styles.empty}>No questions defined yet.</p>
+        <p className={styles.empty}>
+          No questions defined yet. The research questions that drive the
+          project are chosen during the question-selection step.
+        </p>
       ) : (
         questions.map((q) => <QuestionCard key={q.id} question={q} />)
       )}

--- a/packages/viewer-ui/src/components/sections/ResearchLogSection.tsx
+++ b/packages/viewer-ui/src/components/sections/ResearchLogSection.tsx
@@ -77,7 +77,10 @@ export default function ResearchLogSection(): React.JSX.Element {
     return (
       <div className={styles.section}>
         <h2 className={styles.sectionTitle}>Research Log</h2>
-        <p className={styles.empty}>No log entries yet.</p>
+        <p className={styles.empty}>
+          No log entries yet. Each search — of records, images, full text, and
+          external sites — appends an entry here as research proceeds.
+        </p>
       </div>
     )
   }

--- a/packages/viewer-ui/src/components/sections/SourcesSection.tsx
+++ b/packages/viewer-ui/src/components/sections/SourcesSection.tsx
@@ -181,7 +181,11 @@ export default function SourcesSection(): React.JSX.Element {
     <div className={styles.section}>
       <h2 className={styles.sectionTitle}>Sources</h2>
       {sources.length === 0 ? (
-        <p className={styles.empty}>No sources captured yet.</p>
+        <p className={styles.empty}>
+          No sources captured yet. Sources are the records examined during
+          research — each is captured and cited during the record-extraction
+          step.
+        </p>
       ) : (
         sources.map((s) => <SourceCard key={s.id} source={s} />)
       )}

--- a/packages/viewer-ui/src/components/sections/TimelinesSection.tsx
+++ b/packages/viewer-ui/src/components/sections/TimelinesSection.tsx
@@ -14,7 +14,10 @@ export default function TimelinesSection(): React.JSX.Element {
     return (
       <div className={styles.section}>
         <h2 className={styles.sectionTitle}>Timelines</h2>
-        <p className={styles.empty}>No timelines recorded.</p>
+        <p className={styles.empty}>
+          No timelines recorded. A chronology of a person's life events, drawn
+          from the evidence, is assembled during the timeline step.
+        </p>
       </div>
     )
   }

--- a/packages/viewer-ui/src/components/sections/__tests__/AssertionsSection.test.tsx
+++ b/packages/viewer-ui/src/components/sections/__tests__/AssertionsSection.test.tsx
@@ -67,6 +67,7 @@ describe('AssertionsSection — B1 persona row', () => {
   it('renders an empty message when there are no assertions', () => {
     mockResearch({ assertions: [] })
     render(<AssertionsSection />)
-    expect(screen.getByText('No assertions yet.')).toBeInTheDocument()
+    expect(screen.getByText(/No assertions yet\./)).toBeInTheDocument()
+    expect(screen.getByText(/record-extraction step/)).toBeInTheDocument()
   })
 })

--- a/packages/viewer-ui/src/components/sections/__tests__/ConflictsSection.test.tsx
+++ b/packages/viewer-ui/src/components/sections/__tests__/ConflictsSection.test.tsx
@@ -49,7 +49,8 @@ describe('ConflictsSection', () => {
   it('shows the empty state when there are no conflicts', () => {
     mockResearch({ conflicts: [] })
     render(<ConflictsSection />)
-    expect(screen.getByText('No conflicts recorded.')).toBeInTheDocument()
+    expect(screen.getByText(/No conflicts recorded\./)).toBeInTheDocument()
+    expect(screen.getByText(/conflict-resolution step/)).toBeInTheDocument()
   })
 
   // A conflict missing its array fields must not throw (issue #1317: a

--- a/packages/viewer-ui/src/components/sections/__tests__/LocalitiesSection.test.tsx
+++ b/packages/viewer-ui/src/components/sections/__tests__/LocalitiesSection.test.tsx
@@ -59,6 +59,7 @@ describe('LocalitiesSection', () => {
     render(<LocalitiesSection />)
     expect(screen.getByText('Localities')).toBeInTheDocument()
     expect(screen.getByText(/No locality guides saved yet/)).toBeInTheDocument()
+    expect(screen.getByText(/locality-guide step/)).toBeInTheDocument()
   })
 
   it('renders the empty state when localities is empty', () => {

--- a/packages/viewer-ui/src/components/sections/__tests__/QuestionsSection.test.tsx
+++ b/packages/viewer-ui/src/components/sections/__tests__/QuestionsSection.test.tsx
@@ -41,7 +41,8 @@ describe('QuestionsSection', () => {
   it('shows the empty state when there are no questions', () => {
     mockResearch({ questions: [] })
     render(<QuestionsSection />)
-    expect(screen.getByText('No questions defined yet.')).toBeInTheDocument()
+    expect(screen.getByText(/No questions defined yet\./)).toBeInTheDocument()
+    expect(screen.getByText(/question-selection step/)).toBeInTheDocument()
   })
 
   // A question missing exhaustive_declaration and its array fields must not throw

--- a/packages/viewer-ui/src/components/sections/__tests__/emptyStates.test.tsx
+++ b/packages/viewer-ui/src/components/sections/__tests__/emptyStates.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import type { ResearchData } from '../../../lib/schema'
+import { sectionComponents } from '../../../App'
+import { buildMockContext } from '../../../contexts/__tests__/mockContext'
+
+vi.mock('../../../contexts/ResearchDataContext', async () => {
+  const actual = await vi.importActual<typeof import('../../../contexts/ResearchDataContext')>(
+    '../../../contexts/ResearchDataContext'
+  )
+  return { ...actual, useResearchData: vi.fn() }
+})
+
+import { useResearchData } from '../../../contexts/ResearchDataContext'
+
+// Guard for issue #2211: every registered section must render SOME empty-state
+// text when its data is absent, so a section can no longer ship a blank empty
+// state while CI stays green. Iterating sectionComponents (rather than a
+// hand-written list) means a section added later is covered by this test with no
+// further edit.
+//
+// What this proves and what it does not: it asserts an empty-state string is
+// PRESENT. It cannot prove the producer that string names is the correct one —
+// that rests on each section's copy following docs/specs/schemas/ownership.json
+// and on review. The assertion targets the empty-state <p> itself, not the
+// container's aggregate text, because every section renders its <h2> title
+// unconditionally above the guard; asserting on the whole container would stay
+// green even if the <p> string were deleted.
+describe('section empty states', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  for (const [key, Component] of Object.entries(sectionComponents)) {
+    it(`${key} renders non-empty empty-state text for an all-empty project`, () => {
+      vi.mocked(useResearchData).mockReturnValue(
+        buildMockContext({ research: {} as ResearchData, activeSection: key })
+      )
+      const { container } = render(<Component />)
+      const paragraph = container.querySelector('p')
+      expect(paragraph?.textContent?.trim()).toBeTruthy()
+    })
+  }
+})


### PR DESCRIPTION
## Summary

- Rewrites the empty-state copy of 12 research section components so each one names the *step that produces it* (e.g. Conflicts → "…recorded during the conflict-resolution step"), on the pattern `KnownInformationSection` already sets. Fixes the confusion in #2211 where a titled-but-unexplained empty section read as an unsupported feature.
- Adds a table-driven guard (`emptyStates.test.tsx`) that iterates the `sectionComponents` map and asserts every registered section renders non-empty empty-state text — closing the `nothing-checks` gap where 4 of the sections had no test at all.
- Tier: Normal.

## Review guidance

**Start here:** The producer named in each rewritten string is taken from `docs/specs/schemas/ownership.json`, not memory — worth spot-checking the three counter-intuitive ones: `sources` and `assertions` are owned by **record-extraction** (not a search skill), and `log` has `owner: null` so its copy names the searches that append it, not a single step. The guard asserts on the empty-state `<p>` element (`container.querySelector('p')`), not the container's aggregate text, because every section renders its `<h2>` unconditionally above the guard — asserting on the container would be a check that can't fail.

**Unsure about:** Nothing. `KnownInformationSection` is deliberately left untouched (#2069 may delete it), and the `eval/app/` fork is deliberately not synced (#1488 owns it as a class).

## Plan

**Didn't change:** `KnownInformationSection` (already names its producer; #2069 proposes deleting it), `Sidebar.tsx` (renders all 14 sections unconditionally, which is correct), and the drifted `eval/app/components/scenario/components/sections/` fork (#1488).

**Acceptance check:** `emptyStates.test.tsx` fails on `main` (no such test; and a section could ship a blank empty state) and passes here. Proven falsifiable: blanking any rewritten string turns the matching case red. The 4 updated section tests (`AssertionsSection`, `ConflictsSection`, `LocalitiesSection`, `QuestionsSection`) also assert the new producer phrase.

**Deviated from the plan:** Nothing.

## Test plan

- [x] I ran `make test-all` and it passed (3167 passed, 3 skipped). Also `make typecheck` (5 tasks) and the viewer-ui vitest suite (332 tests) green.

## Follow-on issues

**Folded in / filed instead:** Nothing filed. No outbound tester notes are sent from this PR — per #2211 that waits on #2039.
